### PR TITLE
docs: address SEO review follow-ups from #9699

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -2942,7 +2942,8 @@
               ]
             },
             "layout": {
-              "toc": false
+              "toc": false,
+              "pageTitle": false
             }
           },
           "/customers/partech": {


### PR DESCRIPTION
## Summary

Follow-ups for the two Cursor Bugbot findings on #9699.

### Enterprise missing `pageTitle` disable — fixed

`/enterprise` now sets `layout.pageTitle: false` like the other hero pages (`/`, `/pricing`, `/customers`). In practice production already renders a single H1 there — the platform skips the injected title heading when the content opens with a level-1 `scalar-heading` — so this is a consistency/intent fix rather than a bug fix.

### Share images "lost site-wide" — intentional, no revert

Un-pinning the global `og:image` is what enables the platform's generated per-page share cards. Per `stampOgImages` in the docs platform (`packages/ssg-docs/src/postprocess/og/stamp.ts` in scalar-org): a **site-level** `og:image` skips card generation for the whole site, while a **page-level** one (the homepage, after #9699) only skips that page. Every other page gets stamped with a generated `https://scalar.com/og/<hash>.png` card that includes `og:image`, `twitter:image`, and `twitter:card` per page — the same cards customer docs sites like kotoba.apidocumentation.com already ship.

At the time of writing, scalar.com is still serving the pre-merge build (it still has `twitter:card: summary`), so this cannot be confirmed live yet.

**After the next publish, verify** a few non-homepage pages emit `og:image` pointing at `/og/….png`. If generation unexpectedly does not run for this site, the fallback is restoring the global `og:image` — accepting static cards everywhere — until the platform side is sorted.

## Ticket

See #9699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single docs-site layout flag in config; no application or security impact.
> 
> **Overview**
> Sets **`layout.pageTitle: false`** on the **`/enterprise`** route in `scalar.config.json`, matching the other marketing hero pages (`/`, `/pricing`, `/customers`).
> 
> That opts the Enterprise page out of the docs platform’s default injected title heading so the page relies on its own hero H1—mostly a consistency fix after the SEO work in #9699, not a functional overhaul.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efa270a174f0a50bb0deaacc47dccdff62d51e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->