### PR TITLE
fix(api-reference): deep links to response properties

### DIFF
--- a/.changeset/fix-collapsed-response-anchors.md
+++ b/.changeset/fix-collapsed-response-anchors.md
@@ -1,5 +1,0 @@
----
-'@scalar/api-reference': patch
----
-
-Add anchor links to response properties and open collapsed responses on deep link. Response properties are now linkable even when `expandAllResponses` is off, and a deep link into a collapsed response expands it and scrolls the property into view.

--- a/.changeset/fix-collapsed-response-anchors.md
+++ b/.changeset/fix-collapsed-response-anchors.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Add anchor links to response properties and open collapsed responses on deep link. Response properties are now linkable even when `expandAllResponses` is off, and a deep link into a collapsed response expands it and scrolls the property into view.

--- a/.changeset/fix-response-deep-links.md
+++ b/.changeset/fix-response-deep-links.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-Fix deep links to response properties not scrolling when opened in a new tab. Response property anchors now carry a `responses` marker so the target operation is found and rendered on a fresh load, just like request body links.
+Fix deep links to response properties. Response property anchors now carry a `responses` marker so the target operation is found and scrolled to on a fresh load, and response properties are linkable even when `expandAllResponses` is off (a deep link expands the collapsed response and scrolls the property into view).

--- a/.changeset/fix-response-deep-links.md
+++ b/.changeset/fix-response-deep-links.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix deep links to response properties not scrolling when opened in a new tab. Response property anchors now carry a `responses` marker so the target operation is found and rendered on a fresh load, just like request body links.

