### PR TITLE
fix(aspire): copy Directory.Packages.props into Docker build + guard it in CI

### DIFF
--- a/.github/workflows/integration-builds.yml
+++ b/.github/workflows/integration-builds.yml
@@ -141,6 +141,26 @@ jobs:
         working-directory: integrations/dotnet
         run: dotnet test -c Release --no-build
 
+      # Build the Aspire service Docker image the same way the release job does.
+      # The host restore/build above always sees Directory.Packages.props, so it
+      # can't catch a Dockerfile that fails to copy build inputs into its context
+      # (e.g. the NU1015 restore break when Central Package Management landed).
+      # Building it here on every dotnet change makes that class of error visible
+      # in PR CI instead of only at publish time. amd64-only keeps it fast; the
+      # restore errors we care about are platform-independent, and no push.
+      - name: Setup Docker Builder
+        uses: useblacksmith/setup-docker-builder@ab5c1da94f53f5cd75c1038092aa276dddfccbba # v1
+        with:
+          platforms: linux/amd64
+
+      - name: Build Aspire Docker image
+        uses: useblacksmith/build-push-action@fb9e3e6a9299c78462bfadd0d93352c316adc9b8 # v2
+        with:
+          context: integrations/dotnet
+          file: integrations/dotnet/aspire/src/Scalar.Aspire.Service/Dockerfile
+          load: true
+          tags: scalarapi/aspire-api-reference:latest
+
       - name: Mark build-test passed
         id: passed
         run: echo "passed=true" >> "$GITHUB_OUTPUT"

--- a/integrations/dotnet/aspire/src/Scalar.Aspire.Service/Dockerfile
+++ b/integrations/dotnet/aspire/src/Scalar.Aspire.Service/Dockerfile
@@ -3,6 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish
 WORKDIR /src
 
 COPY Directory.Build.props .
+COPY Directory.Packages.props .
 COPY ./aspire .
 
 WORKDIR "/src/src/Scalar.Aspire.Service"


### PR DESCRIPTION
The Aspire Docker publish job started failing after #9627 moved .NET package versions into Central Package Management.

## The bug

Versions now live in `integrations/dotnet/Directory.Packages.props` instead of inline in the `.csproj`, but the Aspire Service Dockerfile only copied `Directory.Build.props` — never `Directory.Packages.props`. So inside the build container the restore had no versions for `Microsoft.Extensions.ServiceDiscovery.Yarp` and `Yarp.ReverseProxy` and failed with:

```
error NU1015: The following PackageReference item(s) do not have a version specified: Microsoft.Extensions.ServiceDiscovery.Yarp, Yarp.ReverseProxy
```

Fix: copy `Directory.Packages.props` into the build stage alongside `Directory.Build.props`. It is already in the build context (`integrations/dotnet`), so it is a one-line add. Verified locally — the image builds and restores cleanly.

## Why CI missed it

The PR-time `dotnet-build-test` job runs a host `dotnet restore/build/test`, which always sees `Directory.Packages.props` locally, so it passed. The Aspire Docker image was only ever built in the release `aspire-publish` job — nothing in PR/main CI exercised the Dockerfile, so the broken `COPY` slipped through to a release.

This PR also adds an **Aspire Docker image build** to `dotnet-build-test` (`load`, no push, amd64-only for speed), gated on `dotnet_changed`. This class of Dockerfile error now surfaces in PR CI. Because the fix and the new check are in the same PR, the new job self-validates — it runs green here, and would have gone red without the fix.

Failing run that prompted this: https://github.com/scalar/scalar/actions/runs/28581260632/job/84750150247

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docker build and CI-only validation changes; no runtime auth, data, or application logic changes.
> 
> **Overview**
> Fixes Aspire Docker **publish** failures after Central Package Management moved package versions into `Directory.Packages.props`. The Aspire Service Dockerfile now **copies** that file into the build stage (alongside `Directory.Build.props`) so `dotnet publish` inside the image can restore packages that no longer specify inline versions.
> 
> The **dotnet** integration CI job also **builds** the Aspire Docker image (amd64, load-only, no push) using the same context and Dockerfile as release, so missing build-context files or restore breaks like NU1015 surface on PRs instead of only at publish time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 748dd8b5c2ee2071e6c2c7977e9d4be23c4d98d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->