### PR TITLE
fix(api-reference): keep base allOf properties when merging oneOf/anyOf branches

### DIFF
--- a/.changeset/short-cobras-relax.md
+++ b/.changeset/short-cobras-relax.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: keep base allOf properties when merging oneOf/anyOf branches
+
+When a schema used `allOf` to factor out shared object properties next to a `oneOf`/`anyOf`, each branch's own `properties`/`required` overwrote the shared base fields instead of being combined with them. The base fields now stay visible alongside each branch's own fields.

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
@@ -183,6 +183,58 @@ describe('optimizeValueForDisplay', () => {
     })
   })
 
+  it('unions root and variant properties/required instead of letting a variant overwrite the base (#9657)', () => {
+    // Mirrors the reported issue: an `allOf` factors out shared object properties
+    // next to a `oneOf` whose branches each define their own distinct properties.
+    // The shared base fields must still show up alongside each branch's own
+    // fields, not disappear because the branch happens to declare `properties`.
+    const input: SchemaObject = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        status: { type: 'string' },
+      },
+      required: ['name', 'status'],
+      oneOf: [
+        {
+          type: 'object',
+          properties: { all_sites: { type: 'boolean' } },
+          required: ['all_sites'],
+        },
+        {
+          type: 'object',
+          properties: { site_ids: { type: 'array', items: { type: 'integer' } } },
+          required: ['site_ids'],
+        },
+      ],
+    }
+
+    const result = optimizeValueForDisplay(input)
+
+    expect(result).toEqual({
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            status: { type: 'string' },
+            all_sites: { type: 'boolean' },
+          },
+          required: ['name', 'status', 'all_sites'],
+        },
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            status: { type: 'string' },
+            site_ids: { type: 'array', items: { type: 'integer' } },
+          },
+          required: ['name', 'status', 'site_ids'],
+        },
+      ],
+    })
+  })
+
   it('should merge root properties into oneOf schemas when they contain allOf', () => {
     const input = {
       type: 'object',

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
@@ -235,6 +235,116 @@ describe('optimizeValueForDisplay', () => {
     })
   })
 
+  it('unions base and variant properties/required for anyOf branches too (#9657)', () => {
+    // Same regression as the oneOf case, but the composition keyword is anyOf.
+    // Both keywords share the merge path, so the base fields must survive here as well.
+    const input: SchemaObject = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        status: { type: 'string' },
+      },
+      required: ['name', 'status'],
+      anyOf: [
+        {
+          type: 'object',
+          properties: { all_sites: { type: 'boolean' } },
+          required: ['all_sites'],
+        },
+        {
+          type: 'object',
+          properties: { site_ids: { type: 'array', items: { type: 'integer' } } },
+          required: ['site_ids'],
+        },
+      ],
+    }
+
+    const result = optimizeValueForDisplay(input)
+
+    expect(result).toEqual({
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            status: { type: 'string' },
+            all_sites: { type: 'boolean' },
+          },
+          required: ['name', 'status', 'all_sites'],
+        },
+        {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            status: { type: 'string' },
+            site_ids: { type: 'array', items: { type: 'integer' } },
+          },
+          required: ['name', 'status', 'site_ids'],
+        },
+      ],
+    })
+  })
+
+  it('unions a sibling allOf base with each variant instead of overwriting it (#9657)', () => {
+    // The exact shape from the issue: the shared fields live in a single-item
+    // `allOf` base inside every branch (not at the root). Flattening that base
+    // must combine its properties/required with the branch's own, not clobber
+    // the branch fields with the base ones.
+    const input = {
+      oneOf: [
+        {
+          type: 'object',
+          properties: { all_sites: { type: 'boolean' } },
+          required: ['all_sites'],
+          allOf: [
+            {
+              type: 'object',
+              properties: { name: { type: 'string' }, status: { type: 'string' } },
+              required: ['name', 'status'],
+            },
+          ],
+        },
+        {
+          type: 'object',
+          properties: { site_ids: { type: 'array', items: { type: 'integer' } } },
+          required: ['site_ids'],
+          allOf: [
+            {
+              type: 'object',
+              properties: { name: { type: 'string' }, status: { type: 'string' } },
+              required: ['name', 'status'],
+            },
+          ],
+        },
+      ],
+    } as unknown as SchemaObject
+
+    const result = optimizeValueForDisplay(input)
+
+    expect(result).toEqual({
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            all_sites: { type: 'boolean' },
+            name: { type: 'string' },
+            status: { type: 'string' },
+          },
+          required: ['all_sites', 'name', 'status'],
+        },
+        {
+          type: 'object',
+          properties: {
+            site_ids: { type: 'array', items: { type: 'integer' } },
+            name: { type: 'string' },
+            status: { type: 'string' },
+          },
+          required: ['site_ids', 'name', 'status'],
+        },
+      ],
+    })
+  })
+
   it('should merge root properties into oneOf schemas when they contain allOf', () => {
     const input = {
       type: 'object',

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
@@ -4,6 +4,51 @@ import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/o
 import { compositions } from './schema-composition'
 
 /**
+ * Shallow-merges schema-like objects, but unions `properties` and `required`
+ * instead of letting a later object's `properties`/`required` completely
+ * overwrite an earlier one's. Without this, a variant schema (e.g. a `oneOf`
+ * branch) that declares its own `properties`/`required` would wipe out the
+ * shared base fields factored out at the root (or via a sibling `allOf`)
+ * instead of being combined with them (#9657).
+ */
+function mergeSchemaProperties(...objects: Record<string, unknown>[]): Record<string, unknown> {
+  const merged: Record<string, unknown> = {}
+  const properties: Record<string, unknown> = {}
+  const required = new Set<string>()
+  let hasProperties = false
+  let hasRequired = false
+
+  for (const object of objects) {
+    for (const [key, val] of Object.entries(object)) {
+      if (key === 'properties' && val && typeof val === 'object') {
+        Object.assign(properties, val)
+        hasProperties = true
+        continue
+      }
+
+      if (key === 'required' && Array.isArray(val)) {
+        for (const name of val) {
+          required.add(name)
+        }
+        hasRequired = true
+        continue
+      }
+
+      merged[key] = val
+    }
+  }
+
+  if (hasProperties) {
+    merged.properties = properties
+  }
+  if (hasRequired) {
+    merged.required = [...required]
+  }
+
+  return merged
+}
+
+/**
  * Optimize the value by removing nulls from compositions and merging root properties.
  *
  * TODO: figure out what this does
@@ -69,9 +114,9 @@ export function optimizeValueForDisplay(value: SchemaObject | undefined): Schema
       // Flatten single-item allOf and merge with root properties
       if (schema.allOf?.length === 1) {
         const { allOf, ...otherProps } = schema
-        return { ...rootProperties, ...otherProps, ...resolve.schema(allOf[0]) }
+        return mergeSchemaProperties(rootProperties, otherProps, resolve.schema(allOf[0]))
       }
-      return { ...rootProperties, ...schema }
+      return mergeSchemaProperties(rootProperties, schema)
     })
 
     // @ts-expect-error - We avoid using coerceValue here as it may be dangerous, so we type cast

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
@@ -11,7 +11,7 @@ import { compositions } from './schema-composition'
  * shared base fields factored out at the root (or via a sibling `allOf`)
  * instead of being combined with them (#9657).
  */
-function mergeSchemaProperties(...objects: Record<string, unknown>[]): Record<string, unknown> {
+function mergeSchemaProperties(...objects: (Record<string, unknown> | undefined)[]): Record<string, unknown> {
   const merged: Record<string, unknown> = {}
   const properties: Record<string, unknown> = {}
   const required = new Set<string>()
@@ -19,6 +19,10 @@ function mergeSchemaProperties(...objects: Record<string, unknown>[]): Record<st
   let hasRequired = false
 
   for (const object of objects) {
+    if (!object) {
+      continue
+    }
+
     for (const [key, val] of Object.entries(object)) {
       if (key === 'properties' && val && typeof val === 'object') {
         Object.assign(properties, val)


### PR DESCRIPTION
When a schema factors shared object properties into an allOf base next to a oneOf/anyOf, each branch's own properties/required replaced the base ones instead of combining with them. Only the last branch's fields showed up, the shared fields disappeared.

Looks like a side effect of #9557: once mergeAllOfSchemas started keeping oneOf/anyOf as a sibling array instead of flattening it, optimizeValueForDisplay still spread the branch schema over the root properties, so a branch with its own properties key wiped out the base ones. Added mergeSchemaProperties to union properties/required instead of overwriting.

Test mirrors the repro attached to the issue.

Closes #9657
