### PR TITLE
fix(dotnet): pin Microsoft.OpenApi to patched 2.7.5

### DIFF
--- a/integrations/dotnet/Directory.Packages.props
+++ b/integrations/dotnet/Directory.Packages.props
@@ -1,11 +1,20 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Pin transitive dependencies centrally so we can override vulnerable versions pulled in by other packages -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <!-- Source / runtime packages -->
   <ItemGroup>
     <PackageVersion Include="NetEscapades.EnumGenerators.Generators" Version="1.0.0-beta21" />
+    <!--
+      Pin the transitive Microsoft.OpenApi to a patched version. Older versions (pulled in via
+      Microsoft.AspNetCore.OpenApi and Swashbuckle.AspNetCore.SwaggerGen) fall under the advisory
+      GHSA-v5pm-xwqc-g5wc, which trips the NuGet security audit (NU1903). Because CI treats warnings
+      as errors, the audit warning breaks the build until the transitive version is bumped past 2.7.4.
+    -->
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.4.0" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />

--- a/integrations/dotnet/Directory.Packages.props
+++ b/integrations/dotnet/Directory.Packages.props
@@ -1,19 +1,12 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <!-- Pin transitive dependencies centrally so we can override vulnerable versions pulled in by other packages -->
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <!-- Source / runtime packages -->
   <ItemGroup>
     <PackageVersion Include="NetEscapades.EnumGenerators.Generators" Version="1.0.0-beta21" />
-    <!--
-      Pin the transitive Microsoft.OpenApi to a patched version. Older versions (pulled in via
-      Microsoft.AspNetCore.OpenApi and Swashbuckle.AspNetCore.SwaggerGen) fall under the advisory
-      GHSA-v5pm-xwqc-g5wc, which trips the NuGet security audit (NU1903). Because CI treats warnings
-      as errors, the audit warning breaks the build until the transitive version is bumped past 2.7.4.
-    -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.4.0" />

--- a/integrations/dotnet/Directory.Packages.props
+++ b/integrations/dotnet/Directory.Packages.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <!-- Source / runtime packages -->

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Microsoft/Scalar.AspNetCore.Microsoft.csproj
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Microsoft/Scalar.AspNetCore.Microsoft.csproj
@@ -15,6 +15,8 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <!-- net10 pulls in a Microsoft.OpenApi version affected by GHSA-v5pm-xwqc-g5wc; pin the patched release. net9 stays on the unaffected 1.x line. -->
+    <PackageReference Include="Microsoft.OpenApi" />
   </ItemGroup>
 
   <ItemGroup>

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Microsoft/Scalar.AspNetCore.Microsoft.csproj
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Microsoft/Scalar.AspNetCore.Microsoft.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-    <!-- net10 pulls in a Microsoft.OpenApi version affected by GHSA-v5pm-xwqc-g5wc; pin the patched release. net9 stays on the unaffected 1.x line. -->
     <PackageReference Include="Microsoft.OpenApi" />
   </ItemGroup>
 

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Scalar.AspNetCore.Swashbuckle.csproj
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Scalar.AspNetCore.Swashbuckle.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
-    <!-- Swashbuckle pulls in a Microsoft.OpenApi version affected by GHSA-v5pm-xwqc-g5wc; pin the patched release -->
     <PackageReference Include="Microsoft.OpenApi" />
   </ItemGroup>
 

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Scalar.AspNetCore.Swashbuckle.csproj
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Scalar.AspNetCore.Swashbuckle.csproj
@@ -12,6 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+    <!-- Swashbuckle pulls in a Microsoft.OpenApi version affected by GHSA-v5pm-xwqc-g5wc; pin the patched release -->
+    <PackageReference Include="Microsoft.OpenApi" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The .NET CI job fails because the NuGet security audit flags the transitive `Microsoft.OpenApi` dependency ([GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc), high severity). Older 2.x versions come in transitively — `2.0.0` via `Microsoft.AspNetCore.OpenApi` (net10) and `2.3.0` via Swashbuckle — and both fall in the vulnerable range (2.x ≤ 2.7.4). CI treats warnings as errors, so the `NU1903` audit warning breaks the build.

The pin has to be **project-scoped**, not global, because the two projects use different major versions of `Microsoft.OpenApi`:

- **Swashbuckle** (`Scalar.AspNetCore.Swashbuckle`) uses the 2.x API on all target frameworks → pin the patched `2.7.5`.
- **Microsoft** (`Scalar.AspNetCore.Microsoft`) uses the 2.x API only on **net10**; on **net9** it deliberately targets the 1.x API (`OpenApiArray`/`OpenApiObject`/`OpenApiString`), and the 1.x line is **not** affected by the advisory. So the pin is applied to net10 only, and net9 stays on the unaffected `1.6.x`.

A global transitive pin (my first attempt) broke the net9 build because it forced the net9 code onto 2.x, where those 1.x types no longer exist.

Test projects inherit the patched version transitively through their project references, so no separate change is needed there.

## Verification

`CI=true dotnet restore --force --no-cache` + `CI=true dotnet build -c Release`:
- Restore passes with zero `NU1903`
- Build succeeds with **0 warnings, 0 errors** across all TFMs
- Resolved versions: `Microsoft.OpenApi 2.7.5` for the 2.x paths, `1.6.17` for net9-Microsoft