### PR TITLE
feat(helpers): add query as an http method

### DIFF
--- a/.changeset/add-query-http-method.md
+++ b/.changeset/add-query-http-method.md
@@ -1,0 +1,6 @@
+---
+'@scalar/helpers': minor
+'@scalar/workspace-store': patch
+---
+
+Add `query` as a supported HTTP method. The QUERY method (a safe, idempotent method that carries its query in the request body, per the IETF HTTP QUERY method and OpenAPI 3.2) is now part of `HTTP_METHODS`, so it is recognized by `isHttpMethod`, `normalizeHttpMethod`, and `getHttpMethodInfo` (rendered with a distinct pink badge), and it is allowed to have a request body via `canMethodHaveBody`. The workspace store now traverses and renders `query` operations on path items, so the API reference and API client handle QUERY operations correctly.

--- a/packages/api-client/src/components/HttpMethod/HttpMethod.test.ts
+++ b/packages/api-client/src/components/HttpMethod/HttpMethod.test.ts
@@ -1,0 +1,38 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import HttpMethod from './HttpMethod.vue'
+
+describe('HttpMethod', () => {
+  describe('display mode', () => {
+    it('renders the short label for the QUERY method', () => {
+      const wrapper = mount(HttpMethod, {
+        props: { method: 'query' },
+      })
+
+      expect(wrapper.text()).toBe('QUERY')
+    })
+
+    it('normalizes casing for the QUERY method', () => {
+      const wrapper = mount(HttpMethod, {
+        props: { method: 'QUERY' },
+      })
+
+      expect(wrapper.text()).toBe('QUERY')
+    })
+  })
+
+  describe('editable dropdown', () => {
+    it('emits the query method when it is selected', () => {
+      const wrapper = mount(HttpMethod, {
+        props: { method: 'get', isEditable: true },
+      })
+
+      // Simulate the listbox selecting the QUERY option
+      const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+      listbox.vm.$emit('update:modelValue', { id: 'query', label: 'QUERY' })
+
+      expect(wrapper.emitted('change')?.[0]).toEqual(['query'])
+    })
+  })
+})

