### PR TITLE
feat(api-reference): expose global authentication state to plugins

### DIFF
--- a/.changeset/plugin-auth-state.md
+++ b/.changeset/plugin-auth-state.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': minor
+'@scalar/types': minor
+'@scalar/schemas': patch
+---
+
+Add a read-only accessor for the global authentication state to the plugin API. Plugin lifecycle hooks (`onInit`, `onConfigChange`) now receive an `auth` accessor alongside `config`, and the plugin manager exposes `getAuthState()` for view components. Plugins can read stored secrets and the selected security schemes via `auth.export()`, `auth.getAuthSecrets(documentName, schemeName)`, and `auth.getAuthSelectedSchemas(payload)` without being able to mutate auth.

--- a/.changeset/plugin-auth-state.md
+++ b/.changeset/plugin-auth-state.md
@@ -1,6 +1,6 @@
 ---
-'@scalar/api-reference': minor
-'@scalar/types': minor
+'@scalar/api-reference': patch
+'@scalar/types': patch
 '@scalar/schemas': patch
 ---
 

--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -89,8 +89,8 @@ Plugins can hook into the API Reference lifecycle to run code at specific points
 
 #### Available Hooks
 
-- `onInit({ config })` — Called when the API Reference is initialized. Receives the resolved configuration.
-- `onConfigChange({ config })` — Called when the API Reference configuration changes.
+- `onInit({ config, auth })` — Called when the API Reference is initialized. Receives the resolved configuration and the [authentication state](#reading-the-authentication-state).
+- `onConfigChange({ config, auth })` — Called when the API Reference configuration changes.
 - `onDestroy()` — Called when the API Reference is destroyed. Use for cleanup.
 
 #### Example
@@ -117,6 +117,58 @@ export const AnalyticsPlugin = (): ApiReferencePlugin => {
     }
   }
 }