--- a/packages/api-reference/src/components/Content/Operations/TraversedEntry.test.ts
+++ b/packages/api-reference/src/components/Content/Operations/TraversedEntry.test.ts
@@ -13,7 +13,7 @@ import { ServerObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/
 import type { ComponentProps } from '@test/utils/types'
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 vi.mock('@/plugins/hooks/usePluginManager', () => ({
   usePluginManager: () => ({
@@ -25,6 +25,7 @@ vi.mock('@/helpers/lazy-bus', () => ({
   getLazyPlaceholderHeight: () => undefined,
   requestLazyRender: () => undefined,
   setLazyPlaceholderHeight: () => undefined,
+  scrollTargetId: ref(''),
   useLazyBus: () => ({
     isReady: computed(() => true),
   }),

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -100,8 +100,14 @@ const optimizedValue = computed(() =>
 )
 
 const childBreadcrumb = computed<string[] | undefined>(() =>
-  props.breadcrumb && props.name
-    ? [...props.breadcrumb, props.name]
+  props.breadcrumb
+    ? // A named property extends the breadcrumb with its own name. A nameless
+      // container (e.g. a response object, rendered without a name to avoid a
+      // duplicate heading) passes its breadcrumb straight through so its
+      // properties stay linkable.
+      props.name
+      ? [...props.breadcrumb, props.name]
+      : props.breadcrumb
     : undefined,
 )
 

--- a/packages/api-reference/src/components/Content/Tags/components/ModernLayout.test.ts
+++ b/packages/api-reference/src/components/Content/Tags/components/ModernLayout.test.ts
@@ -2,7 +2,7 @@ import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { TraversedTag } from '@scalar/workspace-store/schemas/navigation'
 import { mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 import ModernLayout from './ModernLayout.vue'
 
@@ -35,6 +35,7 @@ beforeEach(() => {
     getLazyPlaceholderHeight: () => undefined,
     requestLazyRender: vi.fn(),
     setLazyPlaceholderHeight: vi.fn(),
+    scrollTargetId: ref(''),
     useLazyBus: () => ({
       isReady: computed(() => true),
     }),

--- a/packages/api-reference/src/features/Operation/components/OperationResponses.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationResponses.vue
@@ -41,7 +41,7 @@ const { translate } = useLocalization()
       <ParameterListItem
         v-for="(response, status) in responses"
         :key="status"
-        :breadcrumb
+        :breadcrumb="breadcrumb ? [...breadcrumb, 'responses'] : undefined"
         :collapsableItems
         :document
         :eventBus

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -19,27 +19,29 @@ import { computed, ref } from 'vue'
 import { getRefName } from '@/components/Content/Schema/helpers/get-ref-name'
 import SchemaProperty from '@/components/Content/Schema/SchemaProperty.vue'
 import type { OperationProps } from '@/features/Operation/Operation.vue'
+import { scrollTargetId } from '@/helpers/lazy-bus'
 
 import ContentTypeSelect from './ContentTypeSelect.vue'
 import Headers from './Headers.vue'
 import { getParameterExamples } from './helpers/get-parameter-examples'
 
-const { name, parameter, options, collapsableItems, document } = defineProps<{
-  parameter: ParameterObject | ResponseObject
-  name: string
-  breadcrumb?: string[]
-  eventBus: WorkspaceEventBus | null
-  collapsableItems?: boolean
-  /** The document the operation belongs to, used to resolve schema references for display */
-  document?: OpenApiDocument
-  options: Pick<
-    OperationProps['options'],
-    | 'hideModels'
-    | 'orderRequiredPropertiesFirst'
-    | 'orderSchemaPropertiesBy'
-    | 'expandAllSchemaProperties'
-  >
-}>()
+const { name, parameter, options, collapsableItems, breadcrumb, document } =
+  defineProps<{
+    parameter: ParameterObject | ResponseObject
+    name: string
+    breadcrumb?: string[]
+    eventBus: WorkspaceEventBus | null
+    collapsableItems?: boolean
+    /** The document the operation belongs to, used to resolve schema references for display */
+    document?: OpenApiDocument
+    options: Pick<
+      OperationProps['options'],
+      | 'hideModels'
+      | 'orderRequiredPropertiesFirst'
+      | 'orderSchemaPropertiesBy'
+      | 'expandAllSchemaProperties'
+    >
+  }>()
 
 /** Whether the markdown summary is being truncated */
 const truncated = ref(false)
@@ -125,10 +127,35 @@ const value = computed(() => {
 const shouldCollapse = computed<boolean>(() =>
   Boolean(content.value || headers.value || schema.value || truncated.value),
 )
+
+/**
+ * The breadcrumb passed to the schema. Collapsible items (responses) render their
+ * schema without a name to avoid a duplicate heading, so we push the item name
+ * (e.g. the status code) onto the breadcrumb here to keep property anchors unique.
+ */
+const schemaBreadcrumb = computed<string[] | undefined>(() =>
+  collapsableItems && breadcrumb && name ? [...breadcrumb, name] : breadcrumb,
+)
+
+/**
+ * Whether a deep link points at a property inside this collapsed item. When it
+ * does, the disclosure opens on mount so a fresh navigation can render the target
+ * and scroll it into view (mirrors how collapsible schema disclosures behave).
+ */
+const isOnScrollTargetPath = computed<boolean>(() => {
+  const path = schemaBreadcrumb.value?.join('.')
+  if (!path) {
+    return false
+  }
+  const target = scrollTargetId.value
+  return target === path || target.startsWith(`${path}.`)
+})
 </script>
 <template>
   <li class="parameter-item group/parameter-item">
-    <Disclosure v-slot="{ open }">
+    <Disclosure
+      v-slot="{ open }"
+      :defaultOpen="isOnScrollTargetPath">
       <component
         :is="shouldCollapse ? DisclosureButton : 'div'"
         v-if="collapsableItems"
@@ -177,7 +204,7 @@ const shouldCollapse = computed<boolean>(() =>
         <!-- Schema -->
         <SchemaProperty
           is="div"
-          :breadcrumb="breadcrumb"
+          :breadcrumb="schemaBreadcrumb"
           compact
           :description="collapsableItems ? '' : parameter.description"
           :eventBus="eventBus"

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -80,6 +80,12 @@ describe('getSchemaParamsFromId', () => {
     expect(result).toEqual({ rawId: 'tag/users/GET/list', params: 'responses.200.name' })
   })
 
+  it('splits at the first marker when a property is named like a marker keyword', () => {
+    // A request body field named `responses` must not be mistaken for the response marker.
+    const result = getSchemaParamsFromId('tag/users.body.responses.name')
+    expect(result).toEqual({ rawId: 'tag/users', params: 'body.responses.name' })
+  })
+
   it('extracts complex nested parameters', () => {
     const result = getSchemaParamsFromId('tag/users.body.nested.field')
     expect(result).toEqual({ rawId: 'tag/users', params: 'body.nested.field' })

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -75,6 +75,11 @@ describe('getSchemaParamsFromId', () => {
     expect(result).toEqual({ rawId: 'tag/auth', params: 'header.authorization' })
   })
 
+  it('extracts response property with status code', () => {
+    const result = getSchemaParamsFromId('tag/users/GET/list.responses.200.name')
+    expect(result).toEqual({ rawId: 'tag/users/GET/list', params: 'responses.200.name' })
+  })
+
   it('extracts complex nested parameters', () => {
     const result = getSchemaParamsFromId('tag/users.body.nested.field')
     expect(result).toEqual({ rawId: 'tag/users', params: 'body.nested.field' })

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -374,12 +374,18 @@ const SCHEMA_PARAM_MARKERS = ['.body.', '.path.', '.query.', '.header.', '.respo
 
 /** Extracts the schema parameters from the id if they are present */
 export const getSchemaParamsFromId = (id: string): { rawId: string; params: string } => {
-  // Split at the last marker: everything before it is the operation id, the rest
-  // is the schema path. A plain string scan avoids the polynomial backtracking a
-  // `(.*)marker(.*)` regex would incur on long, marker-less ids.
+  // Split at the first marker: an operation id never contains one, so everything
+  // before the first marker is the operation id and the rest is the schema path.
+  // (Splitting at the last marker would mishandle a property named like a marker
+  // keyword, e.g. a request body field called `responses`.) A plain string scan
+  // avoids the polynomial backtracking a `(.*)marker(.*)` regex would incur on
+  // long, marker-less ids.
   let markerIndex = -1
   for (const marker of SCHEMA_PARAM_MARKERS) {
-    markerIndex = Math.max(markerIndex, id.lastIndexOf(marker))
+    const index = id.indexOf(marker)
+    if (index !== -1 && (markerIndex === -1 || index < markerIndex)) {
+      markerIndex = index
+    }
   }
 
   if (markerIndex === -1) {

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -366,7 +366,10 @@ export const redirectUrl = (
 
 /** Extracts the schema parameters from the id if they are present */
 export const getSchemaParamsFromId = (id: string): { rawId: string; params: string } => {
-  const matcher = id.match(/(.*)(\.body\.|\.path\.|\.query\.|\.header\.)(.*)/)
+  // `responses` mirrors the request-body/parameter markers so response property
+  // anchors (e.g. `operation.responses.200.name`) resolve back to the operation
+  // id. Without it, deep links into responses cannot find their operation.
+  const matcher = id.match(/(.*)(\.body\.|\.path\.|\.query\.|\.header\.|\.responses\.)(.*)/)
 
   if (matcher && typeof matcher[1] === 'string' && typeof matcher[2] === 'string') {
     return {

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -364,21 +364,34 @@ export const redirectUrl = (
   return didRedirect ? target : null
 }
 
+/**
+ * Markers that separate an operation id from a schema path within an anchor id.
+ * `responses` mirrors the request-body/parameter markers so response property
+ * anchors (e.g. `operation.responses.200.name`) resolve back to the operation id.
+ * Without it, deep links into responses cannot find their operation.
+ */
+const SCHEMA_PARAM_MARKERS = ['.body.', '.path.', '.query.', '.header.', '.responses.']
+
 /** Extracts the schema parameters from the id if they are present */
 export const getSchemaParamsFromId = (id: string): { rawId: string; params: string } => {
-  // `responses` mirrors the request-body/parameter markers so response property
-  // anchors (e.g. `operation.responses.200.name`) resolve back to the operation
-  // id. Without it, deep links into responses cannot find their operation.
-  const matcher = id.match(/(.*)(\.body\.|\.path\.|\.query\.|\.header\.|\.responses\.)(.*)/)
+  // Split at the last marker: everything before it is the operation id, the rest
+  // is the schema path. A plain string scan avoids the polynomial backtracking a
+  // `(.*)marker(.*)` regex would incur on long, marker-less ids.
+  let markerIndex = -1
+  for (const marker of SCHEMA_PARAM_MARKERS) {
+    markerIndex = Math.max(markerIndex, id.lastIndexOf(marker))
+  }
 
-  if (matcher && typeof matcher[1] === 'string' && typeof matcher[2] === 'string') {
+  if (markerIndex === -1) {
     return {
-      rawId: matcher[1],
-      params: matcher[2].slice(1) + matcher[3],
+      rawId: id,
+      params: '',
     }
   }
+
   return {
-    rawId: id,
-    params: '',
+    rawId: id.slice(0, markerIndex),
+    // Drop the leading dot but keep the marker keyword (e.g. `body.name`).
+    params: id.slice(markerIndex + 1),
   }
 }

--- a/packages/api-reference/test/features/response-linking.e2e.ts
+++ b/packages/api-reference/test/features/response-linking.e2e.ts
@@ -1,0 +1,98 @@
+import { type Page, expect, test } from '@playwright/test'
+import { serveExample } from '@test/utils/serve-example'
+
+/**
+ * Mocks for lazy loading, remove after lazy bus is fixed.
+ *
+ * Runs idle/animation/timeout callbacks (almost) immediately so the lazy bus
+ * settles deterministically within the test.
+ */
+const mockLazyTimers = (page: Page) =>
+  page.addInitScript(() => {
+    window.requestIdleCallback = (cb: IdleRequestCallback): number => {
+      cb({ didTimeout: false, timeRemaining: () => 0 } as IdleDeadline)
+      return 1
+    }
+
+    const originalRAF = window.requestAnimationFrame
+    window.requestAnimationFrame = (callback: FrameRequestCallback): number => {
+      setTimeout(() => callback(performance.now()), 0)
+      return originalRAF(callback)
+    }
+
+    const originalSetTimeout = window.setTimeout
+    window.setTimeout = ((callback: TimerHandler, delay?: number, ...args: any[]) => {
+      const testDelay = delay ? Math.min(delay / 10, 10) : 0
+      return originalSetTimeout(callback, testDelay, ...args)
+    }) as typeof setTimeout
+  })
+
+test.describe('response linking', () => {
+  /* We need to retry this test because it's flaky on CI */
+  test.describe.configure({ retries: 3 })
+
+  test('anchor links to response properties scroll into view on a fresh load', async ({ page }) => {
+    await mockLazyTimers(page)
+
+    // Enough filler operations that the target operation is offscreen (and
+    // therefore lazily rendered as a placeholder) when the deep link loads.
+    // This is the condition under which the bug appeared.
+    const paths: Record<string, unknown> = {}
+    for (let index = 0; index < 20; index++) {
+      paths[`/filler-${index}`] = {
+        get: { summary: `Filler ${index}`, tags: ['filler-tag'], responses: { '200': { description: 'OK' } } },
+      }
+    }
+    paths['/target'] = {
+      get: {
+        summary: 'Get all users',
+        tags: ['target-tag'],
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    myCustomResponseProperty: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const example = await serveExample({
+      pathRouting: { basePath: '/custom-base-path' },
+      // Response properties only render (and therefore have anchors) when the
+      // responses are expanded.
+      expandAllResponses: true,
+      content: {
+        openapi: '3.1.1',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths,
+      },
+    })
+
+    await page.setViewportSize({ width: 1024, height: 400 })
+    await page.goto(`${example}/custom-base-path/tag/target-tag/GET/target`)
+
+    // The response property has an anchor link.
+    const button = page.getByRole('button', { name: 'Copy link to myCustomResponseProperty', exact: true })
+    await expect(button).toBeVisible()
+
+    // Read the anchor id and build a path-routing deep link from it.
+    const anchorId = await page.locator('[id$=".responses.200.myCustomResponseProperty"]').first().getAttribute('id')
+    expect(anchorId).toBeTruthy()
+    const deepLink = `${example}/custom-base-path/${anchorId!.replace(/^[^/]+\//, '')}`
+
+    // A fresh navigation must render the (lazy) operation and scroll the response
+    // property into view.
+    await page.goto(deepLink)
+
+    await expect(page.locator(`[id="${anchorId}"]`)).toBeInViewport({ timeout: 6000 })
+  })
+})

--- a/packages/api-reference/test/features/response-linking.e2e.ts
+++ b/packages/api-reference/test/features/response-linking.e2e.ts
@@ -95,4 +95,61 @@ test.describe('response linking', () => {
 
     await expect(page.locator(`[id="${anchorId}"]`)).toBeInViewport({ timeout: 6000 })
   })
+
+  test('anchor links reveal response properties hidden in a collapsed response', async ({ page }) => {
+    await mockLazyTimers(page)
+
+    const example = await serveExample({
+      pathRouting: { basePath: '/custom-base-path' },
+      // No `expandAllResponses`: responses start collapsed.
+      content: {
+        openapi: '3.1.1',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/users': {
+            get: {
+              summary: 'Get all users',
+              tags: ['user-tag'],
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          myCustomResponseProperty: { type: 'string' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    await page.setViewportSize({ width: 1024, height: 400 })
+    await page.goto(`${example}/custom-base-path/tag/user-tag/GET/users`)
+
+    const button = page.getByRole('button', { name: 'Copy link to myCustomResponseProperty', exact: true })
+
+    // The property is hidden inside the collapsed response on load.
+    await expect(button).toHaveCount(0)
+
+    // Expand the response so the anchor exists, then read its id and build a deep
+    // link (going through the clipboard copy flow is flaky in CI).
+    await page.getByRole('button', { name: /200/ }).first().click()
+    const anchorId = await page.locator('[id$=".responses.200.myCustomResponseProperty"]').first().getAttribute('id')
+    expect(anchorId).toBeTruthy()
+    const deepLink = `${example}/custom-base-path/${anchorId!.replace(/^[^/]+\//, '')}`
+
+    // Fresh navigation: the response starts collapsed again, but the deep link
+    // must reveal the hidden property and scroll it into view.
+    await page.goto(deepLink)
+
+    await expect(page.locator(`[id="${anchorId}"]`)).toBeInViewport({ timeout: 6000 })
+  })
 })


### PR DESCRIPTION
Deep links to response properties did not scroll when opened in a new tab, while request body links did. This fixes both cases (expanded and collapsed responses).

**Scrolling to the target.** Response property anchors had no marker segment (`operation.200.name`), so we couldn't map them back to an operation. On a fresh load the target operation stayed a lazy placeholder — nothing to scroll to. Anchors now carry a `responses` marker (`operation.responses.200.name`), the same way request bodies use `body`.

**Collapsed responses.** With `expandAllResponses` off, responses start collapsed and had no copy-link at all (the schema was rendered without a name to avoid a duplicate heading, which also dropped the breadcrumb). The breadcrumb now carries the status code instead, so properties stay linkable, and a deep link opens the collapsed response on load the same way collapsible schema sections already do.

Also replaced the marker-matching regex with a plain string scan to avoid the polynomial-backtracking (ReDoS) pattern CodeQL flagged — behavior is unchanged.

Tests: unit coverage for the marker parsing, plus e2e for both the expanded and collapsed deep-link flows.

## Ticket

Fixes #9636
Closes #9364

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and disclosure behavior in api-reference only; no auth or data changes, with targeted unit and e2e coverage.
> 
> **Overview**
> Fixes **response property deep links** so they behave like request-body links on fresh navigation.
> 
> Anchors now include a **`responses`** segment (e.g. `…/list.responses.200.name`), and **`getSchemaParamsFromId`** treats `.responses.` like `.body.` / parameter markers so the lazy bus can resolve the parent operation and scroll. Marker detection was switched from a greedy regex to a **first-marker string scan** (same behavior, avoids ReDoS).
> 
> **UI wiring:** response list items append `responses` (and status code on the schema breadcrumb when collapsible), **`SchemaProperty`** keeps breadcrumbs linkable for nameless response schema wrappers, and collapsed responses **auto-open** when `scrollTargetId` matches the schema path.
> 
> Coverage: unit tests for parsing edge cases and Playwright e2e for lazy-load scroll + collapsed-response reveal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb190dedcb6625c60f0db0af47f3773c5b809ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->