### PR TITLE
fix(api-reference): link response properties in collapsed responses

### DIFF
--- a/.changeset/fix-collapsed-response-anchors.md
+++ b/.changeset/fix-collapsed-response-anchors.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Add anchor links to response properties and open collapsed responses on deep link. Response properties are now linkable even when `expandAllResponses` is off, and a deep link into a collapsed response expands it and scrolls the property into view.

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -100,8 +100,14 @@ const optimizedValue = computed(() =>
 )
 
 const childBreadcrumb = computed<string[] | undefined>(() =>
-  props.breadcrumb && props.name
-    ? [...props.breadcrumb, props.name]
+  props.breadcrumb
+    ? // A named property extends the breadcrumb with its own name. A nameless
+      // container (e.g. a response object, rendered without a name to avoid a
+      // duplicate heading) passes its breadcrumb straight through so its
+      // properties stay linkable.
+      props.name
+      ? [...props.breadcrumb, props.name]
+      : props.breadcrumb
     : undefined,
 )
 

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -19,27 +19,29 @@ import { computed, ref } from 'vue'
 import { getRefName } from '@/components/Content/Schema/helpers/get-ref-name'
 import SchemaProperty from '@/components/Content/Schema/SchemaProperty.vue'
 import type { OperationProps } from '@/features/Operation/Operation.vue'
+import { scrollTargetId } from '@/helpers/lazy-bus'
 
 import ContentTypeSelect from './ContentTypeSelect.vue'
 import Headers from './Headers.vue'
 import { getParameterExamples } from './helpers/get-parameter-examples'
 
-const { name, parameter, options, collapsableItems, document } = defineProps<{
-  parameter: ParameterObject | ResponseObject
-  name: string
-  breadcrumb?: string[]
-  eventBus: WorkspaceEventBus | null
-  collapsableItems?: boolean
-  /** The document the operation belongs to, used to resolve schema references for display */
-  document?: OpenApiDocument
-  options: Pick<
-    OperationProps['options'],
-    | 'hideModels'
-    | 'orderRequiredPropertiesFirst'
-    | 'orderSchemaPropertiesBy'
-    | 'expandAllSchemaProperties'
-  >
-}>()
+const { name, parameter, options, collapsableItems, breadcrumb, document } =
+  defineProps<{
+    parameter: ParameterObject | ResponseObject
+    name: string
+    breadcrumb?: string[]
+    eventBus: WorkspaceEventBus | null
+    collapsableItems?: boolean
+    /** The document the operation belongs to, used to resolve schema references for display */
+    document?: OpenApiDocument
+    options: Pick<
+      OperationProps['options'],
+      | 'hideModels'
+      | 'orderRequiredPropertiesFirst'
+      | 'orderSchemaPropertiesBy'
+      | 'expandAllSchemaProperties'
+    >
+  }>()
 
 /** Whether the markdown summary is being truncated */
 const truncated = ref(false)
@@ -125,10 +127,35 @@ const value = computed(() => {
 const shouldCollapse = computed<boolean>(() =>
   Boolean(content.value || headers.value || schema.value || truncated.value),
 )
+
+/**
+ * The breadcrumb passed to the schema. Collapsible items (responses) render their
+ * schema without a name to avoid a duplicate heading, so we push the item name
+ * (e.g. the status code) onto the breadcrumb here to keep property anchors unique.
+ */
+const schemaBreadcrumb = computed<string[] | undefined>(() =>
+  collapsableItems && breadcrumb && name ? [...breadcrumb, name] : breadcrumb,
+)
+
+/**
+ * Whether a deep link points at a property inside this collapsed item. When it
+ * does, the disclosure opens on mount so a fresh navigation can render the target
+ * and scroll it into view (mirrors how collapsible schema disclosures behave).
+ */
+const isOnScrollTargetPath = computed<boolean>(() => {
+  const path = schemaBreadcrumb.value?.join('.')
+  if (!path) {
+    return false
+  }
+  const target = scrollTargetId.value
+  return target === path || target.startsWith(`${path}.`)
+})
 </script>
 <template>
   <li class="parameter-item group/parameter-item">
-    <Disclosure v-slot="{ open }">
+    <Disclosure
+      v-slot="{ open }"
+      :defaultOpen="isOnScrollTargetPath">
       <component
         :is="shouldCollapse ? DisclosureButton : 'div'"
         v-if="collapsableItems"
@@ -177,7 +204,7 @@ const shouldCollapse = computed<boolean>(() =>
         <!-- Schema -->
         <SchemaProperty
           is="div"
-          :breadcrumb="breadcrumb"
+          :breadcrumb="schemaBreadcrumb"
           compact
           :description="collapsableItems ? '' : parameter.description"
           :eventBus="eventBus"

--- a/packages/api-reference/test/features/response-linking.e2e.ts
+++ b/packages/api-reference/test/features/response-linking.e2e.ts
@@ -95,4 +95,61 @@ test.describe('response linking', () => {
 
     await expect(page.locator(`[id="${anchorId}"]`)).toBeInViewport({ timeout: 6000 })
   })
+
+  test('anchor links reveal response properties hidden in a collapsed response', async ({ page }) => {
+    await mockLazyTimers(page)
+
+    const example = await serveExample({
+      pathRouting: { basePath: '/custom-base-path' },
+      // No `expandAllResponses`: responses start collapsed.
+      content: {
+        openapi: '3.1.1',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/users': {
+            get: {
+              summary: 'Get all users',
+              tags: ['user-tag'],
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          myCustomResponseProperty: { type: 'string' },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    await page.setViewportSize({ width: 1024, height: 400 })
+    await page.goto(`${example}/custom-base-path/tag/user-tag/GET/users`)
+
+    const button = page.getByRole('button', { name: 'Copy link to myCustomResponseProperty', exact: true })
+
+    // The property is hidden inside the collapsed response on load.
+    await expect(button).toHaveCount(0)
+
+    // Expand the response so the anchor exists, then read its id and build a deep
+    // link (going through the clipboard copy flow is flaky in CI).
+    await page.getByRole('button', { name: /200/ }).first().click()
+    const anchorId = await page.locator('[id$=".responses.200.myCustomResponseProperty"]').first().getAttribute('id')
+    expect(anchorId).toBeTruthy()
+    const deepLink = `${example}/custom-base-path/${anchorId!.replace(/^[^/]+\//, '')}`
+
+    // Fresh navigation: the response starts collapsed again, but the deep link
+    // must reveal the hidden property and scroll it into view.
+    await page.goto(deepLink)
+
+    await expect(page.locator(`[id="${anchorId}"]`)).toBeInViewport({ timeout: 6000 })
+  })
 })


### PR DESCRIPTION
Follow-up to #9646. That PR fixed response deep links when `expandAllResponses` is on. This one covers the default case, where responses start collapsed.

Two things were missing:

- Collapsed responses rendered their schema without a name (to avoid a duplicate heading), which also dropped the breadcrumb, so response properties had no copy-link at all. The breadcrumb now carries the status code instead, so properties stay linkable without the extra heading.
- A deep link into a collapsed response did nothing, because the response never opened. It now opens on load when the link points inside it, the same way collapsible schema sections already do.

Stacked on #9646 — the `responses` marker from that PR is what lets these links resolve.

## Ticket

Fixes #9636
Closes #9364