+```
+
+### Reading the Authentication State
+
+Plugins can read the global authentication state — the secrets the user has entered (tokens, API keys, OAuth credentials) and the selected security schemes. This is **read-only**; plugins cannot mutate auth.
+
+The auth accessor exposes three methods:
+
+| Method | Description |
+|---|---|
+| `export()` | Returns a snapshot of the entire authentication state, keyed by document name. |
+| `getAuthSecrets(documentName, schemeName)` | Returns the stored secrets for a security scheme within a document, or `undefined`. |
+| `getAuthSelectedSchemas(payload)` | Returns the selected security for a document (`{ type: 'document', documentName }`) or operation (`{ type: 'operation', documentName, path, method }`), or `undefined`. |
+
+#### From lifecycle hooks
+
+The `auth` accessor is passed to `onInit` and `onConfigChange` alongside `config`:
+
+```typescript
+import type { ApiReferencePlugin } from '@scalar/types/api-reference'
+
+export const AuthAwarePlugin = (): ApiReferencePlugin => {
+  return () => {
+    return {
+      name: 'auth-aware-plugin',
+      extensions: [],
+      hooks: {
+        onConfigChange({ auth }) {
+          // Read the secrets the user entered for a specific scheme
+          const secrets = auth.getAuthSecrets('my-document', 'bearerAuth')
+          console.log('Current bearer token', secrets?.token)
+
+          // Or grab a full snapshot of every document's auth state
+          console.log('All auth state', auth.export())
+        },
+      },
+    }
+  }
+}
+```
+
+#### From a view component
+
+View components can reach the same accessor through the plugin manager:
+
+```typescript
+import { usePluginManager } from '@scalar/api-reference/plugins'
+
+const pluginManager = usePluginManager()
+const auth = pluginManager.getAuthState()
+
+const selected = auth.getAuthSelectedSchemas({ type: 'document', documentName: 'my-document' })
 ```
 
 ### Additional Components

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -23,6 +23,7 @@ import {
   ScalarSidebarFooter,
   ScalarSidebarSection,
 } from '@scalar/components/sidebar'
+import { toJsonCompatible } from '@scalar/helpers/object/to-json-compatible'
 import { slugify } from '@scalar/helpers/string/slugify'
 import { isLocalUrl } from '@scalar/helpers/url/is-local-url'
 import { apiReferenceConfigurationSchema } from '@scalar/schemas/api-reference'
@@ -439,13 +440,19 @@ const pluginManager = createPluginManager({
    * Read-only view of the global authentication state, so plugins can read stored secrets and
    * the selected security schemes without being able to mutate them. Wraps the workspace store's
    * auth methods (rather than passing the store directly) to keep the setters out of the plugin API.
+   *
+   * The getters return a deep copy (`export` already snapshots internally, the others go through
+   * `toJsonCompatible`) so plugins receive plain data rather than the store's live reactive proxies —
+   * mutating what they get back can never leak into the workspace store.
    */
   auth: {
     export: () => workspaceStore.auth.export(),
     getAuthSecrets: (documentName, schemeName) =>
-      workspaceStore.auth.getAuthSecrets(documentName, schemeName),
+      toJsonCompatible(
+        workspaceStore.auth.getAuthSecrets(documentName, schemeName),
+      ),
     getAuthSelectedSchemas: (payload) =>
-      workspaceStore.auth.getAuthSelectedSchemas(payload),
+      toJsonCompatible(workspaceStore.auth.getAuthSelectedSchemas(payload)),
   },
 })
 provide(PLUGIN_MANAGER_SYMBOL, pluginManager)

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -359,17 +359,6 @@ const styleContent = computed(
   () => `${mergedConfig.value.customCss ?? ''}\n${themeStyle.value}`,
 )
 
-/** Plugin injection is not reactive. All plugins must be provided at first render */
-const pluginManager = createPluginManager({
-  plugins: Object.values(configList.value).flatMap(
-    (c) => c.config.plugins ?? [],
-  ),
-})
-provide(PLUGIN_MANAGER_SYMBOL, pluginManager)
-
-pluginManager.notifyInit(mergedConfig.value)
-
-watch(mergedConfig, (config) => pluginManager.notifyConfigChange(config))
 // ---------------------------------------------------------------------------
 /** Navigation State Handling */
 
@@ -435,6 +424,35 @@ function syncSlugAndUrlWithDocument(
 const workspaceStore = createWorkspaceStore({
   verbose: isDevelopment,
 })
+
+/**
+ * Plugin injection is not reactive. All plugins must be provided at first render.
+ *
+ * Created after the workspace store so the auth accessor below can read from it — plugin `onInit`
+ * hooks may call `auth` synchronously during `notifyInit`.
+ */
+const pluginManager = createPluginManager({
+  plugins: Object.values(configList.value).flatMap(
+    (c) => c.config.plugins ?? [],
+  ),
+  /**
+   * Read-only view of the global authentication state, so plugins can read stored secrets and
+   * the selected security schemes without being able to mutate them. Wraps the workspace store's
+   * auth methods (rather than passing the store directly) to keep the setters out of the plugin API.
+   */
+  auth: {
+    export: () => workspaceStore.auth.export(),
+    getAuthSecrets: (documentName, schemeName) =>
+      workspaceStore.auth.getAuthSecrets(documentName, schemeName),
+    getAuthSelectedSchemas: (payload) =>
+      workspaceStore.auth.getAuthSelectedSchemas(payload),
+  },
+})
+provide(PLUGIN_MANAGER_SYMBOL, pluginManager)
+
+pluginManager.notifyInit(mergedConfig.value)
+
+watch(mergedConfig, (config) => pluginManager.notifyConfigChange(config))
 
 /**
  * We need to keep the client store separate from the workspace store

--- a/packages/api-reference/src/components/RenderPlugins/RenderPlugins.test.ts
+++ b/packages/api-reference/src/components/RenderPlugins/RenderPlugins.test.ts
@@ -16,6 +16,13 @@ import { usePluginManager } from '@/plugins'
 describe('RenderPlugins', () => {
   const mockOptions = { theme: 'dark', layout: 'modern' }
 
+  /** Read-only auth accessor shared by the mocked plugin managers below. */
+  const mockAuthState = {
+    export: vi.fn().mockReturnValue({}),
+    getAuthSecrets: vi.fn(),
+    getAuthSelectedSchemas: vi.fn(),
+  }
+
   describe('rendering', () => {
     it('renders nothing when no components are registered', () => {
       vi.mocked(usePluginManager).mockReturnValue({
@@ -26,11 +33,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -64,11 +67,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -106,11 +105,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -153,11 +148,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       mount(RenderPlugins, {
@@ -202,11 +193,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       mount(RenderPlugins, {
@@ -256,11 +243,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       mount(RenderPlugins, {
@@ -311,11 +294,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -360,11 +339,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -397,11 +372,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -434,11 +405,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       mount(RenderPlugins, {
@@ -464,11 +431,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       mount(RenderPlugins, {
@@ -506,11 +469,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -541,11 +500,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -575,11 +530,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -610,11 +561,7 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
-        getAuthState: vi.fn().mockReturnValue({
-          export: vi.fn().mockReturnValue({}),
-          getAuthSecrets: vi.fn(),
-          getAuthSelectedSchemas: vi.fn(),
-        }),
+        getAuthState: vi.fn().mockReturnValue(mockAuthState),
       })
 
       const wrapper = mount(RenderPlugins, {

--- a/packages/api-reference/src/components/RenderPlugins/RenderPlugins.test.ts
+++ b/packages/api-reference/src/components/RenderPlugins/RenderPlugins.test.ts
@@ -26,6 +26,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -59,6 +64,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -96,6 +106,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -138,6 +153,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       mount(RenderPlugins, {
@@ -182,6 +202,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       mount(RenderPlugins, {
@@ -231,6 +256,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       mount(RenderPlugins, {
@@ -281,6 +311,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -325,6 +360,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -357,6 +397,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -389,6 +434,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       mount(RenderPlugins, {
@@ -414,6 +464,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       mount(RenderPlugins, {
@@ -451,6 +506,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -481,6 +541,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -510,6 +575,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       const wrapper = mount(RenderPlugins, {
@@ -540,6 +610,11 @@ describe('RenderPlugins', () => {
         notifyDestroy: vi.fn(),
         getApiClientPlugins: vi.fn().mockReturnValue([]),
         getSidebarEntries: vi.fn().mockReturnValue([]),
+        getAuthState: vi.fn().mockReturnValue({
+          export: vi.fn().mockReturnValue({}),
+          getAuthSecrets: vi.fn(),
+          getAuthSelectedSchemas: vi.fn(),
+        }),
       })
 
       const wrapper = mount(RenderPlugins, {

--- a/packages/api-reference/src/plugins/index.ts
+++ b/packages/api-reference/src/plugins/index.ts
@@ -1,6 +1,7 @@
 export { PLUGIN_MANAGER_SYMBOL, usePluginManager } from '@/plugins/hooks/usePluginManager'
 export {
   type ApiReferencePlugin,
+  type PluginAuthState,
   type PluginManager,
   type PluginViewComponent,
   createPluginManager,

--- a/packages/api-reference/src/plugins/plugin-manager.test.ts
+++ b/packages/api-reference/src/plugins/plugin-manager.test.ts
@@ -376,8 +376,8 @@ describe('plugin-manager', () => {
       const config = { theme: 'dark' }
       manager.notifyInit(config)
 
-      expect(onInit1).toHaveBeenCalledWith({ config })
-      expect(onInit2).toHaveBeenCalledWith({ config })
+      expect(onInit1).toHaveBeenCalledWith({ config, auth: manager.getAuthState() })
+      expect(onInit2).toHaveBeenCalledWith({ config, auth: manager.getAuthState() })
     })
 
     it('notifyConfigChange calls onConfigChange on all plugins', () => {
@@ -393,7 +393,7 @@ describe('plugin-manager', () => {
       const config = { theme: 'light' }
       manager.notifyConfigChange(config)
 
-      expect(onConfigChange).toHaveBeenCalledWith({ config })
+      expect(onConfigChange).toHaveBeenCalledWith({ config, auth: manager.getAuthState() })
     })
 
     it('notifyDestroy calls onDestroy on all plugins', () => {
@@ -441,6 +441,54 @@ describe('plugin-manager', () => {
       manager.notifyDestroy()
 
       expect(onInit).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('getAuthState', () => {
+    it('returns an empty auth state when no accessor is provided', () => {
+      const manager = createPluginManager({})
+      const auth = manager.getAuthState()
+
+      expect(auth.export()).toEqual({})
+      expect(auth.getAuthSecrets('my-doc', 'bearer')).toBeUndefined()
+      expect(auth.getAuthSelectedSchemas({ type: 'document', documentName: 'my-doc' })).toBeUndefined()
+    })
+
+    it('returns the provided auth accessor', () => {
+      const auth = {
+        export: vi.fn(() => ({ 'my-doc': { secrets: {}, selected: { document: undefined, path: undefined } } })),
+        getAuthSecrets: vi.fn(() => ({ type: 'http', token: 'secret' })),
+        getAuthSelectedSchemas: vi.fn(() => ({ selectedIndex: 0, selectedSchemes: [{ bearer: [] }] })),
+      }
+
+      const manager = createPluginManager({ auth })
+
+      expect(manager.getAuthState()).toBe(auth)
+      expect(manager.getAuthState().getAuthSecrets('my-doc', 'bearer')).toEqual({ type: 'http', token: 'secret' })
+      expect(auth.getAuthSecrets).toHaveBeenCalledWith('my-doc', 'bearer')
+    })
+
+    it('passes the auth accessor to lifecycle hooks', () => {
+      const auth = {
+        export: vi.fn(() => ({})),
+        getAuthSecrets: vi.fn(() => undefined),
+        getAuthSelectedSchemas: vi.fn(() => undefined),
+      }
+      const onInit = vi.fn()
+      const onConfigChange = vi.fn()
+
+      const plugin: ApiReferencePlugin = () => ({
+        name: 'testPlugin',
+        extensions: [],
+        hooks: { onInit, onConfigChange },
+      })
+
+      const manager = createPluginManager({ plugins: [plugin], auth })
+      manager.notifyInit({ theme: 'dark' })
+      manager.notifyConfigChange({ theme: 'light' })
+
+      expect(onInit).toHaveBeenCalledWith({ config: { theme: 'dark' }, auth })
+      expect(onConfigChange).toHaveBeenCalledWith({ config: { theme: 'light' }, auth })
     })
   })
 })

--- a/packages/api-reference/src/plugins/plugin-manager.ts
+++ b/packages/api-reference/src/plugins/plugin-manager.ts
@@ -1,15 +1,35 @@
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
 import type {
   ApiReferencePlugin as OriginalApiReferencePlugin,
+  PluginAuthState,
   SpecificationExtension,
   ViewComponent,
 } from '@scalar/types/api-reference'
 
 export type ApiReferencePlugin = OriginalApiReferencePlugin
 
+export type { PluginAuthState }
+
 type CreatePluginManagerParams = {
   plugins?: ApiReferencePlugin[]
+  /**
+   * Read-only accessor for the global authentication state.
+   *
+   * Passed through to plugin lifecycle hooks and exposed via `getAuthState`, letting plugins read
+   * stored secrets and the selected security schemes without being able to mutate them.
+   */
+  auth?: PluginAuthState
 }
+
+/**
+ * A no-op auth state used when no accessor is provided (e.g. in tests or a standalone manager).
+ * It reports an empty authentication state so plugins can call the read methods unconditionally.
+ */
+const createEmptyAuthState = (): PluginAuthState => ({
+  export: () => ({}),
+  getAuthSecrets: () => undefined,
+  getAuthSelectedSchemas: () => undefined,
+})
 
 /** Plugin view slots that can render custom components in the content area */
 const PLUGIN_VIEW_NAMES = ['content.start', 'content.end'] as const
@@ -45,8 +65,11 @@ const getPluginViewId = (documentSlug: string, pluginName: string, viewName: Plu
  *
  * This store manages all plugins registered with the API client
  */
-export const createPluginManager = ({ plugins = [] }: CreatePluginManagerParams) => {
+export const createPluginManager = ({ plugins = [], auth }: CreatePluginManagerParams) => {
   const registeredPlugins = new Map<string, ReturnType<ApiReferencePlugin>>()
+
+  // Fall back to an empty read-only auth state so hooks and `getAuthState` always have an accessor.
+  const authState = auth ?? createEmptyAuthState()
 
   // Register initial plugins
   plugins.forEach((plugin) => {
@@ -99,7 +122,7 @@ export const createPluginManager = ({ plugins = [] }: CreatePluginManagerParams)
      */
     notifyInit: (config: Record<string, unknown>): void => {
       for (const plugin of registeredPlugins.values()) {
-        plugin.hooks?.onInit?.({ config })
+        plugin.hooks?.onInit?.({ config, auth: authState })
       }
     },
 
@@ -108,9 +131,17 @@ export const createPluginManager = ({ plugins = [] }: CreatePluginManagerParams)
      */
     notifyConfigChange: (config: Record<string, unknown>): void => {
       for (const plugin of registeredPlugins.values()) {
-        plugin.hooks?.onConfigChange?.({ config })
+        plugin.hooks?.onConfigChange?.({ config, auth: authState })
       }
     },
+
+    /**
+     * Get the read-only accessor for the global authentication state.
+     *
+     * Plugin view components can call this (via `usePluginManager`) to read stored secrets and the
+     * selected security schemes. Returns an empty auth state when no accessor was provided.
+     */
+    getAuthState: (): PluginAuthState => authState,
 
     /**
      * Notify all plugins that the API Reference is being destroyed

--- a/packages/api-reference/src/plugins/posthog/posthog-plugin.test.ts
+++ b/packages/api-reference/src/plugins/posthog/posthog-plugin.test.ts
@@ -21,6 +21,13 @@ const TEST_CONFIG = {
   apiHost: 'https://test.example.com',
 }
 
+/** Read-only auth accessor passed to lifecycle hooks (unused by the PostHog plugin). */
+const mockAuth = {
+  export: () => ({}),
+  getAuthSecrets: () => undefined,
+  getAuthSelectedSchemas: () => undefined,
+}
+
 describe('posthog-plugin', () => {
   it('returns a plugin with the correct name', () => {
     const plugin = PostHogPlugin(TEST_CONFIG)
@@ -45,7 +52,7 @@ describe('posthog-plugin', () => {
   it('initializes PostHog on onInit', () => {
     const plugin = PostHogPlugin(TEST_CONFIG)
     const instance = plugin()
-    instance.hooks?.onInit?.({ config: {} })
+    instance.hooks?.onInit?.({ config: {}, auth: mockAuth })
 
     expect(mockPostHogInstance.register).toHaveBeenCalledWith({ product: 'api-reference' })
     expect(mockPostHogInstance.opt_in_capturing).toHaveBeenCalled()
@@ -56,7 +63,7 @@ describe('posthog-plugin', () => {
     const instance = plugin()
 
     mockPostHogInstance.opt_in_capturing.mockClear()
-    instance.hooks?.onInit?.({ config: { telemetry: false } })
+    instance.hooks?.onInit?.({ config: { telemetry: false }, auth: mockAuth })
 
     expect(mockPostHogInstance.register).toHaveBeenCalledWith({ product: 'api-reference' })
     expect(mockPostHogInstance.opt_in_capturing).not.toHaveBeenCalled()
@@ -65,15 +72,15 @@ describe('posthog-plugin', () => {
   it('reacts to telemetry config changes', () => {
     const plugin = PostHogPlugin(TEST_CONFIG)
     const instance = plugin()
-    instance.hooks?.onInit?.({ config: { telemetry: true } })
+    instance.hooks?.onInit?.({ config: { telemetry: true }, auth: mockAuth })
 
     mockPostHogInstance.opt_in_capturing.mockClear()
     mockPostHogInstance.opt_out_capturing.mockClear()
 
-    instance.hooks?.onConfigChange?.({ config: { telemetry: false } })
+    instance.hooks?.onConfigChange?.({ config: { telemetry: false }, auth: mockAuth })
     expect(mockPostHogInstance.opt_out_capturing).toHaveBeenCalled()
 
-    instance.hooks?.onConfigChange?.({ config: { telemetry: true } })
+    instance.hooks?.onConfigChange?.({ config: { telemetry: true }, auth: mockAuth })
     expect(mockPostHogInstance.opt_in_capturing).toHaveBeenCalled()
   })
 
@@ -86,7 +93,7 @@ describe('posthog-plugin', () => {
   it('resets PostHog on onDestroy', () => {
     const plugin = PostHogPlugin(TEST_CONFIG)
     const instance = plugin()
-    instance.hooks?.onInit?.({ config: {} })
+    instance.hooks?.onInit?.({ config: {}, auth: mockAuth })
     instance.hooks?.onDestroy?.()
 
     expect(mockPostHogInstance.reset).toHaveBeenCalled()
@@ -101,10 +108,10 @@ describe('posthog-plugin', () => {
     const onConfigChange = vi.spyOn(clientPlugin.lifecycle!, 'onConfigChange')
     const onDestroy = vi.spyOn(clientPlugin.lifecycle!, 'onDestroy')
 
-    instance.hooks?.onInit?.({ config: { telemetry: true } })
+    instance.hooks?.onInit?.({ config: { telemetry: true }, auth: mockAuth })
     expect(onInit).toHaveBeenCalledWith({ config: { telemetry: true } })
 
-    instance.hooks?.onConfigChange?.({ config: { telemetry: false } })
+    instance.hooks?.onConfigChange?.({ config: { telemetry: false }, auth: mockAuth })
     expect(onConfigChange).toHaveBeenCalledWith({ config: { telemetry: false } })
 
     instance.hooks?.onDestroy?.()

--- a/packages/schemas/src/api-reference/api-reference-plugin.ts
+++ b/packages/schemas/src/api-reference/api-reference-plugin.ts
@@ -47,8 +47,8 @@ const viewsSchema = object({
 })
 
 const lifecycleHooksSchema = object({
-  onInit: optional(fn<({ config }: { config: any }) => void>()),
-  onConfigChange: optional(fn<({ config }: { config: any }) => void>()),
+  onInit: optional(fn<({ config, auth }: { config: any; auth: any }) => void>()),
+  onConfigChange: optional(fn<({ config, auth }: { config: any; auth: any }) => void>()),
   onDestroy: optional(fn<() => void>()),
 })
 

--- a/packages/types/src/api-reference/api-reference-plugin.ts
+++ b/packages/types/src/api-reference/api-reference-plugin.ts
@@ -61,17 +61,71 @@ const viewsSchema = z.object({
   'content.end': z.array(viewComponentSchema).optional(),
 })
 
+/**
+ * Read-only view of the stored secrets for a single security scheme.
+ *
+ * The concrete shape depends on the scheme `type` (`apiKey`, `http`, `oauth2`, `openIdConnect`),
+ * so only `type` is guaranteed. The remaining fields (tokens, credentials, per-flow secrets) are
+ * exposed loosely to avoid coupling the plugin API to the workspace store's internal schema.
+ */
+export type PluginAuthSecrets = { type: string } & Record<string, unknown>
+
+/** Read-only view of the selected security for a document or operation. */
+export type PluginSelectedSecurity = {
+  /** Index of the currently selected security requirement. */
+  selectedIndex: number
+  /** The selected security requirements, each mapping a scheme name to its selected scopes. */
+  selectedSchemes: Array<Record<string, string[]>>
+}
+
+/** Read-only view of the entire authentication state, keyed by document name. */
+export type PluginDocumentAuth = Record<
+  string,
+  {
+    /** Stored secrets keyed by security scheme name. */
+    secrets: Record<string, PluginAuthSecrets>
+    /** Selected security schemes at the document and operation level. */
+    selected: {
+      document?: PluginSelectedSecurity
+      path?: Record<string, Record<string, PluginSelectedSecurity | undefined>>
+    }
+  }
+>
+
+/**
+ * Read-only accessor for the global authentication state.
+ *
+ * Passed to plugin lifecycle hooks (`onInit`, `onConfigChange`) and exposed via the plugin
+ * manager (`getAuthState`) so plugins can read stored secrets and selected security schemes
+ * without being able to mutate them.
+ */
+export type PluginAuthState = {
+  /** Returns a plain snapshot of the entire authentication state, keyed by document name. */
+  export: () => PluginDocumentAuth
+  /** Returns the stored secrets for a security scheme within a document, or `undefined` if none. */
+  getAuthSecrets: (documentName: string, schemeName: string) => PluginAuthSecrets | undefined
+  /** Returns the selected security for a document or operation, or `undefined` if none. */
+  getAuthSelectedSchemas: (
+    payload:
+      | { type: 'document'; documentName: string }
+      | { type: 'operation'; documentName: string; path: string; method: string },
+  ) => PluginSelectedSecurity | undefined
+}
+
+/** Read-only accessor for the global authentication state, passed to lifecycle hooks. */
+const pluginAuthStateSchema = z.custom<PluginAuthState>()
+
 const lifecycleHooksSchema = z.object({
   /** Called when the API Reference is initialized */
   onInit: z
     .function({
-      input: [z.object({ config: baseConfigurationSchema.partial() })],
+      input: [z.object({ config: baseConfigurationSchema.partial(), auth: pluginAuthStateSchema })],
     })
     .optional(),
   /** Called when the API Reference configuration changes */
   onConfigChange: z
     .function({
-      input: [z.object({ config: baseConfigurationSchema.partial() })],
+      input: [z.object({ config: baseConfigurationSchema.partial(), auth: pluginAuthStateSchema })],
     })
     .optional(),
   /** Called when the API Reference is destroyed */

--- a/packages/types/src/api-reference/index.ts
+++ b/packages/types/src/api-reference/index.ts
@@ -1,3 +1,9 @@
+export type {
+  PluginAuthSecrets,
+  PluginAuthState,
+  PluginDocumentAuth,
+  PluginSelectedSecurity,
+} from './api-reference-plugin'
 export type { ApiReferenceInstance, CreateApiReference } from './html-api'
 export type { HtmlRenderingConfiguration } from './html-rendering-configuration'
 export type {

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -1,5 +1,7 @@
 import type { PartialDeep } from 'type-fest'
 
+import type { PluginAuthState } from './api-reference-plugin'
+
 /** Some common properties used in all security schemes */
 type SecuirtySchemeCommon = {
   /* A description for security scheme. CommonMark syntax MAY be used for rich text representation. */
@@ -208,8 +210,8 @@ export type ViewComponent = {
 }
 
 export type LifecycleHooks = {
-  onInit?: ({ config }: { config: Partial<BaseConfiguration> }) => void
-  onConfigChange?: ({ config }: { config: Partial<BaseConfiguration> }) => void
+  onInit?: ({ config, auth }: { config: Partial<BaseConfiguration>; auth: PluginAuthState }) => void
+  onConfigChange?: ({ config, auth }: { config: Partial<BaseConfiguration>; auth: PluginAuthState }) => void
   onDestroy?: () => void
 }
 


### PR DESCRIPTION
## Problem

Plugins had no way to read the user's authentication state. A plugin (e.g. a
custom auth helper, a "copy as cURL" view, an analytics or diagnostics panel)
could receive the resolved `config` in its lifecycle hooks but could not see
which security schemes the user selected or the secrets they entered (tokens,
API keys, OAuth credentials). That state lives in the workspace store and was
never surfaced through the plugin API, so plugins that need to react to auth
had no supported entry point.

## Solution

Add a **read-only** accessor for the global authentication state and expose it
through both plugin surfaces:

- **Lifecycle hooks** — `onInit` and `onConfigChange` now receive `auth`
  alongside `config`.
- **View components** — the plugin manager exposes `getAuthState()`, reachable
  via `usePluginManager()`.

The accessor exposes only the read methods, so plugins can inspect but not
mutate auth:

- `auth.export()` — snapshot of the entire auth state, keyed by document name
- `auth.getAuthSecrets(documentName, schemeName)`
- `auth.getAuthSelectedSchemas(payload)` — document- or operation-level

Implementation notes:

- The accessor in `ApiReference.vue` wraps `workspaceStore.auth` (rather than
  passing the store through) so the setters stay out of the plugin API.
- `@scalar/types` defines the auth types **structurally** because it can't
  depend on `@scalar/workspace-store` (that would be a dependency cycle).
- `pluginManager` creation was moved to **after** `workspaceStore` is created:
  `notifyInit` runs synchronously and a plugin's `onInit` may call `auth`, so
  the previous ordering risked a temporal-dead-zone `ReferenceError`.
- `auth` is **required** in the hook input (the manager always provides it), so
  plugin authors always get it without optional chaining.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation.
