### PR TITLE
feat(proxy): surface response cookies via x-scalar-set-cookie

### DIFF
--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -438,6 +438,14 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	// Mirror all Set-Cookie values into x-scalar-set-cookie so browser clients can
+	// read them. Browsers hide Set-Cookie from fetch() for cross-origin responses
+	// (even with Access-Control-Expose-Headers), so the API client relies on this
+	// custom header to surface server-set cookies like a Django csrftoken.
+	if setCookies := resp.Header.Values("Set-Cookie"); len(setCookies) > 0 {
+		w.Header().Set("X-Scalar-Set-Cookie", strings.Join(setCookies, ", "))
+	}
+
 	// Add CORS headers here, after the response headers are copied
 	w.Header().Set("Access-Control-Allow-Headers", "*")
 	w.Header().Set("Access-Control-Allow-Origin", "*")

--- a/projects/proxy-scalar-com/main_test.go
+++ b/projects/proxy-scalar-com/main_test.go
@@ -571,6 +571,64 @@ func TestProxyBehavior(t *testing.T) {
 		}
 	})
 
+	t.Run("Mirrors a single Set-Cookie into X-Scalar-Set-Cookie", func(t *testing.T) {
+		// Create a test server that sets a cookie on the response
+		targetServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Set-Cookie", "csrftoken=abc123; Path=/; SameSite=Lax")
+			w.Write([]byte("success"))
+		})
+		defer targetServer.server.Close()
+
+		req := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetServer.url, nil)
+		w := httptest.NewRecorder()
+
+		proxyServer.handleRequest(w, req)
+
+		// The original Set-Cookie is still forwarded, and mirrored into the custom
+		// header the browser client can actually read.
+		expected := "csrftoken=abc123; Path=/; SameSite=Lax"
+		if got := w.Header().Get("X-Scalar-Set-Cookie"); got != expected {
+			t.Errorf("Expected X-Scalar-Set-Cookie header to be '%s', got '%s'", expected, got)
+		}
+	})
+
+	t.Run("Mirrors multiple Set-Cookie values into X-Scalar-Set-Cookie", func(t *testing.T) {
+		// Create a test server that sets two cookies on the response
+		targetServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Add("Set-Cookie", "csrftoken=abc123; Path=/")
+			w.Header().Add("Set-Cookie", "sessionid=xyz789; Path=/; HttpOnly")
+			w.Write([]byte("success"))
+		})
+		defer targetServer.server.Close()
+
+		req := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetServer.url, nil)
+		w := httptest.NewRecorder()
+
+		proxyServer.handleRequest(w, req)
+
+		// Multiple cookies are joined with ", ", matching the desktop app.
+		expected := "csrftoken=abc123; Path=/, sessionid=xyz789; Path=/; HttpOnly"
+		if got := w.Header().Get("X-Scalar-Set-Cookie"); got != expected {
+			t.Errorf("Expected X-Scalar-Set-Cookie header to be '%s', got '%s'", expected, got)
+		}
+	})
+
+	t.Run("Omits X-Scalar-Set-Cookie when there is no Set-Cookie", func(t *testing.T) {
+		targetServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("success"))
+		})
+		defer targetServer.server.Close()
+
+		req := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetServer.url, nil)
+		w := httptest.NewRecorder()
+
+		proxyServer.handleRequest(w, req)
+
+		if got := w.Header().Get("X-Scalar-Set-Cookie"); got != "" {
+			t.Errorf("Expected no X-Scalar-Set-Cookie header, got '%s'", got)
+		}
+	})
+
 	t.Run("Forwards X-Scalar-Date as Date header", func(t *testing.T) {
 		// Create a test server that checks for the Date header
 		targetServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Companion to #9670 (the API client cookie-persistence fix).

Browsers hide `Set-Cookie` from `fetch()` for cross-origin responses, even with `Access-Control-Expose-Headers: *`, so the web API client never sees a cookie the server sets (like a Django `csrftoken`). 

The desktop app already works around this in `handle-custom-fetch.ts` by mirroring `Set-Cookie` into an `x-scalar-set-cookie` header; this brings the Go proxy to parity.

Every `Set-Cookie` value from the upstream response is joined (with `, `, matching the desktop app) into an `X-Scalar-Set-Cookie` response header. The original `Set-Cookie` is still forwarded unchanged. With this plus #9670, response cookies persist and get replayed on later requests in the web client, not just on desktop.

## Testing

`go test ./...` passes, with three new subtests in `TestProxyBehavior`:

- mirrors a single `Set-Cookie`
- joins multiple `Set-Cookie` values
- omits the header when there is no `Set-Cookie`

See #4310

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive response-header change in the proxy with no auth or routing changes; cookie values are already exposed to clients via Set-Cookie.
> 
> **Overview**
> The Go proxy now **mirrors upstream `Set-Cookie` values into `X-Scalar-Set-Cookie`** so the web API client can read cookies that browsers hide from `fetch()` on cross-origin responses. Original `Set-Cookie` headers are still forwarded unchanged; multiple cookies are joined with `", "` to match the desktop custom-fetch behavior and what the API client already parses.
> 
> Three **`TestProxyBehavior` subtests** cover a single cookie, multiple cookies, and omitting the header when there is no `Set-Cookie`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf527190afa6da2a0dabb6ecb9709e77b029e8b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->