### PR TITLE
docs: restore SEO page titles for scalar.com

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -699,6 +699,7 @@
               "pageTitle": false
             },
             "head": {
+              "title": "Scalar — API Documentation, SDKs, MCP Servers & API Client",
               "links": [
                 {
                   "rel": "canonical",
@@ -761,6 +762,7 @@
               "pageTitle": false
             },
             "head": {
+              "title": "Scalar Pricing — Plans for API Docs, SDKs & MCP Servers",
               "links": [
                 {
                   "rel": "canonical",
@@ -799,6 +801,7 @@
               "pageActions": false
             },
             "head": {
+              "title": "Scalar Customers — Trusted by the World's Best API Teams",
               "links": [
                 {
                   "rel": "canonical",
@@ -920,6 +923,7 @@
                     "title": "Getting Started",
                     "description": "Learn how to create and publish stunning developer documentation with Docs in minutes.",
                     "head": {
+                      "title": "Scalar Docs — API Documentation & Developer Docs Platform",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1355,6 +1359,7 @@
                     "filepath": "documentation/guides/agent/getting-started.md",
                     "description": "Turn OpenAPI into MCP servers and connect APIs to LLMs with minimal context usage, delegated auth, and the Agent SDK or chat UI.",
                     "head": {
+                      "title": "Scalar Agent — Turn OpenAPI into MCP Servers for LLMs",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1476,6 +1481,7 @@
                     "title": "Getting Started",
                     "description": "Automatically generate type-safe SDKs from OpenAPI specifications in multiple programming languages.",
                     "head": {
+                      "title": "Scalar SDK Generator — Generate SDKs from OpenAPI",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1713,6 +1719,7 @@
                     "title": "Getting Started",
                     "description": "Store, version, and manage your OpenAPI specifications in a centralized registry with automated CI/CD workflows.",
                     "head": {
+                      "title": "Scalar Registry — OpenAPI Document Management & Versioning",
                       "links": [
                         {
                           "rel": "canonical",
@@ -1790,6 +1797,7 @@
                     "type": "page",
                     "description": "Create stunning API documentation from OpenAPI specs with a modern, customizable interface and built-in request testing.",
                     "head": {
+                      "title": "Scalar API References — Interactive OpenAPI Documentation",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2334,6 +2342,7 @@
                     "title": "Getting Started",
                     "description": "A modern, open-source API client built on the OpenAPI standard with offline-first design and cross-platform support.",
                     "head": {
+                      "title": "Scalar API Client — Free, Open-Source API Testing Client",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2735,6 +2744,7 @@
                     "title": "Getting Started",
                     "description": "Install and use the Scalar CLI to validate, bundle, and deploy OpenAPI specifications from your terminal.",
                     "head": {
+                      "title": "Scalar CLI — OpenAPI Tools for Your Terminal",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2788,6 +2798,7 @@
                     "type": "page",
                     "description": "Spin up realistic mock API servers instantly from OpenAPI specs with custom handlers and data seeding.",
                     "head": {
+                      "title": "Scalar Mock Server — Instant Mock APIs from OpenAPI",
                       "links": [
                         {
                           "rel": "canonical",
@@ -2858,6 +2869,7 @@
                     "type": "page",
                     "description": "Migrate legacy Swagger 2.0 specs to modern OpenAPI 3.x formats automatically with our free conversion tool.",
                     "head": {
+                      "title": "OpenAPI Upgrader — Convert Swagger 2.0 to OpenAPI 3.1",
                       "links": [
                         {
                           "rel": "canonical",
@@ -3031,6 +3043,7 @@
                     "type": "page",
                     "description": "Complete guide to migrating from Swagger UI to API References with modern features and better UX.",
                     "head": {
+                      "title": "Swagger UI Alternative — Migrate to Scalar API References",
                       "links": [
                         {
                           "rel": "canonical",
@@ -3096,6 +3109,7 @@
                     "type": "page",
                     "description": "Set up SSO and SAML authentication for Scalar with enterprise identity providers and secure team access.",
                     "head": {
+                      "title": "SSO & SAML Single Sign-On for Scalar",
                       "links": [
                         {
                           "rel": "canonical",

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -699,7 +699,7 @@
               "pageTitle": false
             },
             "head": {
-              "title": "Scalar — API Documentation, SDKs, MCP Servers & API Client",
+              "title": "API interfaces built for developers and agents",
               "links": [
                 {
                   "rel": "canonical",


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge until scalar-org#5348 is deployed.** Before that platform fix ships, these `head.title` values leak into the sidebar and mobile nav labels (the reason they were reverted in #9699). After it ships, they affect the `<title>` tag only.

## Summary

Re-applies the 14 SEO titles reverted in #9699 (`git revert` of `002c5183c`):

- scalar.com's `<title>` becomes **"Scalar — API Documentation, SDKs, MCP Servers & API Client"** instead of **"Introduction"**
- The eleven landing pages that all share the `<title>` "Getting Started" get unique, keyword-bearing titles (e.g. "Scalar API Client — Free, Open-Source API Testing Client")
- The Swagger UI migration guide is titled "Swagger UI Alternative — Migrate to Scalar API References"

Sidebar labels, search entries, and page headings keep their short names ("Introduction", "Getting Started", …) — that separation is what scalar-org#5348 implements.

## Verification (after merge + publish)

- `document.title` on scalar.com is the new title; the sidebar still shows "Introduction"
- `/products/docs/getting-started` tab shows "Scalar Docs — API Documentation & Developer Docs Platform"; sidebar still shows "Getting Started"

## Ticket

See #9699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only SEO metadata with no runtime or auth changes; main risk is merging before the platform fix and regressing nav labels until deploy.
> 
> **Overview**
> Re-adds **`head.title`** on 14 key scalar.com routes in `scalar.config.json`, restoring SEO titles that were reverted in #9699.
> 
> Landing and marketing pages (home, pricing, customers) and product/tool **Getting Started** pages get distinct, keyword-rich browser titles instead of generic labels like **Introduction** or duplicate **Getting Started**. Migration (Swagger UI) and SSO getting-started pages get the same treatment. Route **`title`** fields are unchanged so sidebar/nav labels stay short once the platform separates `head.title` from nav (scalar-org#5348).
> 
> **Merge should wait** on that deploy; otherwise long `head.title` values can show up in sidebar/mobile nav again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e66483abf0f0d8386d3988d1e1f9da1c27eef96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->