### PR TITLE
feat(types): add documentType to source configuration

### DIFF
--- a/.changeset/source-document-type.md
+++ b/.changeset/source-document-type.md
@@ -1,0 +1,8 @@
+---
+'@scalar/schemas': minor
+'@scalar/types': minor
+---
+
+feat: add an optional `documentType` field (`'openapi' | 'asyncapi'`) to the source configuration
+
+Sources can now declare their document type explicitly, e.g. `sources: [{ url: '/asyncapi.json', documentType: 'asyncapi' }]`. The field is a forward-compatible hint: the renderer keeps auto-detecting the type from the document content, so it stays optional.

--- a/packages/api-reference/src/helpers/normalize-configuration.test.ts
+++ b/packages/api-reference/src/helpers/normalize-configuration.test.ts
@@ -1,6 +1,36 @@
 import { describe, expect, it } from 'vitest'
 
-import { normalizeContent } from './normalize-configurations'
+import { normalizeConfigurations, normalizeContent } from './normalize-configurations'
+
+describe('normalizeConfigurations', () => {
+  it('preserves the documentType of a source in the normalized config', () => {
+    const normalized = normalizeConfigurations({
+      sources: [
+        {
+          title: 'Streaming API',
+          url: 'https://example.com/asyncapi.json',
+          documentType: 'asyncapi',
+        },
+      ],
+    })
+
+    expect(normalized['streaming-api']?.config).toMatchObject({ documentType: 'asyncapi' })
+    expect(normalized['streaming-api']?.source).toEqual({ url: 'https://example.com/asyncapi.json' })
+  })
+
+  it('leaves documentType undefined when not provided', () => {
+    const normalized = normalizeConfigurations({
+      sources: [
+        {
+          title: 'REST API',
+          url: 'https://example.com/openapi.json',
+        },
+      ],
+    })
+
+    expect(normalized['rest-api']?.config).not.toHaveProperty('documentType', expect.anything())
+  })
+})
 
 describe('normalizeContent', () => {
   describe('function input', () => {

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -104,6 +104,22 @@ describe('html-rendering', () => {
       expect(html).not.toContain('"content"')
     })
 
+    it('serializes the documentType of a source into the configuration', () => {
+      const html = renderApiReference({
+        config: {
+          sources: [
+            {
+              title: 'Streaming API',
+              url: 'https://example.com/asyncapi.json',
+              documentType: 'asyncapi',
+            },
+          ],
+        },
+      })
+      expect(html).toContain('"documentType": "asyncapi"')
+      expect(html).toContain('"url": "https://example.com/asyncapi.json"')
+    })
+
     it('uses custom cdn when provided', () => {
       const html = renderApiReference({ config: {}, cdn: 'https://example.com/scalar.js' })
       expect(html).toContain('https://example.com/scalar.js')

--- a/packages/release-notes/scripts/stage-generated-schema.ts
+++ b/packages/release-notes/scripts/stage-generated-schema.ts
@@ -15,6 +15,7 @@ const repoRoot = getRepoRoot()
 const generateResult = spawnSync('pnpm', ['run', 'schema:generate'], {
   cwd: packageRoot,
   stdio: 'inherit',
+  shell: true,
 })
 
 if (generateResult.status !== 0) {

--- a/packages/schemas/scripts/generate-types.ts
+++ b/packages/schemas/scripts/generate-types.ts
@@ -84,6 +84,7 @@ const formatWithBiome = async (content: string, filePath: string, repoRoot: stri
     const result = spawnSync('pnpm', ['biome', 'format', '--write', '--config-path', biomeConfigPath, tmpFile], {
       cwd: repoRoot,
       stdio: 'pipe',
+      shell: true,
     })
     if (result.status !== 0) {
       return content
@@ -293,7 +294,7 @@ const runBiomeFormat = (paths: readonly string[], cwd: string): void => {
       '--files-ignore-unknown=true',
       ...paths,
     ],
-    { cwd, stdio: 'inherit' },
+    { cwd, stdio: 'inherit', shell: true },
   )
 
   if (result.status !== 0) {

--- a/packages/schemas/scripts/stage-generated-types.ts
+++ b/packages/schemas/scripts/stage-generated-types.ts
@@ -15,6 +15,7 @@ const repoRoot = getRepoRoot()
 const generateResult = spawnSync('pnpm', ['run', 'types:generate'], {
   cwd: packageRoot,
   stdio: 'inherit',
+  shell: true,
 })
 
 if (generateResult.status !== 0) {

--- a/packages/schemas/src/api-reference/api-reference-configuration.test.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.test.ts
@@ -61,6 +61,27 @@ describe('api-reference-configuration', () => {
       expect(() => coerce(apiReferenceConfigurationSchema, completeConfig)).not.toThrow()
     })
 
+    it('preserves the documentType of a source', () => {
+      expect(coerce(apiReferenceConfigurationSchema, { documentType: 'asyncapi' })).toMatchObject({
+        documentType: 'asyncapi',
+      })
+      expect(coerce(apiReferenceConfigurationSchema, { documentType: 'openapi' })).toMatchObject({
+        documentType: 'openapi',
+      })
+    })
+
+    it('falls back to the first listed value for an invalid documentType', () => {
+      // Matches the `union([literal(...), ...])` coercion behavior used elsewhere in this schema
+      // (e.g. `localization.direction`): an invalid value falls back to whichever literal is listed first.
+      const coerced = coerce(apiReferenceConfigurationSchema, { documentType: 'graphql' })
+      expect(coerced.documentType).toBe('openapi')
+    })
+
+    it('leaves documentType undefined when not provided', () => {
+      const coerced = coerce(apiReferenceConfigurationSchema, {})
+      expect(coerced.documentType).toBeUndefined()
+    })
+
     it('validates localization configuration', () => {
       const config = {
         localization: {

--- a/packages/schemas/src/api-reference/source-configuration.ts
+++ b/packages/schemas/src/api-reference/source-configuration.ts
@@ -1,4 +1,4 @@
-import { any, boolean, fn, nullable, object, optional, record, string, union } from '@scalar/validation'
+import { any, boolean, fn, literal, nullable, object, optional, record, string, union } from '@scalar/validation'
 
 /**
  * The content of an OpenAPI document. Accepts any of:
@@ -23,6 +23,10 @@ export const sourceConfigurationSchema = object({
   content: optional(contentSchema, {
     typeComment:
       'Directly embed the OpenAPI document. Can be a string, object, function returning an object, or null. It is recommended to pass a URL instead of content.',
+  }),
+  documentType: optional(union([literal('openapi'), literal('asyncapi')]), {
+    typeComment:
+      "The type of the document. If not set, the type is auto-detected from the document content (an 'asyncapi' version field vs an 'openapi'/'swagger' version field). Set it to be explicit.",
   }),
   title: optional(string(), {
     typeComment:

--- a/packages/types/src/api-reference/api-reference-configuration.test.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.test.ts
@@ -13,6 +13,23 @@ describe('api-reference-configuration', () => {
       expect(() => apiReferenceConfigurationSchema.parse(minimalConfig)).not.toThrow()
     })
 
+    it('preserves the documentType of a source', () => {
+      const parsed = apiReferenceConfigurationWithSourceSchema.parse({
+        url: 'https://example.com/asyncapi.json',
+        documentType: 'asyncapi',
+      })
+
+      expect(parsed.documentType).toBe('asyncapi')
+    })
+
+    it('leaves documentType undefined when not provided', () => {
+      const parsed = apiReferenceConfigurationWithSourceSchema.parse({
+        url: 'https://example.com/openapi.json',
+      })
+
+      expect(parsed.documentType).toBeUndefined()
+    })
+
     it('validates a complete configuration', () => {
       const completeConfig = {
         theme: 'default',

--- a/packages/types/src/api-reference/source-configuration.ts
+++ b/packages/types/src/api-reference/source-configuration.ts
@@ -53,6 +53,15 @@ export const sourceConfigurationSchema = z.object({
     ])
     .optional(),
   /**
+   * The type of the document.
+   *
+   * If not set, the type is auto-detected from the document content (an 'asyncapi' version field vs an
+   * 'openapi'/'swagger' version field). Set it to be explicit.
+   *
+   * @example 'asyncapi'
+   */
+  documentType: z.enum(['openapi', 'asyncapi']).optional(),
+  /**
    * The title of the OpenAPI document.
    *
    * Used for the page title and the document name in the dropdown. With multiple `sources`, set this per source.

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -741,6 +741,8 @@ export type SourceConfiguration = {
   url?: string
   /** Directly embed the OpenAPI document. Can be a string, object, function returning an object, or null. It is recommended to pass a URL instead of content. */
   content?: string | null | Record<string, any> | (() => string | any)
+  /** The type of the document. If not set, the type is auto-detected from the document content (an 'asyncapi' version field vs an 'openapi'/'swagger' version field). Set it to be explicit. */
+  documentType?: 'openapi' | 'asyncapi'
   /** The title of the OpenAPI document. Used for the page title and the document name in the dropdown. With multiple `sources`, set this per source. */
   title?: string
   /** The slug of the OpenAPI document used in the URL. If none is passed, the title will be used. With multiple `sources`, set this per source. */


### PR DESCRIPTION
## Problem

.NET already lets a document declare `DocumentType.AsyncApi` (added in #9413), but that information never reaches the browser — the JS `SourceConfiguration` has no equivalent field. Every other integration (fastapi, django-ninja, Java, Rust) has the same gap: there's no explicit, typed way to say "this source is AsyncAPI" in the config that ends up in the rendered page. The renderer auto-detects the type from document content today, so this isn't a functional bug, but it blocks two things: integrations that want to be explicit (e.g. to pick a route pattern or label before the document has loaded), and parity across languages.

## Solution

Added an optional `documentType: 'openapi' | 'asyncapi'` field to the shared source configuration, in the three places it's defined: `packages/schemas/src/api-reference/source-configuration.ts` (the `@scalar/validation` schema used by `createApiReference` and `normalizeConfigurations`), `packages/types/src/api-reference/source-configuration.ts` (the zod schema), and the hand-written `SourceConfiguration` type in `packages/types/src/api-reference/types.ts`.

Deliberately scoped as pass-through only: nothing in `packages/workspace-store` consumes it yet. The renderer keeps auto-detecting the type from the document's own `asyncapi`/`openapi` version field, so this field is a forward-compatible hint, not a requirement. This also avoids overlapping with the currently-open document-selector type-postfix PR (#9602), which derives the type post-fetch.

Considered making the field required or consuming it immediately in the document selector, but that would duplicate work already in flight on #9602 and add a config requirement where none exists today.

**Included in this branch:** an unrelated fix discovered while committing — `packages/schemas/scripts/generate-types.ts`, `stage-generated-types.ts`, and `packages/release-notes/scripts/stage-generated-schema.ts` call `spawnSync('pnpm', ...)` without `shell: true`, which fails with `ENOENT` on Windows (Node doesn't do `PATHEXT` resolution for a bare command without a shell). This broke the `schemas-types-generate` pre-commit hook on Windows dev machines for every contributor, not just this change, so it's fixed as its own commit ahead of the `documentType` commit.

## Tests

- `packages/schemas/src/api-reference/api-reference-configuration.test.ts` — coercion preserves a valid `documentType` and falls back to the first-listed literal (`'openapi'`) for an invalid one, matching this schema's existing union-literal fallback behavior.
- `packages/types/src/api-reference/api-reference-configuration.test.ts` — zod parse preserves the field.
- `packages/api-reference/src/helpers/normalize-configuration.test.ts` — a source's `documentType` survives into the normalized per-document config.
- `packages/client-side-rendering/src/html-rendering.test.ts` — `documentType` is serialized into the injected `<script>` config.

All four suites pass (58 + 130 + 21 + 39 tests).

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. (`.changeset/source-document-type.md`)
- [x] I added tests.
- [ ] I updated the documentation. (Covered in the separate docs PR, `docs/asyncapi-integrations`, which depends on this one merging first.)
