### PR TITLE
feat(api-reference): don't delete security schemes

### DIFF
--- a/.changeset/auth-selector-can-delete-schemes.md
+++ b/.changeset/auth-selector-can-delete-schemes.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+---
+
+Add a `canDeleteSchemes` prop to the auth selector so the delete (trash) affordance can be hidden. It defaults to `true` (unchanged for the API client, where schemes are editable) and the API reference now passes `false`, since its schemes come from the rendered document and cannot be removed there.

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.test.ts
@@ -50,6 +50,7 @@ describe('AuthSelector', () => {
       environment: any
       envVariables: any[]
       isStatic: boolean
+      canDeleteSchemes: boolean
       securityRequirements: any
       selectedSecurity: any
       securitySchemes: any
@@ -274,6 +275,66 @@ describe('AuthSelector', () => {
         ],
         meta: { type: 'document' },
       })
+    })
+  })
+
+  describe('scheme deletion', () => {
+    // The combobox options render in a teleported popover that calls `scrollIntoView`, which jsdom
+    // does not implement. Polyfill it so opening the dropdown does not throw.
+    if (!HTMLElement.prototype.scrollIntoView) {
+      HTMLElement.prototype.scrollIntoView = () => {}
+    }
+
+    /** Mounts attached to the DOM (so the teleported popover mounts) and opens the auth combobox. */
+    const mountAndOpen = async (canDeleteSchemes: boolean) => {
+      const wrapper = mount(AuthSelector, {
+        attachTo: document.body,
+        props: {
+          environment: baseEnvironment as any,
+          isStatic: true,
+          canDeleteSchemes,
+          securityRequirements: [{ BearerAuth: [] }, { ApiKeyAuth: [] }],
+          selectedSecurity: { selectedIndex: 0, selectedSchemes: [{ BearerAuth: [] }] },
+          securitySchemes: baseSecuritySchemes as any,
+          proxyUrl: '',
+          server: baseServer as any,
+          title: 'Authentication',
+          eventBus: createWorkspaceEventBus(),
+          meta: { type: 'document' },
+        },
+      })
+
+      await wrapper.findComponent({ name: 'ScalarButton' }).trigger('click')
+      await nextTick()
+      await nextTick()
+
+      return wrapper
+    }
+
+    // The delete control is a ScalarIconButton whose label renders as an `sr-only` span
+    // ("Delete <scheme>"), so we match on the button text rather than an aria attribute.
+    const deleteControlCount = () =>
+      Array.from(document.body.querySelectorAll('button')).filter((button) => button.textContent?.includes('Delete '))
+        .length
+
+    it('renders a delete control per scheme by default', async () => {
+      const wrapper = await mountAndOpen(true)
+
+      // Sanity-check the dropdown actually opened before asserting on its contents.
+      expect(document.body.textContent).toContain('BearerAuth')
+      expect(deleteControlCount()).toBeGreaterThan(0)
+
+      wrapper.unmount()
+    })
+
+    it('hides the delete control when canDeleteSchemes is false', async () => {
+      const wrapper = await mountAndOpen(false)
+
+      // The dropdown is open (schemes are listed) but no delete affordance is offered.
+      expect(document.body.textContent).toContain('BearerAuth')
+      expect(deleteControlCount()).toBe(0)
+
+      wrapper.unmount()
     })
   })
 

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/AuthSelector.vue
@@ -44,6 +44,7 @@ const {
   environment,
   eventBus,
   createAnySecurityScheme = false,
+  canDeleteSchemes = true,
   defaultOpen = true,
   isStatic = false,
   meta,
@@ -59,6 +60,11 @@ const {
   eventBus: WorkspaceEventBus
   /** Allows adding authentication which is not in the document */
   createAnySecurityScheme?: boolean
+  /**
+   * Whether schemes can be deleted from the selector. Enabled for the editable client, disabled in
+   * the read-only reference where the schemes come from the document and cannot be removed.
+   */
+  canDeleteSchemes?: boolean
   /** Whether the authentication disclosure should start expanded */
   defaultOpen?: boolean
   /** Creates a static disclosure that cannot be collapsed */
@@ -284,7 +290,7 @@ defineExpose({
             {{ option.label }}
           </div>
           <ScalarIconButton
-            v-if="option.isDeletable"
+            v-if="option.isDeletable && canDeleteSchemes"
             class="-m-0.5 shrink-0 p-0.5 opacity-0 group-hover/item:opacity-100"
             :icon="ScalarIconTrash"
             :label="`Delete ${option.label}`"

--- a/packages/api-reference/src/components/Content/Auth/Auth.vue
+++ b/packages/api-reference/src/components/Content/Auth/Auth.vue
@@ -62,6 +62,7 @@ const selectedSecurity = computed(() =>
 <template>
   <AuthSelector
     v-if="Object.keys(securitySchemes).length"
+    :canDeleteSchemes="false"
     :createAnySecurityScheme="
       options.authentication?.createAnySecurityScheme ?? false
     "


### PR DESCRIPTION
The auth selector always showed a delete (trash) icon on every scheme. That's right in the standalone API client, where you edit your own schemes, but wrong in the API reference, where schemes come from the rendered document and can't be deleted.

**Before**

<img width="559" height="477" alt="Screenshot 2026-07-07 at 14 32 47" src="https://github.com/user-attachments/assets/cc9bf585-e422-4288-8481-6016a57812fe" />

**After**

<img width="562" height="487" alt="Screenshot 2026-07-07 at 14 33 20" src="https://github.com/user-attachments/assets/6497f702-aa52-48bd-8621-31f7d6ac0b9c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only gating of an existing delete control with a backward-compatible default; no auth or data-flow changes.
> 
> **Overview**
> Adds an optional **`canDeleteSchemes`** prop on `AuthSelector` so the per-scheme trash control in the auth combobox can be turned off. The delete button now renders only when both `option.isDeletable` and **`canDeleteSchemes`** are true; the prop defaults to **`true`**, so the standalone API client keeps today’s editable behavior without changes.
> 
> The API reference passes **`canDeleteSchemes="false"`** on its `AuthSelector`, hiding delete affordances for document-defined schemes that cannot be removed in read-only docs.
> 
> Tests cover opening the teleported combobox and asserting delete buttons appear by default vs. are absent when the prop is false. A changeset bumps **`@scalar/api-client`** and **`@scalar/api-reference`** as patch releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb50c2b79a633a4b58c5b0ccd40c39131572dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->