### PR TITLE
fix(docker): serve AsyncAPI documents

### DIFF
--- a/.changeset/docker-asyncapi-scan.md
+++ b/.changeset/docker-asyncapi-scan.md
@@ -1,0 +1,7 @@
+---
+'@scalarapi/docker-api-reference': patch
+---
+
+fix: detect and serve mounted AsyncAPI documents
+
+The document scanner only recognized OpenAPI/Swagger files, so AsyncAPI documents mounted into `/docs` were silently skipped. AsyncAPI files (`.json`/`.yaml`/`.yml` with an `asyncapi` version field) are now detected and included in the generated configuration with `documentType: "asyncapi"`.

--- a/.changeset/docker-asyncapi-scan.md
+++ b/.changeset/docker-asyncapi-scan.md
@@ -1,0 +1,7 @@
+---
+'@scalarapi/docker-api-reference': patch
+---
+
+fix: detect and serve mounted AsyncAPI documents
+
+The document scanner only recognized OpenAPI/Swagger files, so AsyncAPI documents mounted into `/docs` were silently skipped. AsyncAPI files (`.json`/`.yaml`/`.yml` with an `asyncapi` version field) are now detected and included in the generated configuration.

--- a/.changeset/docker-asyncapi-scan.md
+++ b/.changeset/docker-asyncapi-scan.md
@@ -1,5 +1,5 @@
 ---
-'@scalarapi/docker-api-reference': patch
+'@scalarapi/docker-api-reference': minor
 ---
 
 fix: detect and serve mounted AsyncAPI documents

--- a/.changeset/docker-asyncapi-scan.md
+++ b/.changeset/docker-asyncapi-scan.md
@@ -5,3 +5,5 @@
 fix: detect and serve mounted AsyncAPI documents
 
 The document scanner only recognized OpenAPI/Swagger files, so AsyncAPI documents mounted into `/docs` were silently skipped. AsyncAPI files (`.json`/`.yaml`/`.yml` with an `asyncapi` version field) are now detected and included in the generated configuration.
+
+The scanner also produces deterministic output: documents are now scanned in sorted order, so the default document no longer depends on the filesystem's directory order, and filenames containing special characters (quotes, backslashes, tabs) are escaped correctly so the generated configuration stays valid JSON.

--- a/documentation/integrations/docker.md
+++ b/documentation/integrations/docker.md
@@ -46,9 +46,10 @@ docker run \
 ```
 
 The container automatically:
-- Scans for OpenAPI documents (`.json`, `.yaml`, `.yml` files)
-- Serves documents at `/openapi/{filename}`
+- Scans for OpenAPI and AsyncAPI documents (`.json`, `.yaml`, `.yml` files)
+- Serves documents at `/openapi/{filename}` (the path is historical and used for both document types)
 - Generates titles from directory structure
+- Marks AsyncAPI documents with `documentType: "asyncapi"` in the generated configuration
 
 **Directory structure example:**
 ```

--- a/documentation/integrations/docker.md
+++ b/documentation/integrations/docker.md
@@ -36,7 +36,7 @@ docker run \
 
 ### 2. Document Mounting
 
-Mount OpenAPI documents directly into the container for automatic discovery:
+Mount OpenAPI and AsyncAPI documents directly into the container for automatic discovery:
 
 ```bash
 docker run \
@@ -79,7 +79,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      # Mount your OpenAPI documents directory
+      # Mount your OpenAPI and AsyncAPI documents directory
       - ./docs:/docs
     environment:
       # Optional: Add global configuration like theme

--- a/documentation/integrations/docker.md
+++ b/documentation/integrations/docker.md
@@ -46,8 +46,8 @@ docker run \
 ```
 
 The container automatically:
