### PR TITLE
fix(code-highlight): keep rendering Markdown when a code block fails to highlight

### DIFF
--- a/.changeset/tidy-parrots-cheer.md
+++ b/.changeset/tidy-parrots-cheer.md
@@ -1,0 +1,7 @@
+---
+'@scalar/code-highlight': patch
+---
+
+fix: keep rendering Markdown when a code block fails to highlight
+
+Syntax highlighting is now best-effort: if a highlight.js grammar throws at runtime (for example a Unicode regex that a production minifier mangles), the code block falls back to plain text instead of the error taking down the whole Markdown section.

--- a/packages/code-highlight/src/rehype-highlight/rehype-highlight.test.ts
+++ b/packages/code-highlight/src/rehype-highlight/rehype-highlight.test.ts
@@ -1,0 +1,51 @@
+import type { createLowlight } from 'lowlight'
+import rehypeStringify from 'rehype-stringify'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import { unified } from 'unified'
+import { describe, expect, it } from 'vitest'
+
+import { rehypeHighlight } from './rehype-highlight'
+
+/** Render Markdown through the highlight plugin, mirroring the description pipeline */
+const render = (markdown: string, lowlight?: ReturnType<typeof createLowlight>) =>
+  unified()
+    .use(remarkParse)
+    .use(remarkRehype)
+    .use(rehypeHighlight, { detect: true, lowlight })
+    .use(rehypeStringify)
+    .processSync(markdown)
+
+describe('rehypeHighlight', () => {
+  it('highlights fenced code blocks', () => {
+    const html = String(render('```js\nconst answer = 42\n```'))
+
+    expect(html).toContain('hljs')
+    expect(html).toContain('answer')
+  })
+
+  // A grammar can throw at runtime (for example a Unicode regex that a production
+  // minifier mangles). Highlighting must stay best-effort so the surrounding
+  // Markdown section is never dropped.
+  it('keeps the code block when highlighting throws', () => {
+    const throwing = {
+      registerAlias: () => {},
+      highlight: () => {
+        throw new SyntaxError('Invalid regular expression: Invalid escape')
+      },
+      highlightAuto: () => {
+        throw new SyntaxError('Invalid regular expression: Invalid escape')
+      },
+    } as unknown as ReturnType<typeof createLowlight>
+
+    const process = () => render('Before\n\n```\nsome code\n```\n\nAfter', throwing)
+
+    expect(process).not.toThrow()
+
+    const html = String(process())
+
+    expect(html).toContain('some code')
+    expect(html).toContain('Before')
+    expect(html).toContain('After')
+  })
+})

--- a/packages/code-highlight/src/rehype-highlight/rehype-highlight.ts
+++ b/packages/code-highlight/src/rehype-highlight/rehype-highlight.ts
@@ -101,11 +101,23 @@ export function rehypeHighlight(options?: Readonly<HighlightOptions> | null | un
             source: 'rehype-highlight',
           })
 
-          /* c8 ignore next 5 -- throw arbitrary hljs errors */
           return
         }
 
-        throw cause
+        // Highlighting is best-effort, so any other failure must not take down the
+        // whole Markdown render. Some grammars build regexes that throw at runtime
+        // in certain environments (for example a Unicode property escape that a
+        // production minifier mangles), which would otherwise blank out the entire
+        // section. Fall back to the un-highlighted code block instead.
+        file.message('Could not highlight code block', {
+          ancestors: [parent, node],
+          cause,
+          place: node.position,
+          ruleId: 'highlight-error',
+          source: 'rehype-highlight',
+        })
+
+        return
       }
 
       if (!lang && result.data?.language) {


### PR DESCRIPTION
A single code block that fails to highlight currently crashes the whole Markdown render, so the entire section shows up blank.

This happens with fenced code blocks that have no language: we auto-detect against every grammar, and the Haskell one builds a Unicode regex that older Next.js production builds break (highlightjs/highlight.js#4013). It only shows up in a real build, not in `next dev`.

If a grammar throws, we just show the plain code block instead of taking down the section.

Bumping highlight.js does not help. 11.11.1 is already the latest and upstream closed the issue as a build-tool problem.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change in the highlight plugin with a regression test; normal highlighting path is unchanged except failures no longer propagate.
> 
> **Overview**
> **Syntax highlighting is now best-effort** in `rehypeHighlight`: when lowlight throws for any reason other than an unknown language, the plugin records a `highlight-error` message on the file and **returns without replacing the block**, instead of rethrowing and aborting the whole Markdown pipeline.
> 
> That addresses production cases where auto-detect runs every grammar and one (e.g. Haskell) throws on a mangled Unicode regex, which previously blanked entire description sections while dev still worked.
> 
> Adds a **Vitest pipeline test** that mocks a throwing lowlight and asserts surrounding Markdown and plain code text still render, plus a patch changeset for `@scalar/code-highlight`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 286545de7bb6f27c404cb1aa6c0e25e6afe2cfe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->