### PR TITLE
feat(api-client): OAuth2 token-acquisition for bearer schemes

### DIFF
--- a/.changeset/oauth2-token-acquisition.md
+++ b/.changeset/oauth2-token-acquisition.md
@@ -1,0 +1,18 @@
+---
+'@scalar/api-client': minor
+---
+
+Add an OAuth2 token-acquisition shortcut to HTTP bearer schemes, so a bearer
+token can be obtained through an OAuth2 flow without switching auth methods.
+
+- The bearer scheme's form gains an inline **Authorize via OAuth2** shortcut
+  (and, for authorization-code, **Refresh**) that runs the flow and writes the
+  resulting access token onto the bearer scheme — so the panel never switches
+  to oauth2 and the request sends `Authorization: Bearer`. A gear opens the
+  oauth2 configuration in a modal (`OAuth2.hideActions`).
+- A new `getOauth2AcquisitionTarget` helper finds the oauth2 flow the shortcut
+  uses, preferring the authorization-code grant (which can refresh) over
+  implicit. Every defined security scheme, oauth2 included, stays selectable in
+  the auth dropdown — the shortcut is purely additive.
+- `runOAuth2Authorize` + `storeOAuth2Tokens` route the access token to the
+  bearer scheme and the refresh token to the oauth2 scheme.

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.test.ts
@@ -63,6 +63,35 @@ describe('OAuth2', () => {
     })
   }
 
