### PR TITLE
feat(api-reference): preload documents while idle

### DIFF
--- a/.changeset/preload-documents-when-idle.md
+++ b/.changeset/preload-documents-when-idle.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Preload additional documents in a multi-document setup while the browser is idle, so switching between them is instant.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -832,6 +832,126 @@ const addDocument: typeof workspaceStore.addDocument = async (
 // ---------------------------------------------------------------------------
 // Document Management
 
+/** In-flight document loads, so a background preload and a user selection never load the same document twice */
+const documentLoadPromises = new Map<string, Promise<void>>()
+
+/**
+ * Load a document into the workspace store by slug, fetching URL sources or using inline content.
+ *
+ * This does not change the active document, so it is safe to call in the background to warm up
+ * documents the user has not selected yet. Repeated calls are deduplicated and it becomes a no-op
+ * once the document is loaded.
+ */
+const ensureDocumentLoaded = (slug: string): Promise<void> => {
+  // Already loaded, nothing to do
+  if (workspaceStore.workspace.documents[slug]) {
+    return Promise.resolve()
+  }
+
+  // A load is already in flight, reuse it
+  const pending = documentLoadPromises.get(slug)
+  if (pending) {
+    return pending
+  }
+
+  const normalized = configList.value[slug]
+
+  if (!normalized) {
+    return Promise.resolve()
+  }
+
+  const config = withLocalizedConfigurationDefaults(
+    {
+      ...normalized.config,
+      ...configurationOverrides.value,
+    },
+    normalized.config,
+  )
+
+  const promise = (async () => {
+    const result = await addDocument(
+      normalized.source.url
+        ? {
+            name: slug,
+            url: normalized.source.url,
+            fetch: config.customFetch,
+          }
+        : {
+            name: slug,
+            document: normalized.source.content ?? {},
+          },
+      config,
+    )
+
+    const document = clientStore.workspace.documents[slug]
+
+    // If the document does not have a selected server we set it to the first server
+    if (
+      result === true &&
+      isOpenApiDocument(document) &&
+      document['x-scalar-selected-server'] === undefined
+    ) {
+      // Set the active server if the document is loaded successfully
+      const servers = getServers(
+        normalized.config.servers ?? document.servers,
+        {
+          baseServerUrl: mergedConfig.value.baseServerURL,
+          documentUrl: normalized.source.url,
+        },
+      )
+      if (servers.length > 0) {
+        clientStore.updateDocument(
+          slug,
+          'x-scalar-selected-server',
+          servers[0]!.url,
+        )
+      }
+    }
+  })().finally(() => {
+    documentLoadPromises.delete(slug)
+  })
+
+  documentLoadPromises.set(slug, promise)
+
+  return promise
+}
+
+/**
+ * Warm up the documents the user has not selected yet while the browser is idle, so switching
+ * between documents is instant. Runs on the client only and loads one document at a time to avoid
+ * a burst of fetches and parsing work competing with the active document.
+ */
+const preloadDocumentsWhenIdle = () => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const pendingSlugs = Object.keys(configList.value).filter(
+    (slug) => !workspaceStore.workspace.documents[slug],
+  )
+
+  const scheduleIdle = (callback: () => void) => {
+    if (typeof window.requestIdleCallback === 'function') {
+      window.requestIdleCallback(callback, { timeout: 1500 })
+    } else {
+      window.setTimeout(callback, 200)
+    }
+  }
+
+  const loadNext = () => {
+    const slug = pendingSlugs.shift()
+
+    if (!slug) {
+      return
+    }
+
+    // Load one document, then queue the next once the browser is idle again
+    void ensureDocumentLoaded(slug).finally(() => scheduleIdle(loadNext))
+  }
+
+  scheduleIdle(loadNext)
+}
+
 /**
  * Handle changing the active document
  *
@@ -871,49 +991,8 @@ const changeSelectedDocument = async (
     path: '/',
   })
 
-  const isFirstLoad = !workspaceStore.workspace.documents[slug]
-
-  // If the document is not in the store, we asynchronously load it
-  if (isFirstLoad) {
-    const result = await addDocument(
-      normalized.source.url
-        ? {
-            name: slug,
-            url: normalized.source.url,
-            fetch: config.customFetch,
-          }
-        : {
-            name: slug,
-            document: normalized.source.content ?? {},
-          },
-      config,
-    )
-
-    const document = clientStore.workspace.documents[slug]
-
-    // If the document does not have a selected server we set it to the first server
-    if (
-      result === true &&
-      isOpenApiDocument(document) &&
-      document['x-scalar-selected-server'] === undefined
-    ) {
-      // Set the active server if the document is loaded successfully
-      const servers = getServers(
-        normalized.config.servers ?? document.servers,
-        {
-          baseServerUrl: mergedConfig.value.baseServerURL,
-          documentUrl: normalized.source.url,
-        },
-      )
-      if (servers.length > 0) {
-        clientStore.updateDocument(
-          slug,
-          'x-scalar-selected-server',
-          servers[0]!.url,
-        )
-      }
-    }
-  }
+  // Load the document if it is not in the store yet (a background preload may already be loading it)
+  await ensureDocumentLoaded(slug)
 
   // Always set it to active; if the document is null we show a loading state
   workspaceStore.update('x-scalar-active-document', slug)
@@ -1050,6 +1129,9 @@ onBeforeMount(async () => {
       isMultiDocument.value ? undefined : activeSlug.value,
     ),
   )
+
+  // Warm up the remaining documents in the background so switching between them is instant
+  preloadDocumentsWhenIdle()
 })
 
 const documentUrl = computed(() => {

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -916,6 +916,22 @@ const ensureDocumentLoaded = (slug: string): Promise<void> => {
   return promise
 }
 
+/** Whether idle preloading has been stopped, for example when the component unmounts */
+let isPreloadStopped = false
+/** Cancels the currently scheduled idle preload callback, if one is pending */
+let cancelScheduledPreload: (() => void) | undefined
+
+/**
+ * Stop any in-progress idle preloading. Without this, an orphaned instance (an Astro view
+ * transition or a `createApiReference` remount) would keep fetching and parsing documents into
+ * an abandoned store after unmount.
+ */
+const stopPreloadingDocuments = () => {
+  isPreloadStopped = true
+  cancelScheduledPreload?.()
+  cancelScheduledPreload = undefined
+}
+
 /**
  * Warm up the documents the user has not selected yet while the browser is idle, so switching
  * between documents is instant. Runs on the client only and loads one document at a time to avoid
@@ -932,13 +948,19 @@ const preloadDocumentsWhenIdle = () => {
 
   const scheduleIdle = (callback: () => void) => {
     if (typeof window.requestIdleCallback === 'function') {
-      window.requestIdleCallback(callback, { timeout: 1500 })
+      const handle = window.requestIdleCallback(callback, { timeout: 1500 })
+      cancelScheduledPreload = () => window.cancelIdleCallback(handle)
     } else {
-      window.setTimeout(callback, 200)
+      const handle = window.setTimeout(callback, 200)
+      cancelScheduledPreload = () => window.clearTimeout(handle)
     }
   }
 
   const loadNext = () => {
+    if (isPreloadStopped) {
+      return
+    }
+
     const slug = pendingSlugs.shift()
 
     if (!slug) {
@@ -946,7 +968,11 @@ const preloadDocumentsWhenIdle = () => {
     }
 
     // Load one document, then queue the next once the browser is idle again
-    void ensureDocumentLoaded(slug).finally(() => scheduleIdle(loadNext))
+    void ensureDocumentLoaded(slug).finally(() => {
+      if (!isPreloadStopped) {
+        scheduleIdle(loadNext)
+      }
+    })
   }
 
   scheduleIdle(loadNext)
@@ -1047,6 +1073,16 @@ watch(
         },
         updated.config,
       )
+
+      /**
+       * A background preload may still be loading this document against the previous
+       * configuration. Wait for it to finish so the update below rebases onto the loaded
+       * document instead of being skipped, which would otherwise leave stale content in the store.
+       */
+      const pendingLoad = documentLoadPromises.get(updated.slug)
+      if (pendingLoad) {
+        await pendingLoad
+      }
 
       /** If we have not loaded the document previously we don't need to handle any updates to store */
       if (!workspaceStore.workspace.documents[updated.slug]) {
@@ -1198,6 +1234,7 @@ onMounted(async () => {
   })
 })
 onBeforeUnmount(() => {
+  stopPreloadingDocuments()
   pluginManager.notifyDestroy()
   apiClient.value?.app.unmount()
 })

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -891,11 +891,13 @@ const ensureDocumentLoaded = (slug: string): Promise<void> => {
       isOpenApiDocument(document) &&
       document['x-scalar-selected-server'] === undefined
     ) {
-      // Set the active server if the document is loaded successfully
+      // Set the active server if the document is loaded successfully. Resolve relative servers
+      // against this document's own base URL, not the active document's, so a background preload
+      // does not derive its server from whichever document happens to be active.
       const servers = getServers(
         normalized.config.servers ?? document.servers,
         {
-          baseServerUrl: mergedConfig.value.baseServerURL,
+          baseServerUrl: config.baseServerURL,
           documentUrl: normalized.source.url,
         },
       )


### PR DESCRIPTION
With multiple documents, only the active one loaded up front. 

Every other document was fetched and parsed the moment you switched to it.

This preloads the other documents in the background once the browser is idle (one at a time, client-only). 

A small `ensureDocumentLoaded` helper does the loading and dedupes it, so a background preload and a manual switch never load the same document twice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes document load timing and config-update races in multi-document mode; mitigated by deduplication, awaiting in-flight loads on config changes, and stopping preloads on unmount.
> 
> **Overview**
> Multi-document API Reference now **warms up non-active specs in the background** after the initial document loads, using `requestIdleCallback` (with a timeout fallback) to fetch and parse **one unloaded document at a time** so switching in the document picker feels instant without competing with the active view.
> 
> Document loading is centralized in **`ensureDocumentLoaded`**, with an in-flight **`documentLoadPromises`** map so a user switch and idle preload never duplicate the same fetch. **`changeSelectedDocument`** awaits that helper instead of inlining load logic. Preloaded OpenAPI docs get their default server from **that document’s** `baseServerURL`, not the active document’s merged config.
> 
> **Unmount** calls **`stopPreloadingDocuments`** to cancel scheduled idle work. When configuration changes, the config watcher **waits on any pending preload** for a slug before rebasing, avoiding stale store content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f463bb6c274175ff2fc20b083d35ddc249f7daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->