### PR TITLE
fix(types): type the `defaultHttpClient` config against real client ids

### DIFF
--- a/.changeset/type-default-http-client-key.md
+++ b/.changeset/type-default-http-client-key.md
@@ -1,5 +1,6 @@
 ---
 '@scalar/types': patch
+'@scalar/schemas': patch
 ---
 
-Type the `defaultHttpClient` config against the real client ids. `targetKey` and `clientKey` were plain `string`, so there was no autocomplete and no error when the value was wrong — for example passing the display title `'Fetch'` instead of the client id `'fetch'`, which silently did nothing. They are now typed to the actual targets and clients.
+Type the `defaultHttpClient` config against the real client ids. `targetKey` and `clientKey` were plain `string`, so there was no autocomplete and no error when the value was wrong — for example passing the display title `'Fetch'` instead of the client id `'fetch'`, which silently did nothing. They are now typed to the actual targets and clients, in both the `@scalar/types` and `@scalar/schemas` definitions.

--- a/.changeset/type-default-http-client-key.md
+++ b/.changeset/type-default-http-client-key.md
@@ -1,0 +1,5 @@
+---
+'@scalar/types': patch
+---
+
+Type the `defaultHttpClient` config against the real client ids. `targetKey` and `clientKey` were plain `string`, so there was no autocomplete and no error when the value was wrong — for example passing the display title `'Fetch'` instead of the client id `'fetch'`, which silently did nothing. They are now typed to the actual targets and clients.

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -123,9 +123,13 @@ export const apiReferenceConfigurationSchema = intersection([
       },
     ),
     defaultHttpClient: optional(
+      // The keys stay permissive strings at runtime, so `coerce` leaves an unknown value
+      // untouched (a real union would rewrite it to the first client). The cast only tightens
+      // the type, so config authors get autocomplete and an error on typos like the display
+      // title 'Fetch' (the client id is the lowercase 'fetch').
       object({
-        targetKey: string(),
-        clientKey: string(),
+        targetKey: string() as unknown as LiteralSchema<TargetId>,
+        clientKey: string() as unknown as LiteralSchema<ClientId<TargetId>>,
       }),
       {
         typeComment: 'Determine the HTTP client that is selected by default',

--- a/packages/types/src/api-reference/api-reference-configuration.test-d.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.test-d.ts
@@ -1,0 +1,28 @@
+import { assertType, describe, it } from 'vitest'
+
+import type { ApiReferenceConfiguration } from './api-reference-configuration'
+
+describe('defaultHttpClient', () => {
+  it('accepts a target with one of its client ids', () => {
+    assertType<ApiReferenceConfiguration['defaultHttpClient']>({
+      targetKey: 'node',
+      clientKey: 'fetch',
+    })
+  })
+
+  it('rejects the display title used as a client id', () => {
+    assertType<ApiReferenceConfiguration['defaultHttpClient']>({
+      targetKey: 'node',
+      // @ts-expect-error the client id is lowercase 'fetch', not the title 'Fetch'
+      clientKey: 'Fetch',
+    })
+  })
+
+  it('rejects an unknown client id', () => {
+    assertType<ApiReferenceConfiguration['defaultHttpClient']>({
+      targetKey: 'node',
+      // @ts-expect-error 'not-a-client' is not a known client id
+      clientKey: 'not-a-client',
+    })
+  })
+})

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -164,7 +164,7 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
   defaultHttpClient: z
     .object({
       targetKey: z.custom<TargetId>(),
-      clientKey: z.string(),
+      clientKey: z.custom<ClientId<TargetId>>(),
     })
     .optional(),
   /** Custom CSS to be added to the page */

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -686,8 +686,8 @@ type ExtendedConfiguration = {
     | true
   /** Determine the HTTP client that is selected by default */
   defaultHttpClient?: {
-    targetKey: string
-    clientKey: string
+    targetKey: TargetId
+    clientKey: ClientId<TargetId>
   }
   /** Custom CSS to be added to the page */
   customCss?: string


### PR DESCRIPTION
Follow-up to #9680, on the api-reference config side.

The `defaultHttpClient` config used plain `string` for both `targetKey` and `clientKey`:

```ts
defaultHttpClient?: { targetKey: string; clientKey: string }
```

So there was no autocomplete and no error when the value was wrong. The gotcha: `clientKey` must be the lowercase client id (`fetch`, `undici`, `curl`) — the value gets joined into `` `${targetKey}/${clientKey}` `` and matched against the known clients. Passing the display title `'Fetch'` just silently does nothing.

This types both fields against the real targets and clients, so you now get autocomplete and a type error on `'Fetch'`. Type-only change; the runtime schemas stay permissive, so no existing config breaks.

Both definitions are covered:
- `@scalar/types` — the hand-written config type (`types.ts`) and the zod schema.
- `@scalar/schemas` — the parallel valibot-style schema. Here the runtime stays a permissive `string()` on purpose: making it a real union of literals would cause `coerce` to silently rewrite an unknown value to the first client (e.g. a typo'd `clientKey` → `axios`), which is worse than today. The cast tightens only the type.

Added a `.test-d.ts` proving `'fetch'` is accepted and `'Fetch'` / unknown ids are rejected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only tightening on API reference config; runtime schemas remain permissive, so behavior is unchanged except stricter TypeScript for integrators.
> 
> **Overview**
> **`defaultHttpClient`** is now typed with **`TargetId`** and **`ClientId<TargetId>`** instead of plain strings in `@scalar/types` (hand-written config + Zod) and in `@scalar/schemas` (Valibot schema via type-only literal casts).
> 
> Config authors get autocomplete and compile-time errors for mistakes like using the display title **`'Fetch'`** instead of the client id **`'fetch'`**, which previously failed silently at runtime. Runtime validation stays permissive (`string()` / `z.custom`) so existing configs are not rewritten or broken by coercion.
> 
> Adds **`api-reference-configuration.test-d.ts`** to assert valid ids are accepted and bad values are rejected at the type level.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1240ebe7a0ac0c36d5c64d6ad22a1d1a2baf64df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->