### PR TITLE
fix(api-reference): render discriminator-only array-item variants without recursion

### DIFF
--- a/.changeset/fix-discriminator-allof-recursion.md
+++ b/.changeset/fix-discriminator-allof-recursion.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: render the variant selector for discriminator-only schemas used as array items without infinite recursion
+
+A polymorphic base that declares only a `discriminator.mapping` (no explicit `oneOf`) and whose subtypes inherit through `allOf: [$ref base, …]` now renders its "One of" variant selector consistently, whether the base is used directly as an object property or as array `items`. Previously the merged subtype re-surfaced the base's discriminator, which made it look like the base again and drove the selector inference into infinite recursion.

--- a/packages/api-reference/src/components/Content/Schema/Schema.discriminator-inheritance.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.discriminator-inheritance.test.ts
@@ -1,0 +1,137 @@
+import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import Schema from './Schema.vue'
+
+// Regression coverage for https://github.com/scalar/scalar/issues/9674
+const buildDocument = async () => {
+  const store = createWorkspaceStore({ meta: { 'x-scalar-active-document': 'default' } })
+  await store.addDocument({
+    name: 'default',
+    document: {
+      openapi: '3.1.0',
+      info: { title: 'Pets', version: '1.0.0' },
+      paths: {},
+      components: {
+        schemas: {
+          PetType: { type: 'string', enum: ['DOG', 'CAT'] },
+          Pet: {
+            type: 'object',
+            required: ['petType'],
+            discriminator: {
+              propertyName: 'petType',
+              mapping: {
+                DOG: '#/components/schemas/Dog',
+                CAT: '#/components/schemas/Cat',
+              },
+            },
+            properties: { petType: { $ref: '#/components/schemas/PetType' } },
+          },
+          Dog: {
+            allOf: [
+              { $ref: '#/components/schemas/Pet' },
+              { type: 'object', required: ['breed'], properties: { breed: { type: 'string' } } },
+            ],
+          },
+          Cat: {
+            allOf: [
+              { $ref: '#/components/schemas/Pet' },
+              {
+                type: 'object',
+                required: ['livesLeft'],
+                properties: { livesLeft: { type: 'integer', format: 'int32' } },
+              },
+            ],
+          },
+        },
+      },
+    } as never,
+  })
+
+  return store.workspace.documents['default'] as never
+}
+
+describe('Schema discriminator inheritance (issue 9674)', () => {
+  it('renders the variant selector for a discriminator-only base used as an object property', async () => {
+    const document = await buildDocument()
+
+    const wrapper = mount(Schema, {
+      props: {
+        eventBus: null,
+        schema: (document as any).components.schemas.Pet,
+        options: { expandAllSchemaProperties: true, document },
+      },
+    })
+
+    expect(wrapper.find('.composition-selector').exists()).toBe(true)
+    expect(wrapper.text()).toContain('One of')
+    expect(wrapper.text()).toContain('breed')
+    expect(wrapper.text()).toContain('Discriminator')
+  })
+
+  it('renders the variant selector for a discriminator-only base used as array items', async () => {
+    const document = await buildDocument()
+
+    const wrapper = mount(Schema, {
+      props: {
+        eventBus: null,
+        schema: { type: 'array', items: (document as any).components.schemas.Pet } as never,
+        options: { expandAllSchemaProperties: true, document },
+      },
+    })
+
+    expect(wrapper.find('.composition-selector').exists()).toBe(true)
+    expect(wrapper.text()).toContain('One of')
+    expect(wrapper.text()).toContain('breed')
+  })
+
+  it('keeps a discriminator the subtype declares itself (nested polymorphism)', async () => {
+    const store = createWorkspaceStore({ meta: { 'x-scalar-active-document': 'default' } })
+    await store.addDocument({
+      name: 'default',
+      document: {
+        openapi: '3.1.0',
+        info: { title: 'Nested', version: '1.0.0' },
+        paths: {},
+        components: {
+          schemas: {
+            // WorkingDog extends Dog but declares its own discriminator.
+            Dog: {
+              type: 'object',
+              required: ['petType'],
+              properties: { petType: { type: 'string' } },
+            },
+            WorkingDog: {
+              allOf: [{ $ref: '#/components/schemas/Dog' }],
+              discriminator: {
+                propertyName: 'job',
+                mapping: {
+                  GUIDE: '#/components/schemas/GuideDog',
+                },
+              },
+              properties: { job: { type: 'string' } },
+            },
+            GuideDog: {
+              allOf: [
+                { $ref: '#/components/schemas/WorkingDog' },
+                { type: 'object', properties: { handler: { type: 'string' } } },
+              ],
+            },
+          },
+        },
+      } as never,
+    })
+    const document = store.workspace.documents['default'] as never
+
+    const wrapper = mount(Schema, {
+      props: {
+        eventBus: null,
+        schema: (document as any).components.schemas.WorkingDog,
+        options: { expandAllSchemaProperties: true, document },
+      },
+    })
+
+    expect(wrapper.find('.composition-selector').exists()).toBe(true)
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -412,6 +412,7 @@ const isDiscriminatorProperty = computed(() =>
     </div>
 
     <!-- Compositions -->
+    <!-- Fall back to the inherited discriminator to label the property inside an allOf variant (#9674) -->
     <SchemaComposition
       v-for="compositionData in compositionsToRender"
       :key="compositionData.composition"

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -1068,6 +1068,7 @@ const onBeforeMatch = (): void => {
     <!-- Compositions -->
     <!-- This row's own breadcrumb, so sibling compositions do not collide on
          anchors and expansion keys. -->
+    <!-- Fall back to the inherited discriminator to label the property inside an allOf variant (#9674) -->
     <SchemaComposition
       v-for="compositionData in compositionsToRender"
       :key="compositionData.composition"

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.test.ts
@@ -1111,13 +1111,7 @@ describe('mergeAllOfSchemas', () => {
         type: 'string',
       },
       deprecated: false,
-      discriminator: {
-        propertyName: 'type',
-        mapping: {
-          dog: '#/components/schemas/Dog',
-          cat: '#/components/schemas/Cat',
-        },
-      },
+      // A member-contributed discriminator is dropped (see the tests below).
       readOnly: false,
       writeOnly: false,
       xml: {
@@ -1174,6 +1168,48 @@ describe('mergeAllOfSchemas', () => {
         value2: 'Description for value2',
       },
       'x-enum-varnames': ['VALUE_ONE', 'VALUE_TWO'],
+    })
+  })
+
+  // See issue #9674.
+  it('drops a discriminator inherited from an allOf member', () => {
+    const dog = coerceValue(SchemaObjectSchema, {
+      allOf: [
+        {
+          type: 'object',
+          discriminator: {
+            propertyName: 'petType',
+            mapping: { DOG: '#/components/schemas/Dog', CAT: '#/components/schemas/Cat' },
+          },
+          properties: { petType: { type: 'string' } },
+        },
+        { type: 'object', properties: { breed: { type: 'string' } } },
+      ],
+    })
+
+    const result = mergeAllOfSchemas(dog)
+
+    expect('discriminator' in result).toBe(false)
+    expect(result).toMatchObject({
+      properties: { petType: { type: 'string' }, breed: { type: 'string' } },
+    })
+  })
+
+  it('keeps a discriminator the schema declares itself next to allOf', () => {
+    const workingDog = coerceValue(SchemaObjectSchema, {
+      discriminator: {
+        propertyName: 'job',
+        mapping: { GUIDE: '#/components/schemas/GuideDog' },
+      },
+      properties: { job: { type: 'string' } },
+      allOf: [{ type: 'object', properties: { petType: { type: 'string' } } }],
+    })
+
+    const result = mergeAllOfSchemas(workingDog)
+
+    expect(result.discriminator).toEqual({
+      propertyName: 'job',
+      mapping: { GUIDE: '#/components/schemas/GuideDog' },
     })
   })
 

--- a/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/merge-all-of-schemas.ts
@@ -71,6 +71,18 @@ export const mergeAllOfSchemas = (
     }
   }
 
+  // Drop a `discriminator` inherited from an `allOf` member: a merged subtype is
+  // one concrete branch, not a choice-point, and keeping the base's mapping makes
+  // it look like the base again, recursing the selector inference (issue #9674).
+  // A discriminator the schema declares itself is kept.
+  const declaresOwnDiscriminator =
+    'discriminator' in baseSchema ||
+    Boolean(rootSchema && typeof rootSchema === 'object' && 'discriminator' in rootSchema)
+
+  if ('discriminator' in result && !declaresOwnDiscriminator) {
+    delete (result as Record<string, unknown>).discriminator
+  }
+
   return result
 }
 


### PR DESCRIPTION
## What was broken

A schema that uses `discriminator.mapping` (without an explicit `oneOf`), where the subtypes extend the base via `allOf`, rendered inconsistently: the "One of" variant picker showed up when the schema was an object property but not when it was array `items`. On `main` it is worse — both cases now crash with infinite recursion.

## Why

When a subtype like `Dog` (`allOf: [Pet, { breed }]`) is merged, the base `Pet`'s discriminator was copied onto the merged result. That made `Dog` look like the polymorphic base again, so the picker kept re-rendering itself forever.

## The fix

When merging `allOf`, drop a discriminator that came from the base. A merged subtype is one concrete shape, not a choice between shapes, so it should not carry the base's mapping. A discriminator a schema declares on itself is kept.

Now the loop cannot happen no matter how the schema is nested, and the picker shows for both object properties and array items.

## Ticket

Fixes #9674

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to OpenAPI schema display and allOf merge logic in api-reference; behavior change is intentional for discriminator inheritance with tests guarding regressions.
> 
> **Overview**
> Fixes **#9674**: polymorphic bases that only define `discriminator.mapping` (no `oneOf`) with subtypes via `allOf` now show the **"One of"** variant selector for both object properties and array `items`, without infinite recursion.
> 
> **`mergeAllOfSchemas`** now removes a `discriminator` that came only from `allOf` members after merge, so merged subtypes (e.g. `Dog` extending `Pet`) are treated as concrete shapes instead of re-triggering variant inference. Discriminators declared on the schema itself (alongside `allOf`) are still kept for nested polymorphism.
> 
> **Schema rendering** passes the inherited `discriminator` through `Schema` → `SchemaProperty` and into `SchemaComposition` (`schema?.discriminator ?? discriminator`) so discriminator property labeling still works inside `allOf` variants.
> 
> Regression tests cover merge behavior and mounted `Schema` for property, array items, and nested discriminators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e14cc94c015868d0cff70e687fbd6463142199ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->