### PR TITLE
feat(api-reference): load plugins from URLs via new pluginUrls configuration option

### DIFF
--- a/.changeset/plugin-urls.md
+++ b/.changeset/plugin-urls.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-reference': minor
+'@scalar/schemas': minor
+'@scalar/types': minor
+---
+
+feat: add `pluginUrls` configuration option to load API Reference plugins from URLs
+
+Each entry must point to an ESM module that exports a plugin (the same shape as the `plugins` entries) as its default export. The standalone build (`Scalar.createApiReference`) imports the modules before the API reference mounts and registers their default exports alongside the plugins passed directly. Unlike `plugins`, the new option is JSON-serializable, so integrations that pass their configuration as JSON (for example the Docker container or Scalar for Aspire) can load plugins without replacing the whole bundle.

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -983,6 +983,20 @@ Pass an array of custom plugins that you want. [Read more about plugins here.](p
 }
 ```
 
+#### pluginUrls
+
+**Type:** `string[]`
+
+Pass URLs of ESM modules that export a plugin as their default export. The modules are imported before the API reference mounts and their default exports are registered alongside the plugins passed via `plugins`. Unlike `plugins`, this option is JSON-serializable, so it also works in integrations that pass their configuration as JSON. Only supported by the standalone browser build (`Scalar.createApiReference`). [Read more about plugins here.](plugins.md)
+
+```javascript
+{
+  pluginUrls: [
+    'https://cdn.jsdelivr.net/npm/@example/scalar-plugin/dist/plugin.js',
+  ],
+}
+```
+
 #### proxyUrl
 
 **Type:** `string`

--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -15,6 +15,39 @@ const configuration = {
 }
 ```
 
+## Loading a Plugin from a URL
+
+When you use the standalone browser build (`Scalar.createApiReference`), you can also reference plugins by URL.
+Each entry in `pluginUrls` must point to an ESM module that exports a plugin (the same shape as the `plugins`
+entries) as its default export. The modules are imported before the API reference mounts and their default
+exports are registered alongside the plugins passed directly.
+
+```typescript
+const configuration = {
+  url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=json',
+  pluginUrls: [
+    'https://cdn.jsdelivr.net/npm/@example/scalar-plugin/dist/plugin.js',
+  ],
+}
+```
+
+Unlike `plugins`, this option is JSON-serializable. That makes it possible to load plugins from integrations
+that pass their configuration as JSON — for example the Docker container (`API_REFERENCE_CONFIG`) or server-side
+integrations that render the configuration into the HTML — without replacing the whole bundle.
+
+A minimal plugin module looks like this:
+
+```typescript
+// plugin.js — served as an ESM module
+export default () => ({
+  name: 'my-custom-plugin',
+  extensions: [],
+})
+```
+
+Note: When you render the `ApiReference` component yourself (for example in a Vue app), import the plugin
+and pass it via `plugins` instead.
+
 ## Creating a Plugin
 
 ### Specification Extensions

--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -35,6 +35,11 @@ Unlike `plugins`, this option is JSON-serializable. That makes it possible to lo
 that pass their configuration as JSON — for example the Docker container (`API_REFERENCE_CONFIG`) or server-side
 integrations that render the configuration into the HTML — without replacing the whole bundle.
 
