### PR TITLE
chore: link .claude/skills to .agents/skills

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
## Problem

The shared agent skills in `.agents/skills/` (`tests`, `typescript`, `vue-components`, `openapi-glossary`, `scalar-docs`, `mock-server`, `cloud-agents-starter`, `scalar-design-system`) are never discovered by Claude Code: it looks for skills under `.claude/skills`, but `.claude/` only contains `settings.json`. So all of that guidance is invisible to Claude Code sessions in this repo.

## Solution

Add a `.claude/skills` → `../.agents/skills` symlink — the same wiring `scalar/scalar-org` uses (and equivalent to `scalar/bane`'s `.claude` → `.agents` link). `.agents/skills/` stays the single source of truth; Claude Code now loads all eight skills on demand, including the `scalar-design-system` link into `packages/themes`. Verified the symlink resolves to all eight skills.

The alternative of duplicating skills under `.claude/skills/` was rejected because it would drift from `.agents/skills/`.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- not applicable: repo tooling only, no package changes -->
- [ ] I added tests. <!-- not applicable: a symlink, no runtime surface -->
- [ ] I updated the documentation. <!-- not needed: AGENTS.md already references .agents/skills -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zC3YQPAM6tWekpYj9h2oT

---
_Generated by [Claude Code](https://claude.ai/code/session_018zC3YQPAM6tWekpYj9h2oT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Repo tooling only—a symlink with no runtime, package, or application behavior changes.
> 
> **Overview**
> Adds a **`.claude/skills` symlink** to `../.agents/skills` so Claude Code loads the same eight shared skills (`tests`, `typescript`, `vue-components`, etc.) that already live under `.agents/skills/`, without copying or duplicating them.
> 
> `.agents/skills/` remains the single source of truth; only Claude’s expected discovery path is wired up (aligned with patterns used in other Scalar repos).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b982f723fbb5320cb32a5de43410e26adc769d8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->