### PR TITLE
fix(api-reference): read plugin auth from client store

### DIFF
--- a/.changeset/plugin-auth-client-store.md
+++ b/.changeset/plugin-auth-client-store.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix the plugin `auth` accessor reading from the wrong store. It now reads from the client store — the same store the reference-side Authentication panel writes credentials into — so plugins see the secrets and selected security schemes the user actually entered instead of an empty state.

--- a/packages/api-reference/src/components/ApiReference.test.ts
+++ b/packages/api-reference/src/components/ApiReference.test.ts
@@ -1,9 +1,11 @@
+import type { ApiReferencePlugin, PluginAuthState } from '@scalar/types/api-reference'
 import { renderToString } from '@vue/server-renderer'
 import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createSSRApp, h } from 'vue'
 
 import ApiReference from '@/components/ApiReference.vue'
+import { authStorage } from '@/helpers/storage'
 
 enableAutoUnmount(afterEach)
 
@@ -716,5 +718,75 @@ Welcome to the API.
     await introductionToggle.trigger('click')
     expect(introductionButton.attributes('aria-expanded')).toBe('false')
     expect(introductionToggle.attributes('aria-expanded')).toBe('false')
+  })
+})
+
+describe('plugin auth accessor', () => {
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('reads the credentials the reference Authentication panel persists into the client store', async () => {
+    const slug = 'my-api'
+    const schemeName = 'apiKeyAuth'
+    const token = 'super-secret-token'
+
+    // Seed the persisted auth for this document, as if the user had entered it in the
+    // reference-side Authentication panel (which writes into the client store).
+    authStorage().setAuth(slug, {
+      secrets: {
+        [schemeName]: { type: 'apiKey', 'x-scalar-secret-token': token },
+      },
+      selected: { document: undefined, path: undefined },
+    })
+
+    // A plugin captures the read-only auth accessor it receives during `onInit`.
+    let capturedAuth: PluginAuthState | undefined
+
+    const authReaderPlugin: ApiReferencePlugin = () => ({
+      name: 'auth-reader',
+      extensions: [],
+      hooks: {
+        onInit: ({ auth }) => {
+          capturedAuth = auth
+        },
+      },
+    })
+
+    mount(ApiReference, {
+      props: {
+        configuration: {
+          slug,
+          persistAuth: true,
+          plugins: [authReaderPlugin],
+          content: {
+            openapi: '3.1.0',
+            info: { title: 'My API', version: '1.0.0' },
+            components: {
+              securitySchemes: {
+                [schemeName]: { type: 'apiKey', name: 'X-API-Key', in: 'header' },
+              },
+            },
+            paths: {},
+          },
+        },
+      },
+    })
+
+    // Let the document load so the persisted auth is applied to the client store.
+    await flushPromises()
+
+    expect(capturedAuth).toBeDefined()
+
+    // The plugin must see the credentials that were persisted into the client store.
+    // Before the fix the accessor read from the (empty) workspace store, so this was `undefined`.
+    expect(capturedAuth?.getAuthSecrets(slug, schemeName)).toMatchObject({
+      type: 'apiKey',
+      'x-scalar-secret-token': token,
+    })
+    expect(capturedAuth?.export()[slug]?.secrets?.[schemeName]).toMatchObject({
+      type: 'apiKey',
+      'x-scalar-secret-token': token,
+    })
   })
 })

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -427,41 +427,6 @@ const workspaceStore = createWorkspaceStore({
 })
 
 /**
- * Plugin injection is not reactive. All plugins must be provided at first render.
- *
- * Created after the workspace store so the auth accessor below can read from it — plugin `onInit`
- * hooks may call `auth` synchronously during `notifyInit`.
- */
-const pluginManager = createPluginManager({
-  plugins: Object.values(configList.value).flatMap(
-    (c) => c.config.plugins ?? [],
-  ),
-  /**
-   * Read-only view of the global authentication state, so plugins can read stored secrets and
-   * the selected security schemes without being able to mutate them. Wraps the workspace store's
-   * auth methods (rather than passing the store directly) to keep the setters out of the plugin API.
-   *
-   * The getters return a deep copy (`export` already snapshots internally, the others go through
-   * `toJsonCompatible`) so plugins receive plain data rather than the store's live reactive proxies —
-   * mutating what they get back can never leak into the workspace store.
-   */
-  auth: {
-    export: () => workspaceStore.auth.export(),
-    getAuthSecrets: (documentName, schemeName) =>
-      toJsonCompatible(
-        workspaceStore.auth.getAuthSecrets(documentName, schemeName),
-      ),
-    getAuthSelectedSchemas: (payload) =>
-      toJsonCompatible(workspaceStore.auth.getAuthSelectedSchemas(payload)),
-  },
-})
-provide(PLUGIN_MANAGER_SYMBOL, pluginManager)
-
-pluginManager.notifyInit(mergedConfig.value)
-
-watch(mergedConfig, (config) => pluginManager.notifyConfigChange(config))
-
-/**
  * We need to keep the client store separate from the workspace store
  * This is because we want the client store to be a playground where users can test out their requests without affecting the references store
  */
