### PR TITLE
chore(scripts): bump playwright-runner image version to 1.59.1

### DIFF
--- a/tooling/scripts/src/commands/playwright-docker/push-container.ts
+++ b/tooling/scripts/src/commands/playwright-docker/push-container.ts
@@ -5,7 +5,7 @@ import { runCommand } from '@/helpers'
 export const updatePlaywrightDocker = new Command('update-playwright-docker')
   .description('Update the docker image to the latest playwright')
   .action(async () => {
-    const version = '1.56.0'
+    const version = '1.59.1'
 
     await runCommand(
       `docker build -t "scalarapi/playwright:${version}" --build-arg PLAYWRIGHT_VERSION=${version} ${import.meta.dirname}`,


### PR DESCRIPTION
The `update-playwright-docker` script still hardcodes `1.56.0`, but CI runs `scalarapi/playwright-runner:1.59.1` and the `@playwright/test` catalog version is `1.59.1`. Running the script today would build and push the wrong tag.

Bumps the constant to `1.59.1` so a rebuild republishes the tag the workflows actually reference, and adds a note to keep it in sync with the catalog version.

Pairs with #9648 — that PR slims the image to Chromium-only; this makes the publish script target the right tag. The actual `docker push` (needs `scalarapi` credentials) should run after both merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in a maintainer-only publish script; no runtime or application behavior affected.
> 
> **Overview**
> Updates the hardcoded Playwright version in `update-playwright-docker` from **1.56.0** to **1.59.1**, so builds and pushes for `scalarapi/playwright` and `scalarapi/playwright-runner` use the same tag CI already references in workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56007de9b419c7d1eb3eb02dbf8dff1febb70b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->