-- Scans for OpenAPI documents (`.json`, `.yaml`, `.yml` files)
-- Serves documents at `/openapi/{filename}`
+- Scans for OpenAPI and AsyncAPI documents (`.json`, `.yaml`, `.yml` files)
+- Serves documents at `/openapi/{filename}` (the path is historical and used for both document types)
 - Generates titles from directory structure
 
 **Directory structure example:**

--- a/integrations/docker/example/docs/events-api.yaml
+++ b/integrations/docker/example/docs/events-api.yaml
@@ -1,0 +1,26 @@
+asyncapi: 3.0.0
+info:
+  title: Scalar Events API
+  version: 1.0.0
+  description: A minimal AsyncAPI example used to verify the Docker integration detects and serves AsyncAPI documents.
+servers:
+  production:
+    host: events.example.com
+    protocol: wss
+channels:
+  userSignedUp:
+    address: user/signedup
+    messages:
+      userSignedUp:
+        payload:
+          type: object
+          properties:
+            userId:
+              type: string
+            email:
+              type: string
+operations:
+  onUserSignedUp:
+    action: receive
+    channel:
+      $ref: '#/channels/userSignedUp'

--- a/integrations/docker/package.json
+++ b/integrations/docker/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "command -v docker >/dev/null 2>&1 && docker build -t scalarapi/api-reference:latest . || echo '⚠️ Docker is not available, skipping the build.'",
     "compress": "cd ./assets && gzip --keep --verbose --force scalar.js",
-    "copy:standalone": "shx cp ../../packages/api-reference/dist/browser/standalone.js ./assets/scalar.js"
+    "copy:standalone": "shx cp ../../packages/api-reference/dist/browser/standalone.js ./assets/scalar.js",
+    "test": "vitest --run"
   },
   "scalarReadme": {
     "title": "Scalar API Reference for Docker",
@@ -32,5 +33,8 @@
   },
   "dependencies": {
     "@scalar/api-reference": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "catalog:*"
   }
 }

--- a/integrations/docker/scan-documents.sh
+++ b/integrations/docker/scan-documents.sh
@@ -10,7 +10,7 @@ BASE_PATH="${BASE_PATH%/}"
 BASE_URL="${BASE_PATH}/openapi"
 CONFIG_FILE="/tmp/configuration.json"
 
-echo "Scanning for OpenAPI documents in: $MOUNT_DIR"
+echo "Scanning for OpenAPI and AsyncAPI documents in: $MOUNT_DIR"
 
 # Check if mount directory exists
 if [ ! -d "$MOUNT_DIR" ]; then
@@ -18,8 +18,8 @@ if [ ! -d "$MOUNT_DIR" ]; then
     exit 0
 fi
 
