### PR TITLE
ci: bump report actions to their Node 24 releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
           compression-level: 0
       - if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
         name: Upload webpack stats to RelativeCI
-        uses: relative-ci/agent-action@1707825cbfcc7452b2913d273414705415ae64d4 # v3
+        uses: relative-ci/agent-action@fcf45416581928e8dd62eded78ce98c78e5149f8 # v3.2.3
         with:
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,7 +74,7 @@ jobs:
           compression-level: 0
       - if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
         name: Upload webpack stats to RelativeCI
-        uses: relative-ci/agent-action@1707825cbfcc7452b2913d273414705415ae64d4 # v3
+        uses: relative-ci/agent-action@fcf45416581928e8dd62eded78ce98c78e5149f8 # v3.2.3
         with:
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -343,7 +343,7 @@ jobs:
         # Only when the PR is from the same repository
       - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Add Netlify Playwright Report URL to the PR
-        uses: daun/playwright-report-summary@93883773b4f4f0951d8bcdb780c6443ca51eaf7b # v3
+        uses: daun/playwright-report-summary@8bb85779022480a59ed8d33d9a4b8bda1c67666b # v4.0.0
         with:
           comment-title: 'Scalar References End to End Test Results'
           report-url: https://${{env.DEPLOY_ID}}--scalar-snapshots.netlify.app
@@ -389,7 +389,7 @@ jobs:
             --alias=${{env.DEPLOY_ID}}
       - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Add Netlify Playwright Report URL to the PR
-        uses: daun/playwright-report-summary@93883773b4f4f0951d8bcdb780c6443ca51eaf7b # v3
+        uses: daun/playwright-report-summary@8bb85779022480a59ed8d33d9a4b8bda1c67666b # v4.0.0
         with:
           comment-title: 'Scalar App End to End Test Results'
           report-url: https://${{env.DEPLOY_ID}}--scalar-snapshots.netlify.app
@@ -436,7 +436,7 @@ jobs:
         # Only when the PR is from the same repository
       - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Add Netlify Playwright Report URL to the PR
-        uses: daun/playwright-report-summary@93883773b4f4f0951d8bcdb780c6443ca51eaf7b # v3
+        uses: daun/playwright-report-summary@8bb85779022480a59ed8d33d9a4b8bda1c67666b # v4.0.0
         with:
           comment-title: 'Scalar Components Snapshot Test Results'
           report-url: https://${{env.DEPLOY_ID}}--scalar-snapshots.netlify.app
@@ -481,7 +481,7 @@ jobs:
         # Only when the PR is from the same repository
       - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Add Netlify Playwright Report URL to the PR
-        uses: daun/playwright-report-summary@93883773b4f4f0951d8bcdb780c6443ca51eaf7b # v3
+        uses: daun/playwright-report-summary@8bb85779022480a59ed8d33d9a4b8bda1c67666b # v4.0.0
         with:
           comment-title: 'Scalar CDN Snapshot Diff Results'
           report-url: https://${{env.DEPLOY_ID}}--scalar-snapshots.netlify.app


### PR DESCRIPTION
GitHub is deprecating Node 20 on Actions runners, and three of our pinned actions still target it (currently force-run on Node 24 with a deprecation warning). This bumps the two that have a Node 24 release out:

- `relative-ci/agent-action` → v3.2.3 (`node24`)
- `daun/playwright-report-summary` → v4.0.0 (`node24`) - all inputs we use are unchanged; v4 also hardens comment sanitization

Just clears the deprecation warnings before Node 20 is removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency pin bumps with unchanged inputs; minor risk that v4 comment formatting differs slightly on PRs.
> 
> **Overview**
> Updates pinned third-party GitHub Actions in **`main.yml`** and **`pr.yml`** so they run on Node 24 ahead of GitHub removing Node 20 on runners.
> 
> **`relative-ci/agent-action`** moves from v3 to **v3.2.3** on the build job’s webpack stats upload step (both workflows). **`daun/playwright-report-summary`** moves from v3 to **v4.0.0** on all four PR e2e/snapshot jobs that post Netlify Playwright report links to PRs. Step inputs (`key`, `token`, `webpackStatsFile`, `comment-title`, `report-url`, etc.) are unchanged.
> 
> The v4 playwright action also tightens PR comment sanitization; behavior for the inputs this repo uses should stay the same aside from clearing Node 20 deprecation warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c9e4901c5eb7190964b3f0e55a473390a181e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->