### PR TITLE
fix(blocks): serialize multipart array-of-objects as a JSON array

### DIFF
--- a/.changeset/tidy-melons-9688.md
+++ b/.changeset/tidy-melons-9688.md
@@ -1,0 +1,5 @@
+---
+'@scalar/blocks': patch
+---
+
+fix: multipart/form-data array-of-objects fields now serialize as a JSON array instead of a single object in generated request examples

--- a/packages/blocks/src/code-example/helpers/operation-to-har/process-body.test.ts
+++ b/packages/blocks/src/code-example/helpers/operation-to-har/process-body.test.ts
@@ -742,6 +742,85 @@ describe('processBody', () => {
       })
     })
 
+    it('serializes an array of objects as a single JSON array part (issue #9688)', () => {
+      const content = {
+        'multipart/form-data': {
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              asset_name: { type: 'string', example: 'asset name' },
+              items: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    item_id: { type: 'string', example: 'item-abc' },
+                    item_name: { type: 'string', example: 'english audio' },
+                    is_default: { type: 'boolean', example: true },
+                  },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [
+          { name: 'asset_name', value: 'asset name' },
+          {
+            name: 'items',
+            value: JSON.stringify([{ item_id: 'item-abc', item_name: 'english audio', is_default: true }]),
+            contentType: 'application/json',
+          },
+        ],
+      })
+    })
+
+    it('serializes an array of multiple objects as a single JSON array part (issue #9688)', () => {
+      const content = {
+        'multipart/form-data': {
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              items: {
+                type: 'array',
+                example: [{ id: 'a' }, { id: 'b' }],
+                items: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'string' },
+                  },
+                },
+              },
+            },
+          }),
+        },
+      }
+
+      const result = processBody({
+        requestBody: { content },
+        contentType: 'multipart/form-data',
+      })
+
+      expect(result).toEqual({
+        mimeType: 'multipart/form-data',
+        params: [
+          {
+            name: 'items',
+            value: JSON.stringify([{ id: 'a' }, { id: 'b' }]),
+            contentType: 'application/json',
+          },
+        ],
+      })
+    })
+
     it('handles multipart form data with primitive values', () => {
       const content = {
         'multipart/form-data': {

--- a/packages/blocks/src/code-example/helpers/operation-to-har/process-body.ts
+++ b/packages/blocks/src/code-example/helpers/operation-to-har/process-body.ts
@@ -126,21 +126,29 @@ const objectToFormParams = (
         value: JSON.stringify(unpackProxyObject(value)),
         contentType: 'application/json',
       })
+    } else if (
+      Array.isArray(value) &&
+      isMultipart &&
+      !parentKey &&
+      !hasFormStyle &&
+      value.some((item) => typeof item === 'object' && item !== null && !(item instanceof File))
+    ) {
+      /**
+       * Per OpenAPI 3.x: a top-level multipart array whose items are objects defaults to a single
+       * `application/json` part containing the whole array. Serializing each item into its own part
+       * would drop the enclosing array wrapper and emit a bare object (see issue #9688), so keep the
+       * array intact and stringify it as one value.
+       */
+      params.push({
+        name: key,
+        value: JSON.stringify(unpackProxyObject(value)),
+        contentType: 'application/json',
+      })
     } else if (Array.isArray(value)) {
       for (const item of value) {
         if (item instanceof File) {
           const file = unpackProxyObject(item)
           params.push({ name: key, value: `@${file.name}` })
-        } else if (isMultipart && !parentKey && !hasFormStyle && typeof item === 'object' && item !== null) {
-          /**
-           * Per OpenAPI 3.x: a top-level multipart array of complex items defaults each part
-           * to application/json, instead of flattening object items into dotted keys.
-           */
-          params.push({
-            name: key,
-            value: JSON.stringify(unpackProxyObject(item)),
-            contentType: 'application/json',
-          })
         } else {
           params.push({ name: key, value: String(item) })
         }

--- a/packages/blocks/src/code-example/helpers/operation-to-har/process-body.ts
+++ b/packages/blocks/src/code-example/helpers/operation-to-har/process-body.ts
@@ -1,4 +1,5 @@
 import { json2xml } from '@scalar/helpers/file/json2xml'
+import { isObjectLike } from '@scalar/helpers/object/is-object'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
@@ -131,7 +132,7 @@ const objectToFormParams = (
       isMultipart &&
       !parentKey &&
       !hasFormStyle &&
-      value.some((item) => typeof item === 'object' && item !== null && !(item instanceof File))
+      value.some((item) => isObjectLike(item) && !(item instanceof File))
     ) {
       /**
        * Per OpenAPI 3.x: a top-level multipart array whose items are objects defaults to a single


### PR DESCRIPTION
Multipart `type: array` of `type: object` fields were rendered as a bare object in generated request examples, so copied cURL snippets sent a malformed body. They now serialize as a JSON array, wrapper and all.

Arrays of files and arrays of primitives are untouched.

## Ticket

Fixes #9688

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized serialization fix in HAR/example generation for multipart bodies; behavior change only affects array-of-object fields without explicit encoding style.
> 
> **Overview**
> Fixes **#9688**: generated `multipart/form-data` request examples (and copied cURL) were wrong when a top-level field was an **array of objects**—each element became its own `application/json` part with a bare object, so the array wrapper was lost.
> 
> `objectToFormParams` in `process-body.ts` now treats top-level multipart arrays that contain object-like items (not `File`) like single complex values: **one part** named after the field, `contentType: application/json`, and `JSON.stringify` of the **full array**. The old per-item JSON branch inside the generic array loop was removed.
> 
> Arrays of primitives and arrays of files are unchanged. Tests cover schema-derived examples and explicit array examples with multiple objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed66d79ddba3d4f20516646983a3afd6ad395796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->