### PR TITLE
chore: add .asyncapi-tool file for AsyncAPI tools directory

### DIFF
--- a/.asyncapi-tool
+++ b/.asyncapi-tool
@@ -1,0 +1,14 @@
+{
+  "title": "Scalar",
+  "description": "Interactive API reference documentation from OpenAPI and AsyncAPI documents. Open-source, embeddable in any web page or framework, with built-in API client capabilities.",
+  "links": {
+    "websiteUrl": "https://scalar.com",
+    "docsUrl": "https://guides.scalar.com"
+  },
+  "filters": {
+    "language": ["TypeScript", "JavaScript", "C#", "Java", "Python", "Rust", "HTML"],
+    "technology": ["Vue.js", "React JS", "Node js", ".NET", "ASP.NET", "Docker"],
+    "categories": ["documentation-generator", "ui-component"],
+    "hasCommercial": true
+  }
+}

--- a/.asyncapi-tool
+++ b/.asyncapi-tool
@@ -6,9 +6,9 @@
     "docsUrl": "https://guides.scalar.com"
   },
   "filters": {
-    "language": ["TypeScript", "JavaScript", "C#", "Java", "Python", "Rust", "HTML"],
+    "language": ["TypeScript", "JavaScript", "HTML", "C#"],
     "technology": ["Vue.js", "React JS", "Node js", ".NET", "ASP.NET", "Docker"],
-    "categories": ["documentation-generator", "ui-component"],
+    "categories": ["ui-component"],
     "hasCommercial": true
   }
 }

--- a/packages/asyncapi-upgrader/.asyncapi-tool
+++ b/packages/asyncapi-upgrader/.asyncapi-tool
@@ -1,0 +1,15 @@
+{
+  "title": "Scalar AsyncAPI Upgrader",
+  "description": "Upgrade AsyncAPI documents to the latest version. Converts AsyncAPI 1.2 to 2.6, 2.6 to 3.0, and 3.0 to 3.1.",
+  "links": {
+    "websiteUrl": "https://scalar.com",
+    "docsUrl": "https://scalar.com/tools/asyncapi-upgrader/getting-started",
+    "repoUrl": "https://github.com/scalar/scalar/tree/main/packages/asyncapi-upgrader"
+  },
+  "filters": {
+    "language": ["TypeScript", "JavaScript"],
+    "technology": ["Node js"],
+    "categories": ["converter"],
+    "hasCommercial": false
+  }
+}


### PR DESCRIPTION
## What

Adds `.asyncapi-tool` discovery files so Scalar gets listed on the [AsyncAPI Tools Dashboard](https://www.asyncapi.com/tools):

- **`.asyncapi-tool`** (repo root) — Scalar, the interactive API reference for OpenAPI and AsyncAPI documents (`ui-component`)
- **`packages/asyncapi-upgrader/.asyncapi-tool`** — @scalar/asyncapi-upgrader, which converts AsyncAPI 1.2 → 2.6 → 3.0 → 3.1 (`converter`)

## Why

Scalar renders interactive API reference documentation from AsyncAPI documents (in addition to OpenAPI). AsyncAPI discovers tools via [`.asyncapi-tool` files](https://github.com/asyncapi/community/blob/master/docs/040-guides/add-new-asyncapi-tool-to-website.md) in the tool''s own repository — their crawler runs weekly and picks them up automatically, no registration on their side needed. Monorepos are supported via multiple files with explicit `repoUrl`.

## Details

- Both files validate against the [AsyncAPI tools schema](https://github.com/asyncapi/website/blob/master/scripts/tools/tools-schema.json)
- Languages on the main card are scoped to integrations that expose an explicit AsyncAPI option today (.NET, JS/TS ecosystem); the list can grow as `documentType` support rolls out to more integrations
- No changeset: repo metadata only, no package is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)