### PR TITLE
fix(themes): use 1px border width in Firefox for visible shadow-border

### DIFF
--- a/.changeset/fix-firefox-border-rendering.md
+++ b/.changeset/fix-firefox-border-rendering.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+Fix borders invisible in Firefox: add `@supports (-moz-appearance: none)` override to set `--scalar-border-width` to `1px` in Firefox, which rounds sub-pixel box-shadow spread values to `0px` on 1× displays. Also replace hardcoded `0.5px` values in `--scalar-shadow-2` with `var(--scalar-border-width)` so both shadows and borders respect the same variable.

--- a/.changeset/fix-firefox-border-rendering.md
+++ b/.changeset/fix-firefox-border-rendering.md
@@ -2,4 +2,4 @@
 '@scalar/themes': patch
 ---
 
-Fix borders invisible in Firefox: add `@supports (-moz-appearance: none)` override to set `--scalar-border-width` to `1px` in Firefox, which rounds sub-pixel box-shadow spread values to `0px` on 1× displays. Also replace hardcoded `0.5px` values in `--scalar-shadow-2` with `var(--scalar-border-width)` so both shadows and borders respect the same variable.
+Fix borders invisible in Firefox on standard-density displays. Firefox rounds sub-pixel `box-shadow` spread values down to `0px` on 1x displays, which makes the inset box-shadow borders used by `shadow-border` disappear. Add a Firefox-only `@supports (-moz-appearance: none)` override, scoped to 1x displays with `@media (max-resolution: 1dppx)`, that sets `--scalar-border-width` to `1px`. Hi-DPI/retina displays keep the crisp `0.5px` hairline. Also replace hardcoded `0.5px` values in `--scalar-shadow-2` with `var(--scalar-border-width)` so shadows and borders respect the same variable.

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -64,7 +64,8 @@
 
   --scalar-shadow-1: 0 1px 3px 0 rgb(0, 0, 0, 0.1);
   --scalar-shadow-2:
-    0 0 0 var(--scalar-border-width) var(--scalar-border-color), rgba(15, 15, 15, 0.2) 0px 3px 6px, rgba(15, 15, 15, 0.4) 0px 9px 24px;
+    0 0 0 var(--scalar-border-width) var(--scalar-border-color), rgba(15, 15, 15, 0.2) 0px 3px 6px,
+    rgba(15, 15, 15, 0.4) 0px 9px 24px;
 
   --scalar-lifted-brightness: 1.45;
   --scalar-backdrop-brightness: 0.5;
@@ -81,7 +82,9 @@
   --scalar-button-1-color: #fff;
 
   --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
-  --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px, rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 var(--scalar-border-width);
+  --scalar-shadow-2:
+    rgba(0, 0, 0, 0.08) 0px 13px 20px 0px, rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0
+    var(--scalar-border-width);
 
   --scalar-lifted-brightness: 1;
   --scalar-backdrop-brightness: 1;

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -64,7 +64,7 @@
 
   --scalar-shadow-1: 0 1px 3px 0 rgb(0, 0, 0, 0.1);
   --scalar-shadow-2:
-    0 0 0 0.5px var(--scalar-border-color), rgba(15, 15, 15, 0.2) 0px 3px 6px, rgba(15, 15, 15, 0.4) 0px 9px 24px;
+    0 0 0 var(--scalar-border-width) var(--scalar-border-color), rgba(15, 15, 15, 0.2) 0px 3px 6px, rgba(15, 15, 15, 0.4) 0px 9px 24px;
 
   --scalar-lifted-brightness: 1.45;
   --scalar-backdrop-brightness: 0.5;
@@ -81,7 +81,7 @@
   --scalar-button-1-color: #fff;
 
   --scalar-shadow-1: 0 1px 3px 0 rgba(0, 0, 0, 0.11);
-  --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px, rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 0.5px;
+  --scalar-shadow-2: rgba(0, 0, 0, 0.08) 0px 13px 20px 0px, rgba(0, 0, 0, 0.08) 0px 3px 8px 0px, #eeeeed 0px 0 0 var(--scalar-border-width);
 
   --scalar-lifted-brightness: 1;
   --scalar-backdrop-brightness: 1;
@@ -105,5 +105,16 @@
   :root {
     --scalar-heading-1: 24px;
     --scalar-page-description: 20px;
+  }
+}
+
+/*
+ * Firefox rounds sub-pixel box-shadow spread values to 0px on 1x displays,
+ * which makes inset box-shadow borders (used by shadow-border) invisible.
+ * Override to 1px in Firefox so borders render consistently across browsers.
+ */
+@supports (-moz-appearance: none) {
+  :root {
+    --scalar-border-width: 1px;
   }
 }

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -112,12 +112,16 @@
 }
 
 /*
- * Firefox rounds sub-pixel box-shadow spread values to 0px on 1x displays,
- * which makes inset box-shadow borders (used by shadow-border) invisible.
- * Override to 1px in Firefox so borders render consistently across browsers.
+ * Firefox rounds sub-pixel box-shadow spread values down to 0px on
+ * standard-density (1x) displays, which makes the inset box-shadow borders used
+ * by shadow-border invisible. On Hi-DPI displays 0.5px already resolves to at
+ * least one device pixel and renders correctly, so the override is scoped to 1x
+ * displays to keep the crisp hairline border everywhere it works.
  */
 @supports (-moz-appearance: none) {
-  :root {
-    --scalar-border-width: 1px;
+  @media (max-resolution: 1dppx) {
+    :root {
+      --scalar-border-width: 1px;
+    }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes invisible borders (buttons, outlines) in Firefox.

**Root cause:** `--scalar-border-width` is `0.5px`, which is used by the `shadow-border` Tailwind utility as `box-shadow: inset 0 0 0 0.5px var(--scalar-border-color)`. Firefox rounds sub-pixel `box-shadow` spread radii to `0px` on standard (1×) displays, making inset box-shadow borders completely invisible. Chrome and Safari both support fractional-pixel rendering, so the issue is Firefox-only.

**Fix:** Add an `@supports (-moz-appearance: none)` block that overrides `--scalar-border-width` to `1px` in Firefox. This keeps the hairline `0.5px` appearance on Chrome/Safari while ensuring a visible `1px` border on Firefox.

Additionally, replace two hardcoded `0.5px` literals in `--scalar-shadow-2` (dark-mode and light-mode elevation shadows) with `var(--scalar-border-width)` so they also benefit from the Firefox override automatically.

## Changes

**`packages/themes/src/base/variables.css`**
- Added `@supports (-moz-appearance: none) { :root { --scalar-border-width: 1px; } }` at the end of the file
- Changed `--scalar-shadow-2` dark-mode value: `0 0 0 0.5px` → `0 0 0 var(--scalar-border-width)`
- Changed `--scalar-shadow-2` light-mode value: `#eeeeed 0px 0 0 0.5px` → `#eeeeed 0px 0 0 var(--scalar-border-width)`

## Ticket

Related to Firefox border rendering issue reported in #scalar-dashboard Slack channel.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://apidocumentation.slack.com/archives/C07TEEPG2JX/p1783450486775869?thread_ts=1783450486.775869&cid=C07TEEPG2JX)

<div><a href="https://cursor.com/agents/bc-7b6137e5-6a3f-561e-b618-0faeabc6daaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b6137e5-6a3f-561e-b618-0faeabc6daaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

