### PR TITLE
fix(agent-chat): remove start panel heading

### DIFF
--- a/.changeset/remove-agent-chat-heading.md
+++ b/.changeset/remove-agent-chat-heading.md
@@ -1,0 +1,5 @@
+---
+'@scalar/agent-chat': patch
+---
+
+Remove the start panel heading tag to avoid adding an extra document heading to API reference pages.

--- a/packages/agent-chat/src/views/Start.vue
+++ b/packages/agent-chat/src/views/Start.vue
@@ -15,7 +15,7 @@ const { mode } = useState()
 <template>
   <div class="startContainer">
     <Logo class="agentLogo" />
-    <h1 class="heading">How can I help you today?</h1>
+    <p class="promptText">How can I help you today?</p>
     <PromptForm
       ref="promptFormField"
       @submit="emit('submit')"
@@ -59,7 +59,7 @@ const { mode } = useState()
   position: relative;
 }
 
-.heading {
+.promptText {
   font-size: 1.5rem;
   font-weight: var(--scalar-font-bold);
   margin-bottom: 50px;


### PR DESCRIPTION
## Summary

Removes the `h1` from the Agent Chat start panel and renders the prompt text as a paragraph instead.

This prevents hidden Agent Chat markup from adding an extra document heading to API reference pages when the panel is mounted but not opened, which was causing SEO crawlers to report duplicate heading issues.
