### PR TITLE
test(workspace-store): cover optional operation security

### DIFF
--- a/packages/workspace-store/src/schemas/v3.1/strict/operation.test.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/operation.test.ts
@@ -100,6 +100,22 @@ describe('operation', () => {
       expect(result).toEqual(validInput)
     })
 
+    it('parses optional operation security alternatives correctly', () => {
+      const validInput = {
+        operationId: 'searchPublicOrAuthenticatedData',
+        security: [
+          {},
+          {
+            apiKey: [],
+          },
+        ],
+      }
+
+      const result = coerceValue(OperationObjectSchema, validInput)
+
+      expect(result).toEqual(validInput)
+    })
+
     it('fails when given non-object input', () => {
       const invalidInput = 'not an object'
 


### PR DESCRIPTION
## Problem

Operation schema tests cover a required security requirement, but not the OpenAPI optional auth form that uses `{}` as one alternative.

## Solution

Add a regression test for an operation security array with anonymous access and an API key alternative.

## Validation

- Git diff whitespace check passed.
- `pnpm test packages/workspace-store/src/schemas/v3.1/strict/operation.test.ts` could not start because this temporary checkout has no node_modules.

## Checklist

- [x] I explained why the change is needed.
- [x] I added tests.
- [ ] I added a changeset. Not needed for a test-only change.
- [ ] I updated the documentation. Not needed for a test-only change.
