### PR TITLE
ci: purge standalone bundle from jsDelivr on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,11 +237,18 @@ jobs:
           # CHANGELOG.md section into a friendly release-notes entry.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
-      - name: Bust CDN cache
+      - name: Purge CDN Cache
         if: steps.release-check.outputs.published == 'true'
         uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d # v1.16.4
         with:
           url: 'https://purge.jsdelivr.net/npm/@scalar/api-reference'
+          method: 'GET'
+
+      - name: Purge CDN Cache (standalone bundle)
+        if: steps.release-check.outputs.published == 'true'
+        uses: fjogeleit/http-request-action@23ad54bcd1178fcff6a0d17538fa09de3a7f0a4d # v1.16.4
+        with:
+          url: 'https://purge.jsdelivr.net/npm/@scalar/api-reference@latest/dist/browser/standalone.js'
           method: 'GET'
 
       # Record this job's own result so the main-push deploys can gate on the


### PR DESCRIPTION
Adds a second jsDelivr purge on release so the standalone bundle at `@latest` gets busted too, not just the package root.

The existing "Purge CDN Cache" step only purges `@scalar/api-reference`, which doesn't reliably flush the file most people actually load. This adds a step for `@scalar/api-reference@latest/dist/browser/standalone.js` and renames the steps for clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-workflow-only CDN cache invalidation with no application or secret changes; worst case is a redundant HTTP GET if jsDelivr is down.
> 
> **Overview**
> On successful npm publish, the release workflow now runs **two** jsDelivr purge requests instead of one. The existing package-root purge is kept and its step is renamed to **Purge CDN Cache**; a new **Purge CDN Cache (standalone bundle)** step hits `https://purge.jsdelivr.net/npm/@scalar/api-reference@latest/dist/browser/standalone.js` so consumers loading that `@latest` file get a fresh copy after a release, not only the package root URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42ff5ebc76684d297be1a61d88209001f81373b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->