### PR TITLE
fix: package.json readme metadata clobbers npm READMEs

### DIFF
--- a/.changeset/plenty-camels-wave.md
+++ b/.changeset/plenty-camels-wave.md
@@ -1,0 +1,43 @@
+---
+'@scalar/astro': patch
+'@scalar/asyncapi-upgrader': patch
+'@scalar/client-side-rendering': patch
+'@scalar/code-highlight': patch
+'@scalar/components': patch
+'@scalar/core': patch
+'@scalar/docusaurus': patch
+'@scalar/draggable': patch
+'@scalar/express-api-reference': patch
+'@scalar/fastify-api-reference': patch
+'@scalar/galaxy': patch
+'@scalar/helpers': patch
+'@scalar/hono-api-reference': patch
+'@scalar/icons': patch
+'@scalar/import': patch
+'@scalar/json-magic': patch
+'@scalar/mock-server': patch
+'@scalar/nestjs-api-reference': patch
+'@scalar/nextjs-api-reference': patch
+'@scalar/nextjs-openapi': patch
+'@scalar/nuxt': patch
+'@scalar/object-utils': patch
+'@scalar/openapi-parser': patch
+'@scalar/openapi-types': patch
+'@scalar/openapi-upgrader': patch
+'@scalar/postman-to-openapi': patch
+'@scalar/react-renderer': patch
+'@scalar/release-notes': patch
+'@scalar/schemas': patch
+'@scalar/snippetz': patch
+'@scalar/sveltekit': patch
+'@scalar/themes': patch
+'@scalar/ts-to-openapi': patch
+'@scalar/types': patch
+'@scalar/use-codemirror': patch
+'@scalar/use-hooks': patch
+'@scalar/use-toasts': patch
+'@scalar/validation': patch
+'@scalar/void-server': patch
+---
+
+Republish so the updated README (with the Scalar platform overview) reaches npm. Also renames the README generator metadata in package.json from `readme` to `scalarReadme`: npm treats a `readme` field as the readme text itself, so affected packages were published with a literal `[object Object]` readme on the registry instead of README.md.