+> [!WARNING]
+> Each URL is imported and executed as a JavaScript module in the browser, so it runs with the same privileges
+> as the page hosting the API reference. Only reference `pluginUrls` you control or fully trust — treat them like
+> any other `<script>` you add to your site, and prefer pinning a specific version rather than a floating tag.
+
 A minimal plugin module looks like this:
 
 ```typescript

--- a/integrations/django-ninja/scalar_ninja/scalar_ninja.py
+++ b/integrations/django-ninja/scalar_ninja/scalar_ninja.py
@@ -222,6 +222,11 @@ class ScalarConfig(BaseModel):
         description="List of OpenAPI Server Objects. Each item must have a required 'url' (string) and may have optional 'description' (string) and 'variables' (map). Example: [{\"url\": \"https://api.example.com\", \"description\": \"Production\"}]. Default is [] which means no servers are provided.",
     )
 
+    plugin_urls: List[str] = Field(
+        default_factory=list,
+        description="URLs of ESM modules that provide additional API Reference plugins. Each module is imported in the browser before the API Reference mounts, and its default export is registered as a plugin. Default is [] which means no plugin URLs are provided.",
+    )
+
     default_open_all_tags: bool = Field(
         default=False,
         description="A boolean to open all tags by default. Default is False which means all tags are closed by default.",
@@ -453,6 +458,9 @@ def get_scalar_api_reference(config: ScalarConfig) -> HttpResponse:
 
     if config.servers:  # Default is []
         js_config["servers"] = config.servers
+
+    if config.plugin_urls:  # Default is []
+        js_config["pluginUrls"] = config.plugin_urls
 
     if config.default_open_all_tags:  # Default is False
         js_config["defaultOpenAllTags"] = config.default_open_all_tags

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarOptionsMapperTests.cs
@@ -24,6 +24,7 @@ public class ScalarOptionsMapperTests
         configuration.CustomCss.Should().BeNull();
         configuration.SearchHotKey.Should().BeNull();
         configuration.Servers.Should().BeNull();
+        configuration.PluginUrls.Should().BeNull();
         configuration.MetaData.Should().BeNull();
         configuration.DefaultHttpClient.Should().BeNull();
         configuration.HiddenClients.Should().BeNull();
@@ -63,6 +64,7 @@ public class ScalarOptionsMapperTests
             Theme = ScalarTheme.Saturn,
             Layout = ScalarLayout.Classic,
             Servers = [new ScalarServer("https://example.com")],
+            PluginUrls = ["https://example.com/plugin.js"],
             Metadata = new Dictionary<string, string> { ["key"] = "value" },
             DefaultHttpClient = new KeyValuePair<ScalarTarget, ScalarClient>(ScalarTarget.CSharp, ScalarClient.HttpClient),
             HiddenClients = true,
@@ -112,6 +114,7 @@ public class ScalarOptionsMapperTests
         configuration.CustomCss.Should().Be("*{}");
         configuration.SearchHotKey.Should().Be("o");
         configuration.Servers.Should().ContainSingle().Which.Url.Should().Be("https://example.com");
+        configuration.PluginUrls.Should().ContainSingle().Which.Should().Be("https://example.com/plugin.js");
         configuration.MetaData.Should().ContainKey("key").WhoseValue.Should().Be("value");
         configuration.DefaultHttpClient!.TargetKey.Should().Be(ScalarTarget.CSharp);
         configuration.DefaultHttpClient!.ClientKey.Should().Be(ScalarClient.HttpClient);

--- a/integrations/dotnet/shared/src/Scalar.Shared/Contract/ScalarConfiguration.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Contract/ScalarConfiguration.cs
@@ -36,6 +36,8 @@ internal sealed class ScalarConfiguration
 
     public required IEnumerable<ScalarServer>? Servers { get; init; }
 
+    public required IEnumerable<string>? PluginUrls { get; init; }
+
     public required IDictionary<string, string>? MetaData { get; init; }
 
     public required DefaultHttpClient? DefaultHttpClient { get; init; }

--- a/integrations/dotnet/shared/src/Scalar.Shared/Extensions/ScalarOptionsExtensions.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Extensions/ScalarOptionsExtensions.cs
@@ -347,6 +347,18 @@ public static partial class ScalarOptionsExtensions
     public static TOptions AddServer<TOptions>(this TOptions options, [StringSyntax(StringSyntaxAttribute.Uri)] string url, string description) where TOptions : ScalarOptions => options.AddServer(new ScalarServer(url, description));
 
     /// <summary>
+    /// Adds the URL of an ESM module that provides an additional API Reference plugin.
+    /// </summary>
+    /// <param name="options">The options to configure.</param>
+    /// <param name="pluginUrl">The URL of the plugin module to add. The module is imported in the browser before the API Reference mounts, and its default export is registered as a plugin.</param>
+    public static TOptions AddPluginUrl<TOptions>(this TOptions options, [StringSyntax(StringSyntaxAttribute.Uri)] string pluginUrl) where TOptions : ScalarOptions
+    {
+        options.PluginUrls ??= new List<string>();
+        options.PluginUrls.Add(pluginUrl);
+        return options;
+    }
+
+    /// <summary>
     /// Adds metadata to the configuration.
     /// </summary>
     /// <param name="options">The options to configure.</param>

--- a/integrations/dotnet/shared/src/Scalar.Shared/Mapper/ScalarOptionsMapper.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Mapper/ScalarOptionsMapper.cs
@@ -40,6 +40,7 @@ internal static partial class ScalarOptionsMapper
             CustomCss = options.CustomCss,
             SearchHotKey = options.SearchHotKey,
             Servers = options.Servers,
+            PluginUrls = options.PluginUrls,
             MetaData = options.Metadata,
             Authentication = options.Authentication,
             TagSorter = options.TagSorter,

--- a/integrations/dotnet/shared/src/Scalar.Shared/Options/ScalarOptions.cs
+++ b/integrations/dotnet/shared/src/Scalar.Shared/Options/ScalarOptions.cs
@@ -178,6 +178,15 @@ public partial class ScalarOptions
     public IList<ScalarServer>? Servers { get; set; }
 
     /// <summary>
+    /// Controls the URLs of ESM modules that provide additional API Reference plugins.
+    /// </summary>
+    /// <remarks>
+    /// Each module is imported in the browser before the API Reference mounts, and its default export
+    /// is registered as a plugin. The URLs must be reachable from the browser.
+    /// </remarks>
+    public IList<string>? PluginUrls { get; set; }
+
+    /// <summary>
     /// Controls whether to expose 'dotnet' flag to the configuration.
     /// </summary>
     /// <remarks>

--- a/integrations/dotnet/shared/tests/Scalar.Shared.Tests/Extensions/ScalarOptionsExtensionsTests.cs
+++ b/integrations/dotnet/shared/tests/Scalar.Shared.Tests/Extensions/ScalarOptionsExtensionsTests.cs
@@ -14,6 +14,7 @@ public class ScalarOptionsExtensionsTests
             .WithDefaultHttpClient(ScalarTarget.CSharp, ScalarClient.HttpClient)
             .AddServer("https://example.com")
             .AddServer(new ScalarServer("https://example.org", "My other server"))
+            .AddPluginUrl("https://example.com/plugin.js")
             .AddDocument("v1", "Version 1")
             .AddDocuments("v2", "v3")
             .AddDocuments(new ScalarDocument("v4"));
@@ -25,6 +26,7 @@ public class ScalarOptionsExtensionsTests
         options.Servers.Should().HaveCount(2);
         options.Servers.Should().ContainSingle(x => x.Url == "https://example.com");
         options.Servers.Should().ContainSingle(x => x.Url == "https://example.org" && x.Description == "My other server");
+        options.PluginUrls.Should().ContainSingle().Which.Should().Be("https://example.com/plugin.js");
         options.Documents.Should().HaveCount(4);
     }
 

--- a/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
@@ -415,6 +415,17 @@ def get_scalar_api_reference(
             """
         ),
     ] = [],
+    plugin_urls: Annotated[
+        list[str],
+        Doc(
+            """
+            URLs of ESM modules that provide additional API Reference plugins.
+            Each module is imported in the browser before the API Reference mounts,
+            and its default export is registered as a plugin.
+            Default is [] which means no plugin URLs are provided.
+            """
+        ),
+    ] = [],
     default_open_all_tags: Annotated[
         bool,
         Doc(
@@ -635,6 +646,9 @@ def get_scalar_api_reference(
 
     if servers:  # Default is []
         config["servers"] = servers
+
+    if plugin_urls:  # Default is []
+        config["pluginUrls"] = plugin_urls
 
     if default_open_all_tags:  # Default is False
         config["defaultOpenAllTags"] = default_open_all_tags

--- a/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/ScalarProperties.java
+++ b/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/ScalarProperties.java
@@ -104,6 +104,14 @@ public class ScalarProperties {
     private String customCss;
 
     /**
+     * URLs of ESM modules that provide additional API Reference plugins.
+     * Each module is imported in the browser before the API Reference mounts,
+     * and its default export is registered as a plugin.
+     * Defaults to null.
+     */
+    private List<String> pluginUrls;
+
+    /**
      * Whether to show the sidebar search bar.
      * Defaults to false.
      */
@@ -386,6 +394,14 @@ public class ScalarProperties {
 
     public void setCustomCss(String customCss) {
         this.customCss = customCss;
+    }
+
+    public List<String> getPluginUrls() {
+        return pluginUrls;
+    }
+
+    public void setPluginUrls(List<String> pluginUrls) {
+        this.pluginUrls = pluginUrls;
     }
 
     public boolean isHideSearch() {

--- a/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/internal/ScalarConfiguration.java
+++ b/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/internal/ScalarConfiguration.java
@@ -57,6 +57,9 @@ public class ScalarConfiguration {
     @JsonProperty("customCss")
     private String customCss;
 
+    @JsonProperty("pluginUrls")
+    private List<String> pluginUrls;
+
     @JsonProperty("searchHotKey")
     private String searchHotKey;
 
@@ -226,6 +229,14 @@ public class ScalarConfiguration {
 
     public void setCustomCss(String customCss) {
         this.customCss = customCss;
+    }
+
+    public List<String> getPluginUrls() {
+        return pluginUrls;
+    }
+
+    public void setPluginUrls(List<String> pluginUrls) {
+        this.pluginUrls = pluginUrls;
     }
 
     public String getSearchHotKey() {

--- a/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/internal/ScalarConfigurationMapper.java
+++ b/integrations/java/scalar-core/src/main/java/com/scalar/maven/core/internal/ScalarConfigurationMapper.java
@@ -35,6 +35,7 @@ public class ScalarConfigurationMapper {
         config.setDarkMode(properties.isDarkMode());
         config.setHideDarkModeToggle(properties.isHideDarkModeToggle());
         config.setCustomCss(properties.getCustomCss());
+        config.setPluginUrls(properties.getPluginUrls());
         config.setSearchHotKey(properties.getSearchHotKey());
         config.setServers(properties.getServers());
         config.setMetaData(properties.getMetadata());

--- a/integrations/java/scalar-core/src/test/java/com/scalar/maven/core/ScalarConfigurationTest.java
+++ b/integrations/java/scalar-core/src/test/java/com/scalar/maven/core/ScalarConfigurationTest.java
@@ -9,7 +9,10 @@ import com.scalar.maven.core.internal.ScalarConfiguration;
 import com.scalar.maven.core.internal.ScalarConfigurationMapper;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -127,6 +130,28 @@ public class ScalarConfigurationTest {
         assertNotNull(config.getAgent());
         assertEquals("production-agent-key", config.getAgent().getKey());
         assertEquals(false, config.getAgent().getDisabled());
+    }
+
+    @Test
+    public void testScalarConfigurationMappingIncludesPluginUrls() throws JsonProcessingException {
+        ScalarProperties properties = new ScalarProperties();
+        properties.setPluginUrls(List.of("https://example.com/plugin.js"));
+
+        ScalarConfiguration config = ScalarConfigurationMapper.map(properties);
+
+        assertEquals(List.of("https://example.com/plugin.js"), config.getPluginUrls());
+
+        String json = new ObjectMapper().writeValueAsString(config);
+        assertTrue(json.contains("\"pluginUrls\":[\"https://example.com/plugin.js\"]"));
+    }
+
+    @Test
+    public void testPluginUrlsOmittedWhenNotConfigured() throws JsonProcessingException {
+        ScalarConfiguration config = ScalarConfigurationMapper.map(new ScalarProperties());
+        String json = new ObjectMapper().writeValueAsString(config);
+
+        // No plugin URLs configured, so the key must not leak into the serialized configuration
+        assertFalse(json.contains("pluginUrls"));
     }
 
     @Test

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -326,6 +326,49 @@ describe('createApiReference', () => {
     // Assert the configuration was updated
     await flushPromises()
   })
+
+  it('loads plugins from pluginUrls before mounting', async () => {
+    const element = document.querySelector('#mount-point')
+
+    // An ESM module that records when the plugin factory is invoked by the plugin manager
+    const pluginUrl =
+      'data:text/javascript,export default () => { globalThis.__scalarUrlPluginInvoked = true; return { name: "url-plugin", extensions: [] } }'
+
+    const config = {
+      ...coerce(apiReferenceConfigurationSchema, { _integration: 'html' }),
+      content: JSON.stringify({
+        openapi: '3.1.0',
+        info: { title: 'Plugin Test API', version: '1.0.0' },
+        paths: {},
+      }),
+      pluginUrls: [pluginUrl],
+    }
+    createApiReference(element!, config)
+
+    // Mounting is deferred until the plugin module is imported
+    expect(element?.innerHTML).not.toContain('Powered by Scalar')
+
+    await vi.waitFor(() => expect(element?.innerHTML).toContain('Powered by Scalar'))
+
+    // The loaded plugin was registered with the plugin manager
+    expect((globalThis as Record<string, unknown>).__scalarUrlPluginInvoked).toBe(true)
+  })
+
+  it('does not mount when the instance is destroyed while plugins are loading', async () => {
+    const element = document.querySelector('#mount-point')
+
+    const config = {
+      ...coerce(apiReferenceConfigurationSchema, { _integration: 'html' }),
+      pluginUrls: ['data:text/javascript,export default () => ({ name: "url-plugin", extensions: [] })'],
+    }
+    const instance = createApiReference(element!, config)
+    instance.destroy()
+
+    await flushPromises()
+    await sleep(100)
+
+    expect(element?.innerHTML).not.toContain('Powered by Scalar')
+  })
 })
 
 describe('findDataAttributes (legacy)', () => {

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -8,6 +8,7 @@ import { createHead } from '@unhead/vue/client'
 import { createApp, createSSRApp, h, reactive } from 'vue'
 
 import { default as ApiReference } from '@/components/ApiReference.vue'
+import { hasPluginUrls, loadPluginsFromUrls } from '@/standalone/lib/load-plugins-from-urls'
 
 const getSpecScriptTag = (doc: Document) => doc.getElementById('api-reference')
 
@@ -274,9 +275,25 @@ export const createApiReference: CreateApiReference = (
 
   if (optionalConfiguration) {
     if (mountElement) {
-      app.mount(mountElement)
-      hasMounted = true
-      retainStandaloneStyles(document)
+      const mount = () => {
+        app.mount(mountElement)
+        hasMounted = true
+        retainStandaloneStyles(document)
+      }
+
+      if (hasPluginUrls(props.configuration)) {
+        // Plugins referenced by URL must be resolved before the app mounts — plugin registration
+        // happens once at first render and is not reactive, so a plugin that arrives later would
+        // never be picked up.
+        loadPluginsFromUrls(props.configuration).then(() => {
+          // Skip mounting when the instance was destroyed while the plugins were loading.
+          if (!abortController.signal.aborted) {
+            mount()
+          }
+        })
+      } else {
+        mount()
+      }
     } else {
       console.error('Could not find a mount point for API References:', elementOrSelectorOrConfig)
     }

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -350,10 +350,12 @@ export const createApiReference: CreateApiReference = (
   const destroy = () => {
     abortController.abort()
     props.configuration = {}
-    app.unmount()
 
+    // Only unmount an app that actually mounted. With `pluginUrls`, mounting is deferred until the
+    // plugin modules resolve, so `destroy` can run first — unmounting then would just warn.
     if (hasMounted) {
       hasMounted = false
+      app.unmount()
       releaseStandaloneStyles(document)
     }
   }

--- a/packages/api-reference/src/standalone/lib/load-plugins-from-urls.test.ts
+++ b/packages/api-reference/src/standalone/lib/load-plugins-from-urls.test.ts
@@ -1,0 +1,89 @@
+import type { ApiReferencePlugin } from '@scalar/types/api-reference'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { hasPluginUrls, loadPluginsFromUrls } from './load-plugins-from-urls'
+
+/** Create a `data:` URL for an ESM module that exports a minimal plugin factory as its default export */
+const pluginModuleUrl = (name: string) =>
+  `data:text/javascript,export default () => ({ name: '${name}', extensions: [] })`
+
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+afterEach(() => {
+  consoleErrorSpy.mockClear()
+})
+
+describe('hasPluginUrls', () => {
+  it('returns false for configurations without plugin URLs', () => {
+    expect(hasPluginUrls({})).toBe(false)
+    expect(hasPluginUrls({ pluginUrls: [] })).toBe(false)
+    expect(hasPluginUrls([{}, {}])).toBe(false)
+  })
+
+  it('returns true when a configuration references a plugin URL', () => {
+    expect(hasPluginUrls({ pluginUrls: [pluginModuleUrl('example')] })).toBe(true)
+    expect(hasPluginUrls([{}, { pluginUrls: [pluginModuleUrl('example')] }])).toBe(true)
+  })
+})
+
+describe('loadPluginsFromUrls', () => {
+  it('appends the default export of the module to the plugins of the configuration', async () => {
+    const configuration = { pluginUrls: [pluginModuleUrl('loaded-plugin')] }
+
+    await loadPluginsFromUrls(configuration)
+
+    const plugins = (configuration as { plugins?: ApiReferencePlugin[] }).plugins
+    expect(plugins).toHaveLength(1)
+    expect(plugins?.[0]?.()).toMatchObject({ name: 'loaded-plugin' })
+  })
+
+  it('keeps plugins that were passed directly and appends the loaded ones', async () => {
+    const directPlugin: ApiReferencePlugin = () => ({ name: 'direct-plugin', extensions: [] })
+    const configuration = {
+      plugins: [directPlugin],
+      pluginUrls: [pluginModuleUrl('loaded-plugin')],
+    }
+
+    await loadPluginsFromUrls(configuration)
+
+    expect(configuration.plugins).toHaveLength(2)
+    expect(configuration.plugins[0]).toBe(directPlugin)
+    expect(configuration.plugins[1]?.()).toMatchObject({ name: 'loaded-plugin' })
+  })
+
+  it('resolves plugin URLs for every configuration in a list', async () => {
+    const sharedUrl = pluginModuleUrl('shared-plugin')
+    const configurations = [{ pluginUrls: [sharedUrl] }, { pluginUrls: [sharedUrl] }, {}]
+
+    await loadPluginsFromUrls(configurations)
+
+    expect((configurations[0] as { plugins?: ApiReferencePlugin[] }).plugins).toHaveLength(1)
+    expect((configurations[1] as { plugins?: ApiReferencePlugin[] }).plugins).toHaveLength(1)
+    expect((configurations[2] as { plugins?: ApiReferencePlugin[] }).plugins).toBeUndefined()
+  })
+
+  it('skips modules that do not export a function as their default export', async () => {
+    const configuration = { pluginUrls: ['data:text/javascript,export default 42'] }
+
+    await loadPluginsFromUrls(configuration)
+
+    expect((configuration as { plugins?: ApiReferencePlugin[] }).plugins).toBeUndefined()
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('does not export an API Reference plugin'))
+  })
+
+  it('logs failed imports and still loads the remaining plugins', async () => {
+    const configuration = {
+      pluginUrls: ['data:text/javascript,this is not valid javascript(', pluginModuleUrl('working-plugin')],
+    }
+
+    await loadPluginsFromUrls(configuration)
+
+    const plugins = (configuration as { plugins?: ApiReferencePlugin[] }).plugins
+    expect(plugins).toHaveLength(1)
+    expect(plugins?.[0]?.()).toMatchObject({ name: 'working-plugin' })
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to load the plugin module'),
+      expect.anything(),
+    )
+  })
+})

--- a/packages/api-reference/src/standalone/lib/load-plugins-from-urls.ts
+++ b/packages/api-reference/src/standalone/lib/load-plugins-from-urls.ts
@@ -1,0 +1,76 @@
+import type { AnyApiReferenceConfiguration, ApiReferencePlugin } from '@scalar/types/api-reference'
+
+/**
+ * Import a plugin module with a browser-native dynamic `import()`.
+ *
+ * The specifier is fully dynamic, so bundlers can't analyze it and leave the `import()` call
+ * as-is in the output (including the UMD standalone bundle) — the `@vite-ignore` comment just
+ * silences the warning about that.
+ */
+const importModule = (url: string): Promise<Record<string, unknown>> => import(/* @vite-ignore */ url)
+
+/**
+ * Load a single plugin module and return its default export.
+ *
+ * Failures (network errors, modules without a function default export) are logged and swallowed
+ * so a broken plugin URL never prevents the API reference itself from mounting.
+ */
+const loadPluginFromUrl = async (url: string): Promise<ApiReferencePlugin | undefined> => {
+  try {
+    const pluginModule = await importModule(url)
+    const plugin = pluginModule?.default
+
+    if (typeof plugin !== 'function') {
+      console.error(
+        `[@scalar/api-reference] The module at ${url} does not export an API Reference plugin as its default export.`,
+      )
+      return undefined
+    }
+
+    return plugin as ApiReferencePlugin
+  } catch (error) {
+    console.error(`[@scalar/api-reference] Failed to load the plugin module at ${url}:`, error)
+    return undefined
+  }
+}
+
+/** Normalize the configuration input to a list of configuration objects */
+const getConfigurations = (configuration: AnyApiReferenceConfiguration) =>
+  Array.isArray(configuration) ? configuration : [configuration]
+
+/** Whether any of the passed configurations reference a plugin by URL */
+export const hasPluginUrls = (configuration: AnyApiReferenceConfiguration): boolean =>
+  getConfigurations(configuration).some((config) => Boolean(config.pluginUrls?.length))
+
+/**
+ * Resolve the `pluginUrls` of all passed configurations and append the loaded plugins to the
+ * respective configuration's `plugins`.
+ *
+ * Plugin registration is not reactive — plugins are read once when the API reference renders for
+ * the first time — so this must complete before the app is mounted. Each URL is imported only
+ * once, even when multiple configurations reference it.
+ */
+export const loadPluginsFromUrls = async (configuration: AnyApiReferenceConfiguration): Promise<void> => {
+  const pendingImports = new Map<string, Promise<ApiReferencePlugin | undefined>>()
+
+  const importOnce = (url: string) => {
+    const pending = pendingImports.get(url) ?? loadPluginFromUrl(url)
+    pendingImports.set(url, pending)
+    return pending
+  }
+
+  await Promise.all(
+    getConfigurations(configuration).map(async (config) => {
+      if (!config.pluginUrls?.length) {
+        return
+      }
+
+      const loadedPlugins = await Promise.all(config.pluginUrls.map(importOnce))
+      const plugins = loadedPlugins.filter((plugin): plugin is ApiReferencePlugin => plugin !== undefined)
+
+      if (plugins.length) {
+        config.plugins = [...(config.plugins ?? []), ...plugins]
+      }
+    }),
+  )
+}

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -41,6 +41,10 @@ export const apiReferenceConfigurationSchema = intersection([
     plugins: optional(array(apiReferencePluginSchema), {
       typeComment: 'Plugins for the API reference',
     }),
+    pluginUrls: optional(array(string()), {
+      typeComment:
+        'URLs of ESM modules that provide additional plugins for the API reference. Each module is loaded with a dynamic `import()` before the API reference mounts, and its default export is registered as a plugin. Unlike `plugins`, this option is JSON-serializable, so integrations that pass their configuration as JSON can load plugins without replacing the whole bundle. Only supported by the standalone browser build (`Scalar.createApiReference`).',
+    }),
     isEditable: boolean({
       default: false,
       typeComment: 'Allows the user to inject an editor for the spec',

--- a/packages/types/src/api-reference/api-reference-configuration.ts
+++ b/packages/types/src/api-reference/api-reference-configuration.ts
@@ -59,6 +59,23 @@ export const apiReferenceConfigurationSchema = baseConfigurationSchema.extend({
    */
   plugins: z.array(apiReferencePluginSchema).optional(),
   /**
+   * URLs of ESM modules that provide additional plugins for the API reference.
+   *
+   * Each module is loaded with a dynamic `import()` before the API reference mounts, and its
+   * default export is registered as a plugin (the same shape as the `plugins` entries).
+   *
+   * Unlike `plugins`, this option is JSON-serializable, so integrations that pass their
+   * configuration as JSON — for example the Docker container or Scalar for Aspire — can load
+   * plugins without replacing the whole bundle.
+   *
+   * Note: This is only supported by the standalone browser build (`Scalar.createApiReference`).
+   * When you render the `ApiReference` component yourself, import the plugin and pass it via
+   * `plugins` instead.
+   *
+   * @example ['https://cdn.jsdelivr.net/npm/@example/scalar-plugin/dist/plugin.js']
+   */
+  pluginUrls: z.array(z.string()).optional(),
+  /**
    * Allows the user to inject an editor for the spec
    * @default false
    */

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -630,6 +630,22 @@ type ExtendedConfiguration = {
   customFetch?: typeof fetch
   /** Plugins for the API reference */
   plugins?: ApiReferencePlugin[]
+  /**
+   * URLs of ESM modules that provide additional plugins for the API reference.
+   *
+   * Each module is loaded with a dynamic `import()` before the API reference mounts, and its
+   * default export is registered as a plugin (the same shape as the `plugins` entries).
+   *
+   * Unlike `plugins`, this option is JSON-serializable, so integrations that pass their
+   * configuration as JSON can load plugins without replacing the whole bundle.
+   *
+   * Note: This is only supported by the standalone browser build (`Scalar.createApiReference`).
+   * When you render the `ApiReference` component yourself, import the plugin and pass it via
+   * `plugins` instead.
+   *
+   * @example ['https://cdn.jsdelivr.net/npm/@example/scalar-plugin/dist/plugin.js']
+   */
+  pluginUrls?: string[]
   /** Allows the user to inject an editor for the spec */
   isEditable: boolean
   /** Whether to show models in the sidebar, search, and content. */


### PR DESCRIPTION
## Problem

API Reference plugins are functions, so they can only be registered by code that calls
`createApiReference` (or renders the component) itself. Every integration that passes its
configuration as **JSON** — the Docker container (`API_REFERENCE_CONFIG`), Scalar for Aspire,
the .NET/Java/Python server-side integrations — has no way to register a plugin at all.

Today the only workaround is to replace the whole standalone bundle with a custom build that
bakes the plugin in (for example via `ScalarAspireOptions.BundleUrl`). That means forking the
bundle, pinning it to a Scalar version, and rebuilding it for every Scalar release — just to
add one plugin.

## Solution

Add a JSON-serializable `pluginUrls: string[]` configuration option. Each entry points to an
ESM module that exports a plugin (the same shape as the `plugins` entries) as its default
export:

```js
Scalar.createApiReference('#app', {
  url: '/openapi.json',
  pluginUrls: ['https://cdn.jsdelivr.net/npm/@example/scalar-plugin/dist/plugin.js'],
})
```

- The standalone build (`Scalar.createApiReference`) imports the modules with a browser-native
  dynamic `import()` **before mounting**, because plugin registration happens once at first
  render and is not reactive. The loaded default exports are appended to the configuration's
  `plugins`.
- The import specifier is fully dynamic, so bundlers leave the `import()` call as-is in the
  UMD output (`/* @vite-ignore */` silences the analysis warning).
- Failures (network errors, modules without a function default export) are logged and
  swallowed, so a broken plugin URL never prevents the API reference itself from mounting.
- If the instance is destroyed while plugin modules are still loading, mounting is skipped.
- Each URL is imported only once, even when multiple configurations reference it.

Because the option is plain JSON, it flows through every integration that serializes its
configuration — no per-integration bundle swapping needed.

### Alternatives considered

- **Global plugin registry + extra `<script>` tags** (`window.Scalar.registerPlugin(...)`):
  requires changes in every integration's HTML template and careful script ordering; the
  config-driven approach needs no HTML changes anywhere.
- **Making plugin registration reactive** so plugins can arrive after mount: much more
  invasive (plugin manager, views, sidebar all read plugins once) and unnecessary for this
  use case.

### Changes

**Core (JS):**
- `@scalar/types`, `@scalar/schemas`: new optional `pluginUrls` field on the API Reference
  configuration schemas.
- `@scalar/api-reference`: new `load-plugins-from-urls.ts` loader; `createApiReference`
  defers mounting until URL plugins are resolved.

**Integrations with typed configuration models (exposing the new option):**
- **.NET** (`Scalar.AspNetCore` / `Scalar.Aspire` / `Scalar.Azure.Functions` via
  `Scalar.Shared`): `ScalarOptions.PluginUrls`, `ScalarConfiguration.PluginUrls`, mapper, and
  a fluent `AddPluginUrl(...)` extension.
- **Java** (`scalar-core`): `ScalarProperties.pluginUrls` → `ScalarConfiguration.pluginUrls`
  (`@JsonProperty("pluginUrls")`) + mapper.
- **FastAPI** (`scalar_fastapi`): new `plugin_urls` parameter → `pluginUrls` config key.
- **Django Ninja** (`scalar_ninja`): new `plugin_urls` field → `pluginUrls` config key.

No changes needed for: JS framework integrations (they reuse `ApiReferenceConfiguration` from
`@scalar/types`), the Docker container (passes `API_REFERENCE_CONFIG` through as-is), and the
Rust integration (freeform `serde_json::Value` configuration).

**Docs:** new "Loading a Plugin from a URL" section in `documentation/plugins.md` and a
`pluginUrls` entry in `documentation/configuration.md`.

### Tests

- `load-plugins-from-urls.test.ts`: unit tests for the loader (loading via `data:` module
  URLs, preserving directly-passed plugins, multi-configuration lists, non-function default
  exports, failed imports).
- `html-api.test.ts`: integration tests that the standalone mount is deferred until plugins
  are loaded and registered with the plugin manager, and that a destroyed instance does not
  mount late.
- .NET: `ScalarOptionsMapperTests` and `ScalarOptionsExtensionsTests` cover the new property,
  mapping, and fluent extension (green on net8.0/net9.0/net10.0).
- Note: the Java change follows the existing property/configuration/mapper pattern but was
  not compiled locally (no Maven toolchain on the machine this was authored on).

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- .changeset/plugin-urls.md -->
- [x] I added tests.
- [x] I updated the documentation.
