### PR TITLE
feat(api-reference): open Auth Required badge on hover

### DIFF
--- a/.changeset/auth-badge-open-on-hover.md
+++ b/.changeset/auth-badge-open-on-hover.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+The "Auth Required" / "Auth Optional" badge on operations now opens on hover, not just on click

--- a/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.test.ts
+++ b/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.test.ts
@@ -1,4 +1,5 @@
 import { disableConsoleError, disableConsoleWarn } from '@scalar/helpers/testing/console-spies'
+import { sleep } from '@scalar/helpers/testing/sleep'
 import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
@@ -140,5 +141,46 @@ describe('SecurityRequirementBadge', () => {
 
     wrapper.unmount()
     enclosing.remove()
+  })
+
+  it('opens the popover on hover', async () => {
+    disableConsoleError()
+    disableConsoleWarn()
+
+    const wrapper = mount(SecurityRequirementBadge, {
+      props: { requiredSecurity: requiredAndGroup },
+      attachTo: document.body,
+    })
+
+    await wrapper.find('.security-requirement-badge').trigger('mouseenter')
+    await nextTick()
+
+    expect(document.body.textContent).toContain('Requires')
+
+    wrapper.unmount()
+  })
+
+  it('closes the popover after the pointer leaves', async () => {
+    disableConsoleError()
+    disableConsoleWarn()
+
+    const wrapper = mount(SecurityRequirementBadge, {
+      props: { requiredSecurity: requiredAndGroup },
+      attachTo: document.body,
+    })
+
+    const badge = wrapper.find('.security-requirement-badge')
+    await badge.trigger('mouseenter')
+    await nextTick()
+    expect(document.body.textContent).toContain('Requires')
+
+    await badge.trigger('mouseleave')
+    // The close is deferred so the pointer can travel onto the panel.
+    await sleep(150)
+    await nextTick()
+
+    expect(document.body.textContent).not.toContain('Requires')
+
+    wrapper.unmount()
   })
 })

--- a/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.test.ts
+++ b/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.test.ts
@@ -160,6 +160,28 @@ describe('SecurityRequirementBadge', () => {
     wrapper.unmount()
   })
 
+  it('stays open when the click of a hover gesture immediately follows', async () => {
+    disableConsoleError()
+    disableConsoleWarn()
+
+    const wrapper = mount(SecurityRequirementBadge, {
+      props: { requiredSecurity: requiredAndGroup },
+      attachTo: document.body,
+    })
+
+    const badge = wrapper.find('.security-requirement-badge')
+    // A single pointer gesture fires mouseenter (opens) then click.
+    await badge.trigger('mouseenter')
+    await nextTick()
+    await badge.trigger('click')
+    await nextTick()
+
+    // The click must not toggle the freshly hover-opened popover back closed.
+    expect(document.body.textContent).toContain('Requires')
+
+    wrapper.unmount()
+  })
+
   it('closes the popover after the pointer leaves', async () => {
     disableConsoleError()
     disableConsoleWarn()

--- a/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.test.ts
+++ b/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.test.ts
@@ -143,6 +143,39 @@ describe('SecurityRequirementBadge', () => {
     enclosing.remove()
   })
 
+  it('does not bubble panel clicks to an enclosing click handler', async () => {
+    disableConsoleError()
+    disableConsoleWarn()
+
+    // The floating panel is not teleported, so it renders inside the accordion's
+    // DisclosureButton. A click on it (selecting text, or during the close delay)
+    // must not bubble up and toggle the operation.
+    const enclosing = document.createElement('div')
+    const enclosingClick = vi.fn()
+    enclosing.addEventListener('click', enclosingClick)
+    document.body.appendChild(enclosing)
+
+    const wrapper = mount(SecurityRequirementBadge, {
+      props: { requiredSecurity: requiredAndGroup },
+      attachTo: enclosing,
+    })
+
+    // Open on hover, then click an element inside the rendered panel.
+    await wrapper.find('.security-requirement-badge').trigger('mouseenter')
+    await nextTick()
+
+    const schemeType = enclosing.querySelector('code')
+    expect(schemeType).not.toBeNull()
+
+    schemeType!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+
+    expect(enclosingClick).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+    enclosing.remove()
+  })
+
   it('opens the popover on hover', async () => {
     disableConsoleError()
     disableConsoleWarn()

--- a/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.test.ts
+++ b/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.test.ts
@@ -205,4 +205,68 @@ describe('SecurityRequirementBadge', () => {
 
     wrapper.unmount()
   })
+
+  it('keeps a click-pinned popover open when the pointer leaves', async () => {
+    disableConsoleError()
+    disableConsoleWarn()
+
+    const wrapper = mount(SecurityRequirementBadge, {
+      props: { requiredSecurity: requiredAndGroup },
+      attachTo: document.body,
+    })
+
+    const badge = wrapper.find('.security-requirement-badge')
+    await badge.trigger('click')
+    await nextTick()
+    expect(document.body.textContent).toContain('Requires')
+
+    // A pinned popover ignores the pointer leaving, unlike a hover-opened one.
+    await badge.trigger('mouseleave')
+    await sleep(150)
+    await nextTick()
+
+    expect(document.body.textContent).toContain('Requires')
+
+    wrapper.unmount()
+  })
+
+  it('toggles closed on a second click', async () => {
+    const wrapper = await mountAndOpen(requiredAndGroup)
+    expect(document.body.textContent).toContain('Requires')
+
+    await wrapper.find('.security-requirement-badge').trigger('click')
+    await nextTick()
+
+    expect(document.body.textContent).not.toContain('Requires')
+
+    wrapper.unmount()
+  })
+
+  it('reopens on click after being dismissed with Escape', async () => {
+    disableConsoleError()
+    disableConsoleWarn()
+
+    const wrapper = mount(SecurityRequirementBadge, {
+      props: { requiredSecurity: requiredAndGroup },
+      attachTo: document.body,
+    })
+
+    const badge = wrapper.find('.security-requirement-badge')
+
+    // Open on hover, then dismiss with Escape.
+    await badge.trigger('mouseenter')
+    await nextTick()
+    expect(document.body.textContent).toContain('Requires')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await nextTick()
+    expect(document.body.textContent).not.toContain('Requires')
+
+    // The very next click must open it again — no stale guard swallowing it.
+    await badge.trigger('click')
+    await nextTick()
+    expect(document.body.textContent).toContain('Requires')
+
+    wrapper.unmount()
+  })
 })

--- a/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
+++ b/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ScalarPopover } from '@scalar/components/popover'
 import { ScalarIconLockSimple, ScalarIconLockSimpleOpen } from '@scalar/icons'
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, ref } from 'vue'
 
 import { useLocalization } from '@/features/localization'
 import SecurityRequirementBadgeScheme from '@/features/Operation/components/SecurityRequirementBadgeScheme.vue'
