### PR TITLE
style(biome): enable `noNestedTernary` rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -152,7 +152,8 @@
         "useShorthandFunctionType": "warn",
         "useConst": "warn",
         "useArrayLiterals": "warn",
-        "noDescendingSpecificity": "warn"
+        "noDescendingSpecificity": "warn",
+        "noNestedTernary": "warn"
       },
       "suspicious": {
         "noAsyncPromiseExecutor": "warn",


### PR DESCRIPTION
## Problem

The codebase did not have a linting rule to discourage nested ternary operators, which can reduce code readability and maintainability. Adding this rule helps enforce cleaner, more understandable conditional logic.

## Solution

Enabled the `noNestedTernary` rule in Biome's style configuration with a "warn" severity level. This rule will flag nested ternary operators and encourage developers to refactor them into more readable alternatives (e.g., if-else statements or helper functions).

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed for config-only changes -->
- [ ] I added tests. <!-- N/A - configuration change -->
- [ ] I updated the documentation. <!-- N/A - configuration change -->

https://claude.ai/code/session_0141dewSXJK1PLeNfwHA8Rv5