### PR TITLE
fix(workspace-store): only normalize reference objects, not schemas

### DIFF
--- a/.changeset/normalize-refs-schema-position.md
+++ b/.changeset/normalize-refs-schema-position.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/helpers': patch
+---
+
+Only normalize OpenAPI Reference Objects during bundling, never Schema Objects. `normalizeRefs` used to strip every sibling except `$ref` on any node outside `components/schemas`, which also hit inline schemas. In JSON Schema 2020-12 a `$ref` may legally carry sibling keywords — for example a `$defs`/`$dynamicAnchor` binding that specializes a generic template like `Paginated<T>` — and such schemas appear inline anywhere a schema is allowed (a response's `content.<media>.schema`, an `allOf` branch, …). Dropping those siblings discarded the binding, leaving `$dynamicRef` to resolve to the template's empty fallback and rendering an empty array (for example the `data` array of `GET /planets` in the Scalar Galaxy). Reference Objects are still normalized as before. A new `@scalar/helpers/openapi/is-schema-path` helper detects schema positions.

--- a/.changeset/normalize-refs-schema-position.md
+++ b/.changeset/normalize-refs-schema-position.md
@@ -2,6 +2,7 @@
 '@scalar/workspace-store': patch
 '@scalar/helpers': patch
 '@scalar/openapi-upgrader': patch
+'@scalar/json-magic': patch
 ---
 
 Only normalize OpenAPI Reference Objects during bundling, never Schema Objects. `normalizeRefs` used to strip every sibling except `$ref` on any node outside `components/schemas`, which also hit inline schemas. In JSON Schema 2020-12 a `$ref` may legally carry sibling keywords — for example a `$defs`/`$dynamicAnchor` binding that specializes a generic template like `Paginated<T>` — and such schemas appear inline anywhere a schema is allowed (a response's `content.<media>.schema`, an `allOf` branch, …). Dropping those siblings discarded the binding, leaving `$dynamicRef` to resolve to the template's empty fallback and rendering an empty array (for example the `data` array of `GET /planets` in the Scalar Galaxy). Reference Objects are still normalized as before. A new `@scalar/helpers/openapi/is-schema-path` helper detects schema positions.

--- a/.changeset/normalize-refs-schema-position.md
+++ b/.changeset/normalize-refs-schema-position.md
@@ -1,6 +1,7 @@
 ---
 '@scalar/workspace-store': patch
 '@scalar/helpers': patch
+'@scalar/openapi-upgrader': patch
 ---
 
 Only normalize OpenAPI Reference Objects during bundling, never Schema Objects. `normalizeRefs` used to strip every sibling except `$ref` on any node outside `components/schemas`, which also hit inline schemas. In JSON Schema 2020-12 a `$ref` may legally carry sibling keywords — for example a `$defs`/`$dynamicAnchor` binding that specializes a generic template like `Paginated<T>` — and such schemas appear inline anywhere a schema is allowed (a response's `content.<media>.schema`, an `allOf` branch, …). Dropping those siblings discarded the binding, leaving `$dynamicRef` to resolve to the template's empty fallback and rendering an empty array (for example the `data` array of `GET /planets` in the Scalar Galaxy). Reference Objects are still normalized as before. A new `@scalar/helpers/openapi/is-schema-path` helper detects schema positions.

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -88,6 +88,11 @@
       "types": "./dist/object/*.d.ts",
       "default": "./dist/object/*.js"
     },
+    "./openapi/*": {
+      "import": "./dist/openapi/*.js",
+      "types": "./dist/openapi/*.d.ts",
+      "default": "./dist/openapi/*.js"
+    },
     "./playwright/*": {
       "import": "./dist/playwright/*.js",
       "types": "./dist/playwright/*.d.ts",

--- a/packages/helpers/src/openapi/is-schema-path.test.ts
+++ b/packages/helpers/src/openapi/is-schema-path.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSchemaPath } from './is-schema-path'
+
+describe('isSchemaPath', () => {
+  it('identifies schema paths', () => {
+    expect(isSchemaPath(['components', 'schemas', 'User'])).toBe(true)
+    expect(isSchemaPath(['paths', '/users', 'get', 'responses', '200', 'content', 'application/json', 'schema'])).toBe(
+      true,
+    )
+    expect(isSchemaPath(['paths', '/users', 'post', 'requestBody', 'content', 'application/json', 'schema'])).toBe(true)
+    expect(isSchemaPath(['components', 'schemas', 'User', 'properties', 'address'])).toBe(true)
+    expect(isSchemaPath(['components', 'schemas', 'User', 'allOf', '0'])).toBe(true)
+    expect(isSchemaPath(['paths', '/users', 'get', 'parameters', '0', 'schema'])).toBe(true)
+  })
+
+  it('identifies nested schema keywords', () => {
+    expect(isSchemaPath(['components', 'schemas', 'Node', 'items'])).toBe(true)
+    expect(isSchemaPath(['components', 'schemas', 'Node', 'additionalProperties'])).toBe(true)
+    expect(isSchemaPath(['components', 'schemas', 'Node', 'anyOf', '1'])).toBe(true)
+    expect(isSchemaPath(['components', 'schemas', 'Node', 'not'])).toBe(true)
+    // `*Schema` keywords such as `contentSchema` also introduce a schema.
+    expect(isSchemaPath(['components', 'schemas', 'File', 'contentSchema'])).toBe(true)
+  })
+
+  it('identifies non-schema paths', () => {
+    expect(isSchemaPath(['info'])).toBe(false)
+    expect(isSchemaPath(['paths', '/users', 'get', 'summary'])).toBe(false)
+    expect(isSchemaPath(['components', 'parameters', 'userId'])).toBe(false)
+    expect(isSchemaPath(['paths', '/users', 'get', 'responses', '200'])).toBe(false)
+    expect(isSchemaPath(['paths', '/users', 'get', 'parameters', '0'])).toBe(false)
+  })
+
+  it('returns false for an undefined path', () => {
+    expect(isSchemaPath(undefined)).toBe(false)
+  })
+})

--- a/packages/helpers/src/openapi/is-schema-path.test.ts
+++ b/packages/helpers/src/openapi/is-schema-path.test.ts
@@ -14,6 +14,26 @@ describe('isSchemaPath', () => {
     expect(isSchemaPath(['paths', '/users', 'get', 'parameters', '0', 'schema'])).toBe(true)
   })
 
+  it('identifies schema paths in bundled external documents', () => {
+    expect(
+      isSchemaPath([
+        'x-ext',
+        'abc123',
+        'paths',
+        '/users',
+        'get',
+        'responses',
+        '200',
+        'content',
+        'application/json',
+        'schema',
+      ]),
+    ).toBe(true)
+    expect(isSchemaPath(['x-ext', 'abc123', 'components', 'schemas', 'User'])).toBe(true)
+    expect(isSchemaPath(['x-ext', 'abc123', 'components', 'parameters', 'not'])).toBe(false)
+    expect(isSchemaPath(['x-ext', 'abc123', 'paths', '/users', 'get', 'responses', '200'])).toBe(false)
+  })
+
   it('identifies nested schema keywords', () => {
     expect(isSchemaPath(['components', 'schemas', 'Node', 'items'])).toBe(true)
     expect(isSchemaPath(['components', 'schemas', 'Node', 'additionalProperties'])).toBe(true)

--- a/packages/helpers/src/openapi/is-schema-path.test.ts
+++ b/packages/helpers/src/openapi/is-schema-path.test.ts
@@ -31,6 +31,42 @@ describe('isSchemaPath', () => {
     expect(isSchemaPath(['paths', '/users', 'get', 'parameters', '0'])).toBe(false)
   })
 
+  it('does not mistake user-defined names for schema keywords', () => {
+    // Component names may collide with schema keywords.
+    expect(isSchemaPath(['components', 'parameters', 'not'])).toBe(false)
+    expect(isSchemaPath(['components', 'responses', 'ErrorSchema'])).toBe(false)
+    expect(isSchemaPath(['components', 'requestBodies', 'items'])).toBe(false)
+    expect(isSchemaPath(['components', 'callbacks', 'mySchema'])).toBe(false)
+    // …but a real schema below such a name is still detected.
+    expect(isSchemaPath(['components', 'parameters', 'not', 'schema'])).toBe(true)
+    // Path templates, webhook names, header names, and example names are user-defined too.
+    expect(isSchemaPath(['paths', '/fooSchema', 'get', 'summary'])).toBe(false)
+    expect(isSchemaPath(['webhooks', 'items', 'post', 'requestBody'])).toBe(false)
+    expect(isSchemaPath(['paths', '/users', 'get', 'responses', '200', 'headers', 'X-Schema'])).toBe(false)
+    expect(isSchemaPath(['paths', '/users', 'get', 'parameters', '0', 'examples', 'schema'])).toBe(false)
+    // Callbacks nest a callback name and a runtime expression before the path item.
+    expect(isSchemaPath(['paths', '/users', 'post', 'callbacks', 'onSchema', '{$request.body#/url}'])).toBe(false)
+    expect(
+      isSchemaPath([
+        'paths',
+        '/users',
+        'post',
+        'callbacks',
+        'onSchema',
+        '{$request.body#/url}',
+        'post',
+        'requestBody',
+        'content',
+        'application/json',
+        'schema',
+      ]),
+    ).toBe(true)
+    // OAuth2 scope names live under `scopes` and are arbitrary as well.
+    expect(
+      isSchemaPath(['components', 'securitySchemes', 'oauth', 'flows', 'authorizationCode', 'scopes', 'schema']),
+    ).toBe(false)
+  })
+
   it('returns false for an undefined path', () => {
     expect(isSchemaPath(undefined)).toBe(false)
   })

--- a/packages/helpers/src/openapi/is-schema-path.ts
+++ b/packages/helpers/src/openapi/is-schema-path.ts
@@ -1,0 +1,44 @@
+/**
+ * OpenAPI keywords whose values are (or contain) Schema Objects. When any of
+ * these appears as a segment in a document path, the node lives inside a schema.
+ */
+const SCHEMA_SEGMENTS = new Set([
+  'properties',
+  'items',
+  'allOf',
+  'anyOf',
+  'oneOf',
+  'not',
+  'additionalProperties',
+  'schema',
+])
+
+/**
+ * Determine whether a document path points inside a JSON Schema.
+ *
+ * OpenAPI 3.1 schemas are reachable through a handful of well-known keywords
+ * (`schema`, `properties`, `items`, the composition keywords, …), through any
+ * `*Schema` keyword (such as `contentSchema`), or directly under
+ * `components/schemas`. Knowing this lets callers treat schema `$ref`s — which
+ * may legally carry sibling keywords in JSON Schema 2020-12 — differently from
+ * plain OpenAPI Reference Objects, where only `summary` and `description` are
+ * allowed next to `$ref`.
+ */
+export const isSchemaPath = (path: readonly string[] | undefined): boolean => {
+  if (!path) {
+    return false
+  }
+
+  // Most schemas are reached through a well-known schema keyword.
+  if (path.some((segment) => SCHEMA_SEGMENTS.has(segment))) {
+    return true
+  }
+
+  // Keywords such as `contentSchema` also introduce a schema.
+  if (path.some((segment) => segment.endsWith('Schema'))) {
+    return true
+  }
+
+  // Reusable schemas live under `components/schemas`.
+  return path.length >= 2 && path[0] === 'components' && path[1] === 'schemas'
+}

--- a/packages/helpers/src/openapi/is-schema-path.ts
+++ b/packages/helpers/src/openapi/is-schema-path.ts
@@ -1,6 +1,7 @@
 /**
  * OpenAPI keywords whose values are (or contain) Schema Objects. When any of
- * these appears as a segment in a document path, the node lives inside a schema.
+ * these appears as a keyword segment in a document path, the node lives inside
+ * a schema.
  */
 const SCHEMA_SEGMENTS = new Set([
   'properties',
@@ -11,6 +12,33 @@ const SCHEMA_SEGMENTS = new Set([
   'not',
   'additionalProperties',
   'schema',
+  // Reusable schemas live under `components/schemas`, and `schemas` is not a
+  // fixed keyword anywhere else in the document.
+  'schemas',
+])
+
+/**
+ * OpenAPI keywords whose value is a map with user-defined keys (component
+ * names, path templates, media types, status codes, header names, …). A key
+ * inside one of these maps is a *name*, never a keyword, so it must not be
+ * matched against the schema keywords above — a parameter called `not` or a
+ * response called `ErrorSchema` does not put us inside a schema.
+ */
+const USER_KEYED_MAPS = new Set([
+  'paths',
+  'webhooks',
+  'responses',
+  'content',
+  'headers',
+  'examples',
+  'links',
+  'encoding',
+  'variables',
+  'parameters',
+  'requestBodies',
+  'securitySchemes',
+  'pathItems',
+  'scopes',
 ])
 
 /**
@@ -23,22 +51,40 @@ const SCHEMA_SEGMENTS = new Set([
  * may legally carry sibling keywords in JSON Schema 2020-12 — differently from
  * plain OpenAPI Reference Objects, where only `summary` and `description` are
  * allowed next to `$ref`.
+ *
+ * The path is walked left to right so that segments in user-defined key
+ * positions (component names, path templates, header names, …) are never
+ * mistaken for schema keywords.
  */
 export const isSchemaPath = (path: readonly string[] | undefined): boolean => {
   if (!path) {
     return false
   }
 
-  // Most schemas are reached through a well-known schema keyword.
-  if (path.some((segment) => SCHEMA_SEGMENTS.has(segment))) {
-    return true
+  // Number of upcoming segments that are user-defined map keys rather than keywords.
+  let userKeySegments = 0
+
+  for (const segment of path) {
+    if (userKeySegments > 0) {
+      userKeySegments--
+      continue
+    }
+
+    // A schema keyword in keyword position means everything below is a schema.
+    if (SCHEMA_SEGMENTS.has(segment) || segment.endsWith('Schema')) {
+      return true
+    }
+
+    // Callbacks nest two user-defined levels: the callback name, then the runtime expression.
+    if (segment === 'callbacks') {
+      userKeySegments = 2
+      continue
+    }
+
+    if (USER_KEYED_MAPS.has(segment)) {
+      userKeySegments = 1
+    }
   }
 
-  // Keywords such as `contentSchema` also introduce a schema.
-  if (path.some((segment) => segment.endsWith('Schema'))) {
-    return true
-  }
-
-  // Reusable schemas live under `components/schemas`.
-  return path.length >= 2 && path[0] === 'components' && path[1] === 'schemas'
+  return false
 }

--- a/packages/helpers/src/openapi/is-schema-path.ts
+++ b/packages/helpers/src/openapi/is-schema-path.ts
@@ -54,17 +54,20 @@ const USER_KEYED_MAPS = new Set([
  *
  * The path is walked left to right so that segments in user-defined key
  * positions (component names, path templates, header names, …) are never
- * mistaken for schema keywords.
+ * mistaken for schema keywords. Bundled external documents are stored below
+ * `x-ext/<hash>`; that wrapper is skipped before evaluating the embedded path.
  */
 export const isSchemaPath = (path: readonly string[] | undefined): boolean => {
   if (!path) {
     return false
   }
 
+  const segments = path[0] === 'x-ext' && path[1] !== undefined ? path.slice(2) : path
+
   // Number of upcoming segments that are user-defined map keys rather than keywords.
   let userKeySegments = 0
 
-  for (const segment of path) {
+  for (const segment of segments) {
     if (userKeySegments > 0) {
       userKeySegments--
       continue

--- a/packages/json-magic/src/bundle/bundle.ts
+++ b/packages/json-magic/src/bundle/bundle.ts
@@ -262,6 +262,7 @@ export type LoaderPlugin = {
  */
 type NodeProcessContext = {
   path: readonly string[]
+  referencedFromPath?: readonly string[]
   resolutionCache: Map<string, Promise<Readonly<ResolveResult>>>
   parentNode: UnknownObject | null
   rootNode: UnknownObject
@@ -621,6 +622,7 @@ export async function bundle(input: UnknownObject | string, config: Config) {
     depth = 0,
     currentPath: readonly string[] = [],
     parent: UnknownObject = null,
+    referencedFromPath?: readonly string[],
   ) => {
     // If a maximum depth is set in the config, stop bundling when the current depth reaches or exceeds it
     if (config.depth !== undefined && depth > config.depth) {
@@ -641,6 +643,7 @@ export async function bundle(input: UnknownObject | string, config: Config) {
 
     const context = {
       path: currentPath,
+      referencedFromPath,
       resolutionCache: cache,
       parentNode: parent,
       rootNode: documentRoot as UnknownObject,
@@ -675,7 +678,15 @@ export async function bundle(input: UnknownObject | string, config: Config) {
           // referenced by this local reference to ensure the partial bundle is complete.
           // This includes not just the direct reference but also all its dependencies,
           // creating a complete and self-contained partial bundle.
-          await bundler(targetValue.value, targetValue.context, isChunkParent, depth + 1, segments, parent)
+          await bundler(
+            targetValue.value,
+            targetValue.context,
+            isChunkParent,
+            depth + 1,
+            segments,
+            parent,
+            referencedFromPath,
+          )
         }
         await executeHooks('onAfterNodeProcess', root as UnknownObject, context)
         return
@@ -727,11 +738,15 @@ export async function bundle(input: UnknownObject | string, config: Config) {
           // to handle any nested references it may contain. We pass the resolvedPath as the new origin
           // to ensure any relative references within this content are resolved correctly relative to
           // their new location in the bundled document.
-          await bundler(result.data, isChunk ? origin : resolvedPath, isChunk, depth + 1, [
-            config.externalDocumentsKey,
-            compressedPath,
-            documentRoot[config.externalDocumentsMappingsKey],
-          ])
+          await bundler(
+            result.data,
+            isChunk ? origin : resolvedPath,
+            isChunk,
+            depth + 1,
+            [config.externalDocumentsKey, compressedPath],
+            null,
+            currentPath,
+          )
 
           // Store the mapping between hashed keys and original URLs in x-ext-urls
           // This allows tracking which external URLs were bundled and their corresponding locations
@@ -789,7 +804,15 @@ export async function bundle(input: UnknownObject | string, config: Config) {
         continue
       }
 
-      await bundler(root[key], id ?? origin, isChunkParent, depth + 1, [...currentPath, key], root as UnknownObject)
+      await bundler(
+        root[key],
+        id ?? origin,
+        isChunkParent,
+        depth + 1,
+        [...currentPath, key],
+        root as UnknownObject,
+        referencedFromPath,
+      )
     }
 
     await executeHooks('onAfterNodeProcess', root as UnknownObject, context)

--- a/packages/openapi-upgrader/package.json
+++ b/packages/openapi-upgrader/package.json
@@ -76,10 +76,10 @@
   },
   "sideEffects": false,
   "dependencies": {
+    "@scalar/helpers": "workspace:*",
     "@scalar/openapi-types": "workspace:*"
   },
   "devDependencies": {
-    "@scalar/helpers": "workspace:*",
     "@scalar/types": "workspace:*",
     "vite": "catalog:*"
   }

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
@@ -1,26 +1,7 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { describe, expect, it } from 'vitest'
 
-import { isSchemaPath, upgradeFromThreeToThreeOne } from './upgrade-from-three-to-three-one'
-
-describe('isSchemaPath', () => {
-  it('correctly identifies schema paths', () => {
-    expect(isSchemaPath(['components', 'schemas', 'User'])).toBe(true)
-    expect(isSchemaPath(['paths', '/users', 'get', 'responses', '200', 'content', 'application/json', 'schema'])).toBe(
-      true,
-    )
-    expect(isSchemaPath(['paths', '/users', 'post', 'requestBody', 'content', 'application/json', 'schema'])).toBe(true)
-    expect(isSchemaPath(['components', 'schemas', 'User', 'properties', 'address'])).toBe(true)
-    expect(isSchemaPath(['components', 'schemas', 'User', 'allOf', '0'])).toBe(true)
-    expect(isSchemaPath(['paths', '/users', 'get', 'parameters', '0', 'schema'])).toBe(true)
-  })
-
-  it('correctly identifies non-schema paths', () => {
-    expect(isSchemaPath(['info'])).toBe(false)
-    expect(isSchemaPath(['paths', '/users', 'get', 'summary'])).toBe(false)
-    expect(isSchemaPath(['components', 'parameters', 'userId'])).toBe(false)
-  })
-})
+import { upgradeFromThreeToThreeOne } from './upgrade-from-three-to-three-one'
 
 describe('upgradeFromThreeToThreeOne', () => {
   describe('version', () => {

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
@@ -1,44 +1,8 @@
+import { isSchemaPath } from '@scalar/helpers/openapi/is-schema-path'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { UnknownObject } from '@scalar/types/utils'
 
 import { traverse } from '@/helpers/traverse'
-
-// Create Sets for faster schema path lookups
-const SCHEMA_SEGMENTS = new Set([
-  'properties',
-  'items',
-  'allOf',
-  'anyOf',
-  'oneOf',
-  'not',
-  'additionalProperties',
-  'schema',
-])
-
-/** Determine if the current path is within a schema - optimized version */
-export function isSchemaPath(path: string[] | undefined): boolean {
-  // Early return if path is undefined
-  if (!path) {
-    return false
-  }
-
-  // Check for schema segments first (most common case)
-  if (path.some((segment) => SCHEMA_SEGMENTS.has(segment))) {
-    return true
-  }
-
-  // Check for schema suffix
-  if (path.some((segment) => segment.endsWith('Schema'))) {
-    return true
-  }
-
-  // Check for components/schemas path
-  if (path.length >= 2 && path[0] === 'components' && path[1] === 'schemas') {
-    return true
-  }
-
-  return false
-}
 
 // Segments whose value is a map of *named* subschemas. Keys inside these maps are
 // arbitrary names (property names, definition names), never schema keywords.

--- a/packages/workspace-store/src/plugins/bundler/index.test.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.test.ts
@@ -815,14 +815,8 @@ describe('normalizeRefs', () => {
         '/users': {
           post: {
             requestBody: {
-              content: {
-                'application/json': {
-                  schema: {
-                    $ref: '#/components/schemas/User',
-                    extraProperty: 'should be removed',
-                  },
-                },
-              },
+              $ref: '#/components/requestBodies/User',
+              extraProperty: 'should be removed',
             },
           },
         },
@@ -834,53 +828,12 @@ describe('normalizeRefs', () => {
       plugins: [normalizeRefs()],
     })
 
-    expect(input.paths['/users'].post.requestBody.content['application/json'].schema).toEqual({
-      $ref: '#/components/schemas/User',
+    expect(input.paths['/users'].post.requestBody).toEqual({
+      $ref: '#/components/requestBodies/User',
       summary: undefined,
       description: undefined,
       '$status': undefined,
     })
-  })
-
-  it('keeps JSON Schema 2020-12 keywords on an inline schema $ref (Paginated<T> binding)', async () => {
-    // The generic pagination template binds its item type through a `$defs`/`$dynamicAnchor` sibling next to
-    // the `$ref`. This wrapper lives inline on a response schema, not under `components/schemas`, so it must
-    // survive normalization for `$dynamicRef` to resolve to the bound type instead of the empty fallback.
-    const input = {
-      paths: {
-        '/planets': {
-          get: {
-            responses: {
-              200: {
-                content: {
-                  'application/json': {
-                    schema: {
-                      $id: 'https://galaxy.scalar.com/schemas/PaginatedPlanets',
-                      $defs: { itemType: { $dynamicAnchor: 'itemType', $ref: '#/components/schemas/Planet' } },
-                      $ref: '#/components/schemas/Paginated',
-                      extraProperty: 'should be removed',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    }
-
-    await bundle(input, {
-      treeShake: false,
-      plugins: [normalizeRefs()],
-    })
-
-    const schema: Record<string, unknown> =
-      input.paths['/planets'].get.responses['200'].content['application/json'].schema
-    expect(schema.$ref).toBe('#/components/schemas/Paginated')
-    expect(schema.$id).toBe('https://galaxy.scalar.com/schemas/PaginatedPlanets')
-    expect(schema.$defs).toEqual({ itemType: { $dynamicAnchor: 'itemType', $ref: '#/components/schemas/Planet' } })
-    // Genuinely unrelated siblings are still stripped.
-    expect(schema).not.toHaveProperty('extraProperty')
   })
 
   it('normalizes $ref in parameters', async () => {
@@ -1078,7 +1031,9 @@ describe('normalizeRefs', () => {
     })
   })
 
-  it('handles deeply nested $ref normalization', async () => {
+  it('does not normalize a $ref nested inside an inline schema', async () => {
+    // The $ref lives inside a request body schema (an `allOf` branch), so it is a Schema Object rather than a
+    // Reference Object. JSON Schema 2020-12 allows sibling keywords next to `$ref`, so nothing is stripped.
     const input = {
       paths: {
         '/users': {
@@ -1090,7 +1045,7 @@ describe('normalizeRefs', () => {
                     allOf: [
                       {
                         $ref: '#/components/schemas/BaseUser',
-                        extraProperty: 'should be removed',
+                        extraProperty: 'should NOT be removed',
                       },
                     ],
                   },
@@ -1109,9 +1064,45 @@ describe('normalizeRefs', () => {
 
     expect(input.paths['/users'].post.requestBody.content['application/json'].schema.allOf[0]).toEqual({
       $ref: '#/components/schemas/BaseUser',
-      summary: undefined,
-      description: undefined,
-      '$status': undefined,
+      extraProperty: 'should NOT be removed',
+    })
+  })
+
+  it('keeps a $dynamicAnchor binding on an inline response schema $ref', async () => {
+    // The `Paginated<T>` template binds its item type through a `$defs`/`$dynamicAnchor` sibling next to the
+    // `$ref`. The wrapper is inline on a response schema, not under `components/schemas`, yet the binding must
+    // survive so `$dynamicRef` resolves to the bound type instead of the template's empty fallback.
+    const input = {
+      paths: {
+        '/planets': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      $id: 'https://galaxy.scalar.com/schemas/PaginatedPlanets',
+                      $defs: { itemType: { $dynamicAnchor: 'itemType', $ref: '#/components/schemas/Planet' } },
+                      $ref: '#/components/schemas/Paginated',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    await bundle(input, {
+      treeShake: false,
+      plugins: [normalizeRefs()],
+    })
+
+    expect(input.paths['/planets'].get.responses['200'].content['application/json'].schema).toEqual({
+      $id: 'https://galaxy.scalar.com/schemas/PaginatedPlanets',
+      $defs: { itemType: { $dynamicAnchor: 'itemType', $ref: '#/components/schemas/Planet' } },
+      $ref: '#/components/schemas/Paginated',
     })
   })
 

--- a/packages/workspace-store/src/plugins/bundler/index.test.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.test.ts
@@ -1143,6 +1143,74 @@ describe('normalizeRefs', () => {
     })
   })
 
+  it('keeps a $dynamicAnchor binding on a bundled external response schema $ref', async () => {
+    const server = fastify({ logger: false })
+
+    server.get('/paginated-planets', () => ({
+      $id: 'https://galaxy.scalar.com/schemas/PaginatedPlanets',
+      $defs: { itemType: { $dynamicAnchor: 'itemType', type: 'object' } },
+      $ref: '#/$defs/Paginated',
+    }))
+
+    await server.listen({ port: 0 })
+    const url = `http://localhost:${(server.server.address() as AddressInfo).port}/paginated-planets`
+    const input = {
+      paths: {
+        '/planets': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: url,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    await bundle(input, {
+      treeShake: false,
+      plugins: [normalizeRefs(), fetchUrls()],
+    })
+
+    const urlHash = getHash(url)
+
+    expect(input).toEqual({
+      paths: {
+        '/planets': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: {
+                      $ref: `#/x-ext/${urlHash}`,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      'x-ext': {
+        [urlHash]: {
+          $id: 'https://galaxy.scalar.com/schemas/PaginatedPlanets',
+          $defs: { itemType: { $dynamicAnchor: 'itemType', type: 'object' } },
+          $ref: `#/x-ext/${urlHash}/$defs/Paginated`,
+        },
+      },
+    })
+
+    await server.close()
+  })
+
   it('does not normalize $ref when path starts with components/schemas', async () => {
     const input = {
       components: {

--- a/packages/workspace-store/src/plugins/bundler/index.test.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.test.ts
@@ -809,6 +809,43 @@ describe('normalizeRefs', () => {
     })
   })
 
+  it('normalizes $ref on components whose names collide with schema keywords', async () => {
+    const input = {
+      components: {
+        parameters: {
+          not: {
+            $ref: '#/components/parameters/IdParameter',
+            extraProperty: 'should be removed',
+          },
+        },
+        responses: {
+          ErrorSchema: {
+            $ref: '#/components/responses/Error',
+            extraProperty: 'should be removed',
+          },
+        },
+      },
+    }
+
+    await bundle(input, {
+      treeShake: false,
+      plugins: [normalizeRefs()],
+    })
+
+    expect(input.components.parameters.not).toEqual({
+      $ref: '#/components/parameters/IdParameter',
+      summary: undefined,
+      description: undefined,
+      '$status': undefined,
+    })
+    expect(input.components.responses.ErrorSchema).toEqual({
+      $ref: '#/components/responses/Error',
+      summary: undefined,
+      description: undefined,
+      '$status': undefined,
+    })
+  })
+
   it('normalizes $ref in request body', async () => {
     const input = {
       paths: {

--- a/packages/workspace-store/src/plugins/bundler/index.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.ts
@@ -6,6 +6,7 @@
 
 import { HTTP_METHODS } from '@scalar/helpers/http/http-methods'
 import { isObject } from '@scalar/helpers/object/is-object'
+import { isSchemaPath } from '@scalar/helpers/openapi/is-schema-path'
 import type { LifecyclePlugin } from '@scalar/json-magic/bundle'
 
 import { isLocalRef } from '@/helpers/general'
@@ -232,9 +233,12 @@ export const normalizeAuthSchemes = (): LifecyclePlugin => {
 
 /**
  * Lifecycle plugin to normalize $ref nodes:
- * Ensures that for any non-schema object containing a $ref, only $ref,
+ * Ensures that for any OpenAPI Reference Object containing a $ref, only $ref,
  * summary, description, and $status properties are preserved.
  * This keeps $ref references clean and predictable for downstream consumers.
+ *
+ * Schema Objects are deliberately skipped: in JSON Schema 2020-12 a $ref may
+ * carry sibling keywords, so their siblings must not be stripped.
  */
 export const normalizeRefs = (): LifecyclePlugin => {
   return {
@@ -242,26 +246,16 @@ export const normalizeRefs = (): LifecyclePlugin => {
     onBeforeNodeProcess: (node, context) => {
       const { path } = context
 
-      // If the node is a $ref and we are not on the schema object, we need to normalize the $ref
-      if (typeof node['$ref'] === 'string' && !(path[0] === 'components' && path[1] === 'schemas')) {
-        // Remove any other properties from the node and only keep the '$ref', 'summary', 'description' and '$status'.
-        // The JSON Schema 2020-12 reference keywords are also kept: a schema-position `$ref` may carry a
-        // `$defs`/`$dynamicAnchor` binding as a sibling to specialize a generic template (the `Paginated<T>`
-        // pattern). Such a schema can appear inline anywhere a schema is allowed — for example a response's
-        // `content.<media>.schema` — not only under `components/schemas`. Dropping these siblings here would
-        // discard the item-type binding, leaving `$dynamicRef` to resolve to the template's empty fallback and
-        // rendering an empty array. See https://github.com/scalar/scalar/issues/9414.
-        const keepProperties = new Set([
-          '$ref',
-          'summary',
-          'description',
-          '$status',
-          '$id',
-          '$anchor',
-          '$dynamicAnchor',
-          '$dynamicRef',
-          '$defs',
-        ])
+      // Normalization only applies to OpenAPI Reference Objects, where a `$ref` may sit next to nothing but
+      // `summary` and `description`. Schema Objects are left untouched: in JSON Schema 2020-12 a `$ref` may
+      // legally carry sibling keywords — for example a `$defs`/`$dynamicAnchor` binding that specializes a
+      // generic template (the `Paginated<T>` pattern) — and such schemas appear inline anywhere a schema is
+      // allowed, not only under `components/schemas`. Stripping those siblings would discard the binding and
+      // leave `$dynamicRef` resolving to the template's empty fallback. See
+      // https://github.com/scalar/scalar/issues/9414.
+      if (typeof node['$ref'] === 'string' && !isSchemaPath(path)) {
+        // Remove any other properties from the node and only keep the '$ref', 'summary', 'description' and '$status'
+        const keepProperties = new Set(['$ref', 'summary', 'description', '$status'])
 
         Object.keys(node).forEach((key) => {
           if (!keepProperties.has(key)) {

--- a/packages/workspace-store/src/plugins/bundler/index.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.ts
@@ -244,16 +244,16 @@ export const normalizeRefs = (): LifecyclePlugin => {
   return {
     type: 'lifecycle',
     onBeforeNodeProcess: (node, context) => {
-      const { path } = context
+      const { path, referencedFromPath } = context
+      const isSchema = isSchemaPath(path) || isSchemaPath(referencedFromPath)
 
       // Normalization only applies to OpenAPI Reference Objects, where a `$ref` may sit next to nothing but
       // `summary` and `description`. Schema Objects are left untouched: in JSON Schema 2020-12 a `$ref` may
       // legally carry sibling keywords — for example a `$defs`/`$dynamicAnchor` binding that specializes a
-      // generic template (the `Paginated<T>` pattern) — and such schemas appear inline anywhere a schema is
-      // allowed, not only under `components/schemas`. Stripping those siblings would discard the binding and
-      // leave `$dynamicRef` resolving to the template's empty fallback. See
-      // https://github.com/scalar/scalar/issues/9414.
-      if (typeof node['$ref'] === 'string' && !isSchemaPath(path)) {
+      // generic template (the `Paginated<T>` pattern) — and such schemas appear inline, in reusable schemas,
+      // and in raw external schema documents. Stripping those siblings would discard the binding and leave
+      // `$dynamicRef` resolving to the template's empty fallback. See https://github.com/scalar/scalar/issues/9414.
+      if (typeof node['$ref'] === 'string' && !isSchema) {
         // Remove any other properties from the node and only keep the '$ref', 'summary', 'description' and '$status'
         const keepProperties = new Set(['$ref', 'summary', 'description', '$status'])
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,7 +1061,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: ^4.0.0
-        version: 4.3.1(magicast@0.5.2)
+        version: 4.3.1(magicast@0.3.5)
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client
@@ -1080,7 +1080,7 @@ importers:
     devDependencies:
       '@nuxt/module-builder':
         specifier: ^1.0.1
-        version: 1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
+        version: 1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))
       '@types/node':
         specifier: ^24.1.0
         version: 24.10.13
@@ -1089,7 +1089,7 @@ importers:
         version: 10.1.0
       nuxt:
         specifier: ^4.1.0
-        version: 4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3)
+        version: 4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3)
       vitest:
         specifier: catalog:*
         version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))
@@ -2217,13 +2217,13 @@ importers:
 
   packages/openapi-upgrader:
     dependencies:
+      '@scalar/helpers':
+        specifier: workspace:*
+        version: link:../helpers
       '@scalar/openapi-types':
         specifier: workspace:*
         version: link:../openapi-types
     devDependencies:
-      '@scalar/helpers':
-        specifier: workspace:*
-        version: link:../helpers
       '@scalar/types':
         specifier: workspace:*
         version: link:../types
@@ -18697,8 +18697,8 @@ packages:
   vue-component-type-helpers@3.3.3:
     resolution: {integrity: sha512-x4nsFpy5Pe8fqPzp/5vkTPeTTDBpAx4WVtV47Ejt0+2FQrq4pRRsJs7JmYRqMFzTu/LW+pCWEjQ3YVCkPV7f9g==}
 
-  vue-component-type-helpers@3.3.7:
-    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
+  vue-component-type-helpers@3.3.8:
+    resolution: {integrity: sha512-troqCMmQodQDqUqn63NQaFi+CDSclSe7sc8VEBFqf5GFLqmGR2Ph3P2WEC7qwpRVyEWsTi/aAr4vyOe/B1hU3g==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -23663,11 +23663,11 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)(commander@13.1.0)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -23875,9 +23875,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.1.2(magicast@0.5.2)':
+  '@nuxt/kit@4.1.2(magicast@0.3.5)':
     dependencies:
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -23898,6 +23898,31 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unimport: 5.7.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@nuxt/kit@4.3.1(magicast@0.3.5)':
+    dependencies:
+      c12: 3.3.3(magicast@0.3.5)
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.8
+      ignore: 7.0.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      mlly: 1.8.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rc9: 3.0.0
+      scule: 1.3.0
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ufo: 1.6.3
+      unctx: 2.5.0
       untyped: 2.0.0
     transitivePeerDependencies:
       - magicast
@@ -23927,9 +23952,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5))(@vue/compiler-core@3.5.30)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
@@ -24044,9 +24069,9 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.1.2(magicast@0.5.2))':
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.1.2(magicast@0.3.5))':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.5.2)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       citty: 0.2.1
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
@@ -24116,9 +24141,9 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)':
+  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.5.2)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
@@ -25734,7 +25759,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.30(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.7
+      vue-component-type-helpers: 3.3.8
 
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.16.0)':
     dependencies:
@@ -33781,18 +33806,18 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3):
+  nuxt@4.1.2(@biomejs/biome@2.2.4)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.30)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.8.3):
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 2.7.0(vite@8.0.2(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.30(typescript@5.9.3))
-      '@nuxt/kit': 4.1.2(magicast@0.5.2)
+      '@nuxt/kit': 4.1.2(magicast@0.3.5)
       '@nuxt/schema': 4.1.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.1.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.1.2(magicast@0.3.5))
+      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.0.0-rc.11)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.3)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.5.2)
+      c12: 3.3.3(magicast@0.3.5)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2
@@ -38588,7 +38613,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.3: {}
 
-  vue-component-type-helpers@3.3.7: {}
+  vue-component-type-helpers@3.3.8: {}
 
   vue-demi@0.14.10(vue@3.5.30(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
### Problem

`normalizeRefs` strips every sibling except `$ref` on any node outside `components/schemas`. That also hits **inline schemas** — a `$ref` inside a response's `content.<media>.schema`, an `allOf` branch, and so on.

In JSON Schema 2020-12 (OpenAPI 3.1's dialect) a `$ref` may legally carry sibling keywords. The `Paginated<T>` pattern relies on this: it binds its item type through a `$defs`/`$dynamicAnchor` sibling next to the `$ref`. Stripping those siblings discards the binding, so `$dynamicRef` falls back to an empty result and the example renders an empty `data: []` (for example `GET /planets` in the Scalar Galaxy).

### Fix

`normalizeRefs` should only clean OpenAPI **Reference Objects**, never **Schema Objects**. Schema positions are detected with a new `isSchemaPath` helper (extracted to `@scalar/helpers/openapi/is-schema-path` and reused from `openapi-upgrader`, which already had a private copy). Reference Objects are normalized exactly as before; every inline schema keeps all of its siblings.

This generalizes #9652, which already merged. That PR whitelisted the specific 2020-12 keywords; this one stops touching schemas at all, so it also keeps other valid siblings (`default`, `title`, `examples`, `x-*`, …) that the whitelist would still strip. This rebase replaces that whitelist with the schema-position skip.

## Ticket

Refs #9414

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenAPI bundling semantics for any document with `$ref` plus extra properties; behavior is narrower (schemas untouched) but path detection must be correct everywhere refs appear.
> 
> **Overview**
> **`normalizeRefs`** no longer strips siblings from every `$ref` outside `components/schemas`. It now runs only when the node is **not** inside a schema (`!isSchemaPath(path)`), so OpenAPI **Reference Objects** still keep only `$ref`, `summary`, `description`, and `$status`, while **Schema Objects** keep all JSON Schema 2020-12 siblings (e.g. `$defs` / `$dynamicAnchor` on inline `Paginated<T>` wrappers). That fixes empty `data` arrays when `$dynamicRef` lost its binding during bundle.
> 
> A shared **`@scalar/helpers/openapi/is-schema-path`** export walks document paths and distinguishes schema keywords from user-defined map keys (parameters named `not`, responses named `ErrorSchema`, callbacks, OAuth scopes, etc.). **`openapi-upgrader`** drops its local `isSchemaPath` and depends on the helper as a runtime dependency. Bundler tests cover inline `allOf` `$ref`s, Galaxy-style pagination schemas, and keyword-colliding component names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b106db4878cec9747cde5eaaa9caa53b1a12410f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->