### PR TITLE
fix(types): type the hiddenClients config against real target and client ids

### DIFF
--- a/.changeset/type-hidden-clients.md
+++ b/.changeset/type-hidden-clients.md
@@ -1,0 +1,6 @@
+---
+'@scalar/types': patch
+'@scalar/schemas': patch
+---
+
+Type the `hiddenClients` config against the real target and client ids. It was `Record<string, boolean | string[]> | string[] | true`, so there was no autocomplete and no error on a typo. An array entry is now typed as a target (`'node'`), a client name (`'fetch'`), or a full id (`'node/fetch'`), and the record form is keyed by target. Runtime stays permissive, so unknown names are still ignored gracefully as before.

--- a/packages/api-client/src/v2/features/modal/helpers/map-hidden-clients-config.test.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/map-hidden-clients-config.test.ts
@@ -3,13 +3,15 @@ import { describe, expect, it } from 'vitest'
 
 import { mapHiddenClientsConfig } from './map-hidden-clients-config'
 
+type HiddenClients = Parameters<typeof mapHiddenClientsConfig>[0]
+
 describe('mapHiddenClientsConfig', () => {
   /**
    * Array format - hiding specific clients by their full identifiers
    * This is the most straightforward case where users list exact client IDs to hide.
    */
   it('filters out specific clients when hiddenClients is an array', () => {
-    const hiddenClients = ['js/fetch', 'js/axios', 'java/unirest']
+    const hiddenClients: HiddenClients = ['js/fetch', 'js/axios', 'java/unirest']
     const result = mapHiddenClientsConfig(hiddenClients)
 
     // Should not include the hidden clients
@@ -28,7 +30,7 @@ describe('mapHiddenClientsConfig', () => {
 
   /** Array format - hiding cross language clients */
   it('filters out groups of clients when hiddenClients is an array', () => {
-    const hiddenClients = ['fetch', 'axios', 'ruby']
+    const hiddenClients: HiddenClients = ['fetch', 'axios', 'ruby']
     const result = mapHiddenClientsConfig(hiddenClients)
 
     // Should not include the hidden clients
@@ -40,7 +42,7 @@ describe('mapHiddenClientsConfig', () => {
 
   /** Array format - hiding whole groups */
   it('filters out groups of clients when hiddenClients is an array', () => {
-    const hiddenClients = ['js', 'java', 'ruby']
+    const hiddenClients: HiddenClients = ['js', 'java', 'ruby']
     const result = mapHiddenClientsConfig(hiddenClients)
 
     // Should not include the hidden clients
@@ -69,7 +71,7 @@ describe('mapHiddenClientsConfig', () => {
    * When a target is set to true, all clients for that language should be hidden.
    */
   it('filters out entire target languages when hiddenClients object has boolean true values', () => {
-    const hiddenClients = { node: true, python: true }
+    const hiddenClients: HiddenClients = { node: true, python: true }
     const result = mapHiddenClientsConfig(hiddenClients)
 
     // Should not include any node clients
@@ -95,7 +97,7 @@ describe('mapHiddenClientsConfig', () => {
    * This allows fine-grained control to hide only certain clients of a language.
    */
   it('filters out specific clients within a target when hiddenClients object has array values', () => {
-    const hiddenClients = { python: ['requests', 'httpx_async'], java: ['unirest'] }
+    const hiddenClients: HiddenClients = { python: ['requests', 'httpx_async'], java: ['unirest'] }
     const result = mapHiddenClientsConfig(hiddenClients)
 
     // Should not include the specified python clients
@@ -121,7 +123,7 @@ describe('mapHiddenClientsConfig', () => {
    * and others have only specific clients hidden.
    */
   it('handles mixed object format with both boolean and array values', () => {
-    const hiddenClients = {
+    const hiddenClients: HiddenClients = {
       node: true, // Hide all node clients
       python: ['requests'], // Hide only python requests
       js: ['axios', 'jquery'], // Hide specific js clients

--- a/packages/api-reference/test/configuration/hidden-clients.e2e.ts
+++ b/packages/api-reference/test/configuration/hidden-clients.e2e.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import galaxy from '@scalar/galaxy/latest.json' with { type: 'json' }
+import type { HtmlRenderingConfiguration } from '@scalar/types/api-reference'
 import { serveExample } from '@test/utils/serve-example'
 
 test.describe('hiddenClients', () => {
@@ -162,11 +163,13 @@ test.describe('hiddenClients', () => {
 
   test('handles non-existent names gracefully', async ({ page }) => {
     const example = await serveExample({
+      // Intentionally invalid target and client names to verify they are ignored at runtime.
+      // Cast past the typed config, which only allows real ids.
       hiddenClients: {
         nonexistent: true,
         alsoNonexistent: ['fetch'],
         js: ['does-not-exist'],
-      },
+      } as unknown as HtmlRenderingConfiguration['hiddenClients'],
     })
 
     await page.goto(example)

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -1,5 +1,7 @@
 import { DEFAULT_MODELS_SECTION_LABEL } from '@scalar/types/api-reference'
+import type { AvailableClient, ClientId, TargetId } from '@scalar/types/snippetz'
 import {
+  type LiteralSchema,
   any,
   array,
   boolean,
@@ -103,7 +105,14 @@ export const apiReferenceConfigurationSchema = intersection([
       typeComment: 'Path to a favicon image',
     }),
     hiddenClients: optional(
-      union([record(string(), union([boolean(), array(string())])), array(string()), literal(true)]),
+      // The client/target names stay permissive strings at runtime, so `coerce` leaves unknown
+      // values untouched (a real union would rewrite them to the first literal). The casts only
+      // tighten the type so config authors get autocomplete on the known ids.
+      union([
+        record(string(), union([boolean(), array(string() as unknown as LiteralSchema<ClientId<TargetId>>)])),
+        array(string() as unknown as LiteralSchema<TargetId | ClientId<TargetId> | AvailableClient>),
+        literal(true),
+      ]),
       {
         typeComment:
           'List of httpsnippet clients to hide from the clients menu. By default hides Unirest, pass `[]` to show all clients',

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -1,6 +1,6 @@
 import { type ZodType, z } from 'zod'
 
-import type { TargetId } from '../snippetz'
+import type { AvailableClient, ClientId, TargetId } from '../snippetz'
 import { apiReferencePluginSchema } from './api-reference-plugin'
 import type { AuthenticationConfiguration } from './authentication-configuration'
 import { NEW_PROXY_URL, OLD_PROXY_URL, baseConfigurationSchema } from './base-configuration'
@@ -137,7 +137,11 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
    * By default hides Unirest, pass `[]` to show all clients
    */
   hiddenClients: z
-    .union([z.record(z.string(), z.union([z.boolean(), z.array(z.string())])), z.array(z.string()), z.literal(true)])
+    .union([
+      z.record(z.string(), z.union([z.boolean(), z.array(z.custom<ClientId<TargetId>>())])),
+      z.array(z.custom<TargetId | ClientId<TargetId> | AvailableClient>()),
+      z.literal(true),
+    ])
     .optional(),
   /** Determine the HTTP client that's selected by default */
   defaultHttpClient: z

--- a/packages/types/src/api-reference/hidden-clients.test-d.ts
+++ b/packages/types/src/api-reference/hidden-clients.test-d.ts
@@ -1,0 +1,29 @@
+import { assertType, describe, it } from 'vitest'
+
+import type { ApiReferenceConfiguration } from './types'
+
+type HiddenClients = ApiReferenceConfiguration['hiddenClients']
+
+describe('hiddenClients', () => {
+  it('accepts a list of targets, client names, and full ids', () => {
+    assertType<HiddenClients>(['node', 'fetch', 'node/fetch'])
+  })
+
+  it('accepts the record form keyed by target', () => {
+    assertType<HiddenClients>({ node: ['fetch', 'axios'], python: true })
+  })
+
+  it('accepts true to hide every client', () => {
+    assertType<HiddenClients>(true)
+  })
+
+  it('rejects an unknown client name in the array', () => {
+    // @ts-expect-error 'nope' is not a known client id
+    assertType<HiddenClients>(['nope'])
+  })
+
+  it('rejects an unknown target key in the record', () => {
+    // @ts-expect-error 'nope' is not a known target
+    assertType<HiddenClients>({ nope: true })
+  })
+})

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -1,5 +1,6 @@
 import type { PartialDeep } from 'type-fest'
 
+import type { AvailableClient, ClientId, TargetId } from '../snippetz'
 import type { PluginAuthState } from './api-reference-plugin'
 
 /** Some common properties used in all security schemes */
@@ -656,8 +657,16 @@ type ExtendedConfiguration = {
   metaData?: any
   /** Path to a favicon image */
   favicon?: string
-  /** List of httpsnippet clients to hide from the clients menu. By default hides Unirest, pass `[]` to show all clients */
-  hiddenClients?: Record<string, boolean | string[]> | string[] | true
+  /**
+   * List of httpsnippet clients to hide from the clients menu. By default hides Unirest, pass `[]` to show all clients
+   *
+   * An entry can be a target (`'node'`), a client name (`'fetch'`), or a full id (`'node/fetch'`). The record form is
+   * keyed by target, with `true` to hide the whole target or a list of client names to hide within it.
+   */
+  hiddenClients?:
+    | Partial<Record<TargetId, boolean | ClientId<TargetId>[]>>
+    | Array<TargetId | ClientId<TargetId> | AvailableClient>
+    | true
   /** Determine the HTTP client that is selected by default */
   defaultHttpClient?: {
     targetKey: string


### PR DESCRIPTION
Third in the client-id typing series (after #9680 and #9684).

`hiddenClients` was typed as `Record<string, boolean | string[]> | string[] | true`, so there was no autocomplete and no error on a typo. Based on how the config is actually consumed, an entry can be:

- a **target** — `'node'` (hides the whole target)
- a **client name** — `'fetch'` (hides that client everywhere)
- a **full id** — `'node/fetch'` (hides that one client)

The record form is keyed by target, with `true` or a list of client names. The type now reflects exactly this, so you get autocomplete and a type error on unknown names.

Runtime stays permissive on purpose: `hiddenClients` is meant to ignore unknown names gracefully (there is an e2e test for it), and a strict runtime union would make `coerce` rewrite an unknown value to the first client. So the `@scalar/schemas` schema keeps `string()` at runtime and only tightens the type, matching #9684. The one e2e test that passes deliberately-invalid names now casts past the type.

Added a `.test-d.ts` covering the array, record, and `true` forms plus rejections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only tightening in @scalar/types and @scalar/schemas with permissive runtime validation unchanged; no changes to client-hiding logic.
> 
> **Overview**
> **`hiddenClients`** is now typed with snippetz **`TargetId`**, **`ClientId`**, and **`AvailableClient`** instead of loose strings, so config authors get autocomplete and compile-time errors on typos.
> 
> Array entries can be a target (`'node'`), a cross-language client name (`'fetch'`), or a full id (`'node/fetch'`). The record form is **`Partial<Record<TargetId, boolean | ClientId[]>>`**, matching how the option is consumed. **`@scalar/types`** (Zod + `types.ts`), **`@scalar/schemas`** (validation schema with type-only casts), tests, and a **`.test-d.ts`** cover valid shapes and rejections.
> 
> **Runtime behavior is unchanged:** schemas still accept arbitrary strings so unknown names are ignored gracefully; the e2e case that uses invalid keys now casts past the stricter type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f157e18ecd5375b4208ba55ab94e36fbcecea537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->