### PR TITLE
docs: improve SEO metadata across scalar.com pages

### DIFF
--- a/documentation/guides/api-references/getting-started.md
+++ b/documentation/guides/api-references/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started
+# API References
 <div class="flex gap-2">
 <a href="https://www.npmjs.com/@scalar/api-reference" aria-label="View @scalar/api-reference on NPM"><img alt="NPM Version" src="https://img.shields.io/npm/v/@scalar/api-reference"></a>
 <a href="https://www.npmjs.com/@scalar/api-reference" aria-label="View NPM downloads for @scalar/api-reference"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@scalar/api-reference"></a>

--- a/documentation/guides/cli/getting-started.md
+++ b/documentation/guides/cli/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Scalar CLI
 <div class="flex gap-2">
 <a href="https://www.npmjs.com/@scalar/cli" aria-label="View @scalar/cli on NPM"><img alt="NPM Version" src="https://img.shields.io/npm/v/@scalar/cli"></a>
 <a href="https://www.npmjs.com/@scalar/cli" aria-label="View NPM downloads for @scalar/cli"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@scalar/cli"></a>

--- a/documentation/guides/customers/customers.md
+++ b/documentation/guides/customers/customers.md
@@ -1,5 +1,5 @@
 <div class="flex flex-col gap-3 hero small-test customers-hero">
-  <scalar-heading level="2" slug="customers" class="text-balance">
+  <scalar-heading level="1" slug="customers" class="text-balance">
     Trusted by the world's best API teams.
   </scalar-heading>
   <p>

--- a/documentation/guides/docs/configuration/site-config.md
+++ b/documentation/guides/docs/configuration/site-config.md
@@ -1,4 +1,4 @@
-# Site
+# Site Config
 
 The site configuration defines global settings for your documentation site: branding, custom head elements, footer content, and routing rules. These settings apply across your entire documentation site.
 

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Scalar Docs
 
 Documentation that stays in sync with your API and code. Pull content from GitHub, get previews on every pull request, deploy on merge, or publish from anywhere with the CLI.
 

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -10,7 +10,7 @@
       <span aria-hidden="true">→</span>
     </span>
   </a>
-  <scalar-heading level="2" slug="introduction" class="text-balance">
+  <scalar-heading level="1" slug="introduction" class="text-balance">
     API interfaces built for developers and agents
   </scalar-heading>
   <p>

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -1,5 +1,5 @@
 <div class="flex flex-col gap-3 hero small-test">