--- a/packages/api-reference/src/components/HttpMethod/HttpMethod.test.ts
+++ b/packages/api-reference/src/components/HttpMethod/HttpMethod.test.ts
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+
 import HttpMethod from './HttpMethod.vue'
 
 describe('HttpMethod', () => {
@@ -67,6 +68,7 @@ describe('HttpMethod', () => {
         { method: 'DELETE', expected: 'DEL' },
         { method: 'OPTIONS', expected: 'OPTS' },
         { method: 'HEAD', expected: 'HEAD' },
+        { method: 'QUERY', expected: 'QUERY' },
         { method: 'TRACE', expected: 'TRACE' },
       ]
 
@@ -88,6 +90,8 @@ describe('HttpMethod', () => {
         { input: 'Put', expected: 'put' },
         { input: 'patch', expected: 'patch' },
         { input: 'Delete', expected: 'delete' },
+        { input: 'QUERY', expected: 'query' },
+        { input: 'Query', expected: 'query' },
       ]
 
       testCases.forEach(({ input, expected }) => {

--- a/packages/blocks/src/code-example/components/HttpMethod.test.ts
+++ b/packages/blocks/src/code-example/components/HttpMethod.test.ts
@@ -68,6 +68,7 @@ describe('HttpMethod', () => {
         { method: 'delete', expected: 'DEL' },
         { method: 'options', expected: 'OPTS' },
         { method: 'head', expected: 'HEAD' },
+        { method: 'query', expected: 'QUERY' },
         { method: 'trace', expected: 'TRACE' },
       ]
 

--- a/packages/helpers/src/http/can-method-have-body.test.ts
+++ b/packages/helpers/src/http/can-method-have-body.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { canMethodHaveBody } from './can-method-have-body'
+import { buildSafeBodyRequest, canMethodHaveBody } from './can-method-have-body'
 import type { HttpMethod } from './http-methods'
 
 vi.mock('@/general/is-electron', () => ({
@@ -20,16 +20,32 @@ describe('can-method-have-body', () => {
   })
 
   describe('HTTP methods with body support', () => {
-    it.each(['post', 'put', 'patch', 'delete'] as const)('returns true for %s method', (method) => {
+    it.each(['post', 'put', 'patch', 'delete', 'query'] as const)('returns true for %s method', (method) => {
       expect(canMethodHaveBody(method)).toBe(true)
     })
 
-    it.each(['POST', 'PUT', 'PATCH', 'DELETE'] as const)('handles uppercase %s method', (method) => {
+    it.each(['POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'] as const)('handles uppercase %s method', (method) => {
       expect(canMethodHaveBody(method as HttpMethod)).toBe(true)
     })
 
-    it.each(['Post', 'Put', 'Patch', 'Delete'] as const)('handles mixed case %s method', (method) => {
+    it.each(['Post', 'Put', 'Patch', 'Delete', 'Query'] as const)('handles mixed case %s method', (method) => {
       expect(canMethodHaveBody(method as HttpMethod)).toBe(true)
+    })
+  })
+
+  describe('QUERY method', () => {
+    it('can have a body because the query is carried in the request body', () => {
+      expect(canMethodHaveBody('query')).toBe(true)
+    })
+
+    it('keeps the body when building a safe request', () => {
+      const request = buildSafeBodyRequest('https://example.com/search', {
+        method: 'QUERY',
+        body: 'q=scalar',
+      })
+
+      expect(request.method).toBe('QUERY')
+      expect(request.body).not.toBeNull()
     })
   })
 

--- a/packages/helpers/src/http/can-method-have-body.ts
+++ b/packages/helpers/src/http/can-method-have-body.ts
@@ -1,7 +1,12 @@
 import { isElectron } from '@/general/is-electron'
 
-/** HTTP Methods which can have a body */
-export const BODY_METHODS = new Set(['post', 'put', 'patch', 'delete'])
+/**
+ * HTTP Methods which can have a body
+ *
+ * QUERY is included because it is a safe, idempotent method that carries its query in the request body,
+ * which is the whole point of the method (see the IETF HTTP QUERY method and OpenAPI 3.2).
+ */
+export const BODY_METHODS = new Set(['post', 'put', 'patch', 'delete', 'query'])
 
 /**
  * Makes a check to see if this method CAN have a body.

--- a/packages/helpers/src/http/http-info.test.ts
+++ b/packages/helpers/src/http/http-info.test.ts
@@ -36,7 +36,17 @@ describe('REQUEST_METHODS', () => {
     expect(REQUEST_METHODS.delete.short).toBe('DEL')
     expect(REQUEST_METHODS.options.short).toBe('OPTS')
     expect(REQUEST_METHODS.head.short).toBe('HEAD')
+    expect(REQUEST_METHODS.query.short).toBe('QUERY')
     expect(REQUEST_METHODS.trace.short).toBe('TRACE')
+  })
+
+  it('has an entry for the QUERY method with a distinct color', () => {
+    expect(REQUEST_METHODS.query).toEqual({
+      short: 'QUERY',
+      colorClass: 'text-pink',
+      colorVar: 'var(--scalar-color-pink)',
+      backgroundColor: 'bg-pink/10',
+    })
   })
 })
 
@@ -50,6 +60,9 @@ describe('getHttpMethodInfo', () => {
       { input: 'delete', expectedShort: 'DEL' },
       { input: 'OPTIONS', expectedShort: 'OPTS' },
       { input: 'head', expectedShort: 'HEAD' },
+      { input: 'QUERY', expectedShort: 'QUERY' },
+      { input: '  query  ', expectedShort: 'QUERY' },
+      { input: 'Query', expectedShort: 'QUERY' },
       { input: 'trace', expectedShort: 'TRACE' },
     ]
 

--- a/packages/helpers/src/http/http-info.ts
+++ b/packages/helpers/src/http/http-info.ts
@@ -54,6 +54,12 @@ export const REQUEST_METHODS = {
     colorVar: 'var(--scalar-color-2)',
     backgroundColor: 'bg-c-2/10',
   },
+  query: {
+    short: 'QUERY',
+    colorClass: 'text-pink',
+    colorVar: 'var(--scalar-color-pink)',
+    backgroundColor: 'bg-pink/10',
+  },
   trace: {
     short: 'TRACE',
     colorClass: 'text-c-2',

--- a/packages/helpers/src/http/http-methods.test.ts
+++ b/packages/helpers/src/http/http-methods.test.ts
@@ -1,12 +1,18 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
+
 import { HTTP_METHODS, type HttpMethod, httpMethods } from './http-methods'
 
 describe('HTTP Methods', () => {
   it('should contain all standard HTTP methods', () => {
-    const expectedMethods = ['delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'trace']
+    const expectedMethods = ['delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'query', 'trace']
 
     expect(HTTP_METHODS).toEqual(expectedMethods)
     expect(HTTP_METHODS).toHaveLength(expectedMethods.length)
+  })
+
+  it('includes the QUERY method', () => {
+    expect(HTTP_METHODS).toContain('query')
+    expect(httpMethods.has('query')).toBe(true)
   })
 
   it('should have a Set containing all HTTP methods', () => {

--- a/packages/helpers/src/http/http-methods.ts
+++ b/packages/helpers/src/http/http-methods.ts
@@ -1,5 +1,5 @@
 /** All OpenAPI HTTP methods */
-export const HTTP_METHODS = ['delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'trace'] as const
+export const HTTP_METHODS = ['delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'query', 'trace'] as const
 
 /** All http methods we support */
 export type HttpMethod = (typeof HTTP_METHODS)[number]

--- a/packages/helpers/src/http/is-http-method.test.ts
+++ b/packages/helpers/src/http/is-http-method.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest'
-import { isHttpMethod } from './is-http-method'
+import { describe, expect, it } from 'vitest'
+
 import { HTTP_METHODS } from './http-methods'
+import { isHttpMethod } from './is-http-method'
 
 describe('isHttpMethod', () => {
   describe('valid HTTP methods', () => {
@@ -12,6 +13,12 @@ describe('isHttpMethod', () => {
       expect(isHttpMethod(method.toUpperCase())).toBe(true)
       expect(isHttpMethod(method.toLowerCase())).toBe(true)
       expect(isHttpMethod(method.charAt(0).toUpperCase() + method.slice(1))).toBe(true)
+    })
+
+    it('recognizes the QUERY method in any casing', () => {
+      expect(isHttpMethod('query')).toBe(true)
+      expect(isHttpMethod('QUERY')).toBe(true)
+      expect(isHttpMethod('Query')).toBe(true)
     })
   })
 

--- a/packages/helpers/src/http/normalize-http-method.test.ts
+++ b/packages/helpers/src/http/normalize-http-method.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest'
-import { normalizeHttpMethod } from './normalize-http-method'
-import { HTTP_METHODS } from './http-methods'
+import { describe, expect, it } from 'vitest'
+
 import { consoleWarnSpy } from '@/testing/console-spies'
+
+import { HTTP_METHODS } from './http-methods'
+import { normalizeHttpMethod } from './normalize-http-method'
 
 describe('normalizeHttpMethod', () => {
   describe('valid HTTP methods', () => {
@@ -23,6 +25,12 @@ describe('normalizeHttpMethod', () => {
       expect(normalizeHttpMethod(' get ')).toBe('get')
       expect(normalizeHttpMethod('\tpost\n')).toBe('post')
       expect(normalizeHttpMethod('  put  ')).toBe('put')
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+    })
+
+    it('normalizes the QUERY method without warning', () => {
+      expect(normalizeHttpMethod('QUERY')).toBe('query')
+      expect(normalizeHttpMethod('  Query  ')).toBe('query')
       expect(consoleWarnSpy).not.toHaveBeenCalled()
     })
   })

--- a/packages/workspace-store/src/helpers/for-each-path-item-operation.test.ts
+++ b/packages/workspace-store/src/helpers/for-each-path-item-operation.test.ts
@@ -72,6 +72,24 @@ describe('forEachPathItemOperation', () => {
     expect(callback.mock.calls).toStrictEqual([['get', { summary: 'Get users' }]])
   })
 
+  it('invokes the callback for a QUERY operation', () => {
+    const callback = vi.fn()
+
+    forEachPathItemOperation(
+      {
+        get: { summary: 'Get users' },
+        query: { summary: 'Query users' },
+      },
+      callback,
+    )
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback.mock.calls).toStrictEqual([
+      ['get', { summary: 'Get users' }],
+      ['query', { summary: 'Query users' }],
+    ])
+  })
+
   it('does not invoke the callback when the path item is undefined', () => {
     const callback = vi.fn()
 

--- a/packages/workspace-store/src/plugins/bundler/index.test.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.test.ts
@@ -1267,6 +1267,7 @@ describe('syncPathParameters', () => {
           patch: { summary: 'Patch user', parameters: undefined },
           options: { summary: 'Options user', parameters: undefined },
           head: { summary: 'Head user', parameters: undefined },
+          query: { summary: 'Query user', parameters: undefined },
           trace: { summary: 'Trace user', parameters: undefined },
         },
       },

--- a/packages/workspace-store/src/schemas/v3.1/openapi/index.ts
+++ b/packages/workspace-store/src/schemas/v3.1/openapi/index.ts
@@ -1052,6 +1052,7 @@ export const generateSchema = (maybeRef: (inner: Schema) => Schema) => {
       connect: optional(maybeRef(lazy((): Schema => operation))),
       options: optional(maybeRef(lazy((): Schema => operation))),
       head: optional(maybeRef(lazy((): Schema => operation))),
+      query: optional(maybeRef(lazy((): Schema => operation))),
       trace: optional(maybeRef(lazy((): Schema => operation))),
       servers: optional(array(servers, { typeName: 'PathItemServers' })),
       parameters: optional(array(maybeRef(lazy((): Schema => parameter)), { typeName: 'PathItemParameters' })),

--- a/packages/workspace-store/src/schemas/v3.1/strict/path-item.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/path-item.ts
@@ -33,6 +33,8 @@ export const PathItemObjectSchemaDefinition = Type.Object({
   options: Type.Optional(Type.Union([OperationObjectRef, reference(OperationObjectRef)])),
   /** A definition of a HEAD operation on this path. */
   head: Type.Optional(Type.Union([OperationObjectRef, reference(OperationObjectRef)])),
+  /** A definition of a QUERY operation on this path. */
+  query: Type.Optional(Type.Union([OperationObjectRef, reference(OperationObjectRef)])),
   /** A definition of a TRACE operation on this path. */
   trace: Type.Optional(Type.Union([OperationObjectRef, reference(OperationObjectRef)])),
   /** An alternative servers array to service all operations in this path. If a servers array is specified at the OpenAPI Object level, it will be overridden by this value. */
@@ -68,6 +70,8 @@ export type PathItemObject = {
   options?: ReferenceType<OperationObject>
   /** A definition of a HEAD operation on this path. */
   head?: ReferenceType<OperationObject>
+  /** A definition of a QUERY operation on this path. */
+  query?: ReferenceType<OperationObject>
   /** A definition of a TRACE operation on this path. */
   trace?: ReferenceType<OperationObject>
   /** An alternative servers array to service all operations in this path. If a servers array is specified at the OpenAPI Object level, it will be overridden by this value. */

--- a/packages/workspace-store/src/server.test.ts
+++ b/packages/workspace-store/src/server.test.ts
@@ -595,6 +595,20 @@ describe('filter-http-methods-only', () => {
     // check the contents of the operation
     expect(result['/path']?.get).toEqual({ description: 'some description' })
   })
+
+  it('keeps the QUERY method', () => {
+    const result = filterHttpMethodsOnly({
+      '/path': {
+        get: { description: 'get description' },
+        query: { description: 'query description' },
+        // @ts-expect-error - this is a test
+        'x-scalar-test': 'test',
+      },
+    })
+
+    expect(Object.keys(result['/path'] ?? {})).toEqual(['get', 'query'])
+    expect(result['/path']?.query).toEqual({ description: 'query description' })
+  })
 })
 
 describe('escape-paths', () => {

--- a/packages/workspace-store/src/server.ts
+++ b/packages/workspace-store/src/server.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import { cwd } from 'node:process'
 
+import { isHttpMethod } from '@scalar/helpers/http/is-http-method'
 import { parseJsonPointerSegments } from '@scalar/helpers/json/parse-json-pointer-segments'
 import { getValueAtPath } from '@scalar/helpers/object/get-value-at-path'
 import type { LoaderPlugin } from '@scalar/json-magic/bundle'
@@ -55,8 +56,6 @@ type CreateServerWorkspaceStoreProps =
       mode: 'ssr'
     } & CreateServerWorkspaceStoreBase)
 
-const httpMethods = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'])
-
 /**
  * Filters an OpenAPI PathsObject to only include standard HTTP methods.
  * Removes any vendor extensions or other non-HTTP properties.
@@ -87,7 +86,7 @@ export function filterHttpMethodsOnly(paths: PathsObject): Record<string, Record
     const filteredMethods: Record<string, OperationObject> = {}
 
     forEachPathItemOperation(pathItemRef, (method, operation) => {
-      if (httpMethods.has(method.toLowerCase())) {
+      if (isHttpMethod(method)) {
         filteredMethods[method] = getResolvedRef(operation) ?? operation
       }
     })
@@ -181,7 +180,7 @@ export function externalizePathReferences(
     const escapedPath = escapeJsonPointer(path)
 
     keyOf(pathItemRecord).forEach((type) => {
-      if (httpMethods.has(type)) {
+      if (isHttpMethod(type)) {
         const ref =
           meta.mode === 'ssr'
             ? `${meta.baseUrl}/${meta.name}/operations/${escapedPath}/${type}#`


### PR DESCRIPTION
## Problem

`QUERY` is a safe, idempotent HTTP method that carries its query in the request body (per the IETF HTTP QUERY method and OpenAPI 3.2). The v3.2 OpenAPI schema in this repo already recognizes `QUERY`, but the shared HTTP helpers and the workspace store did not, so QUERY operations could not be recognized, rendered, or sent with a body by the API reference and API client.

## Solution

Add `query` as a first-class HTTP method and make sure the reference and client handle it correctly.

**`@scalar/helpers/http`**
- Add `'query'` to `HTTP_METHODS`, so it flows through `isHttpMethod`, `normalizeHttpMethod`, and the `httpMethods` set.
- Add a `REQUEST_METHODS.query` entry with a distinct pink badge (the only unused color in the existing palette).
- Allow QUERY to have a request body via `canMethodHaveBody` (added to `BODY_METHODS`), so `buildSafeBodyRequest` preserves the body.

**`@scalar/workspace-store`**
- Add `query` to the v3.1 path-item schemas (strict typebox schema + type, and the non-strict generator) so QUERY operations are traversed and rendered.
- Replace a duplicated local method `Set` in `server.ts` with the canonical `isHttpMethod` helper, which also picks up `query`.

**Tests** were added across helpers (`http-methods`, `http-info`, `is-http-method`, `normalize-http-method`, `can-method-have-body`), the workspace store (`for-each-path-item-operation`, `server`, `bundler`), and the api-reference, blocks, and api-client `HttpMethod` components (including a new api-client test verifying QUERY is selectable and emits correctly).

Verification: full helpers (863) and workspace-store (2566) suites pass; type checks pass across all consuming packages; Biome + Prettier clean.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HX6GmipCVdHBFoL1eG8xJQ)_