### PR TITLE
fix(snippetz): tie plugin client to its target in the type

### DIFF
--- a/.changeset/snippetz-plugin-target-client-types.md
+++ b/.changeset/snippetz-plugin-target-client-types.md
@@ -1,0 +1,6 @@
+---
+'@scalar/types': patch
+'@scalar/snippetz': patch
+---
+
+Tie a snippetz plugin's `client` to its `target` at the type level. Before, a plugin could pair any target with any client (for example `node` + `curl`) without a type error. Now `target: 'node'` only allows node clients, and TypeScript catches mistakes like using the display title `'Fetch'` where the lowercase client id `'fetch'` is expected.

--- a/packages/snippetz/src/plugins/shared/axios.ts
+++ b/packages/snippetz/src/plugins/shared/axios.ts
@@ -138,7 +138,7 @@ const buildData = (
   }
 }
 
-export const createAxiosPlugin = (target: Extract<TargetId, 'js' | 'node'>): Plugin => ({
+export const createAxiosPlugin = <T extends Extract<TargetId, 'js' | 'node'>>(target: T): Plugin => ({
   target,
   client: 'axios',
   title: 'Axios',

--- a/packages/types/src/snippetz/snippetz.test-d.ts
+++ b/packages/types/src/snippetz/snippetz.test-d.ts
@@ -1,6 +1,6 @@
 import { assertType, describe, it } from 'vitest'
 
-import type { ClientId, TargetId } from './index'
+import type { ClientId, Plugin, TargetId } from './index'
 
 describe('TargetId', () => {
   it('has node as a target', () => {
@@ -41,5 +41,36 @@ describe('TargetId', () => {
 
     // @ts-expect-error client does exist, but not for the given target
     assertType<ClientId<'shell'>>(client)
+  })
+})
+
+describe('Plugin', () => {
+  it('allows a client that belongs to the target', () => {
+    assertType<Plugin>({
+      target: 'node',
+      client: 'fetch',
+      title: 'Fetch',
+      generate: () => '',
+    })
+  })
+
+  it('rejects a client from a different target', () => {
+    // @ts-expect-error curl is a shell client, not a node client
+    assertType<Plugin>({
+      target: 'node',
+      client: 'curl',
+      title: 'cURL',
+      generate: () => '',
+    })
+  })
+
+  it('rejects a title used as a client id', () => {
+    assertType<Plugin>({
+      target: 'node',
+      // @ts-expect-error the client id is lowercase 'fetch', not the title 'Fetch'
+      client: 'Fetch',
+      title: 'Fetch',
+      generate: () => '',
+    })
   })
 })

--- a/packages/types/src/snippetz/snippetz.ts
+++ b/packages/types/src/snippetz/snippetz.ts
@@ -105,15 +105,17 @@ export type Target = {
  * for its target language and client library.
  */
 export type Plugin = {
-  /** The language or environment this plugin targets. */
-  target: TargetId
-  /** The identifier of the HTTP client within the target. */
-  client: ClientId<TargetId>
-  /** Human-readable name for the client. */
-  title: string
-  /** Generates source code for the given HTTP request. */
-  generate: (request?: Partial<HarRequest>, configuration?: PluginConfiguration) => string
-}
+  [T in TargetId]: {
+    /** The language or environment this plugin targets. */
+    target: T
+    /** The identifier of the HTTP client within the target. */
+    client: ClientId<T>
+    /** Human-readable name for the client. */
+    title: string
+    /** Generates source code for the given HTTP request. */
+    generate: (request?: Partial<HarRequest>, configuration?: PluginConfiguration) => string
+  }
+}[TargetId]
 
 /**
  * Optional configuration that can be passed to any code generation plugin.


### PR DESCRIPTION
A snippetz plugin declares a `target` (like `node`) and a `client` (like `fetch`). The `Plugin` type was not linking the two, so any target could be paired with any client and TypeScript would not complain — for example `node` + `curl`, or the display title `'Fetch'` used where the lowercase id `'fetch'` belongs.

This makes `Plugin` a discriminated union, so `target: 'node'` only allows node's clients. It is a type-only change; all existing plugins already use correct pairs, so nothing changes at runtime.

Also adds type tests for the good and bad cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only typing and tests; existing plugin implementations already use correct target/client pairs.
> 
> **Overview**
> **Type-level fix:** `Plugin` no longer uses `client: ClientId<TargetId>` for every target. It is modeled as a union over `TargetId`, so when `target` is `'node'`, `client` must be a node client (e.g. `'fetch'`), not shell clients like `'curl'` or display strings like `'Fetch'`.
> 
> **Supporting changes:** Adds `snippetz.test-d.ts` cases for valid pairings and `@ts-expect-error` for cross-target and wrong-casing mistakes. **`createAxiosPlugin`** is generic over `js | node` so returned plugins stay correctly typed. **Changeset** bumps `@scalar/types` and `@scalar/snippetz` as patch releases. No runtime behavior change for existing plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e87bbdc7f41e770603f02fb71ccc34f73ce2512f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->