### PR TITLE
test(scalar-app): fix flaky get-exchange-token test

### DIFF
--- a/projects/scalar-app/entrypoints/electron/main/actions/get-exchange-token.test.ts
+++ b/projects/scalar-app/entrypoints/electron/main/actions/get-exchange-token.test.ts
@@ -14,8 +14,8 @@ vi.mock('electron/common', () => ({
   },
 }))
 
-vi.mock('get-port', () => ({
-  default: getPortMock,
+vi.mock('get-port-please', () => ({
+  getPort: getPortMock,
 }))
 
 vi.mock('@/environment', () => ({


### PR DESCRIPTION
The `get-exchange-token` test was flaky in CI (failing with `EADDRINUSE 127.0.0.1:3000` and `expected "vi.fn()" to be called at least once`).

The test mocked the wrong module. The source imports `getPort` from `get-port-please`, but the test mocked `get-port` with a `default` export, so the mock never applied. The real `getPort` ran and defaulted to trying port 3000, defeating the intended unique-port-per-test scheme (`38200++`) and colliding across workers.

Fixed by mocking the module the source actually imports:

```ts
vi.mock('get-port-please', () => ({ getPort: getPortMock }))
```

Seen in #9644.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to module mocking; no production auth or Electron behavior is modified.
> 
> **Overview**
> Fixes flaky CI failures in **`get-exchange-token.test.ts`** by aligning the Vitest mock with the module the implementation actually imports.
> 
> The test previously mocked **`get-port`** with a **`default`** export, while **`get-exchange-token`** uses **`getPort`** from **`get-port-please`**. The mock never applied, so real port selection ran (often **3000**), causing **`EADDRINUSE`** and missed **`openExternal`** assertions when parallel workers collided.
> 
> The mock now targets **`get-port-please`** and stubs **`getPort`** with the existing **`getPortMock`**, so each test keeps its intended sequential local ports (**38200++**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 151605d52da6d66598ff8507ad671e458c6c4697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->