-# Function to check if a file is a valid OpenAPI document
-is_openapi_doc() {
+# Function to print the document type of a file: "openapi", "asyncapi", or empty if neither.
+get_doc_type() {
     file="$1"
     ext="${file##*.}"
 
@@ -27,10 +27,20 @@ is_openapi_doc() {
         json|yaml|yml)
             if [ "$ext" = "json" ]; then
                 if grep -q '"openapi"' "$file" 2>/dev/null || grep -q '"swagger"' "$file" 2>/dev/null; then
+                    echo "openapi"
+                    return 0
+                fi
+                if grep -q '"asyncapi"' "$file" 2>/dev/null; then
+                    echo "asyncapi"
                     return 0
                 fi
             else
                 if grep -q "openapi:" "$file" 2>/dev/null || grep -q "swagger:" "$file" 2>/dev/null; then
+                    echo "openapi"
+                    return 0
+                fi
+                if grep -q "asyncapi:" "$file" 2>/dev/null; then
+                    echo "asyncapi"
                     return 0
                 fi
             fi
@@ -83,10 +93,14 @@ TEMP_FILE=$(mktemp)
 find "$MOUNT_DIR" -type f \( -name "*.json" -o -name "*.yaml" -o -name "*.yml" \) -print0 > "$TEMP_FILE"
 
 while IFS= read -r -d '' file; do
-    if is_openapi_doc "$file"; then
+    doc_type=$(get_doc_type "$file")
+    if [ -n "$doc_type" ]; then
         relative_path="${file#$MOUNT_DIR/}"
         title=$(generate_title "$file")
         slug=$(generate_slug "$file")
+        # Historical path: kept as "/openapi" for both document types so existing deployments
+        # don't need to change their mount/proxy setup. The Caddyfile serves the whole /docs
+        # mount under this path regardless of document type.
         url="${BASE_URL}/${relative_path}"
 
         # Escape for JSON
@@ -94,7 +108,13 @@ while IFS= read -r -d '' file; do
         escaped_slug=$(escape_json "$slug")
         escaped_url=$(escape_json "$url")
 
-        # Found OpenAPI document: $relative_path -> $title ($slug)
+        if [ "$doc_type" = "asyncapi" ]; then
+            document_type_field=",\"documentType\":\"asyncapi\""
+        else
+            document_type_field=""
+        fi
+
+        # Found document: $relative_path -> $title ($slug) [$doc_type]
 
         # Add comma if not first
         if [ "$FIRST" = "false" ]; then
@@ -110,7 +130,7 @@ while IFS= read -r -d '' file; do
         fi
 
         # Add source
-        SOURCES="${SOURCES}{\"title\":\"${escaped_title}\",\"slug\":\"${escaped_slug}\",\"url\":\"${escaped_url}\",\"default\":${default}}"
+        SOURCES="${SOURCES}{\"title\":\"${escaped_title}\",\"slug\":\"${escaped_slug}\",\"url\":\"${escaped_url}\",\"default\":${default}${document_type_field}}"
     fi
 done < "$TEMP_FILE"
 

--- a/integrations/docker/scan-documents.sh
+++ b/integrations/docker/scan-documents.sh
@@ -80,11 +80,15 @@ escape_json() {
 SOURCES=""
 FIRST=true
 
-# Find and process OpenAPI documents using a temporary file for POSIX compatibility
+# Find and process documents using a temporary file so the loop body runs in the
+# current shell (a piped `while` would run in a subshell and lose SOURCES/FIRST).
+# Use newline-delimited output and a plain `read`: `find -print0` paired with
+# `read -d ''` is a bashism that fails under a POSIX `/bin/sh` such as dash, which
+# is what CI uses. Document filenames do not contain newlines, so this is safe.
 TEMP_FILE=$(mktemp)
-find "$MOUNT_DIR" -type f \( -name "*.json" -o -name "*.yaml" -o -name "*.yml" \) -print0 > "$TEMP_FILE"
+find "$MOUNT_DIR" -type f \( -name "*.json" -o -name "*.yaml" -o -name "*.yml" \) > "$TEMP_FILE"
 
-while IFS= read -r -d '' file; do
+while IFS= read -r file; do
     if is_api_document "$file"; then
         relative_path="${file#$MOUNT_DIR/}"
         title=$(generate_title "$file")

--- a/integrations/docker/scan-documents.sh
+++ b/integrations/docker/scan-documents.sh
@@ -16,7 +16,7 @@ echo "Scanning for OpenAPI and AsyncAPI documents in: $MOUNT_DIR"
 
 # Check if mount directory exists
 if [ ! -d "$MOUNT_DIR" ]; then
-    echo '{"sources":[]}' > "$CONFIG_FILE"
+    printf '%s\n' '{"sources":[]}' > "$CONFIG_FILE"
     exit 0
 fi
 
@@ -41,7 +41,10 @@ is_api_document() {
     return 1
 }
 
-# Function to generate title from filename
+# Function to generate title from filename.
+# `printf '%s\n'` is used instead of `echo` so a filename containing a backslash
+# sequence (for example "a\name.json") is not mangled by shells whose `echo`
+# interprets backslash escapes.
 generate_title() {
     filepath="$1"
     filename=$(basename "$filepath")
@@ -50,9 +53,9 @@ generate_title() {
 
     if [ "$dirname" != "$MOUNT_DIR" ] && [ "$dirname" != "." ]; then
         parent_dir=$(basename "$dirname")
-        echo "${parent_dir} - ${name}"
+        printf '%s\n' "${parent_dir} - ${name}"
     else
-        echo "$name"
+        printf '%s\n' "$name"
     fi
 }
 
@@ -65,15 +68,28 @@ generate_slug() {
 
     if [ "$dirname" != "$MOUNT_DIR" ] && [ "$dirname" != "." ]; then
         parent_dir=$(basename "$dirname")
-        echo "${parent_dir}-${name}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g'
+        printf '%s\n' "${parent_dir}-${name}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g'
     else
-        echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g'
+        printf '%s\n' "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g'
     fi
 }
 
-# Function to escape JSON strings
+# Function to escape a string for embedding inside a JSON string literal.
+# Order matters: backslashes are escaped first so the backslashes added when
+# escaping the other characters are not doubled again.
+# `printf '%s'` is used instead of `echo` because some POSIX shells (dash,
+# busybox) let `echo` interpret backslash sequences in the value, which would
+# corrupt a filename containing a backslash before it is ever escaped.
+# Tabs and carriage returns are control characters that are invalid unescaped
+# inside a JSON string; they are spelled out via `printf` because POSIX `sed`
+# does not portably understand the "\t"/"\r" escapes. Newlines cannot reach here
+# because the file list is newline delimited.
 escape_json() {
-    echo "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+    tab=$(printf '\t')
+    cr=$(printf '\r')
+    printf '%s' "$1" \
+        | sed 's/\\/\\\\/g; s/"/\\"/g' \
+        | sed "s/${tab}/\\\\t/g; s/${cr}/\\\\r/g"
 }
 
 # Build sources array
@@ -85,12 +101,14 @@ FIRST=true
 # Use newline-delimited output and a plain `read`: `find -print0` paired with
 # `read -d ''` is a bashism that fails under a POSIX `/bin/sh` such as dash, which
 # is what CI uses. Document filenames do not contain newlines, so this is safe.
+# `sort` makes the traversal order deterministic so the "first document is the
+# default" selection below does not depend on the filesystem's directory order.
 TEMP_FILE=$(mktemp)
-find "$MOUNT_DIR" -type f \( -name "*.json" -o -name "*.yaml" -o -name "*.yml" \) > "$TEMP_FILE"
+find "$MOUNT_DIR" -type f \( -name "*.json" -o -name "*.yaml" -o -name "*.yml" \) | sort > "$TEMP_FILE"
 
 while IFS= read -r file; do
     if is_api_document "$file"; then
-        relative_path="${file#$MOUNT_DIR/}"
+        relative_path="${file#"$MOUNT_DIR"/}"
         title=$(generate_title "$file")
         slug=$(generate_slug "$file")
         # Historical path: kept as "/openapi" for both document types so existing deployments
@@ -126,10 +144,13 @@ done < "$TEMP_FILE"
 # Clean up temporary file
 rm -f "$TEMP_FILE"
 
-# Generate final JSON
+# Generate final JSON.
+# `printf '%s\n'` is used instead of `echo` because SOURCES contains JSON escape
+# sequences (`\"`, `\\`, `\t`) and some shells let `echo` re-interpret those
+# backslashes, which would corrupt the escaping added by escape_json.
 if [ -n "$SOURCES" ]; then
-    echo "{\"sources\":[${SOURCES}]}" > "$CONFIG_FILE"
+    printf '%s\n' "{\"sources\":[${SOURCES}]}" > "$CONFIG_FILE"
 else
-    echo "No OpenAPI documents found"
-    echo '{"sources":[]}' > "$CONFIG_FILE"
+    echo "No documents found"
+    printf '%s\n' '{"sources":[]}' > "$CONFIG_FILE"
 fi

--- a/integrations/docker/scan-documents.sh
+++ b/integrations/docker/scan-documents.sh
@@ -3,14 +3,16 @@
 # Document scanning script for Scalar Docker integration
 # Scans mounted directories for OpenAPI documents and generates configuration
 
-MOUNT_DIR="/docs"
+# Directory to scan and output file. Both default to the container paths but can be
+# overridden via the environment, which keeps the script testable outside Docker.
+MOUNT_DIR="${MOUNT_DIR:-/docs}"
 # Optional URL prefix when serving under a subpath (for example, "/docs").
 # Strip any trailing slash so the prefix concatenates cleanly.
 BASE_PATH="${BASE_PATH%/}"
 BASE_URL="${BASE_PATH}/openapi"
-CONFIG_FILE="/tmp/configuration.json"
+CONFIG_FILE="${CONFIG_FILE:-/tmp/configuration.json}"
 
-echo "Scanning for OpenAPI documents in: $MOUNT_DIR"
+echo "Scanning for OpenAPI and AsyncAPI documents in: $MOUNT_DIR"
 
 # Check if mount directory exists
 if [ ! -d "$MOUNT_DIR" ]; then
@@ -18,19 +20,19 @@ if [ ! -d "$MOUNT_DIR" ]; then
     exit 0
 fi
 
-# Function to check if a file is a valid OpenAPI document
-is_openapi_doc() {
+# Function to check if a file is an OpenAPI, Swagger, or AsyncAPI document
+is_api_document() {
     file="$1"
     ext="${file##*.}"
 
     case "$ext" in
         json|yaml|yml)
             if [ "$ext" = "json" ]; then
-                if grep -q '"openapi"' "$file" 2>/dev/null || grep -q '"swagger"' "$file" 2>/dev/null; then
+                if grep -q '"openapi"' "$file" 2>/dev/null || grep -q '"swagger"' "$file" 2>/dev/null || grep -q '"asyncapi"' "$file" 2>/dev/null; then
                     return 0
                 fi
             else
-                if grep -q "openapi:" "$file" 2>/dev/null || grep -q "swagger:" "$file" 2>/dev/null; then
+                if grep -q "openapi:" "$file" 2>/dev/null || grep -q "swagger:" "$file" 2>/dev/null || grep -q "asyncapi:" "$file" 2>/dev/null; then
                     return 0
                 fi
             fi
@@ -83,10 +85,13 @@ TEMP_FILE=$(mktemp)
 find "$MOUNT_DIR" -type f \( -name "*.json" -o -name "*.yaml" -o -name "*.yml" \) -print0 > "$TEMP_FILE"
 
 while IFS= read -r -d '' file; do
-    if is_openapi_doc "$file"; then
+    if is_api_document "$file"; then
         relative_path="${file#$MOUNT_DIR/}"
         title=$(generate_title "$file")
         slug=$(generate_slug "$file")
+        # Historical path: kept as "/openapi" for both document types so existing deployments
+        # don't need to change their mount/proxy setup. The Caddyfile serves the whole /docs
+        # mount under this path regardless of document type.
         url="${BASE_URL}/${relative_path}"
 
         # Escape for JSON
@@ -94,7 +99,7 @@ while IFS= read -r -d '' file; do
         escaped_slug=$(escape_json "$slug")
         escaped_url=$(escape_json "$url")
 
-        # Found OpenAPI document: $relative_path -> $title ($slug)
+        # Found document: $relative_path -> $title ($slug)
 
         # Add comma if not first
         if [ "$FIRST" = "false" ]; then

--- a/integrations/docker/scan-documents.test.ts
+++ b/integrations/docker/scan-documents.test.ts
@@ -1,0 +1,128 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const scriptPath = fileURLToPath(new URL('./scan-documents.sh', import.meta.url))
+
+type Source = {
+  title: string
+  slug: string
+  url: string
+  default: boolean
+}
+
+const tempDirs: string[] = []
+
+afterEach(() => {
+  while (tempDirs.length) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true })
+  }
+})
+
+/**
+ * Write the given files into a fresh mount directory, run the scanner against it,
+ * and return the parsed sources from the generated configuration.
+ *
+ * Keys are paths relative to the mount directory (nested paths are supported),
+ * values are the file contents.
+ */
+const scan = (files: Record<string, string>, env: Record<string, string> = {}): Source[] => {
+  const workDir = mkdtempSync(join(tmpdir(), 'scalar-docker-scan-'))
+  tempDirs.push(workDir)
+
+  const mountDir = join(workDir, 'docs')
+  const configFile = join(workDir, 'configuration.json')
+
+  for (const [relativePath, content] of Object.entries(files)) {
+    const absolutePath = join(mountDir, relativePath)
+    mkdirSync(dirname(absolutePath), { recursive: true })
+    writeFileSync(absolutePath, content)
+  }
+  // The mount directory may not exist yet when no files are provided.
+  mkdirSync(mountDir, { recursive: true })
+
+  execFileSync('sh', [scriptPath], {
+    env: { ...process.env, MOUNT_DIR: mountDir, CONFIG_FILE: configFile, ...env },
+    stdio: 'pipe',
+  })
+
+  return JSON.parse(readFileSync(configFile, 'utf8')).sources
+}
+
+const bySlug = (sources: Source[], slug: string) => sources.find((source) => source.slug === slug)
+
+describe('scan-documents', () => {
+  it('detects OpenAPI, Swagger, and AsyncAPI documents', () => {
+    const sources = scan({
+      'openapi.json': '{"openapi":"3.1.0","info":{"title":"OpenAPI"}}',
+      'swagger.yaml': 'swagger: "2.0"\ninfo:\n  title: Swagger\n',
+      'events.yaml': 'asyncapi: 3.0.0\ninfo:\n  title: Events\n',
+    })
+
+    expect(sources).toHaveLength(3)
+    expect(sources.map((source) => source.slug).sort()).toEqual(['events', 'openapi', 'swagger'])
+  })
+
+  it('detects AsyncAPI documents in both JSON and YAML', () => {
+    const sources = scan({
+      'events.yaml': 'asyncapi: 3.0.0\ninfo:\n  title: Events\n',
+      'chat.json': '{"asyncapi":"3.0.0","info":{"title":"Chat"}}',
+    })
+
+    expect(sources.map((source) => source.slug).sort()).toEqual(['chat', 'events'])
+  })
+
+  it('skips files without an OpenAPI, Swagger, or AsyncAPI version marker', () => {
+    const sources = scan({
+      'openapi.json': '{"openapi":"3.1.0","info":{"title":"OpenAPI"}}',
+      'config.json': '{"hello":"world"}',
+      'notes.yaml': 'foo: bar\n',
+    })
+
+    expect(sources).toHaveLength(1)
+    expect(sources[0]?.slug).toBe('openapi')
+  })
+
+  it('does not emit a documentType field', () => {
+    const sources = scan({
+      'events.yaml': 'asyncapi: 3.0.0\ninfo:\n  title: Events\n',
+    })
+
+    expect(sources[0]).not.toHaveProperty('documentType')
+    expect(Object.keys(sources[0] ?? {}).sort()).toEqual(['default', 'slug', 'title', 'url'])
+  })
+
+  it('marks exactly one document as the default', () => {
+    const sources = scan({
+      'a.json': '{"openapi":"3.1.0"}',
+      'b.json': '{"openapi":"3.1.0"}',
+      'c.json': '{"openapi":"3.1.0"}',
+    })
+
+    expect(sources.filter((source) => source.default)).toHaveLength(1)
+  })
+
+  it('generates titles and slugs from nested directories', () => {
+    const sources = scan({
+      'internal/admin-api.yml': 'openapi: 3.0.0\ninfo:\n  title: Admin\n',
+    })
+
+    const source = bySlug(sources, 'internal-admin-api')
+    expect(source?.title).toBe('internal - admin-api')
+    expect(source?.url).toBe('/openapi/internal/admin-api.yml')
+  })
+
+  it('returns an empty sources array when no documents are found', () => {
+    expect(scan({})).toEqual([])
+  })
+
+  it('applies BASE_PATH as a URL prefix', () => {
+    const sources = scan({ 'openapi.json': '{"openapi":"3.1.0"}' }, { BASE_PATH: '/docs' })
+
+    expect(sources[0]?.url).toBe('/docs/openapi/openapi.json')
+  })
+})

--- a/integrations/docker/scan-documents.test.ts
+++ b/integrations/docker/scan-documents.test.ts
@@ -106,6 +106,35 @@ describe('scan-documents', () => {
     expect(sources.filter((source) => source.default)).toHaveLength(1)
   })
 
+  it('selects the alphabetically first document as the default regardless of write order', () => {
+    const sources = scan({
+      'zebra.json': '{"openapi":"3.1.0"}',
+      'alpha.json': '{"openapi":"3.1.0"}',
+      'middle.json': '{"openapi":"3.1.0"}',
+    })
+
+    expect(sources.find((source) => source.default)?.slug).toBe('alpha')
+  })
+
+  it('escapes special characters in filenames so the configuration stays valid JSON', () => {
+    // A parse error inside the scan helper would already fail the test, but assert
+    // the escaped values explicitly to document the expected output.
+    const sources = scan({ 'we"ird\\name.json': '{"openapi":"3.1.0"}' })
+
+    expect(sources).toHaveLength(1)
+    expect(sources[0]?.title).toBe('we"ird\\name')
+    expect(sources[0]?.url).toBe('/openapi/we"ird\\name.json')
+  })
+
+  it('escapes control characters in filenames as JSON escape sequences', () => {
+    // A tab in the filename must be emitted as a "\t" escape, not a raw control
+    // character, so the configuration stays valid JSON.
+    const sources = scan({ 'a\tb.json': '{"openapi":"3.1.0"}' })
+
+    expect(sources).toHaveLength(1)
+    expect(sources[0]?.title).toBe('a\tb')
+  })
+
   it('generates titles and slugs from nested directories', () => {
     const sources = scan({
       'internal/admin-api.yml': 'openapi: 3.0.0\ninfo:\n  title: Admin\n',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -768,6 +768,10 @@ importers:
       '@scalar/api-reference':
         specifier: workspace:*
         version: link:../../packages/api-reference
+    devDependencies:
+      vitest:
+        specifier: catalog:*
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))
 
   integrations/docusaurus:
     dependencies:


### PR DESCRIPTION
## Problem

The Docker integration only scanned mounted files for OpenAPI/Swagger. AsyncAPI documents dropped into `/docs` were silently skipped, so they never showed up in the generated `configuration.json` — even though Caddy already serves the whole mount.

## Solution

The document scanner now also recognizes AsyncAPI files (`"asyncapi"` in JSON, `asyncapi:` in YAML) next to OpenAPI/Swagger. They are served at the existing `/openapi/{filename}` path, which is kept for both document types so existing deployments do not need to change their mount or proxy setup.

Also added `integrations/docker/example/docs/events-api.yaml` as a small AsyncAPI sample so the example directory covers both document types.

## Tests

Added `integrations/docker/scan-documents.test.ts`, a Vitest suite that runs the scanner against temporary fixture directories and checks the generated configuration. It covers OpenAPI, Swagger, and AsyncAPI detection (both JSON and YAML), skipping files without a version marker, default selection, titles and slugs from nested directories, and the `BASE_PATH` prefix.

To make the script testable outside Docker, `MOUNT_DIR` and `CONFIG_FILE` are now read from the environment with the existing container paths as defaults, so runtime behavior is unchanged.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation.