--- a/integrations/astro/package.json
+++ b/integrations/astro/package.json
@@ -35,7 +35,7 @@
     "!src/**/*.spec.*",
     "index.ts"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference for Astro",
     "badges": [
       {

--- a/integrations/django-ninja/package.json
+++ b/integrations/django-ninja/package.json
@@ -19,7 +19,7 @@
     "dev": "command -v python >/dev/null 2>&1 && python manage.py runserver || echo '⚠️ python is not available, skipping the dev server.'",
     "test": "command -v python >/dev/null 2>&1 && python run_tests.py || echo '⚠️ python is not available, skipping the tests.'"
   },
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference Plugin for Django Ninja",
     "badges": [
       {

--- a/integrations/docker/package.json
+++ b/integrations/docker/package.json
@@ -20,7 +20,7 @@
     "compress": "cd ./assets && gzip --keep --verbose --force scalar.js",
     "copy:standalone": "shx cp ../../packages/api-reference/dist/browser/standalone.js ./assets/scalar.js"
   },
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference for Docker",
     "badges": [
       {

--- a/integrations/docusaurus/package.json
+++ b/integrations/docusaurus/package.json
@@ -34,7 +34,7 @@
     "dist",
     "CHANGELOG.md"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference Plugin for Docusaurus",
     "badges": [
       {

--- a/integrations/dotnet/aspire/package.json
+++ b/integrations/dotnet/aspire/package.json
@@ -24,7 +24,7 @@
     "@scalar/api-reference": "workspace:*",
     "@scalar/dotnet-shared": "workspace:*"
   },
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference for Aspire",
     "badges": [
       {

--- a/integrations/dotnet/aspnetcore/package.json
+++ b/integrations/dotnet/aspnetcore/package.json
@@ -20,7 +20,7 @@
     "copy:standalone": "shx cp ../../../packages/api-reference/dist/browser/standalone.js ./src/Scalar.AspNetCore/StaticAssets/scalar.js",
     "test": "vitest --run"
   },
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference for ASP.NET Core",
     "badges": [
       {

--- a/integrations/dotnet/azure-functions/package.json
+++ b/integrations/dotnet/azure-functions/package.json
@@ -19,7 +19,7 @@
     "compress": "cd ./src/Scalar.Azure.Functions/StaticAssets && gzip --keep --verbose --force scalar.js scalar.azure.functions.js favicon.svg",
     "copy:standalone": "shx cp ../../../packages/api-reference/dist/browser/standalone.js ./src/Scalar.Azure.Functions/StaticAssets/scalar.js"
   },
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference for Azure Functions",
     "badges": [
       {

--- a/integrations/express/package.json
+++ b/integrations/express/package.json
@@ -38,7 +38,7 @@
     "./dist",
     "CHANGELOG.md"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference Plugin for Express",
     "badges": [
       {

--- a/integrations/fastapi/package.json
+++ b/integrations/fastapi/package.json
@@ -19,7 +19,7 @@
     "dev": "command -v uvicorn >/dev/null 2>&1 && cd playground && uvicorn main:app --reload || echo '⚠️ uvicorn is not available, skipping the dev server.'",
     "test": "command -v python >/dev/null 2>&1 && python run_tests.py || echo '⚠️ python is not available, skipping the tests.'"
   },
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference Plugin for FastAPI",
     "badges": [
       {

--- a/integrations/fastify/package.json
+++ b/integrations/fastify/package.json
@@ -44,7 +44,7 @@
     "./dist",
     "CHANGELOG.md"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference for Fastify",
     "badges": [
       {

--- a/integrations/hono/package.json
+++ b/integrations/hono/package.json
@@ -36,7 +36,7 @@
   "files": [
     "dist"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference for Hono",
     "badges": [
       {

--- a/integrations/java/package.json
+++ b/integrations/java/package.json
@@ -23,7 +23,7 @@
     "mvn:run:webmvc": "cd scalar-playground-webmvc && mvn spring-boot:run",
     "update:version": "mvn versions:set -DnewVersion=$npm_package_version -DgenerateBackupPoms=false"
   },
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference for Java",
     "badges": [
       {

--- a/integrations/nestjs/package.json
+++ b/integrations/nestjs/package.json
@@ -48,7 +48,7 @@
   "files": [
     "dist"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference Plugin for NestJS",
     "badges": [
       {

--- a/integrations/nextjs/package.json
+++ b/integrations/nextjs/package.json
@@ -40,7 +40,7 @@
     "dist",
     "CHANGELOG.md"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference Handler for Next.js",
     "badges": [
       {

--- a/integrations/nuxt/package.json
+++ b/integrations/nuxt/package.json
@@ -45,7 +45,7 @@
   "files": [
     "dist"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference Module for Nuxt",
     "badges": [
       {

--- a/integrations/rust/package.json
+++ b/integrations/rust/package.json
@@ -71,7 +71,7 @@
     "README.md",
     "CHANGELOG.md"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference Crate for Rust",
     "badges": [
       {

--- a/integrations/sveltekit/package.json
+++ b/integrations/sveltekit/package.json
@@ -44,7 +44,7 @@
     "!src/**/*.test.*",
     "!src/**/*.spec.*"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar API Reference for SvelteKit",
     "badges": [
       {

--- a/packages/asyncapi-upgrader/package.json
+++ b/packages/asyncapi-upgrader/package.json
@@ -59,7 +59,7 @@
     "dist",
     "CHANGELOG.md"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar AsyncAPI Upgrader",
     "badges": [
       {

--- a/packages/mock-server/docker/package.json
+++ b/packages/mock-server/docker/package.json
@@ -26,7 +26,7 @@
   },
   "type": "module",
   "main": "dist/docker-entrypoint.js",
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar Mock Server - Docker",
     "badges": [
       {

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -40,7 +40,7 @@
     "./dist",
     "CHANGELOG.md"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar Mock Server",
     "badges": [
       {

--- a/packages/openapi-upgrader/package.json
+++ b/packages/openapi-upgrader/package.json
@@ -59,7 +59,7 @@
     "dist",
     "CHANGELOG.md"
   ],
-  "readme": {
+  "scalarReadme": {
     "title": "Scalar OpenAPI Upgrader",
     "badges": [
       {

--- a/tooling/scripts/README.md
+++ b/tooling/scripts/README.md
@@ -170,9 +170,11 @@ pnpm --filter @scalar-internal/build-scripts start generate-blog
 
 ### `generate-readme`
 
-Generate README.md files for packages with readme metadata.
+Generate README.md files for packages with scalarReadme metadata.
 
-This command scans all packages in `packages/` and `integrations/` directories, finds those with `readme` metadata in their `package.json`, and generates standardized README.md files.
+This command scans all packages in `packages/` and `integrations/` directories, finds those with `scalarReadme` metadata in their `package.json`, and generates standardized README.md files.
+
+> The metadata key is intentionally named `scalarReadme` and not `readme`: npm treats a `readme` field in `package.json` as the readme _text_ and publishes it to the registry, which clobbers the real README.md with `[object Object]` on npmjs.com.
 
 **Usage:**
 ```bash
@@ -193,7 +195,7 @@ The generated README includes:
 **Package.json metadata format:**
 ```json
 {
-  "readme": {
+  "scalarReadme": {
     "title": "Package Name",
     "badges": [
       { "type": "npm-version" },

--- a/tooling/scripts/src/commands/generate-readme.ts
+++ b/tooling/scripts/src/commands/generate-readme.ts
@@ -85,11 +85,11 @@ interface PackageJson {
   repository?: {
     directory?: string
   }
-  readme?: ReadmeMetadata
+  scalarReadme?: ReadmeMetadata
 }
 
 export const generateReadme = new Command('generate-readme')
-  .description('Generate README.md files for packages with readme metadata')
+  .description('Generate README.md files for packages with scalarReadme metadata')
   .action(async () => {
     await generateReadmeFiles()
   })
@@ -99,7 +99,7 @@ async function generateReadmeFiles() {
   const integrationsDir = path.join(root, 'integrations')
   const packagesDir = path.join(root, 'packages')
 
-  console.log(as.cyan('Scanning for packages with readme metadata...\n'))
+  console.log(as.cyan('Scanning for packages with scalarReadme metadata...\n'))
 
   // Find all package.json files in integrations and packages directories
   const packageJsonPaths: string[] = []
@@ -122,7 +122,7 @@ async function generateReadmeFiles() {
     // Directory doesn't exist, skip
   }
 
-  // Filter to only packages with readme metadata
+  // Filter to only packages with scalarReadme metadata
   const packagesWithReadme: Array<{ directory: string; packageJson: PackageJson }> = []
 
   for (const packageJsonPath of packageJsonPaths) {
@@ -130,7 +130,7 @@ async function generateReadmeFiles() {
       const packageJsonContent = await fs.readFile(packageJsonPath, 'utf-8')
       const packageJson: PackageJson = JSON.parse(packageJsonContent)
 
-      if (packageJson.readme) {
+      if (packageJson.scalarReadme) {
         const directory = path.dirname(packageJsonPath)
         packagesWithReadme.push({ directory, packageJson })
       }
@@ -143,11 +143,11 @@ async function generateReadmeFiles() {
   }
 
   if (packagesWithReadme.length === 0) {
-    console.log(as.yellow('No packages with readme metadata found.'))
+    console.log(as.yellow('No packages with scalarReadme metadata found.'))
     return
   }
 
-  console.log(as.cyan(`Found ${packagesWithReadme.length} package(s) with readme metadata\n`))
+  console.log(as.cyan(`Found ${packagesWithReadme.length} package(s) with scalarReadme metadata\n`))
 
   // Process each package
   let successCount = 0
@@ -181,11 +181,11 @@ async function generateReadmeFiles() {
 }
 
 async function generateReadmeForPackage(root: string, directory: string, packageJson: PackageJson): Promise<void> {
-  if (!packageJson.readme) {
-    throw new Error('No readme metadata found')
+  if (!packageJson.scalarReadme) {
+    throw new Error('No scalarReadme metadata found')
   }
 
-  const metadata = packageJson.readme
+  const metadata = packageJson.scalarReadme
   const readmePath = path.join(directory, 'README.md')
   const changelogPath = path.join(directory, 'CHANGELOG.md')
 

--- a/tooling/scripts/src/commands/packages/format.ts
+++ b/tooling/scripts/src/commands/packages/format.ts
@@ -85,7 +85,7 @@ const restrictedKeys = [
   'types',
   'exports',
   'files',
-  'readme',
+  'scalarReadme',
   'UNSORTED',
   'dependencies',
   'devDependencies',


### PR DESCRIPTION
## Summary

Follow-up to #9706. The updated READMEs only appeared on npm for some packages (e.g. `@scalar/api-reference`) but not others (e.g. `@scalar/hono-api-reference`). Investigation found two causes:

1. **npm only refreshes a README on publish.** Most packages simply have not had a release since #9706 merged, so they still show the old README. Fixed by the changeset below.
2. **A real bug: the README generator's `readme` metadata object in `package.json` collides with npm's reserved `readme` field.** npm treats that field as the readme *text*, so every package using the generator has been publishing a literal `[object Object]` readme to the registry — npmjs.com then keeps rendering an old README forever. This is why `@scalar/fastify-api-reference`, `@scalar/mock-server`, and `@scalar/nuxt` published *after* the merge (tarball verified to contain the new README.md) yet npmjs.com still shows stale content.

## Changes

- Rename the generator metadata key `readme` → `scalarReadme` in all 21 package.json files that use it, so npm no longer misinterprets it
- Update `generate-readme.ts`, `packages/format.ts` (key sort order), and the tooling README, with a note explaining why the key must not be called `readme`
- Add a changeset patch-bumping the 39 public packages whose npm README is stale or corrupted, so the next release republishes them with the platform overview block (the 12 packages already correct on npm are excluded)

## Verification

- `generate-readme` finds all 21 packages via the new key and regenerates byte-identical READMEs (zero diff)
- `@scalar-internal/build-scripts` test suite passes (33 tests)
- Biome clean on modified TS files; pre-existing tsc errors in untouched files (`generate-blog.ts`, `catalog.ts`) are identical on main
- Registry audit script confirmed: every package with the metadata publishes `readme: "[object Object]"`; every package without it publishes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)