### PR TITLE
docs: patch document titles for key scalar.com pages

### DIFF
--- a/documentation/assets/seo-titles.js
+++ b/documentation/assets/seo-titles.js
@@ -1,0 +1,51 @@
+/*
+ * Temporary SEO title patch.
+ *
+ * The docs platform currently derives the document <title> from the
+ * navigation title, so pages like the homepage render as "Introduction"
+ * and every product landing page as "Getting Started". This script owns
+ * document.title for those routes without touching sidebar labels.
+ *
+ * Remove once scalar-org#5348 is deployed and the titles move into
+ * scalar.config.json head.title (see scalar/scalar#9704).
+ */
+;(() => {
+  const TITLES = {
+    '/': 'Scalar — API Documentation, SDKs, MCP Servers & API Client',
+    '/pricing': 'Scalar Pricing — Plans for API Docs, SDKs & MCP Servers',
+    '/customers': "Scalar Customers — Trusted by the World's Best API Teams",
+    '/products/docs/getting-started': 'Scalar Docs — API Documentation & Developer Docs Platform',
+    '/products/agent/getting-started': 'Scalar Agent — Turn OpenAPI into MCP Servers for LLMs',
+    '/products/sdks/getting-started': 'Scalar SDK Generator — Generate SDKs from OpenAPI',
+    '/products/registry/getting-started': 'Scalar Registry — OpenAPI Document Management & Versioning',
+    '/products/api-references/getting-started': 'Scalar API References — Interactive OpenAPI Documentation',
+    '/products/api-client/getting-started': 'Scalar API Client — Free, Open-Source API Testing Client',
+    '/tools/cli/getting-started': 'Scalar CLI — OpenAPI Tools for Your Terminal',
+    '/tools/mock-server/getting-started': 'Scalar Mock Server — Instant Mock APIs from OpenAPI',
+    '/tools/openapi-upgrader/getting-started': 'OpenAPI Upgrader — Convert Swagger 2.0 to OpenAPI 3.1',
+    '/resources/sso/getting-started': 'SSO & SAML Single Sign-On for Scalar',
+    '/resources/migration/swagger-ui': 'Swagger UI Alternative — Migrate to Scalar API References',
+  }
+
+  const applyTitle = () => {
+    const path = location.pathname.replace(/\/+$/, '') || '/'
+    const wanted = TITLES[path]
+
+    // The equality check keeps the observer from looping on our own write.
+    if (wanted && document.title !== wanted) {
+      document.title = wanted
+    }
+  }
+
+  // The app resets the title after hydration and on every client-side
+  // navigation, so re-apply whenever anything in <head> changes.
+  const observer = new MutationObserver(applyTitle)
+  observer.observe(document.head, {
+    subtree: true,
+    childList: true,
+    characterData: true,
+  })
+
+  window.addEventListener('popstate', applyTitle)
+  applyTitle()
+})()

--- a/documentation/assets/seo-titles.js
+++ b/documentation/assets/seo-titles.js
@@ -11,7 +11,7 @@
  */
 ;(() => {
   const TITLES = {
-    '/': 'Scalar — API Documentation, SDKs, MCP Servers & API Client',
+    '/': 'API interfaces built for developers and agents',
     '/pricing': 'Scalar Pricing — Plans for API Docs, SDKs & MCP Servers',
     '/customers': "Scalar Customers — Trusted by the World's Best API Teams",
     '/products/docs/getting-started': 'Scalar Docs — API Documentation & Developer Docs Platform',

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -12,6 +12,9 @@
     "head": {
       "scripts": [
         {
+          "path": "documentation/assets/seo-titles.js"
+        },
+        {
           "path": "documentation/assets/landing.js"
         },
         {


### PR DESCRIPTION
## Summary

Gets the title fix live now, without waiting on the platform. The docs platform derives the `<title>` tag from the navigation title, so scalar.com's homepage is titled **"Introduction"** and eleven product landing pages are all titled **"Getting Started"**.

This adds `documentation/assets/seo-titles.js` (injected via the existing `siteConfig.head.scripts` mechanism) that owns `document.title` for 14 mapped routes. Sidebar labels, search entries, and headings are untouched — the script only writes `document.title`. A `MutationObserver` on `<head>` re-applies the title after hydration and on every client-side navigation; unmapped routes are left alone.

## Verified locally (`scalar project preview`)

| Route | Tab title |
|---|---|
| `/` | Scalar — API Documentation, SDKs, MCP Servers & API Client |
| `/pricing` (SPA nav) | Scalar Pricing — Plans for API Docs, SDKs & MCP Servers |
| `/products/docs/getting-started` | Scalar Docs — API Documentation & Developer Docs Platform |
| `/products/sdks/managing` (unmapped) | Managing Your SDK — unchanged |

Sidebar shows the original short labels everywhere.

## Caveat

The server-rendered HTML still contains the old `<title>`; the patched title applies when JS runs. Google's renderer picks up JS-set titles, and non-JS scrapers (Slack, X) use `og:title`, which this does not touch — so coverage is good but not perfect. The proper fix is scalar-org#5348 + #9704, at which point this script and its `head.scripts` entry should be deleted (the file header says so).

## Ticket

See #9699

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only marketing script with no auth or data changes; minor caveat that tab titles are JS-dependent until the platform ships native title support.
> 
> **Overview**
> Adds a **temporary client-side SEO fix** because the docs platform still sets `<title>` from nav labels (e.g. homepage **Introduction**, product landings **Getting Started**).
> 
> A new `documentation/assets/seo-titles.js` maps **14 paths** to marketing-friendly `document.title` strings and is loaded globally via `scalar.config.json` `siteConfig.head.scripts`. It only updates the browser tab title—sidebar and page headings stay unchanged. A `MutationObserver` on `<head>` plus `popstate` re-applies titles after hydration and SPA navigations; routes not in the map are untouched.
> 
> **Note:** Titles apply after JS runs; SSR HTML and `og:title` are unchanged until the platform fix lands (script is documented as removable then).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ad07c16d680b5786962e6233062ea4fa33ffbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->