### PR TITLE
fix(api-reference): show constraints of primitive array items

### DIFF
--- a/.changeset/wild-actors-shine.md
+++ b/.changeset/wild-actors-shine.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Show the `format` of primitive array items (e.g. an array of `uuid` strings) in the schema property heading

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -49,6 +49,66 @@ describe('SchemaPropertyHeading', () => {
     expect(detailsElement.text()).toContain('date-time')
   })
 
+  it('renders the format of primitive array items', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: coerceValue(SchemaObjectSchema, {
+          type: 'array',
+          items: {
+            type: 'string',
+            format: 'uuid',
+          },
+        }),
+      },
+    })
+
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('array string[]')
+    expect(detailsElement.text()).toContain('uuid')
+  })
+
+  it('renders string constraints of primitive array items', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: coerceValue(SchemaObjectSchema, {
+          type: 'array',
+          items: {
+            type: 'string',
+            minLength: 2,
+            maxLength: 8,
+            pattern: '^[a-z]+$',
+          },
+        }),
+      },
+    })
+
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('2')
+    expect(detailsElement.text()).toContain('8')
+    expect(detailsElement.text()).toContain('^[a-z]+$')
+  })
+
+  it('renders numeric constraints of primitive array items', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: coerceValue(SchemaObjectSchema, {
+          type: 'array',
+          items: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 10,
+            multipleOf: 2,
+          },
+        }),
+      },
+    })
+
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('1')
+    expect(detailsElement.text()).toContain('10')
+    expect(detailsElement.text()).toContain('2')
+  })
+
   describe('const', () => {
     it('renders const value', () => {
       const wrapper = mount(SchemaPropertyHeading, {

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -83,33 +83,23 @@ const constValue = computed(() => {
   return undefined
 })
 
-const validationProperties = computed(() => {
-  if (!valueRef.value) {
-    return []
-  }
+type ValidationProperty = {
+  key: string
+  value: string | number
+  prefix?: string
+  code?: boolean
+  truncate?: boolean
+}
 
-  const schema = valueRef.value
-  const properties = []
+/**
+ * Constraints that live on a leaf (string or number) schema: length, pattern,
+ * format and numeric ranges. Extracted so they can be surfaced for a primitive
+ * schema as well as for a primitive array's items, which are not rendered on
+ * their own. See https://github.com/scalar/scalar/issues/9690
+ */
+const getLeafConstraints = (schema: SchemaObject) => {
+  const properties: ValidationProperty[] = []
 
-  // Array validation properties
-  if (isArraySchema(schema)) {
-    if (schema.minItems || schema.maxItems) {
-      properties.push({
-        key: 'array-range',
-        value: `${schema.minItems || ''}…${schema.maxItems || ''}`,
-      })
-    }
-
-    // Unique items
-    if (schema.uniqueItems) {
-      properties.push({
-        key: 'unique-items',
-        value: `${translate('common.unique')}!`,
-      })
-    }
-  }
-
-  // String length properties
   if (isStringSchema(schema)) {
     if (schema.minLength) {
       properties.push({
@@ -127,7 +117,6 @@ const validationProperties = computed(() => {
       })
     }
 
-    // Pattern
     if (schema.pattern) {
       properties.push({
         key: 'pattern',
@@ -138,18 +127,14 @@ const validationProperties = computed(() => {
     }
   }
 
-  // Format
-  if (isStringSchema(schema) || isNumberSchema(schema)) {
-    if (schema.format) {
-      properties.push({
-        key: 'format',
-        value: schema.format,
-        truncate: true,
-      })
-    }
+  if ((isStringSchema(schema) || isNumberSchema(schema)) && schema.format) {
+    properties.push({
+      key: 'format',
+      value: schema.format,
+      truncate: true,
+    })
   }
 
-  // Numeric validation properties
   if (isNumberSchema(schema)) {
     if (isDefined(schema.exclusiveMinimum)) {
       properties.push({
@@ -190,6 +175,43 @@ const validationProperties = computed(() => {
         value: schema.multipleOf,
       })
     }
+  }
+
+  return properties
+}
+
+const validationProperties = computed(() => {
+  if (!valueRef.value) {
+    return []
+  }
+
+  const schema = valueRef.value
+  const properties: ValidationProperty[] = []
+
+  // Array validation properties
+  if (isArraySchema(schema)) {
+    if (schema.minItems || schema.maxItems) {
+      properties.push({
+        key: 'array-range',
+        value: `${schema.minItems || ''}…${schema.maxItems || ''}`,
+      })
+    }
+
+    // Unique items
+    if (schema.uniqueItems) {
+      properties.push({
+        key: 'unique-items',
+        value: `${translate('common.unique')}!`,
+      })
+    }
+  }
+
+  properties.push(...getLeafConstraints(schema))
+
+  // Primitive array items carry their own constraints (e.g. an array of `uuid`
+  // strings) but are not rendered separately, so surface them here.
+  if (isArraySchema(schema) && schema.items) {
+    properties.push(...getLeafConstraints(resolve.schema(schema.items)))
   }
 
   return properties


### PR DESCRIPTION
Arrays of primitives (like an array of `uuid` strings) dropped the constraints defined on their items. The `format`, `minLength`/`maxLength`, `pattern`, and numeric range only showed up for standalone properties, never for the items of an array.

Now those constraints show up in the array's heading, matching what you already get for a plain string or number.

## Ticket

Fixes #9690

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in schema headings with refactored constraint extraction and new unit tests; no API or data handling impact.
> 
> **Overview**
> Fixes schema property headings so **arrays of primitives** show the same leaf constraints as standalone strings or numbers (e.g. `format: uuid`, length, pattern, min/max, `multipleOf`).
> 
> Leaf validation badges are moved into a shared **`getLeafConstraints`** helper. For `type: array`, the heading still shows array-level rules (`minItems`/`maxItems`, `uniqueItems`), then merges constraints from **resolved `items`** because those items are not rendered as their own row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b60f2ffb98f2d14064babb196422332fef41cc76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->