### PR TITLE
ci: upload Playwright reports to Netlify only on failure

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -331,7 +331,7 @@ jobs:
       - name: Run e2e tests (@scalar/api-reference)
         run: pnpm --filter api-reference test:e2e:ci
         # Only when the PR is from the same repository
-      - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+      - if: ${{ failure() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Deploy Playwright Report to Netlify
         run: |
           pnpx netlify deploy --dir "./packages/api-reference/playwright-report" \
@@ -341,7 +341,7 @@ jobs:
             --filter @scalar/components \
             --alias=${{env.DEPLOY_ID}}
         # Only when the PR is from the same repository
-      - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+      - if: ${{ failure() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Add Netlify Playwright Report URL to the PR
         uses: daun/playwright-report-summary@93883773b4f4f0951d8bcdb780c6443ca51eaf7b # v3
         with:
@@ -378,7 +378,7 @@ jobs:
         run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV" && echo $DEPLOY_ID
       - name: Run e2e tests (scalar-app)
         run: pnpm --filter scalar-app test:e2e:ci
-      - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+      - if: ${{ failure() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Deploy Playwright Report to Netlify
         run: |
           pnpx netlify deploy --dir "./projects/scalar-app/playwright-report" \
@@ -387,7 +387,7 @@ jobs:
             --auth ${{ secrets.NETLIFY_AUTH_TOKEN }} \
             --filter @scalar/components \
             --alias=${{env.DEPLOY_ID}}
-      - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+      - if: ${{ failure() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Add Netlify Playwright Report URL to the PR
         uses: daun/playwright-report-summary@93883773b4f4f0951d8bcdb780c6443ca51eaf7b # v3
         with:
@@ -424,7 +424,7 @@ jobs:
       - name: Run e2e tests (@scalar/components)
         run: pnpm --filter components test:e2e:ci
         # Only when the PR is from the same repository
-      - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+      - if: ${{ failure() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Deploy Playwright Report to Netlify
         run: |
           pnpx netlify deploy --dir "./packages/components/playwright-report" \
@@ -434,7 +434,7 @@ jobs:
             --filter @scalar/components \
             --alias=${{env.DEPLOY_ID}}
         # Only when the PR is from the same repository
-      - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+      - if: ${{ failure() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Add Netlify Playwright Report URL to the PR
         uses: daun/playwright-report-summary@93883773b4f4f0951d8bcdb780c6443ca51eaf7b # v3
         with:
@@ -469,7 +469,7 @@ jobs:
       - name: Run snapshot tests (@scalar/api-reference)
         run: pnpm --filter api-reference test:e2e:cdn:ci
         # Only when the PR is from the same repository
-      - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+      - if: ${{ failure() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Deploy Playwright Report to Netlify
         run: |
           pnpx netlify deploy --dir "./packages/api-reference/playwright-report-cdn" \
@@ -479,7 +479,7 @@ jobs:
             --filter @scalar/components \
             --alias=${{env.DEPLOY_ID}}
         # Only when the PR is from the same repository
-      - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
+      - if: ${{ failure() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Add Netlify Playwright Report URL to the PR
         uses: daun/playwright-report-summary@93883773b4f4f0951d8bcdb780c6443ca51eaf7b # v3
         with:


### PR DESCRIPTION
The Playwright report jobs deploy their HTML report to Netlify and drop a PR comment on **every** run — including green ones, where there is nothing to look at. That upload sits on the critical path.

This gates the Netlify deploy + comment steps behind `failure()` in the four report jobs (component snapshots, api-reference e2e, scalar-app e2e, CDN snapshots), so a passing run skips them. When a test actually fails or a snapshot changes, the report still uploads — that is exactly when you want it.

### Before / after

The two report jobs are the last things a green PR run waits on. On a recent run each spent ~20s on the Netlify upload after tests already passed:

| Job | Netlify upload (green run) | After |
|-----|------|-------|
| `test-component-snapshots` (tail job) | ~20s | skipped |
| `test-e2e-api-reference` | ~19s | skipped |

`test-component-snapshots` is what sets the finish line, so this trims ~20s off total wall-clock for every passing PR (~3m40s → ~3m20s), and stops posting empty report comments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow condition changes; failure paths still upload reports, with slightly less visibility if a later step fails after tests pass.
> 
> **Overview**
> **PR CI** now runs Netlify Playwright report uploads and PR summary comments only when the preceding test step **fails**, instead of on every non-cancelled run.
> 
> The condition on both follow-up steps in **`test-e2e-api-reference`**, **`test-e2e-scalar-app`**, **`test-component-snapshots`**, and **`test-cdn-snapshots`** changes from `!cancelled()` to **`failure()`**. Same-repo and non-bot guards are unchanged. Passing runs skip deploy and comments, which trims wall-clock time and avoids empty report comments; failed or snapshot-mismatch runs still get the hosted report and PR link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c02d74599ddc7305e5571e1b72fabf9dc34171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->