@@ -12,6 +12,38 @@ const { requiredSecurity, hideLabel = false } = defineProps<{
   hideLabel?: boolean
 }>()
 const { translate } = useLocalization()
+
+/**
+ * The popover is built on a click-triggered Headless UI popover. To also open
+ * it on hover we drive the same trigger button programmatically: the button
+ * reflects the open state via `aria-expanded`, so we toggle it by dispatching a
+ * click. A short close delay bridges the gap between the badge and the panel so
+ * moving the pointer onto the popover keeps it open.
+ */
+const triggerRef = ref<HTMLButtonElement | null>(null)
+let closeTimeout: ReturnType<typeof setTimeout> | undefined
+
+const isOpen = () => triggerRef.value?.getAttribute('aria-expanded') === 'true'
+
+const openOnHover = () => {
+  clearTimeout(closeTimeout)
+  if (!isOpen()) {
+    triggerRef.value?.click()
+  }
+}
+
+const closeOnHover = () => {
+  clearTimeout(closeTimeout)
+  closeTimeout = setTimeout(() => {
+    if (isOpen()) {
+      triggerRef.value?.click()
+    }
+  }, 120)
+}
+
+const cancelClose = () => clearTimeout(closeTimeout)
+
+onBeforeUnmount(() => clearTimeout(closeTimeout))
 
 const label = computed(() =>
   requiredSecurity.state === 'required'
@@ -50,6 +82,7 @@ const isOrAlternatives = computed(
     v-if="requiredSecurity.state !== 'none'"
     placement="bottom-end">
     <button
+      ref="triggerRef"
       class="security-requirement-badge inline-flex w-fit shrink-0 items-center justify-center gap-1 text-sm"
       :class="
         requiredSecurity.state === 'optional'
@@ -57,7 +90,9 @@ const isOrAlternatives = computed(
           : 'text-c-1 font-medium'
       "
       type="button"
-      @click.stop>
+      @click.stop
+      @mouseenter="openOnHover"
+      @mouseleave="closeOnHover">
       <ScalarIconLockSimple
         v-if="requiredSecurity.state === 'required'"
         class="size-3"
@@ -69,7 +104,10 @@ const isOrAlternatives = computed(
       <span v-if="!hideLabel">{{ label }}</span>
     </button>
     <template #popover>
-      <div class="flex max-w-xs min-w-48 flex-col gap-1.5 p-2 text-sm">
+      <div
+        class="flex max-w-xs min-w-48 flex-col gap-1.5 p-2 text-sm"
+        @mouseenter="cancelClose"
+        @mouseleave="closeOnHover">
         <div class="font-medium">
           {{ verb }}
           <template v-if="isSingleScheme">

--- a/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
+++ b/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
@@ -25,16 +25,44 @@ let closeTimeout: ReturnType<typeof setTimeout> | undefined
 
 const isOpen = () => triggerRef.value?.getAttribute('aria-expanded') === 'true'
 
+/**
+ * Swallow the real click that immediately follows a hover-open. A single
+ * pointer gesture fires `mouseenter` (which opens the popover here) and then a
+ * `click` — without this guard that click would toggle the freshly opened
+ * popover straight back closed, so a tap or click from outside could never open
+ * it. Runs in the capture phase on the document so it beats Headless UI's own
+ * click handler on the trigger button, then disarms itself.
+ */
+const swallowNextClick = (event: MouseEvent) => {
+  document.removeEventListener('click', swallowNextClick, true)
+  const target = event.target as Node | null
+  if (target && triggerRef.value?.contains(target)) {
+    event.stopImmediatePropagation()
+    event.preventDefault()
+  }
+}
+
+const armClickGuard = () =>
+  document.addEventListener('click', swallowNextClick, true)
+const disarmClickGuard = () =>
+  document.removeEventListener('click', swallowNextClick, true)
+
 const openOnHover = () => {
   clearTimeout(closeTimeout)
-  if (!isOpen()) {
-    triggerRef.value?.click()
+  if (isOpen()) {
+    return
   }
+  // Clear any stale guard so it cannot swallow the synthetic open click below.
+  disarmClickGuard()
+  triggerRef.value?.click()
+  // Arm only after opening, so the guard targets the upcoming real click.
+  armClickGuard()
 }
 
 const closeOnHover = () => {
   clearTimeout(closeTimeout)
   closeTimeout = setTimeout(() => {
+    disarmClickGuard()
     if (isOpen()) {
       triggerRef.value?.click()
     }
@@ -43,7 +71,10 @@ const closeOnHover = () => {
 
 const cancelClose = () => clearTimeout(closeTimeout)
 
-onBeforeUnmount(() => clearTimeout(closeTimeout))
+onBeforeUnmount(() => {
+  clearTimeout(closeTimeout)
+  disarmClickGuard()
+})
 
 const label = computed(() =>
   requiredSecurity.state === 'required'

--- a/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
+++ b/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
@@ -152,6 +152,7 @@ const isOrAlternatives = computed(
         v-if="isOpen"
         ref="panelRef"
         class="relative flex flex-col p-0.75"
+        @click.stop
         @mouseenter="cancelClose"
         @mouseleave="scheduleClose">
         <div class="flex max-w-xs min-w-48 flex-col gap-1.5 p-2 text-sm">

--- a/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
+++ b/packages/api-reference/src/features/Operation/components/SecurityRequirementBadge.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
-import { ScalarPopover } from '@scalar/components/popover'
+import {
+  ScalarFloating,
+  ScalarFloatingBackdrop,
+} from '@scalar/components/floating'
 import { ScalarIconLockSimple, ScalarIconLockSimpleOpen } from '@scalar/icons'
+import { onClickOutside, onKeyStroke } from '@vueuse/core'
 import { computed, onBeforeUnmount, ref } from 'vue'
 
 import { useLocalization } from '@/features/localization'
@@ -14,67 +18,74 @@ const { requiredSecurity, hideLabel = false } = defineProps<{
 const { translate } = useLocalization()
 
 /**
- * The popover is built on a click-triggered Headless UI popover. To also open
- * it on hover we drive the same trigger button programmatically: the button
- * reflects the open state via `aria-expanded`, so we toggle it by dispatching a
- * click. A short close delay bridges the gap between the badge and the panel so
- * moving the pointer onto the popover keeps it open.
+ * The badge shows a small panel with the security details. It opens on hover
+ * and on click, so we own the open state directly instead of leaning on a
+ * click-only popover. Owning the state keeps the two interactions from fighting
+ * each other: hover and the click of the same gesture (a tap fires both) can no
+ * longer toggle each other off.
  */
 const triggerRef = ref<HTMLButtonElement | null>(null)
-let closeTimeout: ReturnType<typeof setTimeout> | undefined
-
-const isOpen = () => triggerRef.value?.getAttribute('aria-expanded') === 'true'
+const panelRef = ref<HTMLElement | null>(null)
+const isOpen = ref(false)
 
 /**
- * Swallow the real click that immediately follows a hover-open. A single
- * pointer gesture fires `mouseenter` (which opens the popover here) and then a
- * `click` — without this guard that click would toggle the freshly opened
- * popover straight back closed, so a tap or click from outside could never open
- * it. Runs in the capture phase on the document so it beats Headless UI's own
- * click handler on the trigger button, then disarms itself.
+ * Whether the panel is pinned open by a click. A pinned panel ignores the
+ * pointer leaving so it behaves like the old click-to-open popover, and it only
+ * closes on another click, a click outside, or Escape.
  */
-const swallowNextClick = (event: MouseEvent) => {
-  document.removeEventListener('click', swallowNextClick, true)
-  const target = event.target as Node | null
-  if (target && triggerRef.value?.contains(target)) {
-    event.stopImmediatePropagation()
-    event.preventDefault()
-  }
-}
+const isPinned = ref(false)
+let closeTimeout: ReturnType<typeof setTimeout> | undefined
 
-const armClickGuard = () =>
-  document.addEventListener('click', swallowNextClick, true)
-const disarmClickGuard = () =>
-  document.removeEventListener('click', swallowNextClick, true)
-
-const openOnHover = () => {
-  clearTimeout(closeTimeout)
-  if (isOpen()) {
+/**
+ * Close after a short delay so the pointer can travel across the gap between the
+ * badge and the panel without the panel disappearing. A pinned panel stays open.
+ */
+const scheduleClose = () => {
+  if (isPinned.value) {
     return
   }
-  // Clear any stale guard so it cannot swallow the synthetic open click below.
-  disarmClickGuard()
-  triggerRef.value?.click()
-  // Arm only after opening, so the guard targets the upcoming real click.
-  armClickGuard()
-}
-
-const closeOnHover = () => {
   clearTimeout(closeTimeout)
   closeTimeout = setTimeout(() => {
-    disarmClickGuard()
-    if (isOpen()) {
-      triggerRef.value?.click()
-    }
+    isOpen.value = false
   }, 120)
 }
 
 const cancelClose = () => clearTimeout(closeTimeout)
 
-onBeforeUnmount(() => {
-  clearTimeout(closeTimeout)
-  disarmClickGuard()
+const openOnHover = () => {
+  cancelClose()
+  isOpen.value = true
+}
+
+const close = () => {
+  cancelClose()
+  isOpen.value = false
+  isPinned.value = false
+}
+
+/**
+ * Toggle on click. A hover already opened the panel (and a tap's `mouseenter`
+ * fires just before its `click`), so the first click pins it open rather than
+ * closing it; a click on an already pinned panel closes it.
+ */
+const toggleOnClick = () => {
+  if (isPinned.value) {
+    close()
+    return
+  }
+  cancelClose()
+  isOpen.value = true
+  isPinned.value = true
+}
+
+onClickOutside(triggerRef, close, { ignore: [panelRef] })
+onKeyStroke('Escape', () => {
+  if (isOpen.value) {
+    close()
+  }
 })
+
+onBeforeUnmount(() => clearTimeout(closeTimeout))
 
 const label = computed(() =>
   requiredSecurity.state === 'required'
@@ -109,7 +120,7 @@ const isOrAlternatives = computed(
 </script>
 
 <template>
-  <ScalarPopover
+  <ScalarFloating
     v-if="requiredSecurity.state !== 'none'"
     placement="bottom-end">
     <button
@@ -121,9 +132,11 @@ const isOrAlternatives = computed(
           : 'text-c-1 font-medium'
       "
       type="button"
-      @click.stop
+      :aria-expanded="isOpen"
+      aria-haspopup="dialog"
+      @click.stop="toggleOnClick"
       @mouseenter="openOnHover"
-      @mouseleave="closeOnHover">
+      @mouseleave="scheduleClose">
       <ScalarIconLockSimple
         v-if="requiredSecurity.state === 'required'"
         class="size-3"
@@ -134,66 +147,71 @@ const isOrAlternatives = computed(
         weight="bold" />
       <span v-if="!hideLabel">{{ label }}</span>
     </button>
-    <template #popover>
+    <template #floating>
       <div
-        class="flex max-w-xs min-w-48 flex-col gap-1.5 p-2 text-sm"
+        v-if="isOpen"
+        ref="panelRef"
+        class="relative flex flex-col p-0.75"
         @mouseenter="cancelClose"
-        @mouseleave="closeOnHover">
-        <div class="font-medium">
-          {{ verb }}
-          <template v-if="isSingleScheme">
-            <SecurityRequirementBadgeScheme
-              is="span"
-              class="contents"
-              :scheme="requiredSecurity.requirements[0]!.schemes[0]!" />
-          </template>
-          <template v-else-if="isOrAlternatives">
-            {{ translate('authentication.oneOf') }}
-          </template>
-          <template v-else-if="isAndGroup">
-            {{ translate('authentication.allOf') }}
-          </template>
-          <template v-else>
-            {{ translate('authentication.authentication') }}
-          </template>
-        </div>
-
-        <!-- Multiple OR alternatives -->
-        <ul
-          v-if="isOrAlternatives"
-          class="contents">
-          <li
-            v-for="(group, gi) in requiredSecurity.requirements"
-            :key="gi"
-            class="markdown">
-            <!-- Single scheme in this OR branch -->
-            <SecurityRequirementBadgeScheme
-              is="span"
-              v-if="group.schemes.length === 1"
-              class="contents"
-              :scheme="group.schemes[0]!" />
-            <!-- Multiple AND schemes in this OR branch -->
-            <template v-else>
-              <ul class="contents">
-                <SecurityRequirementBadgeScheme
-                  v-for="(scheme, si) in group.schemes"
-                  :key="si"
-                  :scheme />
-              </ul>
+        @mouseleave="scheduleClose">
+        <div class="flex max-w-xs min-w-48 flex-col gap-1.5 p-2 text-sm">
+          <div class="font-medium">
+            {{ verb }}
+            <template v-if="isSingleScheme">
+              <SecurityRequirementBadgeScheme
+                is="span"
+                class="contents"
+                :scheme="requiredSecurity.requirements[0]!.schemes[0]!" />
             </template>
-          </li>
-        </ul>
+            <template v-else-if="isOrAlternatives">
+              {{ translate('authentication.oneOf') }}
+            </template>
+            <template v-else-if="isAndGroup">
+              {{ translate('authentication.allOf') }}
+            </template>
+            <template v-else>
+              {{ translate('authentication.authentication') }}
+            </template>
+          </div>
 
-        <!-- Single group, multiple AND schemes -->
-        <ul
-          v-else-if="isAndGroup"
-          class="contents">
-          <SecurityRequirementBadgeScheme
-            v-for="(scheme, key) in requiredSecurity.requirements[0]!.schemes"
-            :key
-            :scheme />
-        </ul>
+          <!-- Multiple OR alternatives -->
+          <ul
+            v-if="isOrAlternatives"
+            class="contents">
+            <li
+              v-for="(group, gi) in requiredSecurity.requirements"
+              :key="gi"
+              class="markdown">
+              <!-- Single scheme in this OR branch -->
+              <SecurityRequirementBadgeScheme
+                is="span"
+                v-if="group.schemes.length === 1"
+                class="contents"
+                :scheme="group.schemes[0]!" />
+              <!-- Multiple AND schemes in this OR branch -->
+              <template v-else>
+                <ul class="contents">
+                  <SecurityRequirementBadgeScheme
+                    v-for="(scheme, si) in group.schemes"
+                    :key="si"
+                    :scheme />
+                </ul>
+              </template>
+            </li>
+          </ul>
+
+          <!-- Single group, multiple AND schemes -->
+          <ul
+            v-else-if="isAndGroup"
+            class="contents">
+            <SecurityRequirementBadgeScheme
+              v-for="(scheme, key) in requiredSecurity.requirements[0]!.schemes"
+              :key
+              :scheme />
+          </ul>
+        </div>
+        <ScalarFloatingBackdrop />
       </div>
     </template>
-  </ScalarPopover>
+  </ScalarFloating>
 </template>


### PR DESCRIPTION
The "Auth Required" / "Auth Optional" badge on operations only opened its details popover on click. Now it opens on hover too (click still works).

Moving the pointer onto the popover keeps it open, with a short close delay bridging the gap between the badge and the panel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI interaction change in api-reference with broad unit test coverage; no auth or API behavior changes.
> 
> **Overview**
> **Auth Required / Auth Optional** badges on operations now show security details on **hover** as well as click.
> 
> `SecurityRequirementBadge` drops `ScalarPopover` for `ScalarFloating` and **manages open state locally** (`isOpen`, `isPinned`). Hover opens the panel; the first click after hover **pins** it (so tap doesn’t immediately close). Unpinned panels close after pointer leave with a **~120ms delay** so users can move onto the panel; pinned panels stay open until another click, outside click, or Escape. Panel clicks still use `@click.stop` so they don’t toggle the parent operation accordion.
> 
> Tests cover hover open/close, hover-then-click, pin-on-leave, toggle, Escape + reopen, and panel click bubbling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1de1e24399b92e2a2c4b687028b6ea73562545d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->