### PR TITLE
fix(api-client): persist response cookies

### DIFF
--- a/.changeset/persist-response-cookies.md
+++ b/.changeset/persist-response-cookies.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Persist cookies set by a response into the document cookie jar so values like a Django CSRF token survive a page reload and are replayed on later requests

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -318,6 +318,42 @@ describe('OperationBlock', () => {
     })
   })
 
+  it('persists server-set cookies into the document jar after a response', async () => {
+    const mockEventBus = createMockEventBus()
+    const mockResponse = {
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      cookieHeaderKeys: ['csrftoken=abc123; Path=/; SameSite=Lax'],
+      duration: 100,
+      method: 'get',
+      path: '/api/users',
+      data: '{}',
+      size: 2,
+    } as unknown as ResponseInstance
+
+    vi.mocked(sendRequest).mockResolvedValue([
+      null,
+      {
+        timestamp: Date.now(),
+        requestPayload: ['https://api.example.com/api/users', { method: 'GET', headers: new Headers() }],
+        response: mockResponse,
+        originalResponse: createMockOriginalResponse(),
+      },
+    ])
+
+    const wrapper = mount(OperationBlock, {
+      props: { ...createDefaultProps(), eventBus: mockEventBus },
+    })
+
+    await triggerExecute(wrapper)
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith('cookie:upsert:cookie', {
+      collectionType: 'document',
+      payload: { name: 'csrftoken', value: 'abc123', domain: 'api.example.com', path: '/' },
+    })
+  })
+
   it('flushes debounced events before building a request', async () => {
     const mockEventBus = createMockEventBus()
     vi.mocked(sendRequest).mockResolvedValue([

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -132,6 +132,10 @@ import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
 import { harToFetchRequest } from '@/v2/blocks/operation-block/helpers/har-to-fetch-request'
 import { harToFetchResponse } from '@/v2/blocks/operation-block/helpers/har-to-fetch-response'
 import {
+  getCookieRequestUrl,
+  getResponseCookieActions,
+} from '@/v2/blocks/operation-block/helpers/persist-response-cookies'
+import {
   getOperationExampleKey,
   isStreamingResponse,
   responseCache,
@@ -194,6 +198,42 @@ const requestPayload = ref<RequestPayload | null>(null)
 
 /** Cancel the request */
 const cancelRequest = () => abortController.value?.abort(ERRORS.REQUEST_ABORTED)
+
+/**
+ * Persist server-set cookies from a response into the document cookie jar.
+ *
+ * Scalar keeps its own cookie jar because browsers hide `Set-Cookie` from `fetch`.
+ * Mirroring browser behavior, cookies are stored scoped to the request host and
+ * path and removed when the server expires them, so a value like a Django CSRF
+ * token stays available for later PUT/PATCH requests after a page reload.
+ */
+const persistResponseCookies = (sendResult: {
+  response: ResponseInstance
+  requestPayload: RequestPayload
+}) => {
+  const actions = getResponseCookieActions({
+    cookieHeaderKeys: sendResult.response.cookieHeaderKeys ?? [],
+    documentCookies,
+    requestUrl: getCookieRequestUrl(String(sendResult.requestPayload[0])),
+  })
+
+  for (const action of actions) {
+    if (action.type === 'delete') {
+      eventBus.emit('cookie:delete:cookie', {
+        collectionType: 'document',
+        cookieName: action.cookieName,
+        index: action.index,
+      })
+      continue
+    }
+
+    eventBus.emit('cookie:upsert:cookie', {
+      collectionType: 'document',
+      payload: action.cookie,
+      ...(action.index === undefined ? {} : { index: action.index }),
+    })
+  }
+}
 
 /**
  * Copy the executable URL — same pipeline as Send (`requestFactory` +
@@ -369,6 +409,10 @@ const handleExecute = async () => {
   // Store the response
   response.value = sendResult.response
   requestPayload.value = sendResult.requestPayload
+
+  // Persist server-set cookies into the document jar so values like a CSRF token
+  // survive a page reload and get replayed on the next request, like a browser would.
+  persistResponseCookies(sendResult)
 
   // Cache non-streaming responses so they can be restored when navigating back
   if (!isStreamingResponse(sendResult.response)) {

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.test.ts
@@ -1,0 +1,199 @@
+import { filterGlobalCookie } from '@scalar/workspace-store/request-example'
+import type { XScalarCookie } from '@scalar/workspace-store/schemas/extensions/general/x-scalar-cookies'
+import { describe, expect, it } from 'vitest'
+
+import { getCookieRequestUrl, getResponseCookieActions } from './persist-response-cookies'
+
+describe('getCookieRequestUrl', () => {
+  it('returns the URL as-is when it is not proxied', () => {
+    expect(getCookieRequestUrl('https://example.com/api/things')).toBe('https://example.com/api/things')
+  })
+
+  it('unwraps the target URL from a proxied request', () => {
+    const proxied = 'https://proxy.scalar.com/?scalar_url=https%3A%2F%2Fexample.com%2Fapi%2Fthings'
+    expect(getCookieRequestUrl(proxied)).toBe('https://example.com/api/things')
+  })
+
+  it('returns the input when it cannot be parsed as a URL', () => {
+    expect(getCookieRequestUrl('not a url')).toBe('not a url')
+  })
+})
+
+describe('getResponseCookieActions', () => {
+  it('adds a new cookie scoped to the response Set-Cookie attributes', () => {
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: ['csrftoken=abc123; Path=/; Domain=example.com; SameSite=Lax'],
+      documentCookies: [],
+      requestUrl: 'https://example.com/api/things',
+    })
+
+    expect(actions).toEqual([
+      {
+        type: 'upsert',
+        cookie: { name: 'csrftoken', value: 'abc123', domain: 'example.com', path: '/' },
+      },
+    ])
+  })
+
+  it('falls back to the request host and default path when the cookie omits them', () => {
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: ['session=xyz'],
+      documentCookies: [],
+      requestUrl: 'https://api.example.com/v1/users',
+    })
+
+    expect(actions).toEqual([
+      {
+        type: 'upsert',
+        cookie: { name: 'session', value: 'xyz', domain: 'api.example.com', path: '/v1' },
+      },
+    ])
+  })
+
+  it('updates an existing cookie in place by index', () => {
+    const documentCookies: XScalarCookie[] = [{ name: 'csrftoken', value: 'old', domain: 'example.com', path: '/' }]
+
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: ['csrftoken=new; Path=/; Domain=example.com'],
+      documentCookies,
+      requestUrl: 'https://example.com/api',
+    })
+
+    expect(actions).toEqual([
+      {
+        type: 'upsert',
+        cookie: { name: 'csrftoken', value: 'new', domain: 'example.com', path: '/' },
+        index: 0,
+      },
+    ])
+  })
+
+  it('deletes a cookie when the server expires it via Max-Age', () => {
+    const documentCookies: XScalarCookie[] = [{ name: 'csrftoken', value: 'abc', domain: 'example.com', path: '/' }]
+
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: ['csrftoken=; Max-Age=0; Path=/; Domain=example.com'],
+      documentCookies,
+      requestUrl: 'https://example.com/api',
+    })
+
+    expect(actions).toEqual([{ type: 'delete', cookieName: 'csrftoken', index: 0 }])
+  })
+
+  it('deletes a cookie when the server expires it via a past Expires date', () => {
+    const documentCookies: XScalarCookie[] = [{ name: 'session', value: 'abc', domain: 'example.com', path: '/' }]
+
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: ['session=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Domain=example.com'],
+      documentCookies,
+      requestUrl: 'https://example.com/api',
+      now: 1_000_000,
+    })
+
+    expect(actions).toEqual([{ type: 'delete', cookieName: 'session', index: 0 }])
+  })
+
+  it('ignores expiring a cookie that is not stored', () => {
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: ['csrftoken=; Max-Age=0; Path=/; Domain=example.com'],
+      documentCookies: [],
+      requestUrl: 'https://example.com/api',
+    })
+
+    expect(actions).toEqual([])
+  })
+
+  it('keeps a cookie with a future Expires date', () => {
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: ['session=abc; Expires=Tue, 19 Jan 2038 03:14:07 GMT; Path=/'],
+      documentCookies: [],
+      requestUrl: 'https://example.com/api',
+      now: 1_000_000,
+    })
+
+    expect(actions).toEqual([
+      {
+        type: 'upsert',
+        cookie: { name: 'session', value: 'abc', domain: 'example.com', path: '/' },
+      },
+    ])
+  })
+
+  it('orders index-based changes before appends and deletes from highest index down', () => {
+    const documentCookies: XScalarCookie[] = [
+      { name: 'a', value: '1', domain: 'example.com', path: '/' },
+      { name: 'b', value: '2', domain: 'example.com', path: '/' },
+    ]
+
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: [
+        'c=3; Path=/; Domain=example.com', // new -> append
+        'a=; Max-Age=0; Path=/; Domain=example.com', // delete index 0
+        'b=; Max-Age=0; Path=/; Domain=example.com', // delete index 1
+      ],
+      documentCookies,
+      requestUrl: 'https://example.com/api',
+    })
+
+    expect(actions).toEqual([
+      { type: 'delete', cookieName: 'b', index: 1 },
+      { type: 'delete', cookieName: 'a', index: 0 },
+      { type: 'upsert', cookie: { name: 'c', value: '3', domain: 'example.com', path: '/' } },
+    ])
+  })
+
+  it('skips headers without a cookie name', () => {
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: ['', '=value'],
+      documentCookies: [],
+      requestUrl: 'https://example.com/api',
+    })
+
+    expect(actions).toEqual([])
+  })
+})
+
+/**
+ * End-to-end check against the real request builder: a cookie persisted from a
+ * response must actually be replayed on later requests to the same host, which
+ * is what fixes the Django CSRF token being lost on reload (issue #4310).
+ */
+describe('response cookies are replayed by the request builder', () => {
+  const persistCsrfToken = () => {
+    const [action] = getResponseCookieActions({
+      cookieHeaderKeys: ['csrftoken=abc123; Path=/; SameSite=Lax'],
+      documentCookies: [],
+      requestUrl: 'https://api.example.com/things',
+    })
+
+    if (action?.type !== 'upsert') {
+      throw new Error('expected an upsert action')
+    }
+
+    return action.cookie
+  }
+
+  it('sends the persisted cookie on a later PUT to the same host', () => {
+    const cookie = persistCsrfToken()
+
+    expect(
+      filterGlobalCookie({
+        cookie,
+        url: 'https://api.example.com/things/1',
+        disabledGlobalCookies: {},
+      }),
+    ).toBe(true)
+  })
+
+  it('does not send the persisted cookie to a different host', () => {
+    const cookie = persistCsrfToken()
+
+    expect(
+      filterGlobalCookie({
+        cookie,
+        url: 'https://evil.example.org/things',
+        disabledGlobalCookies: {},
+      }),
+    ).toBe(false)
+  })
+})

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.test.ts
@@ -142,6 +142,69 @@ describe('getResponseCookieActions', () => {
     ])
   })
 
+  it('keeps only the last header when a response sets the same cookie twice', () => {
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: ['csrftoken=first; Path=/; Domain=example.com', 'csrftoken=second; Path=/; Domain=example.com'],
+      documentCookies: [{ name: 'csrftoken', value: 'old', domain: 'example.com', path: '/' }],
+      requestUrl: 'https://example.com/api',
+    })
+
+    expect(actions).toEqual([
+      {
+        type: 'upsert',
+        cookie: { name: 'csrftoken', value: 'second', domain: 'example.com', path: '/' },
+        index: 0,
+      },
+    ])
+  })
+
+  it('deletes a stored cookie when a later header in the same response expires it', () => {
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: [
+        'csrftoken=fresh; Path=/; Domain=example.com',
+        'csrftoken=; Max-Age=0; Path=/; Domain=example.com',
+      ],
+      documentCookies: [{ name: 'csrftoken', value: 'old', domain: 'example.com', path: '/' }],
+      requestUrl: 'https://example.com/api',
+    })
+
+    expect(actions).toEqual([{ type: 'delete', cookieName: 'csrftoken', index: 0 }])
+  })
+
+  it('re-sets a cookie when a later header in the same response follows an expiry', () => {
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: [
+        'csrftoken=; Max-Age=0; Path=/; Domain=example.com',
+        'csrftoken=fresh; Path=/; Domain=example.com',
+      ],
+      documentCookies: [{ name: 'csrftoken', value: 'old', domain: 'example.com', path: '/' }],
+      requestUrl: 'https://example.com/api',
+    })
+
+    expect(actions).toEqual([
+      {
+        type: 'upsert',
+        cookie: { name: 'csrftoken', value: 'fresh', domain: 'example.com', path: '/' },
+        index: 0,
+      },
+    ])
+  })
+
+  it('does not throw when the request URL is not parseable', () => {
+    const actions = getResponseCookieActions({
+      cookieHeaderKeys: ['session=xyz'],
+      documentCookies: [],
+      requestUrl: 'http://[',
+    })
+
+    expect(actions).toEqual([
+      {
+        type: 'upsert',
+        cookie: { name: 'session', value: 'xyz', domain: '', path: '/' },
+      },
+    ])
+  })
+
   it('skips headers without a cookie name', () => {
     const actions = getResponseCookieActions({
       cookieHeaderKeys: ['', '=value'],

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.test.ts
@@ -17,6 +17,11 @@ describe('getCookieRequestUrl', () => {
   it('returns the input when it cannot be parsed as a URL', () => {
     expect(getCookieRequestUrl('not a url')).toBe('not a url')
   })
+
+  it('falls back to the proxied URL when scalar_url is empty', () => {
+    const proxied = 'https://proxy.scalar.com/?scalar_url='
+    expect(getCookieRequestUrl(proxied)).toBe(proxied)
+  })
 })
 
 describe('getResponseCookieActions', () => {

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.ts
@@ -1,0 +1,138 @@
+import type { XScalarCookie } from '@scalar/workspace-store/schemas/extensions/general/x-scalar-cookies'
+import { parseSetCookie } from 'set-cookie-parser'
+
+/**
+ * A single change to apply to the persisted document cookie jar in response to a
+ * server's `Set-Cookie` headers. This mirrors how a browser stores server-set
+ * cookies so that values like a Django CSRF token survive a page reload and get
+ * replayed on the next request.
+ */
+export type ResponseCookieAction =
+  | {
+      type: 'upsert'
+      /** The cookie fields to store. Merged over the existing cookie when `index` is set. */
+      cookie: Pick<XScalarCookie, 'name' | 'value' | 'domain' | 'path'>
+      /** Index of the existing cookie to update, or undefined to add a new one. */
+      index?: number
+    }
+  | {
+      type: 'delete'
+      cookieName: string
+      /** Index of the existing cookie to remove. */
+      index: number
+    }
+
+/**
+ * Resolve the real target URL a request was sent to, so cookies are scoped to
+ * the API host rather than the proxy. When a request is proxied, the target URL
+ * is carried in the `scalar_url` query parameter; otherwise the URL is used as-is.
+ */
+export const getCookieRequestUrl = (payloadUrl: string): string => {
+  try {
+    return new URL(payloadUrl).searchParams.get('scalar_url') ?? payloadUrl
+  } catch {
+    return payloadUrl
+  }
+}
+
+/**
+ * Compute the default cookie path from the request URL, following the browser
+ * default-path algorithm (RFC 6265, section 5.1.4): the request path up to, but
+ * not including, its rightmost slash — or "/" when there is nothing before it.
+ */
+const getDefaultPath = (requestUrl: string): string => {
+  const { pathname } = new URL(requestUrl, 'https://example.com')
+
+  if (!pathname.startsWith('/')) {
+    return '/'
+  }
+
+  const lastSlash = pathname.lastIndexOf('/')
+
+  return lastSlash <= 0 ? '/' : pathname.slice(0, lastSlash)
+}
+
+/** Two stored cookies share an identity when name, domain, and path all match. */
+const isSameCookie = (a: Pick<XScalarCookie, 'name' | 'domain' | 'path'>, b: XScalarCookie): boolean =>
+  a.name === b.name && (a.domain ?? '') === (b.domain ?? '') && (a.path ?? '') === (b.path ?? '')
+
+/**
+ * Translate a response's `Set-Cookie` headers into a list of changes for the
+ * document cookie jar.
+ *
+ * Scalar sends requests through a proxy and reads `Set-Cookie` from a custom
+ * header because browsers hide it from `fetch`, so it has to maintain its own
+ * cookie jar instead of relying on the browser. This function is that jar's
+ * write path: it decides which cookies to add, update, or remove.
+ *
+ * Cookies are scoped like a browser would scope them — using the `Set-Cookie`
+ * `Domain`/`Path` attributes, or falling back to the request host and default
+ * path — so they are only replayed on matching requests. Expired cookies (an
+ * `Expires` in the past or a non-positive `Max-Age`) remove the matching cookie,
+ * matching how a server deletes a cookie.
+ *
+ * @param cookieHeaderKeys - Serialized `Set-Cookie` values from the response
+ * @param documentCookies - The current persisted document cookies (order matches the store)
+ * @param requestUrl - The request URL, used to derive the default domain and path
+ * @param now - Current time in ms, injectable for testing
+ */
+export const getResponseCookieActions = ({
+  cookieHeaderKeys,
+  documentCookies,
+  requestUrl,
+  now = Date.now(),
+}: {
+  cookieHeaderKeys: string[]
+  documentCookies: XScalarCookie[]
+  requestUrl: string
+  now?: number
+}): ResponseCookieAction[] => {
+  const upserts: ResponseCookieAction[] = []
+  const deletes: ResponseCookieAction[] = []
+
+  for (const header of cookieHeaderKeys) {
+    // Each header holds a single Set-Cookie value, so take the first parsed cookie.
+    const [parsed] = parseSetCookie(header)
+
+    if (!parsed?.name) {
+      continue
+    }
+
+    // Scope the cookie the way a browser would, so it is only replayed on matching requests.
+    const domain = parsed.domain || new URL(requestUrl, 'https://example.com').hostname
+    const path = parsed.path || getDefaultPath(requestUrl)
+
+    const identity = { name: parsed.name, domain, path }
+    const index = documentCookies.findIndex((cookie) => isSameCookie(identity, cookie))
+
+    // A cookie is deleted when it is already expired via Expires or Max-Age.
+    const isExpired =
+      (parsed.maxAge !== undefined && parsed.maxAge <= 0) ||
+      (parsed.expires instanceof Date && parsed.expires.getTime() <= now)
+
+    if (isExpired) {
+      if (index !== -1) {
+        deletes.push({ type: 'delete', cookieName: parsed.name, index })
+      }
+      continue
+    }
+
+    upserts.push({
+      type: 'upsert',
+      cookie: { name: parsed.name, value: parsed.value, domain, path },
+      ...(index === -1 ? {} : { index }),
+    })
+  }
+
+  /**
+   * Apply index-based changes (updates and deletes) before appends, and process
+   * deletes from the highest index down, so earlier indices stay valid as the
+   * underlying array shrinks.
+   */
+  const indexed = [...upserts.filter((action) => action.index !== undefined), ...deletes].sort(
+    (a, b) => (b.index ?? 0) - (a.index ?? 0),
+  )
+  const appends = upserts.filter((action) => action.index === undefined)
+
+  return [...indexed, ...appends]
+}

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.ts
@@ -36,13 +36,11 @@ export const getCookieRequestUrl = (payloadUrl: string): string => {
 }
 
 /**
- * Compute the default cookie path from the request URL, following the browser
+ * Compute the default cookie path from a request pathname, following the browser
  * default-path algorithm (RFC 6265, section 5.1.4): the request path up to, but
  * not including, its rightmost slash — or "/" when there is nothing before it.
  */
-const getDefaultPath = (requestUrl: string): string => {
-  const { pathname } = new URL(requestUrl, 'https://example.com')
-
+const getDefaultPath = (pathname: string): string => {
   if (!pathname.startsWith('/')) {
     return '/'
   }
@@ -50,6 +48,22 @@ const getDefaultPath = (requestUrl: string): string => {
   const lastSlash = pathname.lastIndexOf('/')
 
   return lastSlash <= 0 ? '/' : pathname.slice(0, lastSlash)
+}
+
+/**
+ * Derive the host and default path a cookie should be scoped to from the request
+ * URL. The URL is parsed defensively: `getCookieRequestUrl` may hand back a value
+ * that is not a valid URL (for example a malformed `scalar_url`), and a throw here
+ * would otherwise abort persistence after an otherwise successful request.
+ */
+const getRequestScope = (requestUrl: string): { hostname: string; defaultPath: string } => {
+  try {
+    const { hostname, pathname } = new URL(requestUrl, 'https://example.com')
+
+    return { hostname, defaultPath: getDefaultPath(pathname) }
+  } catch {
+    return { hostname: '', defaultPath: '/' }
+  }
 }
 
 /** Two stored cookies share an identity when name, domain, and path all match. */
@@ -87,8 +101,19 @@ export const getResponseCookieActions = ({
   requestUrl: string
   now?: number
 }): ResponseCookieAction[] => {
-  const upserts: ResponseCookieAction[] = []
-  const deletes: ResponseCookieAction[] = []
+  const { hostname, defaultPath } = getRequestScope(requestUrl)
+
+  /**
+   * Collapse the response's `Set-Cookie` headers into one final state per cookie
+   * identity. A browser applies them in order, so a later header for the same
+   * name/domain/path wins — whether it sets a new value or expires the cookie.
+   * Resolving this first also keeps a single action per identity, so the same
+   * stored cookie never gets a conflicting upsert and delete on the same index.
+   */
+  const resolved = new Map<
+    string,
+    { cookie: Pick<XScalarCookie, 'name' | 'value' | 'domain' | 'path'>; expired: boolean }
+  >()
 
   for (const header of cookieHeaderKeys) {
     // Each header holds a single Set-Cookie value, so take the first parsed cookie.
@@ -99,27 +124,36 @@ export const getResponseCookieActions = ({
     }
 
     // Scope the cookie the way a browser would, so it is only replayed on matching requests.
-    const domain = parsed.domain || new URL(requestUrl, 'https://example.com').hostname
-    const path = parsed.path || getDefaultPath(requestUrl)
-
-    const identity = { name: parsed.name, domain, path }
-    const index = documentCookies.findIndex((cookie) => isSameCookie(identity, cookie))
+    const domain = parsed.domain || hostname
+    const path = parsed.path || defaultPath
 
     // A cookie is deleted when it is already expired via Expires or Max-Age.
-    const isExpired =
+    const expired =
       (parsed.maxAge !== undefined && parsed.maxAge <= 0) ||
       (parsed.expires instanceof Date && parsed.expires.getTime() <= now)
 
-    if (isExpired) {
+    resolved.set(`${parsed.name}\n${domain}\n${path}`, {
+      cookie: { name: parsed.name, value: parsed.value, domain, path },
+      expired,
+    })
+  }
+
+  const upserts: ResponseCookieAction[] = []
+  const deletes: ResponseCookieAction[] = []
+
+  for (const { cookie, expired } of resolved.values()) {
+    const index = documentCookies.findIndex((existing) => isSameCookie(cookie, existing))
+
+    if (expired) {
       if (index !== -1) {
-        deletes.push({ type: 'delete', cookieName: parsed.name, index })
+        deletes.push({ type: 'delete', cookieName: cookie.name, index })
       }
       continue
     }
 
     upserts.push({
       type: 'upsert',
-      cookie: { name: parsed.name, value: parsed.value, domain, path },
+      cookie,
       ...(index === -1 ? {} : { index }),
     })
   }

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.ts
@@ -29,7 +29,9 @@ type ResponseCookieAction =
  */
 export const getCookieRequestUrl = (payloadUrl: string): string => {
   try {
-    return new URL(payloadUrl).searchParams.get('scalar_url') ?? payloadUrl
+    // Fall back to the proxied URL when `scalar_url` is missing or empty, so an
+    // empty query value never scopes cookies against a placeholder host.
+    return new URL(payloadUrl).searchParams.get('scalar_url') || payloadUrl
   } catch {
     return payloadUrl
   }

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-response-cookies.ts
@@ -7,7 +7,7 @@ import { parseSetCookie } from 'set-cookie-parser'
  * cookies so that values like a Django CSRF token survive a page reload and get
  * replayed on the next request.
  */
-export type ResponseCookieAction =
+type ResponseCookieAction =
   | {
       type: 'upsert'
       /** The cookie fields to store. Merged over the existing cookie when `index` is set. */


### PR DESCRIPTION
Server-set cookies (like a Django Ninja `csrftoken`) showed up in the response cookie panel but were never written to the persisted document cookie jar. So on a page reload the token was gone, and the next PUT/PATCH went out without it. Django then rejected it as a CSRF failure.

Scalar keeps its own cookie jar because browsers hide `Set-Cookie` from `fetch`. This wires up the missing write path: after a response, its `Set-Cookie` values are stored in the document jar, scoped to the request host and path, and removed when the server expires the cookie (past `Expires` or non-positive `Max-Age`) — matching how a browser manages cookies. Persisted cookies then get replayed on later requests by the existing request builder.

## Ticket

Fixes #4310

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request cookie persistence and replay semantics (host/path scoping and deletes); behavior is well-tested but wrong scoping could leak or omit cookies on later requests.
> 
> **Overview**
> After a successful **Send**, response `Set-Cookie` values (from `cookieHeaderKeys`) are now written into the **persisted document cookie jar**, not only shown in the response UI. That closes the gap where tokens such as Django **`csrftoken`** disappeared on reload and were missing on later PUT/PATCH requests.
> 
> A new helper **`getResponseCookieActions`** parses `Set-Cookie` headers (via `set-cookie-parser`), scopes cookies like a browser (domain/path from attributes or request URL, including **`scalar_url`** unwrap for proxied calls), handles expiry (`Max-Age` / `Expires`), and orders upserts/deletes safely. **`OperationBlock`** calls **`persistResponseCookies`** after each success and emits existing **`cookie:upsert:cookie`** / **`cookie:delete:cookie`** events with `collectionType: 'document'`. Unit and integration tests cover proxy URLs, expiry, duplicate headers, and replay via **`filterGlobalCookie`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee69b822bc2ca7c3af68bc27257b8d05ae5bd0ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->