@@ -473,6 +438,43 @@ const clientStore = createWorkspaceStore({
     }),
   ],
 })
+
+/**
+ * Plugin injection is not reactive. All plugins must be provided at first render.
+ *
+ * Created after the client store so the auth accessor below can read from it — plugin `onInit`
+ * hooks may call `auth` synchronously during `notifyInit`. The reference-side Authentication panel
+ * (Content → Auth.vue) persists credentials into `clientStore.auth`, so plugins must read the same
+ * store to see what the user entered.
+ */
+const pluginManager = createPluginManager({
+  plugins: Object.values(configList.value).flatMap(
+    (c) => c.config.plugins ?? [],
+  ),
+  /**
+   * Read-only view of the global authentication state, so plugins can read stored secrets and
+   * the selected security schemes without being able to mutate them. Wraps the client store's
+   * auth methods (rather than passing the store directly) to keep the setters out of the plugin API.
+   *
+   * The getters return a deep copy (`export` already snapshots internally, the others go through
+   * `toJsonCompatible`) so plugins receive plain data rather than the store's live reactive proxies —
+   * mutating what they get back can never leak into the store.
+   */
+  auth: {
+    export: () => clientStore.auth.export(),
+    getAuthSecrets: (documentName, schemeName) =>
+      toJsonCompatible(
+        clientStore.auth.getAuthSecrets(documentName, schemeName),
+      ),
+    getAuthSelectedSchemas: (payload) =>
+      toJsonCompatible(clientStore.auth.getAuthSelectedSchemas(payload)),
+  },
+})
+provide(PLUGIN_MANAGER_SYMBOL, pluginManager)
+
+pluginManager.notifyInit(mergedConfig.value)
+
+watch(mergedConfig, (config) => pluginManager.notifyConfigChange(config))
 
 // TODO: persistence should be hoisted into standalone
 // Client side integrations will want to handle dark mode externally


### PR DESCRIPTION
## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->

While building a custom SignalR console plugin, I tried to read the current
authentication state via the plugin `auth` accessor (`getAuthSecrets` /
`getAuthSelectedSchemas` / `export`) so the console could reuse the credentials
the user had already entered. It always came back empty.

The reason: the reference-side Authentication panel (Content → `Auth.vue`)
persists credentials and selected security schemes into `clientStore.auth`, but
the plugin `auth` accessor was wired to `workspaceStore.auth` — a different
store. So plugins never saw what the user actually entered in the UI.

## Solution

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

Point the plugin `auth` accessor at `clientStore.auth` instead of
`workspaceStore.auth`, so plugins read from the same store the Authentication
panel writes to. All three getters (`export`, `getAuthSecrets`,
`getAuthSelectedSchemas`) now resolve against the client store.

Because plugin `onInit` hooks may call `auth()` synchronously during
`notifyInit`, the client store must exist before the plugin manager is created.
So the `clientStore` creation was moved above `createPluginManager`.

No public API change — the accessor still wraps the store's auth methods (rather
than exposing the store directly) to keep setters out of the plugin API, and
getters still return deep copies so plugins can't mutate the live reactive
proxies.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [ ] I updated the documentation.