-  <scalar-heading level="2" slug="pricing" class="text-balance">
+  <scalar-heading level="1" slug="pricing" class="text-balance">
     Plans for every API interface
   </scalar-heading>
   <p>

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -37,10 +37,6 @@
       ],
       "meta": [
         {
-          "name": "description",
-          "content": "Guides for Scalar, covering your favorite frameworks, languages and use cases."
-        },
-        {
           "property": "og:image",
           "name": "og:image",
           "content": "https://api.scalar.com/cdn/images/IlMnm9Mxy-SabmLxE_i0L/8O99z8O2xzEypGxOzuZYo.png"
@@ -71,7 +67,7 @@
         },
         {
           "name": "twitter:card",
-          "content": "summary"
+          "content": "summary_large_image"
         },
         {
           "name": "twitter:title",
@@ -149,18 +145,6 @@
         {
           "from": "/download",
           "to": "/products/api-client/download"
-        },
-        {
-          "from": "/scalar/introduction",
-          "to": "/"
-        },
-        {
-          "from": "/scalar/pricing",
-          "to": "/pricing"
-        },
-        {
-          "from": "/scalar/access",
-          "to": "/products/docs/configuration/private-docs"
         },
         {
           "from": "/scalar/scalar-docs/getting-started",
@@ -559,10 +543,6 @@
           "to": "/resources/changelog/api-reference"
         },
         {
-          "from": "/download",
-          "to": "/products/api-client/download"
-        },
-        {
           "from": "/terms-and-conditions",
           "to": "/legal/terms-and-conditions"
         },
@@ -748,9 +728,11 @@
             "icon": "phosphor/regular/house",
             "description": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve.",
             "layout": {
-              "toc": false
+              "toc": false,
+              "pageTitle": false
             },
             "head": {
+              "title": "Scalar — API Documentation, SDKs, MCP Servers & API Client",
               "links": [
                 {
                   "rel": "canonical",
@@ -776,9 +758,11 @@
             "filepath": "documentation/guides/pricing.md",
             "type": "page",
             "layout": {
-              "toc": false
+              "toc": false,
+              "pageTitle": false
             },
             "head": {
+              "title": "Scalar Pricing — Plans for API Docs, SDKs & MCP Servers",
               "links": [
                 {
                   "rel": "canonical",
@@ -817,6 +801,7 @@
               "pageActions": false
             },
             "head": {
+              "title": "Scalar Customers — Trusted by the World's Best API Teams",
               "links": [
                 {
                   "rel": "canonical",
@@ -938,6 +923,7 @@
                     "title": "Getting Started",
                     "description": "Learn how to create and publish stunning developer documentation with Docs in minutes.",
                     "head": {
+                      "title": "Scalar Docs — API Documentation & Developer Docs Platform",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1342,6 +1328,7 @@
                     "filepath": "documentation/guides/agent/getting-started.md",
                     "description": "Turn OpenAPI into MCP servers and connect APIs to LLMs with minimal context usage, delegated auth, and the Agent SDK or chat UI.",
                     "head": {
+                      "title": "Scalar Agent — Turn OpenAPI into MCP Servers for LLMs",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1396,7 +1383,15 @@
                   "release-notes": {
                     "title": "Release notes",
                     "filepath": "packages/agent-chat/RELEASE_NOTES.md",
-                    "type": "page"
+                    "type": "page",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/changelog/agent"
+                        }
+                      ]
+                    }
                   },
                   "examples": {
                     "title": "Examples",
@@ -1445,6 +1440,7 @@
                     "title": "Getting Started",
                     "description": "Automatically generate type-safe SDKs from OpenAPI specifications in multiple programming languages.",
                     "head": {
+                      "title": "Scalar SDK Generator — Generate SDKs from OpenAPI",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1669,6 +1665,7 @@
                     "title": "Getting Started",
                     "description": "Store, version, and manage your OpenAPI specifications in a centralized registry with automated CI/CD workflows.",
                     "head": {
+                      "title": "Scalar Registry — OpenAPI Document Management & Versioning",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1740,6 +1737,7 @@
                     "type": "page",
                     "description": "Create stunning API documentation from OpenAPI specs with a modern, customizable interface and built-in request testing.",
                     "head": {
+                      "title": "Scalar API References — Interactive OpenAPI Documentation",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1914,11 +1912,13 @@
                       "html-js": {
                         "title": "HTML/JS",
                         "filepath": "documentation/integrations/html-js.md",
+                        "description": "Render a Scalar API reference from any OpenAPI document with a single HTML file or CDN script tag. No build step required.",
                         "type": "page"
                       },
                       "aspire": {
                         "title": "Aspire",
                         "filepath": "documentation/integrations/aspire.md",
+                        "description": "Add a Scalar API reference to your .NET Aspire application for interactive, beautiful API documentation.",
                         "type": "page"
                       },
                       "aspnetcore": {
@@ -1929,21 +1929,25 @@
                           "integration": {
                             "title": "Integration",
                             "filepath": "documentation/integrations/aspnetcore/integration.md",
+                            "description": "Add a Scalar API reference to ASP.NET Core with the Scalar.AspNetCore package. A modern Swagger UI alternative for .NET.",
                             "type": "page"
                           },
                           "build-time-generation": {
                             "title": "Build-Time Generation",
                             "filepath": "documentation/integrations/aspnetcore/build-time-generation.md",
+                            "description": "Generate OpenAPI documents for ASP.NET Core at build time and render them as a Scalar API reference.",
                             "type": "page"
                           },
                           "openapi-extensions": {
                             "title": "OpenAPI Extensions",
                             "filepath": "documentation/integrations/aspnetcore/openapi-extensions.md",
+                            "description": "Use Scalar OpenAPI extensions in ASP.NET Core to customize authentication, code samples, and more in your API reference.",
                             "type": "page"
                           },
                           "legacy-integration": {
                             "title": "Legacy Integration",
                             "filepath": "documentation/integrations/aspnetcore/legacy-integration.md",
+                            "description": "Integrate a Scalar API reference with legacy .NET applications and earlier ASP.NET Core versions.",
                             "type": "page"
                           }
                         }
@@ -1951,46 +1955,55 @@
                       "adonisjs": {
                         "title": "AdonisJS",
                         "filepath": "documentation/integrations/adonisjs.md",
+                        "description": "Add a Scalar API reference to your AdonisJS application for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "astro": {
                         "title": "Astro",
                         "filepath": "documentation/integrations/astro.md",
+                        "description": "Embed a Scalar API reference in your Astro site to publish interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "django": {
                         "title": "Django",
                         "filepath": "documentation/integrations/django.md",
+                        "description": "Add a Scalar API reference to your Django application for modern, interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "django-ninja": {
                         "title": "Django Ninja",
                         "filepath": "documentation/integrations/django-ninja.md",
+                        "description": "Replace the default Django Ninja docs with a Scalar API reference for modern, interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "docker": {
                         "title": "Docker",
                         "filepath": "documentation/integrations/docker.md",
+                        "description": "Serve a Scalar API reference from any OpenAPI document with the official Docker image. No code required.",
                         "type": "page"
                       },
                       "docusaurus": {
                         "title": "Docusaurus",
                         "filepath": "documentation/integrations/docusaurus.md",
+                        "description": "Add interactive Scalar API references to your Docusaurus site with the official plugin.",
                         "type": "page"
                       },
                       "effect": {
                         "title": "Effect",
                         "filepath": "documentation/integrations/effect.md",
+                        "description": "Add a Scalar API reference to your Effect HttpApi application for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "elixir": {
                         "title": "Elixir",
                         "filepath": "documentation/integrations/elixir.md",
+                        "description": "Add a Scalar API reference to your Elixir Phoenix application for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "elysiajs": {
                         "title": "ElysiaJS",
                         "filepath": "documentation/integrations/elysiajs.md",
+                        "description": "Add a Scalar API reference to your ElysiaJS app with the built-in swagger plugin for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "express": {
@@ -2044,46 +2057,55 @@
                       "fastify": {
                         "title": "Fastify",
                         "filepath": "documentation/integrations/fastify.md",
+                        "description": "Add a Scalar API reference to Fastify with the official @scalar/fastify-api-reference plugin.",
                         "type": "page"
                       },
                       "flask": {
                         "title": "Flask",
                         "filepath": "documentation/integrations/flask.md",
+                        "description": "Add a Scalar API reference to your Flask application. A modern Swagger UI alternative for Python APIs.",
                         "type": "page"
                       },
                       "go": {
                         "title": "Go",
                         "filepath": "documentation/integrations/go.md",
+                        "description": "Add a Scalar API reference to your Go HTTP server for modern, interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "hapi": {
                         "title": "Hapi",
                         "filepath": "documentation/integrations/hapi.md",
+                        "description": "Add a Scalar API reference to your Hapi application for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "hono": {
                         "title": "Hono",
                         "filepath": "documentation/integrations/hono.md",
+                        "description": "Add a Scalar API reference to Hono with the official @scalar/hono-api-reference middleware.",
                         "type": "page"
                       },
                       "java": {
                         "title": "Java",
                         "filepath": "documentation/integrations/java.md",
+                        "description": "Add a Scalar API reference to your Java application for modern, interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "laravel": {
                         "title": "Laravel",
                         "filepath": "documentation/integrations/laravel.md",
+                        "description": "Add a Scalar API reference to your Laravel application with the official package. A modern Swagger UI alternative for PHP.",
                         "type": "page"
                       },
                       "laravel-scribe": {
                         "title": "Laravel Scribe",
                         "filepath": "documentation/integrations/laravel-scribe.md",
+                        "description": "Use Scalar as the documentation UI for Laravel Scribe to get a modern, interactive API reference.",
                         "type": "page"
                       },
                       "micronaut": {
                         "title": "Micronaut",
                         "filepath": "documentation/integrations/micronaut.md",
+                        "description": "Add a Scalar API reference to your Micronaut application for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "nextjs": {
@@ -2113,26 +2135,31 @@
                       "nestjs": {
                         "title": "NestJS",
                         "filepath": "documentation/integrations/nestjs.md",
+                        "description": "Add a Scalar API reference to NestJS with @scalar/nestjs-api-reference. A modern Swagger UI alternative for Node.js.",
                         "type": "page"
                       },
                       "nitro": {
                         "title": "Nitro",
                         "filepath": "documentation/integrations/nitro.md",
+                        "description": "Add a Scalar API reference to your Nitro server for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "nuxt": {
                         "title": "Nuxt",
                         "filepath": "documentation/integrations/nuxt.md",
+                        "description": "Add a Scalar API reference to your Nuxt application with the official module for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "platformatic": {
                         "title": "Platformatic",
                         "filepath": "documentation/integrations/platformatic.md",
+                        "description": "Platformatic ships with Scalar built in. Serve a modern, interactive API reference out of the box.",
                         "type": "page"
                       },
                       "python": {
                         "title": "Python",
                         "filepath": "documentation/integrations/python.md",
+                        "description": "Add a Scalar API reference to any Python web framework for modern, interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "react": {
@@ -2162,6 +2189,7 @@
                       "ruby-on-rails": {
                         "title": "Ruby on Rails",
                         "filepath": "documentation/integrations/ruby-on-rails.md",
+                        "description": "Add a Scalar API reference to your Ruby on Rails application for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "rust": {
@@ -2172,26 +2200,31 @@
                           "": {
                             "title": "Rust",
                             "filepath": "documentation/integrations/rust.md",
+                            "description": "Add a Scalar API reference to your Rust web application for modern, interactive OpenAPI documentation.",
                             "type": "page"
                           },
                           "axum": {
                             "title": "Axum",
                             "filepath": "documentation/integrations/axum.md",
+                            "description": "Add a Scalar API reference to your Axum application for interactive OpenAPI documentation in Rust.",
                             "type": "page"
                           },
                           "actix-web": {
                             "title": "Actix-web",
                             "filepath": "documentation/integrations/actix-web.md",
+                            "description": "Add a Scalar API reference to your Actix-web application for interactive OpenAPI documentation in Rust.",
                             "type": "page"
                           },
                           "warp": {
                             "title": "Warp",
                             "filepath": "documentation/integrations/warp.md",
+                            "description": "Add a Scalar API reference to your Warp application for interactive OpenAPI documentation in Rust.",
                             "type": "page"
                           },
                           "aide": {
                             "title": "Aide",
                             "filepath": "documentation/integrations/aide.md",
+                            "description": "Add a Scalar API reference to your Aide application for interactive OpenAPI documentation in Rust.",
                             "type": "page"
                           }
                         }
@@ -2199,26 +2232,31 @@
                       "spring-boot": {
                         "title": "Spring Boot",
                         "filepath": "documentation/integrations/spring-boot.md",
+                        "description": "Add a Scalar API reference to Spring Boot with springdoc-openapi. A modern Swagger UI alternative for Java.",
                         "type": "page"
                       },
                       "spry": {
                         "title": "Spry",
                         "filepath": "documentation/integrations/spry.md",
+                        "description": "Add a Scalar API reference to your Spry application for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "sveltekit": {
                         "title": "SvelteKit",
                         "filepath": "documentation/integrations/sveltekit.md",
+                        "description": "Add a Scalar API reference to your SvelteKit application for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "tsed": {
                         "title": "Ts.ED",
                         "filepath": "documentation/integrations/tsed.md",
+                        "description": "Add a Scalar API reference to your Ts.ED application for interactive OpenAPI documentation.",
                         "type": "page"
                       },
                       "vue": {
                         "title": "Vue.js",
                         "filepath": "documentation/integrations/vue.md",
+                        "description": "Embed a Scalar API reference in your Vue.js application with the official component for interactive OpenAPI documentation.",
                         "type": "page"
                       }
                     }
@@ -2238,6 +2276,7 @@
                     "title": "Getting Started",
                     "description": "A modern, open-source API client built on the OpenAPI standard with offline-first design and cross-platform support.",
                     "head": {
+                      "title": "Scalar API Client — Free, Open-Source API Testing Client",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2305,7 +2344,7 @@
                       "links": [
                         {
                           "rel": "canonical",
-                          "href": "https://scalar.com/products/api-client/release-notes"
+                          "href": "https://scalar.com/resources/changelog/api-client"
                         }
                       ],
                       "meta": [
@@ -2639,6 +2678,7 @@
                     "title": "Getting Started",
                     "description": "Install and use the Scalar CLI to validate, bundle, and deploy OpenAPI specifications from your terminal.",
                     "head": {
+                      "title": "Scalar CLI — OpenAPI Tools for Your Terminal",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2690,6 +2730,7 @@
                     "type": "page",
                     "description": "Spin up realistic mock API servers instantly from OpenAPI specs with custom handlers and data seeding.",
                     "head": {
+                      "title": "Scalar Mock Server — Instant Mock APIs from OpenAPI",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2756,6 +2797,7 @@
                     "type": "page",
                     "description": "Migrate legacy Swagger 2.0 specs to modern OpenAPI 3.x formats automatically with our free conversion tool.",
                     "head": {
+                      "title": "OpenAPI Upgrader — Convert Swagger 2.0 to OpenAPI 3.1",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2805,10 +2847,36 @@
             "type": "page",
             "filepath": "documentation/guides/enterprise/enterprise.md",
             "showInSidebar": false,
+            "description": "Enterprise-grade API platform: one OpenAPI system of record for docs, SDKs, governance, and MCP servers with SSO and enterprise support.",
             "head": {
+              "title": "Scalar Enterprise — API Platform for Enterprise Teams",
               "scripts": [
                 {
                   "path": "documentation/assets/enterprise-contact-form.js"
+                }
+              ],
+              "links": [
+                {
+                  "rel": "canonical",
+                  "href": "https://scalar.com/enterprise"
+                }
+              ],
+              "meta": [
+                {
+                  "name": "description",
+                  "content": "Enterprise-grade API platform: one OpenAPI system of record for docs, SDKs, governance, and MCP servers with SSO and enterprise support."
+                },
+                {
+                  "property": "og:title",
+                  "content": "Scalar Enterprise — API Platform for Enterprise Teams"
+                },
+                {
+                  "property": "og:description",
+                  "content": "Enterprise-grade API platform: one OpenAPI system of record for docs, SDKs, governance, and MCP servers with SSO and enterprise support."
+                },
+                {
+                  "name": "robots",
+                  "content": "index, follow"
                 }
               ]
             },
@@ -2895,6 +2963,7 @@
                     "type": "page",
                     "description": "Complete guide to migrating from Swagger UI to API References with modern features and better UX.",
                     "head": {
+                      "title": "Swagger UI Alternative — Migrate to Scalar API References",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2924,21 +2993,25 @@
                   "stoplight": {
                     "title": "Stoplight",
                     "filepath": "documentation/migration/stoplight.md",
+                    "description": "Step-by-step guide to migrating your API documentation from Stoplight to Scalar.",
                     "type": "page"
                   },
                   "api-hub": {
                     "title": "API Hub",
                     "filepath": "documentation/migration/api-hub.md",
+                    "description": "How to migrate from Smartbear API Hub (formerly SwaggerHub) to Scalar for docs, registry, and API references.",
                     "type": "page"
                   },
                   "bump": {
                     "title": "Bump.sh",
                     "filepath": "documentation/migration/bump.md",
+                    "description": "Compare Bump.sh with Scalar and migrate your OpenAPI documentation step by step.",
                     "type": "page"
                   },
                   "zuplo": {
                     "title": "Zuplo",
                     "filepath": "documentation/migration/zuplo.md",
+                    "description": "Compare Zuplo docs with Scalar and migrate your API reference step by step.",
                     "type": "page"
                   }
                 }
@@ -2956,6 +3029,7 @@
                     "type": "page",
                     "description": "Set up SSO and SAML authentication for Scalar with enterprise identity providers and secure team access.",
                     "head": {
+                      "title": "SSO & SAML Single Sign-On for Scalar",
                       "links": [
                         {
                           "rel": "canonical",
@@ -3066,25 +3140,61 @@
                     "type": "page",
                     "title": "API Client",
                     "filepath": "projects/scalar-app/RELEASE_NOTES.md",
-                    "icon": "phosphor/regular/paper-plane-tilt"
+                    "icon": "phosphor/regular/paper-plane-tilt",
+                    "description": "Release notes for the Scalar API Client desktop and web app.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/changelog/api-client"
+                        }
+                      ]
+                    }
                   },
                   "/api-reference": {
                     "type": "page",
                     "title": "API Reference",
                     "filepath": "packages/api-reference/RELEASE_NOTES.md",
-                    "icon": "phosphor/regular/notebook"
+                    "icon": "phosphor/regular/notebook",
+                    "description": "Release notes for the Scalar API Reference.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/changelog/api-reference"
+                        }
+                      ]
+                    }
                   },
                   "/agent": {
                     "type": "page",
                     "title": "Agent",
                     "filepath": "packages/agent-chat/RELEASE_NOTES.md",
-                    "icon": "phosphor/regular/sparkle"
+                    "icon": "phosphor/regular/sparkle",
+                    "description": "Release notes for Scalar Agent and MCP servers.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/changelog/agent"
+                        }
+                      ]
+                    }
                   },
                   "/mock-server": {
                     "type": "page",
                     "title": "Mock Server",
                     "filepath": "packages/mock-server/RELEASE_NOTES.md",
-                    "icon": "phosphor/regular/cloud"
+                    "icon": "phosphor/regular/cloud",
+                    "description": "Release notes for the Scalar Mock Server.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/changelog/mock-server"
+                        }
+                      ]
+                    }
                   }
                 }
               },

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -949,6 +949,7 @@
                   "privacy": {
                     "title": "Privacy",
                     "type": "page",
+                    "description": "How Scalar Docs handles privacy: no analytics and no tracking scripts on your documentation by default.",
                     "filepath": "documentation/guides/docs/privacy.md"
                   },
                   "configuration": {
@@ -958,11 +959,13 @@
                     "icon": "phosphor/regular/gear",
                     "children": {
                       "starter-kit": {
+                        "description": "Scaffold a documentation site in minutes with the Scalar Docs starter kit: example pages, scalar.config.json, and GitHub deployment.",
                         "filepath": "documentation/guides/docs/starter-kit.md",
                         "type": "page",
                         "title": "Starter Kit"
                       },
                       "agent-skills": {
+                        "description": "Add Agent Skills to your repository so AI coding agents can write and update Scalar Docs content and configuration.",
                         "filepath": "documentation/guides/docs/configuration/agent-skills.md",
                         "type": "page",
                         "title": "Agent Skills"
@@ -994,24 +997,29 @@
                       "site-config": {
                         "title": "Site Config",
                         "type": "page",
+                        "description": "Configure site-wide settings for Scalar Docs: branding, logo, theme, custom head tags, footer, and routing rules.",
                         "filepath": "documentation/guides/docs/configuration/site-config.md"
                       },
                       "domains": {
                         "title": "Domains",
                         "type": "page",
+                        "description": "Publish Scalar Docs on a free apidocumentation.com subdomain or connect a custom domain with a simple CNAME record.",
                         "filepath": "documentation/guides/docs/configuration/domains.md"
                       },
                       "navigation": {
                         "title": "Navigation",
                         "type": "page",
+                        "description": "Structure your documentation with navigation routes: pages, groups, tabs, links, and OpenAPI references.",
                         "filepath": "documentation/guides/docs/configuration/navigation.md"
                       },
                       "versions": {
                         "title": "Versions",
                         "type": "page",
+                        "description": "Publish multiple documentation versions with a version selector using the versions key in scalar.config.json.",
                         "filepath": "documentation/guides/docs/configuration/versions.md"
                       },
                       "redirects": {
+                        "description": "Keep old URLs working with redirects in Scalar Docs, including wildcard and path pattern support.",
                         "filepath": "documentation/guides/docs/configuration/redirects.md",
                         "type": "page",
                         "title": "Redirects"
@@ -1091,6 +1099,7 @@
                       "migration": {
                         "title": "Migrate from 1.0",
                         "type": "page",
+                        "description": "Upgrade your documentation from Scalar Docs 1.0 to 2.0 by converting guides and references to navigation routes.",
                         "filepath": "documentation/guides/docs/configuration/migration.md"
                       }
                     }
@@ -1104,11 +1113,13 @@
                       "automatic-deployment": {
                         "title": "Automatic Deployment",
                         "type": "page",
+                        "description": "Publish Scalar Docs automatically on every merge with GitHub sync and automatic deployments.",
                         "filepath": "documentation/guides/docs/deployment/automatic-deployment.md"
                       },
                       "cli": {
                         "title": "CLI",
                         "type": "page",
+                        "description": "Deploy Scalar Docs from your terminal or any CI provider with the Scalar CLI.",
                         "filepath": "documentation/guides/docs/deployment/cli.md"
                       },
                       "github-actions": {
@@ -1138,11 +1149,13 @@
                       "preview-deployments": {
                         "title": "Preview Deployments",
                         "type": "page",
+                        "description": "Review documentation changes before they go live with a preview deployment for every pull request.",
                         "filepath": "documentation/guides/docs/deployment/preview-deployments.md"
                       },
                       "build-failures": {
                         "title": "Build Failures",
                         "type": "page",
+                        "description": "Diagnose and fix Scalar Docs build failures: common causes, error messages, and debugging steps.",
                         "filepath": "documentation/guides/docs/deployment/build-failures.md"
                       }
                     }
@@ -1156,16 +1169,19 @@
                       "assets": {
                         "title": "Assets",
                         "type": "page",
+                        "description": "Serve images, fonts, and other static assets in Scalar Docs with the assetsDir configuration.",
                         "filepath": "documentation/guides/docs/content/assets.md"
                       },
                       "html-css-js": {
                         "title": "HTML/CSS/JS",
                         "type": "page",
+                        "description": "Use custom HTML, CSS, and JavaScript in Scalar Docs pages for full control over your documentation.",
                         "filepath": "documentation/guides/docs/content/html-css-js.md"
                       },
                       "mdx": {
                         "title": "MDX",
                         "type": "page",
+                        "description": "Write documentation with MDX in Scalar Docs: use components, expressions, and imports inside Markdown.",
                         "filepath": "documentation/guides/docs/content/mdx.mdx"
                       }
                     }
@@ -1179,6 +1195,7 @@
                       "github": {
                         "title": "GitHub",
                         "type": "page",
+                        "description": "Sync your documentation with GitHub: connect a repository, publish on merge, and preview pull requests.",
                         "filepath": "documentation/guides/docs/integrations/github.md"
                       }
                     }
@@ -1214,21 +1231,25 @@
                         }
                       },
                       "buttons": {
+                        "description": "Add styled button links to your Scalar Docs pages with the button component.",
                         "filepath": "documentation/guides/docs/components/buttons.mdx",
                         "type": "page",
                         "title": "Buttons"
                       },
                       "callouts": {
+                        "description": "Highlight notes, warnings, and tips in your documentation with callout components.",
                         "filepath": "documentation/guides/docs/components/callouts.mdx",
                         "type": "page",
                         "title": "Callouts"
                       },
                       "math": {
+                        "description": "Render LaTeX math equations in your Scalar Docs pages.",
                         "filepath": "documentation/guides/docs/components/math.mdx",
                         "type": "page",
                         "title": "Math"
                       },
                       "embeds": {
+                        "description": "Embed videos and external content like YouTube in your documentation pages.",
                         "filepath": "documentation/guides/docs/components/embeds.mdx",
                         "type": "page",
                         "title": "Embeds"
@@ -1258,51 +1279,61 @@
                         }
                       },
                       "images": {
+                        "description": "Add images with captions and dark mode variants to your documentation.",
                         "filepath": "documentation/guides/docs/components/images.mdx",
                         "type": "page",
                         "title": "Images"
                       },
                       "icons": {
+                        "description": "Use thousands of built-in Phosphor icons in your Scalar Docs pages.",
                         "filepath": "documentation/guides/docs/components/icons.mdx",
                         "type": "page",
                         "title": "Icons"
                       },
                       "tabs": {
+                        "description": "Organize alternative content like multi-language code examples with tab components.",
                         "filepath": "documentation/guides/docs/components/tabs.mdx",
                         "type": "page",
                         "title": "Tabs"
                       },
                       "tables": {
+                        "description": "Present structured data in your documentation with Markdown and HTML tables.",
                         "filepath": "documentation/guides/docs/components/tables.mdx",
                         "type": "page",
                         "title": "Tables"
                       },
                       "steps": {
+                        "description": "Guide readers through sequential instructions with step components.",
                         "filepath": "documentation/guides/docs/components/steps.mdx",
                         "type": "page",
                         "title": "Steps"
                       },
                       "cards": {
+                        "description": "Link related pages and highlight content with card components in Scalar Docs.",
                         "filepath": "documentation/guides/docs/components/cards.mdx",
                         "type": "page",
                         "title": "Cards"
                       },
                       "details": {
+                        "description": "Add collapsible sections to your documentation with the details component.",
                         "filepath": "documentation/guides/docs/components/details.mdx",
                         "type": "page",
                         "title": "Details"
                       },
                       "page-link": {
+                        "description": "Link to other documentation pages with rich page-link previews.",
                         "filepath": "documentation/guides/docs/components/page-link.mdx",
                         "type": "page",
                         "title": "Page Link"
                       },
                       "grid": {
+                        "description": "Lay out cards and content in responsive grids in your Scalar Docs pages.",
                         "filepath": "documentation/guides/docs/components/grid.mdx",
                         "type": "page",
                         "title": "Grid"
                       },
                       "row": {
+                        "description": "The deprecated row component for horizontal layouts. Use the grid component instead.",
                         "filepath": "documentation/guides/docs/components/row.mdx",
                         "type": "page",
                         "title": "Row (Deprecated)"
@@ -1353,26 +1384,31 @@
                   "mcp": {
                     "title": "MCP Servers",
                     "type": "page",
+                    "description": "Generate secure MCP servers from your OpenAPI documents so LLMs can call your API with just-in-time tools and delegated auth.",
                     "filepath": "documentation/guides/agent/mcp.md"
                   },
                   "sdk": {
                     "title": "Agent SDK",
                     "type": "page",
+                    "description": "Build AI agents on your API with the Scalar Agent SDK: chat, tool calls, and OpenAPI-backed context.",
                     "filepath": "documentation/guides/agent/sdk.md"
                   },
                   "api-reference": {
                     "title": "Agent in API Reference",
                     "type": "page",
+                    "description": "Add the Scalar Agent chat to your API reference so developers can ask questions and try your API with AI.",
                     "filepath": "documentation/guides/agent/api-reference.md"
                   },
                   "pricing": {
                     "title": "Pricing",
                     "type": "page",
+                    "description": "Scalar Agent pricing: what is free, what is metered, and how usage is billed.",
                     "filepath": "documentation/guides/agent/pricing.md"
                   },
                   "key": {
                     "title": "API Keys",
                     "type": "page",
+                    "description": "Create and manage API keys for Scalar Agent and MCP servers.",
                     "filepath": "documentation/guides/agent/key.md"
                   },
                   "release-notes": {
@@ -1394,26 +1430,31 @@
                     "mode": "flat",
                     "children": {
                       "incident-monitor": {
+                        "description": "Example: build an incident monitoring agent with Scalar Agent connected to your APIs.",
                         "filepath": "documentation/guides/agent/examples/incident-monitor.md",
                         "type": "page",
                         "title": "Incident Monitor"
                       },
                       "billing-sweep": {
+                        "description": "Example: build a billing sweep agent with Scalar Agent connected to your APIs.",
                         "filepath": "documentation/guides/agent/examples/billing-sweep.md",
                         "type": "page",
                         "title": "Billing Sweep"
                       },
                       "meeting-scheduler": {
+                        "description": "Example: build a meeting scheduling agent with Scalar Agent connected to your APIs.",
                         "filepath": "documentation/guides/agent/examples/meeting-scheduler.md",
                         "type": "page",
                         "title": "Meeting Scheduler"
                       },
                       "revenue-dashboard": {
+                        "description": "Example: build a revenue dashboard agent with Scalar Agent connected to your APIs.",
                         "filepath": "documentation/guides/agent/examples/revenue-dashboard.md",
                         "type": "page",
                         "title": "Revenue Dashboard"
                       },
                       "stakeholder-digest": {
+                        "description": "Example: build a stakeholder digest agent with Scalar Agent connected to your APIs.",
                         "filepath": "documentation/guides/agent/examples/stakeholder-digest.md",
                         "type": "page",
                         "title": "Stakeholder Digest"
@@ -1573,66 +1614,79 @@
                       },
                       "typescript": {
                         "title": "TypeScript",
+                        "description": "Configuration reference for the TypeScript SDK target: package metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/typescript.md",
                         "type": "page"
                       },
                       "python": {
                         "title": "Python",
+                        "description": "Configuration reference for the Python SDK target: package metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/python.md",
                         "type": "page"
                       },
                       "cli": {
+                        "description": "Configuration reference for generating a CLI from your OpenAPI document with Scalar.",
                         "filepath": "documentation/guides/sdks/cli.md",
                         "type": "page",
                         "title": "CLI"
                       },
                       "go": {
                         "title": "Go (Experimental)",
+                        "description": "Configuration reference for the experimental Go SDK target: module metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/go.md",
                         "type": "page"
                       },
                       "java": {
                         "title": "Java (Experimental)",
+                        "description": "Configuration reference for the experimental Java SDK target: package metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/java.md",
                         "type": "page"
                       },
                       "csharp": {
                         "title": "C# (Experimental)",
+                        "description": "Configuration reference for the experimental C# SDK target: package metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/csharp.md",
                         "type": "page"
                       },
                       "php": {
                         "title": "PHP (Experimental)",
+                        "description": "Configuration reference for the experimental PHP SDK target: package metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/php.md",
                         "type": "page"
                       },
                       "ruby": {
                         "title": "Ruby (Experimental)",
+                        "description": "Configuration reference for the experimental Ruby SDK target: gem metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/ruby.md",
                         "type": "page"
                       },
                       "swift": {
                         "title": "Swift (Experimental)",
+                        "description": "Configuration reference for the experimental Swift SDK target: package metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/swift.md",
                         "type": "page"
                       },
                       "rust": {
                         "title": "Rust (Experimental)",
+                        "description": "Configuration reference for the experimental Rust SDK target: crate metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/rust.md",
                         "type": "page"
                       },
                       "kotlin": {
                         "title": "Kotlin (Experimental)",
+                        "description": "Configuration reference for the experimental Kotlin SDK target: package metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/kotlin.md",
                         "type": "page"
                       },
                       "dart": {
                         "title": "Dart (Experimental)",
+                        "description": "Configuration reference for the experimental Dart SDK target: package metadata, naming, and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/dart.md",
                         "type": "page"
                       },
                       "cpp": {
                         "title": "C++ (Experimental)",
+                        "description": "Configuration reference for the experimental C++ SDK target: naming and generation options.",
                         "filepath": "documentation/guides/sdks/configuration/cpp.md",
                         "type": "page"
                       }
@@ -1687,31 +1741,37 @@
                   },
                   "upload": {
                     "title": "Upload",
+                    "description": "Upload OpenAPI documents to the Scalar Registry from the dashboard, CLI, or CI.",
                     "filepath": "documentation/guides/registry/upload.md",
                     "type": "page"
                   },
                   "schemas": {
                     "title": "Schemas",
+                    "description": "Work with schemas in the Scalar Registry: store, version, and share your API data models.",
                     "filepath": "documentation/guides/registry/schemas.md",
                     "type": "page"
                   },
                   "rules": {
+                    "description": "Enforce API standards by linting OpenAPI documents in the Scalar Registry with rules.",
                     "filepath": "documentation/guides/registry/rules.md",
                     "type": "page",
                     "title": "Rules"
                   },
                   "cli": {
+                    "description": "Manage the Scalar Registry from your terminal: upload, version, and validate OpenAPI documents with the CLI.",
                     "filepath": "documentation/guides/registry/cli.md",
                     "type": "page",
                     "title": "CLI"
                   },
                   "github-actions": {
                     "title": "GitHub Actions",
+                    "description": "Push OpenAPI documents to the Scalar Registry automatically with GitHub Actions.",
                     "filepath": "documentation/guides/registry/github-actions.md",
                     "type": "page"
                   },
                   "gitlab-ci": {
                     "title": "GitLab CI/CD",
+                    "description": "Push OpenAPI documents to the Scalar Registry automatically with GitLab CI/CD.",
                     "filepath": "documentation/guides/registry/gitlab-ci.md",
                     "type": "page"
                   }
@@ -1830,6 +1890,7 @@
                   },
                   "plugins": {
                     "title": "Plugins",
+                    "description": "Extend Scalar API References with plugins to customize rendering and behavior.",
                     "filepath": "documentation/plugins.md",
                     "type": "page"
                   },
@@ -1841,11 +1902,13 @@
                     "children": {
                       "getting-started": {
                         "title": "Getting Started",
+                        "description": "Compose API documentation from individual blocks: render operations, schemas, and code examples anywhere.",
                         "filepath": "documentation/guides/blocks/getting-started.md",
                         "type": "page"
                       },
                       "code-example": {
                         "title": "Code Example",
+                        "description": "Render standalone code examples for any operation with the Scalar code example block.",
                         "filepath": "documentation/guides/blocks/code-example.md",
                         "type": "page"
                       }
@@ -1877,16 +1940,19 @@
                   },
                   "asyncapi": {
                     "title": "AsyncAPI",
+                    "description": "Render AsyncAPI documents with Scalar for beautiful event-driven API documentation.",
                     "filepath": "documentation/asyncapi.md",
                     "type": "page"
                   },
                   "markdown": {
                     "title": "Markdown",
+                    "description": "Use Markdown in your OpenAPI descriptions: supported syntax and rendering in Scalar API References.",
                     "filepath": "documentation/markdown.md",
                     "type": "page"
                   },
                   "server-side-rendering": {
                     "title": "Server-Side Rendering",
+                    "description": "Server-side render Scalar API References in Node.js for faster loads and better SEO.",
                     "filepath": "documentation/server-side-rendering.md",
                     "type": "page"
                   },
@@ -2696,11 +2762,13 @@
                     }
                   },
                   "authentication": {
+                    "description": "Authenticate the Scalar CLI with your Scalar account using login, tokens, and CI environment variables.",
                     "filepath": "documentation/guides/cli/authentication.md",
                     "type": "page",
                     "title": "Authentication"
                   },
                   "commands": {
+                    "description": "Full command reference for the Scalar CLI: projects, registry, OpenAPI validation, bundling, and mocking.",
                     "filepath": "documentation/guides/cli/commands.md",
                     "type": "page",
                     "title": "Commands"
@@ -2748,21 +2816,25 @@
                   },
                   "docker": {
                     "title": "Docker",
+                    "description": "Run the Scalar Mock Server in Docker to mock any OpenAPI document in containers and CI.",
                     "filepath": "documentation/guides/mock-server/docker.md",
                     "type": "page"
                   },
                   "custom-request-handler": {
                     "title": "Custom Request Handlers",
+                    "description": "Customize mock responses with x-handler: write JavaScript request handlers for any operation.",
                     "filepath": "documentation/guides/mock-server/custom-request-handler.md",
                     "type": "page"
                   },
                   "agent-skills": {
                     "title": "Agent Skills",
+                    "description": "Use Agent Skills to help AI coding agents build and configure Scalar Mock Server setups.",
                     "filepath": "documentation/guides/mock-server/agent-skills.md",
                     "type": "page"
                   },
                   "data-seeding": {
                     "title": "Data Seeding",
+                    "description": "Seed realistic mock data with x-seed to get consistent, related responses from your mock API.",
                     "filepath": "documentation/guides/mock-server/data-seeding.md",
                     "type": "page"
                   },
@@ -2814,6 +2886,7 @@
                   },
                   "changelog": {
                     "title": "Changelog",
+                    "description": "Changelog for @scalar/openapi-upgrader releases.",
                     "filepath": "packages/openapi-upgrader/CHANGELOG.md",
                     "type": "page"
                   }
@@ -2874,10 +2947,17 @@
           },
           "/customers/partech": {
             "type": "page",
-            "title": "How PAR Technology Corporation Enhanced Its Developer Experience With a Modern, Open Standards Platform",
+            "title": "How PAR Modernized Its Developer Experience With Scalar",
             "filepath": "documentation/guides/customers/partech.md",
             "showInSidebar": false,
+            "description": "How PAR Technology modernized its developer experience with Scalar, a modern, open-standards API platform.",
             "head": {
+              "links": [
+                {
+                  "rel": "canonical",
+                  "href": "https://scalar.com/customers/partech"
+                }
+              ],
               "meta": [
                 {
                   "property": "og:image",
@@ -3049,31 +3129,37 @@
                     "children": {
                       "auth0": {
                         "title": "Auth0",
+                        "description": "Configure SAML single sign-on for Scalar with Auth0: step-by-step IdP setup, metadata, and claims.",
                         "filepath": "documentation/guides/sso/providers/auth0.md",
                         "type": "page"
                       },
                       "google": {
                         "title": "Google",
+                        "description": "Configure SAML single sign-on for Scalar with Google Workspace: step-by-step IdP setup, metadata, and claims.",
                         "filepath": "documentation/guides/sso/providers/google.md",
                         "type": "page"
                       },
                       "microsoft-entra-id": {
                         "title": "Microsoft Entra ID",
+                        "description": "Configure SAML single sign-on for Scalar with Microsoft Entra ID (formerly Azure AD).",
                         "filepath": "documentation/guides/sso/providers/microsoft-entra-id.md",
                         "type": "page"
                       },
                       "okta": {
                         "title": "Okta",
+                        "description": "Configure SAML single sign-on for Scalar with Okta: step-by-step IdP setup, metadata, and claims.",
                         "filepath": "documentation/guides/sso/providers/okta.md",
                         "type": "page"
                       },
                       "onelogin": {
                         "title": "OneLogin",
+                        "description": "Configure SAML single sign-on for Scalar with OneLogin: step-by-step IdP setup, metadata, and claims.",
                         "filepath": "documentation/guides/sso/providers/onelogin.md",
                         "type": "page"
                       },
                       "ping-identity": {
                         "title": "Ping Identity",
+                        "description": "Configure SAML single sign-on for Scalar with Ping Identity: step-by-step IdP setup, metadata, and claims.",
                         "filepath": "documentation/guides/sso/providers/ping-identity.md",
                         "type": "page"
                       }
@@ -3188,6 +3274,7 @@
                 "type": "page",
                 "title": "Blog",
                 "icon": "phosphor/regular/newspaper",
+                "description": "News and engineering stories from the Scalar team on OpenAPI, API documentation, and developer experience.",
                 "filepath": "documentation/blog/index.md",
                 "showInSidebar": true,
                 "layout": {
@@ -3224,12 +3311,14 @@
           "/blog/posts/2026-04-11-oss-pledge": {
             "type": "page",
             "title": "Scalar's 2025 Open Source Pledge",
+            "description": "Scalar renews its Open Source Pledge for 2025, continuing to fund the open source maintainers we depend on.",
             "filepath": "documentation/blog/2026-04-11-oss-pledge.md",
             "showInSidebar": false
           },
           "/blog/posts/2026-03-25-scalar-mcp-oauth": {
             "type": "page",
             "title": "Too Long; Didn't Read; Used MCP",
+            "description": "How OAuth works with Scalar MCP servers: authenticate agents against your API with delegated user permissions.",
             "filepath": "documentation/blog/2026-03-25-scalar-mcp-oauth.md",
             "showInSidebar": false,
             "head": {
@@ -3243,6 +3332,7 @@
           "/blog/posts/2026-03-17-agent-mcp": {
             "type": "page",
             "title": "Use your API in Cursor",
+            "description": "Expose your OpenAPI document as an MCP server and use your API directly in Cursor or any MCP-compatible tool.",
             "filepath": "documentation/blog/2026-03-17-agent-mcp.md",
             "showInSidebar": false,
             "head": {
@@ -3256,78 +3346,91 @@
           "/blog/posts/2026-03-05-agent-scalar": {
             "type": "page",
             "title": "Introducing Agent",
+            "description": "Introducing Scalar Agent: connect LLMs to your API using a fraction of the context window instead of pasting your whole OpenAPI document.",
             "filepath": "documentation/blog/2026-03-05-agent-scalar.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-08-19-how-to-set-up-an-openapi-mock-server": {
             "type": "page",
             "title": "How to set up an OpenAPI mock server",
+            "description": "How to set up an OpenAPI mock server with the Scalar CLI in a few commands.",
             "filepath": "documentation/blog/2025-08-19-how-to-set-up-an-openapi-mock-server.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-07-07-how-to-do-openapi-validation-and": {
             "type": "page",
             "title": "How to do OpenAPI validation (and why it matters)",
+            "description": "How to validate OpenAPI documents with the Scalar CLI, and why validation matters for your API workflow.",
             "filepath": "documentation/blog/2025-07-07-how-to-do-openapi-validation-and.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-05-28-how-we-created-an-animated-responsive": {
             "type": "page",
             "title": "How we created an animated, responsive README",
+            "description": "How we built an animated, responsive README for the Scalar GitHub repository with GitHub-flavored Markdown.",
             "filepath": "documentation/blog/2025-05-28-how-we-created-an-animated-responsive.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-05-07-how-scalar-themes-work": {
             "type": "page",
             "title": "How Scalar themes work",
+            "description": "How Scalar themes work: the CSS variable system that lets you restyle an entire API reference.",
             "filepath": "documentation/blog/2025-05-07-how-scalar-themes-work.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-04-28-how-cloudinarys-api-docs-create-a": {
             "type": "page",
             "title": "How Cloudinary’s API docs create a great developer experience",
+            "description": "What Cloudinary API docs get right, and what API-first companies can learn from their developer experience.",
             "filepath": "documentation/blog/2025-04-28-how-cloudinarys-api-docs-create-a.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-04-23-an-introduction-to-openapi-variables": {
             "type": "page",
             "title": "An introduction to OpenAPI variables",
+            "description": "An introduction to OpenAPI variables: the different types and how to use them in your API documentation.",
             "filepath": "documentation/blog/2025-04-23-an-introduction-to-openapi-variables.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-04-06-how-we-extended-the-openapi-specification": {
             "type": "page",
             "title": "How we extended the OpenAPI specification",
+            "description": "The extensions we added to the OpenAPI specification and how we process them under the hood.",
             "filepath": "documentation/blog/2025-04-06-how-we-extended-the-openapi-specification.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-03-26-a-guide-to-openapi-security-and-how": {
             "type": "page",
             "title": "A guide to OpenAPI security (and how we handle it in Scalar)",
+            "description": "A practical guide to defining authentication and authorization in OpenAPI, and how Scalar renders security schemes.",
             "filepath": "documentation/blog/2025-03-26-a-guide-to-openapi-security-and-how.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-03-19-the-hidden-complexity-of-building": {
             "type": "page",
             "title": "The hidden complexity of building drag and drop",
+            "description": "Why drag and drop is deceptively hard to build, and how we implemented it in the Scalar API Client.",
             "filepath": "documentation/blog/2025-03-19-the-hidden-complexity-of-building.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-03-12-how-we-sped-up-our-api-docs-25x": {
             "type": "page",
             "title": "How we sped up our API docs 25x",
+            "description": "The structural and rendering changes that made our API documentation 25x faster.",
             "filepath": "documentation/blog/2025-03-12-how-we-sped-up-our-api-docs-25x.md",
             "showInSidebar": false
           },
           "/blog/posts/2025-03-05-how-net-9-and-scalar-solve-the-problem": {
             "type": "page",
             "title": "How .NET 9 and Scalar solve the problem of under-documented APIs",
+            "description": "How .NET 9 OpenAPI document generation and Scalar work together to keep your APIs documented.",
             "filepath": "documentation/blog/2025-03-05-how-net-9-and-scalar-solve-the-problem.md",
             "showInSidebar": false
           },
           "/blog/posts/2024-09-01-oss-pledge": {
             "type": "page",
             "title": "Scalar Joins the Open-Source Pledge",
+            "description": "Scalar joins the Open Source Pledge, committing at least $2,000 per developer per year to open source maintainers.",
             "filepath": "documentation/blog/2024-09-01-oss-pledge.md",
             "showInSidebar": false
           }
@@ -3339,6 +3442,7 @@
         "children": {
           "/terms-and-conditions": {
             "title": "Terms and Conditions",
+            "description": "The terms and conditions for using Scalar products and services.",
             "filepath": "documentation/legal/terms-and-conditions.md",
             "type": "page",
             "layout": {
@@ -3347,6 +3451,7 @@
           },
           "/privacy-policy": {
             "title": "Privacy Policy",
+            "description": "How Scalar collects, uses, and protects your data.",
             "filepath": "documentation/legal/privacy-policy.md",
             "type": "page",
             "layout": {

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -732,7 +732,6 @@
               "pageTitle": false
             },
             "head": {
-              "title": "Scalar — API Documentation, SDKs, MCP Servers & API Client",
               "links": [
                 {
                   "rel": "canonical",
@@ -762,7 +761,6 @@
               "pageTitle": false
             },
             "head": {
-              "title": "Scalar Pricing — Plans for API Docs, SDKs & MCP Servers",
               "links": [
                 {
                   "rel": "canonical",
@@ -801,7 +799,6 @@
               "pageActions": false
             },
             "head": {
-              "title": "Scalar Customers — Trusted by the World's Best API Teams",
               "links": [
                 {
                   "rel": "canonical",
@@ -923,7 +920,6 @@
                     "title": "Getting Started",
                     "description": "Learn how to create and publish stunning developer documentation with Docs in minutes.",
                     "head": {
-                      "title": "Scalar Docs — API Documentation & Developer Docs Platform",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1328,7 +1324,6 @@
                     "filepath": "documentation/guides/agent/getting-started.md",
                     "description": "Turn OpenAPI into MCP servers and connect APIs to LLMs with minimal context usage, delegated auth, and the Agent SDK or chat UI.",
                     "head": {
-                      "title": "Scalar Agent — Turn OpenAPI into MCP Servers for LLMs",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1440,7 +1435,6 @@
                     "title": "Getting Started",
                     "description": "Automatically generate type-safe SDKs from OpenAPI specifications in multiple programming languages.",
                     "head": {
-                      "title": "Scalar SDK Generator — Generate SDKs from OpenAPI",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1665,7 +1659,6 @@
                     "title": "Getting Started",
                     "description": "Store, version, and manage your OpenAPI specifications in a centralized registry with automated CI/CD workflows.",
                     "head": {
-                      "title": "Scalar Registry — OpenAPI Document Management & Versioning",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1737,7 +1730,6 @@
                     "type": "page",
                     "description": "Create stunning API documentation from OpenAPI specs with a modern, customizable interface and built-in request testing.",
                     "head": {
-                      "title": "Scalar API References — Interactive OpenAPI Documentation",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2276,7 +2268,6 @@
                     "title": "Getting Started",
                     "description": "A modern, open-source API client built on the OpenAPI standard with offline-first design and cross-platform support.",
                     "head": {
-                      "title": "Scalar API Client — Free, Open-Source API Testing Client",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2678,7 +2669,6 @@
                     "title": "Getting Started",
                     "description": "Install and use the Scalar CLI to validate, bundle, and deploy OpenAPI specifications from your terminal.",
                     "head": {
-                      "title": "Scalar CLI — OpenAPI Tools for Your Terminal",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2730,7 +2720,6 @@
                     "type": "page",
                     "description": "Spin up realistic mock API servers instantly from OpenAPI specs with custom handlers and data seeding.",
                     "head": {
-                      "title": "Scalar Mock Server — Instant Mock APIs from OpenAPI",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2797,7 +2786,6 @@
                     "type": "page",
                     "description": "Migrate legacy Swagger 2.0 specs to modern OpenAPI 3.x formats automatically with our free conversion tool.",
                     "head": {
-                      "title": "OpenAPI Upgrader — Convert Swagger 2.0 to OpenAPI 3.1",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2963,7 +2951,6 @@
                     "type": "page",
                     "description": "Complete guide to migrating from Swagger UI to API References with modern features and better UX.",
                     "head": {
-                      "title": "Swagger UI Alternative — Migrate to Scalar API References",
                       "links": [
                         {
                           "rel": "canonical",
@@ -3029,7 +3016,6 @@
                     "type": "page",
                     "description": "Set up SSO and SAML authentication for Scalar with enterprise identity providers and secure team access.",
                     "head": {
-                      "title": "SSO & SAML Single Sign-On for Scalar",
                       "links": [
                         {
                           "rel": "canonical",

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -37,11 +37,6 @@
       ],
       "meta": [
         {
-          "property": "og:image",
-          "name": "og:image",
-          "content": "https://api.scalar.com/cdn/images/IlMnm9Mxy-SabmLxE_i0L/8O99z8O2xzEypGxOzuZYo.png"
-        },
-        {
           "name": "description",
           "content": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve."
         },
@@ -60,18 +55,6 @@
         {
           "name": "twitter:card",
           "content": "summary_large_image"
-        },
-        {
-          "name": "twitter:image",
-          "content": "https://cdn.scalar.com/images/twitter-image.png"
-        },
-        {
-          "name": "twitter:image:width",
-          "content": "1200"
-        },
-        {
-          "name": "twitter:image:height",
-          "content": "630"
         }
       ],
       "links": [
@@ -723,6 +706,23 @@
                 }
               ],
               "meta": [
+                {
+                  "property": "og:image",
+                  "name": "og:image",
+                  "content": "https://api.scalar.com/cdn/images/IlMnm9Mxy-SabmLxE_i0L/8O99z8O2xzEypGxOzuZYo.png"
+                },
+                {
+                  "name": "twitter:image",
+                  "content": "https://cdn.scalar.com/images/twitter-image.png"
+                },
+                {
+                  "name": "twitter:image:width",
+                  "content": "1200"
+                },
+                {
+                  "name": "twitter:image:height",
+                  "content": "630"
+                },
                 {
                   "property": "og:title",
                   "content": "Scalar - The API Company"

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -46,14 +46,6 @@
           "content": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve."
         },
         {
-          "property": "og:title",
-          "content": "Scalar - The API Company"
-        },
-        {
-          "property": "og:description",
-          "content": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve."
-        },
-        {
           "property": "og:site_name",
           "content": "Scalar"
         },
@@ -68,14 +60,6 @@
         {
           "name": "twitter:card",
           "content": "summary_large_image"
-        },
-        {
-          "name": "twitter:title",
-          "content": "Scalar - The API Company"
-        },
-        {
-          "name": "twitter:description",
-          "content": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve."
         },
         {
           "name": "twitter:image",
@@ -739,6 +723,22 @@
                 }
               ],
               "meta": [
+                {
+                  "property": "og:title",
+                  "content": "Scalar - The API Company"
+                },
+                {
+                  "property": "og:description",
+                  "content": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve."
+                },
+                {
+                  "name": "twitter:title",
+                  "content": "Scalar - The API Company"
+                },
+                {
+                  "name": "twitter:description",
+                  "content": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve."
+                },
                 {
                   "name": "robots",
                   "content": "index, follow"


### PR DESCRIPTION
## Summary

SEO audit fixes for the scalar.com pages hosted with Scalar Docs.

> **Note on title tags:** page-level `head.title` was tried for unique `<title>` tags, but the platform also uses it for sidebar labels, so those were reverted (only `/enterprise` keeps one — it is not shown in the sidebar). Unique titles for the eleven pages currently all titled "Getting Started" need a small docs-platform change first: resolve sidebar labels from `title` only, and let `head.title` affect just the `<title>` tag.

### Homepage & marketing pages
- The scalar.com homepage's only H1 was the platform-injected "Introduction". The injected title is now disabled (`pageTitle: false`) and the hero *"API interfaces built for developers and agents"* is a `level="1"` heading — one H1, the right one.
- Same hero-to-H1 fix on `/pricing` and `/customers` (customers previously had **zero** H1s).
- `/enterprise` gets a title, meta description, canonical, and OG tags (it had none).

### Heading fixes
Generic H1s replaced with product names on the Docs, API References, and CLI getting-started pages, plus the truncated "Site" heading on the site-config page.

### Global head fixes
- Removed the duplicate `name="description"` meta (two different contents were declared — which one Google picked was undefined).
- `twitter:card`: `summary` → `summary_large_image` to match the declared 1200×630 image, so shares render as full-width cards instead of thumbnails.
- Un-pinned the global `og:image`/`twitter:image`. The platform auto-generates per-page share cards (`/og/<hash>.png` with the page title and description — the "new way", as seen on customer docs sites), but only for pages without an `og:image`. The global pin forced the same static card on every page. The static brand card now lives on the homepage route only. **Verify on the preview deployment that generated cards appear for other pages** — the local preview does not run the generation pipeline.
- Scoped `og:title`/`og:description` and `twitter:title`/`twitter:description` to the homepage route. Previously they were global, so every page without its own tags shared to Slack/X as "Scalar - The API Company" with homepage boilerplate. Now those pages fall back to their own title tag and meta description; the homepage share card is unchanged.

### Meta descriptions
Added to every page that lacked one — the 40 API Reference integration pages, 4 migration guides, and a follow-up batch of 98 covering Docs configuration/components, Agent, SDK configuration, Registry, CLI, Mock Server, SSO providers, all blog posts, and legal pages. Site-wide: 61 → 209 of 212 pages with descriptions (the 3 without are duplicate release-notes routes that are redirected or canonicaled away). Blog descriptions are written from each post's content. "Swagger UI alternative" is worked naturally into the .NET, Flask, Laravel, NestJS, and Spring Boot descriptions.

### Duplicate content & redirects
- The API Client and Agent release notes were each served at two URLs with no canonical linking them. Both route pairs now share a canonical pointing at `/resources/changelog/*` (consistent with the existing `/changelog/*` redirects).
- Removed four duplicate redirect entries.

## Verification

- `npx @scalar/cli project check-config` passes; Prettier/Biome clean via lefthook.
- Rendered the changed pages with `scalar project preview` in a browser and confirmed: exactly one H1 per page (the correct one), single description meta, `summary_large_image`, canonicals, new descriptions — and sidebar/menu labels unchanged.

| Page | Rendered H1 (was) | Rendered H1 (now) |
|---|---|---|
| `/` | Introduction *(injected)* | API interfaces built for developers and agents |
| `/pricing` | Pricing *(injected)* | Plans for every API interface |
| `/customers` | *none* | Trusted by the world's best API teams. |

### Small cleanups
- PAR customer story: title shortened from 108 characters to 55, plus a description and canonical URL.
- Legal pages flagged in the audit as missing H1s turned out fine — the platform injects one from the page title.

## Follow-ups (not in this PR)

- **Docs platform:** separate the sidebar label from the `<title>` tag so the eleven pages titled "Getting Started" (and the homepage's "Introduction") can get unique, keyword-bearing titles.
- Dedicated competitor "alternative" landing pages (GitBook, Stainless, Postman, Swagger UI) — currently zero indexable content targets these queries.
- Per-post OG images and descriptions for the blog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and `scalar.config.json` SEO/redirect metadata only; verify preview deploy shows per-page OG images where global pins were removed.
> 
> **Overview**
> Improves **SEO and social sharing** for scalar.com by updating `scalar.config.json` and a handful of guide pages—no application runtime changes.
> 
> **Marketing pages & headings:** Homepage, pricing, and customers disable injected `pageTitle` and promote hero copy to **`level="1"`** headings so each page has one meaningful H1. Generic “Getting Started” / “Site” titles on Docs, API References, CLI, and site-config guides are renamed to product-specific headings.
> 
> **Global vs per-route head:** Site-wide meta is trimmed (duplicate `description`, redundant OG/Twitter title tags). **`twitter:card`** is `summary_large_image`. Brand OG/Twitter images and homepage share copy move from global `siteConfig` to the **homepage route only**, so other pages can use auto-generated share cards and their own descriptions.
> 
> **Coverage:** Adds **`description`** fields across many navigation routes (integrations, docs config, agent, registry, changelog, blog posts, legal, enterprise, etc.). **`/enterprise`** and customer story routes get canonicals and richer head metadata. Release-note URLs get **canonicals** pointing at `/resources/changelog/*`; duplicate redirect rules are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f3ff8fad34f4afe585e7325c6dc187a044ec5c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