+  it('hides the Authorize / Refresh / Clear actions when hideActions is set', () => {
+    const wrapper = mount(OAuth2, {
+      attachTo: document.body,
+      props: {
+        environment: baseEnv as any,
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://example.com/auth',
+            tokenUrl: 'https://example.com/token',
+            refreshUrl: '',
+            'x-usePkce': 'no',
+            scopes: {},
+          },
+        } as any,
+        type: 'authorizationCode',
+        selectedScopes: [],
+        server: null,
+        proxyUrl: '',
+        scheme: { type: 'oauth2' } as any,
+        options: {},
+        eventBus,
+        name: 'OAuth2',
+        hideActions: true,
+      },
+    })
+
+    expect(wrapper.text()).not.toContain('Authorize')
+  })
+
   it('renders Access Token view when token is present and supports clearing', async () => {
     const wrapper = mountWithProps({
       flows: {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
@@ -82,6 +82,12 @@ const {
   eventBus: WorkspaceEventBus
   /**  Any config options required for the OAuth2 flow */
   options?: OAuth2Options
+  /**
+   * Hides the Authorize / Refresh / Clear actions. Used when the form is embedded as a
+   * configuration-only view (e.g. behind a gear icon), so the host component owns the
+   * authorize action and the tokens are routed to the scheme it chooses.
+   */
+  hideActions?: boolean
 }>()
 
 const emits = defineEmits<{
@@ -389,7 +395,9 @@ const handleSecretLocationUpdate = (value: string): void => {
       </RequestAuthDataTableInput>
     </DataTableRow>
 
-    <DataTableRow class="min-w-full">
+    <DataTableRow
+      v-if="!hideActions"
+      class="min-w-full">
       <div class="flex h-8 items-center justify-end gap-2 border-t">
         <ScalarButton
           v-if="supportsRefreshToken"
@@ -563,7 +571,9 @@ const handleSecretLocationUpdate = (value: string): void => {
         @delete:scope="(v) => emits('delete:scope', v)" />
     </DataTableRow>
 
-    <DataTableRow class="min-w-full">
+    <DataTableRow
+      v-if="!hideActions"
+      class="min-w-full">
       <div class="flex h-8 w-full items-center justify-end border-t">
         <!-- Allow clearing the oauth section and going back to discovery -->
         <ScalarButton

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.test.ts
@@ -8,6 +8,14 @@ import OpenIDConnect from '@/v2/blocks/scalar-auth-selector-block/components/Ope
 import RequestAuthDataTableInput from '@/v2/blocks/scalar-auth-selector-block/components/RequestAuthDataTableInput.vue'
 import RequestAuthTab from '@/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue'
 
+// Avoid a real OAuth round-trip (window.open) when the Authorize shortcut is clicked.
+vi.mock('@/v2/blocks/scalar-auth-selector-block/helpers/run-oauth2-authorize', () => ({
+  runOAuth2Authorize: vi.fn(),
+  storeOAuth2Tokens: vi.fn(),
+}))
+
+import { runOAuth2Authorize } from '@/v2/blocks/scalar-auth-selector-block/helpers/run-oauth2-authorize'
+
 describe('RequestAuthTab', () => {
   const baseEnvironment = {
     uid: 'env-1' as any,
@@ -919,6 +927,58 @@ describe('RequestAuthTab', () => {
       // Descriptions are rendered separately as rich text below each header
       expect(wrapper.text()).toContain('Bearer token authentication')
       expect(wrapper.text()).toContain('API Key authentication')
+    })
+  })
+
+  describe('OAuth2 token acquisition', () => {
+    const schemesWithOauth2 = {
+      BearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        description: 'Bearer token authentication',
+        'x-scalar-secret-token': '',
+      },
+      OAuth2: {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            authorizationUrl: 'https://example.com/auth',
+            tokenUrl: 'https://example.com/token',
+            refreshUrl: '',
+            'x-usePkce': 'no',
+            scopes: {},
+          },
+        },
+      },
+    }
+
+    it('renders an Authorize via OAuth2 shortcut when a bearer scheme has an oauth2 source', () => {
+      const wrapper = mountWithProps({ securitySchemes: schemesWithOauth2 })
+
+      expect(wrapper.text()).toContain('Authorize via OAuth2')
+    })
+
+    it('hides the shortcut when there is no oauth2 acquisition source', () => {
+      // Default mountWithProps: bearer scheme only, no oauth2
+      const wrapper = mountWithProps()
+
+      expect(wrapper.text()).not.toContain('Authorize via OAuth2')
+    })
+
+    it('runs authorize against the bearer scheme on click', async () => {
+      vi.mocked(runOAuth2Authorize).mockResolvedValue([null, { accessToken: 'tok' }])
+
+      const wrapper = mountWithProps({ securitySchemes: schemesWithOauth2 })
+      const button = wrapper.findAll('button').find((b) => b.text().includes('Authorize via'))
+      await button?.trigger('click')
+      await nextTick()
+
+      expect(runOAuth2Authorize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bearerSchemeName: 'BearerAuth',
+          oauth2Name: 'OAuth2',
+        }),
+      )
     })
   })
 })

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
+import { ScalarButton } from '@scalar/components/button'
+import { ScalarIconButton } from '@scalar/components/icon-button'
+import { useLoadingState } from '@scalar/components/loading'
 import { ScalarMarkdownSummary } from '@scalar/components/markdown'
+import { ScalarModal, useModal } from '@scalar/components/modal'
+import { ScalarIconGear } from '@scalar/icons'
+import { useToasts } from '@scalar/use-toasts'
 import type {
   SecretsApiKey,
   SecretsHttp,
@@ -10,6 +16,7 @@ import type {
 } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import {
+  getEnvironmentVariables,
   isEncryptionSchemeType,
   isSaslSchemeType,
   type EncryptionObjectSecret,
@@ -28,7 +35,17 @@ import type {
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { capitalize, computed, ref } from 'vue'
 
-import { DataTableCell, DataTableRow } from '@/v2/components/data-table'
+import { refreshOauth2Token } from '@/v2/blocks/scalar-auth-selector-block/helpers/oauth'
+import {
+  runOAuth2Authorize,
+  storeOAuth2Tokens,
+} from '@/v2/blocks/scalar-auth-selector-block/helpers/run-oauth2-authorize'
+import { getOauth2AcquisitionTarget } from '@/v2/blocks/scalar-auth-selector-block/helpers/security-scheme'
+import {
+  DataTable,
+  DataTableCell,
+  DataTableRow,
+} from '@/v2/components/data-table'
 
 import OAuth2, { type OAuth2Options } from './OAuth2.vue'
 import OpenIDConnect from './OpenIDConnect.vue'
@@ -290,6 +307,106 @@ const getFlowTabClasses = (flowKey: string, index: number): string => {
     ? `${baseClasses} ${activeClasses} ${isStatic ? 'opacity-100' : ''}`
     : baseClasses
 }
+
+/**
+ * OAuth2 token-acquisition target (an oauth2 scheme with an interactive grant) sourced from
+ * the merged schemes. When the active scheme is HTTP bearer, this powers the inline
+ * "Authorize via OAuth2" shortcut: the flow's bearer token is written onto the bearer scheme,
+ * so the panel never switches to oauth2.
+ *
+ * The shortcut is purely a convenience, so it is offered for any interactive oauth2 scheme —
+ * including one that is also independently selectable in the dropdown (e.g. Scalar Galaxy's
+ * `oAuth2`). Whether that oauth2 scheme is *hidden* from the dropdown is a separate decision made
+ * in the selector; here we only surface the shortcut.
+ */
+const oauth2Target = computed(() => getOauth2AcquisitionTarget(securitySchemes))
+
+/** Resolved oauth2 scheme object, for embedding its config form behind the gear. */
+const oauth2Scheme = computed(() =>
+  oauth2Target.value
+    ? getResolvedRef(securitySchemes[oauth2Target.value.name])
+    : undefined,
+)
+
+const acquisitionLoader = useLoadingState()
+const { toast } = useToasts()
+const configModal = useModal()
+/** Bearer scheme that opened the config modal, so its Authorize callback targets it. */
+const configBearerName = ref<string | undefined>()
+
+/** Runs the OAuth2 flow and writes the resulting bearer token onto the bearer scheme. */
+const handleAcquisitionAuthorize = async (
+  bearerName: string,
+): Promise<void> => {
+  const target = oauth2Target.value
+  if (!target || acquisitionLoader.isLoading) {
+    return
+  }
+  acquisitionLoader.start()
+  const [error] = await runOAuth2Authorize({
+    eventBus,
+    bearerSchemeName: bearerName,
+    oauth2Name: target.name,
+    flows: target.flows,
+    flowType: target.flowType,
+    scopes: target.scopes,
+    server,
+    proxyUrl,
+    environment,
+    options,
+  })
+  await acquisitionLoader.clear()
+  if (error) {
+    toast(error?.message ?? 'Failed to authorize', 'error')
+  }
+}
+
+/** Refreshes the OAuth2 token and rewrites it onto the bearer scheme. */
+const handleAcquisitionRefresh = async (bearerName: string): Promise<void> => {
+  const target = oauth2Target.value
+  // Only the authorization-code flow carries a refresh token; implicit can't be refreshed.
+  if (
+    !target ||
+    target.flowType !== 'authorizationCode' ||
+    acquisitionLoader.isLoading
+  ) {
+    return
+  }
+  acquisitionLoader.start()
+  const [error, tokens] = await refreshOauth2Token(
+    target.flows,
+    target.flowType,
+    proxyUrl,
+    server,
+    getEnvironmentVariables(environment),
+    options?.customFetch,
+  )
+  await acquisitionLoader.clear()
+  if (tokens?.accessToken) {
+    storeOAuth2Tokens(eventBus, {
+      bearerSchemeName: bearerName,
+      oauth2Name: target.name,
+      flowType: target.flowType,
+      tokens,
+    })
+  } else if (error) {
+    toast(error?.message ?? 'Failed to refresh', 'error')
+  }
+}
+
+const openAcquisitionConfig = (bearerName: string): void => {
+  configBearerName.value = bearerName
+  configModal.show()
+}
+
+/** Closes the config modal and runs Authorize against the bearer scheme that opened it. */
+const handleConfigAuthorize = (): void => {
+  const bearerName = configBearerName.value
+  configModal.hide()
+  if (bearerName) {
+    void handleAcquisitionAuthorize(bearerName)
+  }
+}
 </script>
 <template>
   <template
@@ -341,6 +458,40 @@ const getFlowTabClasses = (flowKey: string, index: number): string => {
           ">
           Bearer Token
         </RequestAuthDataTableInput>
+      </DataTableRow>
+
+      <!-- OAuth2 token-acquisition shortcut (shown when an interactive oauth2 flow exists) -->
+      <DataTableRow v-if="scheme.scheme === 'bearer' && oauth2Target">
+        <div class="flex h-8 items-center gap-2 border-t px-3">
+          <span class="text-c-3 mr-auto text-xs">Get a token</span>
+          <ScalarButton
+            class="p-0 px-2 py-0.5"
+            :loader="acquisitionLoader"
+            size="sm"
+            type="button"
+            variant="outlined"
+            @click="handleAcquisitionAuthorize(name)">
+            Authorize via {{ oauth2Target.name }}
+          </ScalarButton>
+          <ScalarButton
+            v-if="
+              scheme['x-scalar-secret-token'] &&
+              oauth2Target.flowType === 'authorizationCode'
+            "
+            class="p-0 px-2 py-0.5"
+            :disabled="acquisitionLoader.isLoading"
+            size="sm"
+            type="button"
+            variant="outlined"
+            @click="handleAcquisitionRefresh(name)">
+            Refresh
+          </ScalarButton>
+          <ScalarIconButton
+            :icon="ScalarIconGear"
+            :label="`Configure ${oauth2Target.name}`"
+            size="xs"
+            @click="openAcquisitionConfig(name)" />
+        </div>
       </DataTableRow>
 
       <!-- HTTP Basic Authentication -->
@@ -597,4 +748,51 @@ const getFlowTabClasses = (flowKey: string, index: number): string => {
       {{ documentTypeLabel }} document or Authentication Configuration
     </div>
   </template>
+
+  <!-- OAuth2 configuration modal (opened from the bearer scheme's gear) -->
+  <ScalarModal
+    v-if="oauth2Target && oauth2Scheme"
+    :state="configModal"
+    size="sm"
+    :title="`Configure ${oauth2Target.name}`">
+    <DataTable
+      :columns="['']"
+      presentational>
+      <OAuth2
+        hideActions
+        :environment
+        :eventBus
+        :flows="oauth2Target.flows"
+        :name="oauth2Target.name"
+        :options
+        :proxyUrl
+        :scheme="oauth2Scheme"
+        :selectedScopes="oauth2Target.scopes"
+        :server
+        :type="oauth2Target.flowType"
+        @delete:scope="(event) => handleScopeDelete(oauth2Target!.name, event)"
+        @update:selectedScopes="
+          (event) => handleScopesUpdate(oauth2Target!.name, event)
+        "
+        @upsert:scope="
+          (event) => handleScopeUpsert(oauth2Target!.name, event)
+        " />
+    </DataTable>
+    <div class="flex h-8 items-center justify-end gap-2 border-t">
+      <ScalarButton
+        class="p-0 px-2 py-0.5"
+        size="sm"
+        variant="outlined"
+        @click="configModal.hide()">
+        Cancel
+      </ScalarButton>
+      <ScalarButton
+        class="p-0 px-2 py-0.5"
+        :loader="acquisitionLoader"
+        size="sm"
+        @click="handleConfigAuthorize">
+        Authorize
+      </ScalarButton>
+    </div>
+  </ScalarModal>
 </template>

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/run-oauth2-authorize.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/run-oauth2-authorize.test.ts
@@ -1,0 +1,158 @@
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { runOAuth2Authorize, storeOAuth2Tokens } from './run-oauth2-authorize'
+
+// authorizeOauth2 is mocked so the helper's token-routing is tested without a real OAuth round-trip.
+vi.mock('./oauth', () => ({ authorizeOauth2: vi.fn() }))
+
+import { authorizeOauth2 } from './oauth'
+
+const baseFlows = {
+  authorizationCode: {
+    authorizationUrl: 'https://auth.example.com/authorize',
+    tokenUrl: 'https://auth.example.com/token',
+    refreshUrl: '',
+    'x-usePkce': 'no',
+    scopes: { openid: '', profile: '' },
+    'x-scalar-secret-client-id': 'client',
+    'x-scalar-secret-redirect-uri': '',
+  },
+} as never
+
+const environment = { variables: [] } as never
+
+describe('runOAuth2Authorize', () => {
+  const emit = vi.fn()
+  const eventBus = { emit } as unknown as WorkspaceEventBus
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes the access token to the bearer scheme and the refresh token to oauth2', async () => {
+    vi.mocked(authorizeOauth2).mockResolvedValue([null, { accessToken: 'acc', refreshToken: 'ref' }])
+
+    const [error, tokens] = await runOAuth2Authorize({
+      eventBus,
+      bearerSchemeName: 'BearerAuth',
+      oauth2Name: 'OAuth2',
+      flows: baseFlows,
+      flowType: 'authorizationCode',
+      scopes: ['openid'],
+      server: null,
+      proxyUrl: '',
+      environment,
+    })
+
+    expect(error).toBeNull()
+    expect(tokens).toEqual({ accessToken: 'acc', refreshToken: 'ref' })
+    // access token → bearer scheme (sent as Authorization: Bearer)
+    expect(emit).toHaveBeenCalledWith('auth:update:security-scheme-secrets', {
+      payload: { type: 'http', 'x-scalar-secret-token': 'acc' },
+      name: 'BearerAuth',
+    })
+    // refresh token → oauth2 scheme (the only thing that knows how to refresh)
+    expect(emit).toHaveBeenCalledWith('auth:update:security-scheme-secrets', {
+      payload: {
+        type: 'oauth2',
+        authorizationCode: { 'x-scalar-secret-refresh-token': 'ref' },
+      },
+      name: 'OAuth2',
+    })
+  })
+
+  it('omits the refresh emit when the flow returns no refresh token', async () => {
+    vi.mocked(authorizeOauth2).mockResolvedValue([null, { accessToken: 'acc' }])
+
+    await runOAuth2Authorize({
+      eventBus,
+      bearerSchemeName: 'BearerAuth',
+      oauth2Name: 'OAuth2',
+      flows: baseFlows,
+      flowType: 'authorizationCode',
+      scopes: [],
+      server: null,
+      proxyUrl: '',
+      environment,
+    })
+
+    expect(emit).toHaveBeenCalledTimes(1)
+    expect(emit).toHaveBeenCalledWith('auth:update:security-scheme-secrets', {
+      payload: { type: 'http', 'x-scalar-secret-token': 'acc' },
+      name: 'BearerAuth',
+    })
+  })
+
+  it('does not store secrets when authorization fails', async () => {
+    vi.mocked(authorizeOauth2).mockResolvedValue([new Error('denied'), null])
+
+    const [error, tokens] = await runOAuth2Authorize({
+      eventBus,
+      bearerSchemeName: 'BearerAuth',
+      oauth2Name: 'OAuth2',
+      flows: baseFlows,
+      flowType: 'authorizationCode',
+      scopes: [],
+      server: null,
+      proxyUrl: '',
+      environment,
+    })
+
+    expect(error?.message).toBe('denied')
+    expect(tokens).toBeNull()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('defaults the redirect URI for interactive flows before authorizing', async () => {
+    vi.mocked(authorizeOauth2).mockResolvedValue([null, { accessToken: 'acc' }])
+
+    await runOAuth2Authorize({
+      eventBus,
+      bearerSchemeName: 'BearerAuth',
+      oauth2Name: 'OAuth2',
+      flows: baseFlows,
+      flowType: 'authorizationCode',
+      scopes: [],
+      server: null,
+      proxyUrl: '',
+      environment,
+    })
+
+    const passedFlows = vi.mocked(authorizeOauth2).mock.calls[0]![0] as {
+      authorizationCode: { 'x-scalar-secret-redirect-uri': string }
+    }
+    expect(passedFlows.authorizationCode['x-scalar-secret-redirect-uri']).not.toBe('')
+  })
+})
+
+describe('storeOAuth2Tokens', () => {
+  const emit = vi.fn()
+  const eventBus = { emit } as unknown as WorkspaceEventBus
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes access to bearer and refresh to oauth2', () => {
+    storeOAuth2Tokens(eventBus, {
+      bearerSchemeName: 'BearerAuth',
+      oauth2Name: 'OAuth2',
+      flowType: 'authorizationCode',
+      tokens: { accessToken: 'a', refreshToken: 'r' },
+    })
+
+    expect(emit).toHaveBeenCalledTimes(2)
+    expect(emit).toHaveBeenCalledWith('auth:update:security-scheme-secrets', {
+      payload: { type: 'http', 'x-scalar-secret-token': 'a' },
+      name: 'BearerAuth',
+    })
+    expect(emit).toHaveBeenCalledWith('auth:update:security-scheme-secrets', {
+      payload: {
+        type: 'oauth2',
+        authorizationCode: { 'x-scalar-secret-refresh-token': 'r' },
+      },
+      name: 'OAuth2',
+    })
+  })
+})

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/run-oauth2-authorize.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/run-oauth2-authorize.ts
@@ -1,0 +1,105 @@
+import type { ErrorResponse } from '@scalar/helpers/errors/normalize-error'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import { type OAuthFlowsObjectSecret, getEnvironmentVariables } from '@scalar/workspace-store/request-example'
+import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
+import type { ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+
+import type { OAuth2Options } from '@/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue'
+import { type OAuth2Tokens, authorizeOauth2 } from '@/v2/blocks/scalar-auth-selector-block/helpers/oauth'
+import { resolveDefaultOAuth2RedirectUri } from '@/v2/blocks/scalar-auth-selector-block/helpers/resolve-default-oauth2-redirect-url'
+
+/**
+ * Persists OAuth2 tokens split across the two schemes that care about them:
+ *
+ * - The **access token** lands on the consuming HTTP bearer scheme, so it is sent as
+ *   `Authorization: Bearer <token>` without the bearer scheme losing focus.
+ * - The **refresh token** stays on the oauth2 scheme, which is the only place that knows
+ *   how to refresh (token URL, flow, client credentials).
+ */
+export const storeOAuth2Tokens = (
+  eventBus: WorkspaceEventBus,
+  params: {
+    bearerSchemeName: string
+    oauth2Name: string
+    flowType: keyof OAuthFlowsObjectSecret
+    tokens: OAuth2Tokens
+  },
+): void => {
+  const { bearerSchemeName, oauth2Name, flowType, tokens } = params
+
+  eventBus.emit('auth:update:security-scheme-secrets', {
+    payload: { type: 'http', 'x-scalar-secret-token': tokens.accessToken },
+    name: bearerSchemeName,
+  })
+
+  if (tokens.refreshToken) {
+    eventBus.emit('auth:update:security-scheme-secrets', {
+      payload: {
+        type: 'oauth2',
+        [flowType]: { 'x-scalar-secret-refresh-token': tokens.refreshToken },
+      },
+      name: oauth2Name,
+    })
+  }
+}
+
+/**
+ * Runs the OAuth2 authorization flow and stores the resulting tokens on the bearer scheme
+ * (access token) and the oauth2 scheme (refresh token).
+ *
+ * Used by the bearer scheme's "Authorize via OAuth2" shortcut: it defaults the redirect URI
+ * (`authorizeOauth2` reads it straight off the flow), kicks off the flow, then routes the
+ * tokens through {@link storeOAuth2Tokens}.
+ */
+export const runOAuth2Authorize = async (params: {
+  eventBus: WorkspaceEventBus
+  bearerSchemeName: string
+  oauth2Name: string
+  flows: OAuthFlowsObjectSecret
+  flowType: keyof OAuthFlowsObjectSecret
+  scopes: string[]
+  server: ServerObject | null
+  proxyUrl: string
+  environment: XScalarEnvironment
+  options?: OAuth2Options
+}): Promise<ErrorResponse<OAuth2Tokens>> => {
+  const { eventBus, bearerSchemeName, oauth2Name, flows, flowType, scopes, server, proxyUrl, environment, options } =
+    params
+
+  const flow = flows[flowType]
+
+  // authorizeOauth2 reads the redirect URI directly off interactive flows, so default it
+  // when unset — a scheme merged in from Scalar config can then authorize without first
+  // opening the configuration form.
+  const preparedFlows =
+    flow && (flowType === 'authorizationCode' || flowType === 'implicit')
+      ? {
+          ...flows,
+          [flowType]: {
+            ...flow,
+            'x-scalar-secret-redirect-uri':
+              (flow as unknown as Record<string, string | undefined>)['x-scalar-secret-redirect-uri'] ||
+              resolveDefaultOAuth2RedirectUri(options ?? {}) ||
+              '',
+          },
+        }
+      : flows
+
+  const result = await authorizeOauth2(
+    preparedFlows,
+    flowType,
+    scopes,
+    server,
+    proxyUrl,
+    getEnvironmentVariables(environment),
+    options?.customFetch,
+    options?.captureOAuth2Callback,
+  )
+  const tokens = result[1]
+
+  if (tokens?.accessToken) {
+    storeOAuth2Tokens(eventBus, { bearerSchemeName, oauth2Name, flowType, tokens })
+  }
+
+  return result
+}

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
@@ -6,6 +6,7 @@ import {
   type SecuritySchemeOption,
   formatComplexScheme,
   formatScheme,
+  getOauth2AcquisitionTarget,
   getSecuritySchemeOptions,
 } from './security-scheme'
 
@@ -732,6 +733,58 @@ describe('security-scheme', () => {
       expect(groups[0]?.options[0]?.label).toBe('OAuth2')
       expect(groups[0]?.options[0]?.value).toEqual({ OAuth2: ['read'] })
       expect(groups[1]?.options.some((option) => option.label === 'OAuth2')).toBe(false)
+    })
+  })
+
+  describe('getOauth2AcquisitionTarget', () => {
+    it('returns null when no oauth2 scheme has an interactive grant', () => {
+      const schemes: NonNullable<ComponentsObject['securitySchemes']> = {
+        BearerAuth: { type: 'http', scheme: 'bearer' },
+        ClientCredentials: {
+          type: 'oauth2',
+          flows: { clientCredentials: { tokenUrl: 'https://auth.example.com/token', refreshUrl: '', scopes: {} } },
+        },
+      }
+
+      expect(getOauth2AcquisitionTarget(schemes)).toBeNull()
+    })
+
+    it('prefers an authorization-code grant over an implicit one even when implicit is declared first', () => {
+      const schemes: NonNullable<ComponentsObject['securitySchemes']> = {
+        ImplicitOnly: {
+          type: 'oauth2',
+          flows: { implicit: { authorizationUrl: 'https://auth.example.com/authorize', refreshUrl: '', scopes: {} } },
+        },
+        AuthCode: {
+          type: 'oauth2',
+          flows: {
+            authorizationCode: {
+              authorizationUrl: 'https://auth.example.com/authorize',
+              tokenUrl: 'https://auth.example.com/token',
+              refreshUrl: '',
+              'x-usePkce': 'no',
+              scopes: {},
+            },
+          },
+        },
+      }
+
+      const target = getOauth2AcquisitionTarget(schemes)
+      expect(target?.name).toBe('AuthCode')
+      expect(target?.flowType).toBe('authorizationCode')
+    })
+
+    it('falls back to an implicit grant when no authorization-code flow exists', () => {
+      const schemes: NonNullable<ComponentsObject['securitySchemes']> = {
+        ImplicitOnly: {
+          type: 'oauth2',
+          flows: { implicit: { authorizationUrl: 'https://auth.example.com/authorize', refreshUrl: '', scopes: {} } },
+        },
+      }
+
+      const target = getOauth2AcquisitionTarget(schemes)
+      expect(target?.name).toBe('ImplicitOnly')
+      expect(target?.flowType).toBe('implicit')
     })
   })
 })

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
@@ -1,6 +1,6 @@
 import { generateHash } from '@scalar/helpers/string/generate-hash'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
-import type { MergedSecuritySchemes } from '@scalar/workspace-store/request-example'
+import type { MergedSecuritySchemes, OAuthFlowsObjectSecret } from '@scalar/workspace-store/request-example'
 import type {
   ComponentsObject,
   OpenApiDocument,
@@ -73,6 +73,54 @@ const formatSecurityRequirement = (
   }
 
   return undefined
+}
+
+/**
+ * Finds the oauth2 scheme best suited to power a bearer scheme's "Authorize via OAuth2" shortcut:
+ * the first scheme with an interactive grant (authorization code / implicit), the kind that sends
+ * a user to an IdP login. Prefers the authorization-code grant (which can refresh) over one
+ * offering only implicit, so the more capable flow wins even when it is declared later.
+ *
+ * This only surfaces a convenience shortcut on the bearer form — it never hides the oauth2 scheme,
+ * which stays independently selectable in the auth dropdown.
+ */
+export const getOauth2AcquisitionTarget = (
+  securitySchemes: NonNullable<ComponentsObject['securitySchemes']> | MergedSecuritySchemes,
+): {
+  name: string
+  flows: OAuthFlowsObjectSecret
+  flowType: 'authorizationCode' | 'implicit'
+  scopes: string[]
+} | null => {
+  let implicitFallback: {
+    name: string
+    flows: OAuthFlowsObjectSecret
+    flowType: 'implicit'
+    scopes: string[]
+  } | null = null
+
+  for (const [name, schemeRef] of Object.entries(securitySchemes)) {
+    const scheme = getResolvedRef(schemeRef)
+    if (scheme?.type !== 'oauth2') {
+      continue
+    }
+    const flows = scheme.flows as OAuthFlowsObjectSecret | undefined
+    if (!flows) {
+      continue
+    }
+    const scopes = (scheme as { 'x-default-scopes'?: string[] })['x-default-scopes'] ?? []
+
+    // Authorization code can refresh, so it wins outright the moment we find one.
+    if (flows.authorizationCode) {
+      return { name, flows, flowType: 'authorizationCode', scopes }
+    }
+    // Otherwise remember the first implicit-only scheme in case no auth-code flow turns up.
+    if (flows.implicit && !implicitFallback) {
+      implicitFallback = { name, flows, flowType: 'implicit', scopes }
+    }
+  }
+
+  return implicitFallback
 }
 
 /**


### PR DESCRIPTION
## What this does

Treats a config-defined OAuth2 flow as a **token-acquisition source** for a declared HTTP bearer scheme, rather than a competing auth method.

- An `oauth2` scheme that no operation declares is **kept out of the auth dropdown**, so it can't be multi-selected alongside bearer (which would collide on `Authorization`). A new `getOauth2AcquisitionTarget` helper finds the first interactive (authorization-code / implicit) flow.
- The bearer scheme's form gains an inline **"Authorize via OAuth2"** shortcut (plus **Refresh** for authorization-code, plus a **gear** that opens the OAuth2 configuration in a modal). The flow's access token is written onto the **bearer** scheme, so the panel never switches to oauth2 and the request sends `Authorization: Bearer`. The refresh token stays on the oauth2 scheme — the only place that knows how to refresh.
- `runOAuth2Authorize` + `storeOAuth2Tokens` route the access token to the bearer scheme and the refresh token to the oauth2 scheme.

## Why config-side

Our gateway serves one merged spec declaring only `BearerAuth`. Declaring oauth2 in the spec isn't safe across generators: openapi-generator emits OAuth2 token-acquisition infrastructure for every consumer the moment `oauth2` appears in `components.securitySchemes`, and kiota's plugin generator throws on multiple security requirements. So the flow has to live in Scalar config (`authentication.oauth2`) — which is what made it surface as a confusing peer "auth method" in the first place.

## Related

- #9592 / #9637 — the per-operation security gating that previously hid a config-defined oauth2 scheme.
