### PR TITLE
chore(docs): rename SDKs product path to sdk-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Ready? [Create your Scalar Account](https://scalar.com)
 | [Scalar Registry](https://scalar.com/products/registry/getting-started)            | Manage OpenAPI documents         |
 | [Scalar Docs](https://scalar.com/products/docs/getting-started)                    | Hosted documentation             |
 | [Scalar Docs Starter](https://github.com/scalar/starter)                           | Starter template for Scalar Docs |
-| [Scalar SDKs](https://scalar.com/products/sdks/getting-started)                    | SDK generation                   |
+| [Scalar SDKs](https://scalar.com/products/sdk-generator/getting-started)                    | SDK generation                   |
 | [Scalar CLI](https://scalar.com/tools/cli/getting-started)                         | Command-line interface           |
 | [Scalar Mock Server](https://scalar.com/tools/mock-server/getting-started)      | Mock APIs from OpenAPI documents |
 | [Scalar Galaxy](packages/galaxy/README.md)                                         | Our OpenAPI Example              |

--- a/documentation/footer.html
+++ b/documentation/footer.html
@@ -83,7 +83,7 @@
         </a>
         <a
           class="text-c-2 hover:text-c-1 font-normal"
-          href="/products/sdks/getting-started"
+          href="/products/sdk-generator/getting-started"
           target="_blank">
           SDKs
         </a>

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -160,7 +160,7 @@ You can define multiple tabs to provide quick access to different sections:
   },
   {
     "title": "SDKs",
-    "path": "/products/sdks",
+    "path": "/products/sdk-generator",
     "icon": "phosphor/regular/package"
   }
 ]

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -206,7 +206,7 @@
           File Streaming Support
         </b>
       </div>
-      <a class="mt-3 t-editor__anchor" href="/products/sdks/getting-started" aria-label="Generate your first SDK with Scalar">Generate your first SDK →</a>
+      <a class="mt-3 t-editor__anchor" href="/products/sdk-generator/getting-started" aria-label="Generate your first SDK with Scalar">Generate your first SDK →</a>
     </div>
     <div class="product-image">
       <div class="product-image-transform">
@@ -355,7 +355,7 @@
           Bring your OpenAPI document and get type-safe client libraries for TypeScript, Python and more.
         </div>
       </div>
-      <a class="expander-hover-link" href="/products/sdks/getting-started" aria-label="Learn more about SDKs">Learn More</a>
+      <a class="expander-hover-link" href="/products/sdk-generator/getting-started" aria-label="Learn more about SDKs">Learn More</a>
     </div>
   </div>
   <div class="expander-hover">

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -744,7 +744,7 @@
           Bring your OpenAPI document and get type-safe client libraries across supported languages.
         </div>
       </div>
-      <a class="expander-hover-link" href="/products/sdks/getting-started" aria-label="Learn more about SDKs">Learn More</a>
+      <a class="expander-hover-link" href="/products/sdk-generator/getting-started" aria-label="Learn more about SDKs">Learn More</a>
     </div>
   </div>
   <div class="expander-hover">

--- a/documentation/guides/security.md
+++ b/documentation/guides/security.md
@@ -39,7 +39,7 @@ Scalar treats OpenAPI as a source of truth for developer docs, API clients, gene
 
 - **Auth-aware API descriptions:** Model API keys, bearer tokens, OAuth flows, and other security schemes directly in your OpenAPI document.
 - **Rules and validation:** Add review gates and linting so API changes are caught before they reach consumers.
-- **SDK generation:** Generate production-ready SDKs and CLIs from reviewed API descriptions. See the [SDK Generator](/products/sdks/getting-started).
+- **SDK generation:** Generate production-ready SDKs and CLIs from reviewed API descriptions. See the [SDK Generator](/products/sdk-generator/getting-started).
 - **MCP guardrails:** Choose which endpoints become tools, decide search versus execute modes, and apply API auth per installation. See [MCP & Agent](/products/agent/getting-started).
 - **Self-hostable foundation:** Run Scalar's open-source tooling in your own environment when your architecture requires it.
 

--- a/integrations/astro/README.md
+++ b/integrations/astro/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/integrations/docusaurus/README.md
+++ b/integrations/docusaurus/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/integrations/express/README.md
+++ b/integrations/express/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/integrations/fastify/README.md
+++ b/integrations/fastify/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/integrations/hono/README.md
+++ b/integrations/hono/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/integrations/nestjs/README.md
+++ b/integrations/nestjs/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/integrations/nextjs/README.md
+++ b/integrations/nextjs/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/integrations/nuxt/README.md
+++ b/integrations/nuxt/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/integrations/sveltekit/README.md
+++ b/integrations/sveltekit/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/agent-chat/README.md
+++ b/packages/agent-chat/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/api-client-react/README.md
+++ b/packages/api-client-react/README.md
@@ -11,7 +11,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -17,7 +17,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/api-reference-react/README.md
+++ b/packages/api-reference-react/README.md
@@ -11,7 +11,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/api-reference/README.md
+++ b/packages/api-reference/README.md
@@ -14,7 +14,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/asyncapi-upgrader/README.md
+++ b/packages/asyncapi-upgrader/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/client-side-rendering/README.md
+++ b/packages/client-side-rendering/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/code-highlight/README.md
+++ b/packages/code-highlight/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -19,7 +19,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/draggable/README.md
+++ b/packages/draggable/README.md
@@ -11,7 +11,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/galaxy/README.md
+++ b/packages/galaxy/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/import/README.md
+++ b/packages/import/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/json-magic/README.md
+++ b/packages/json-magic/README.md
@@ -14,7 +14,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/mock-server/README.md
+++ b/packages/mock-server/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/nextjs-openapi/README.md
+++ b/packages/nextjs-openapi/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/oas-utils/README.md
+++ b/packages/oas-utils/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/object-utils/README.md
+++ b/packages/object-utils/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/openapi-parser/README.md
+++ b/packages/openapi-parser/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/openapi-to-markdown/README.md
+++ b/packages/openapi-to-markdown/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/openapi-types/README.md
+++ b/packages/openapi-types/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/openapi-upgrader/README.md
+++ b/packages/openapi-upgrader/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/postman-to-openapi/README.md
+++ b/packages/postman-to-openapi/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/pre-post-request-scripts/README.md
+++ b/packages/pre-post-request-scripts/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/react-renderer/README.md
+++ b/packages/react-renderer/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/release-notes/README.md
+++ b/packages/release-notes/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/schemas/README.md
+++ b/packages/schemas/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/server-side-rendering/README.md
+++ b/packages/server-side-rendering/README.md
@@ -20,7 +20,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/sidebar/README.md
+++ b/packages/sidebar/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/snippetz/README.md
+++ b/packages/snippetz/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/themes/README.md
+++ b/packages/themes/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/ts-to-openapi/README.MD
+++ b/packages/ts-to-openapi/README.MD
@@ -15,7 +15,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/use-codemirror/README.md
+++ b/packages/use-codemirror/README.md
@@ -11,7 +11,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/use-hooks/README.md
+++ b/packages/use-hooks/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/use-toasts/README.md
+++ b/packages/use-toasts/README.md
@@ -11,7 +11,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/validation/README.md
+++ b/packages/validation/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/void-server/README.md
+++ b/packages/void-server/README.md
@@ -13,7 +13,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/packages/workspace-store/README.md
+++ b/packages/workspace-store/README.md
@@ -8,7 +8,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -191,47 +191,183 @@
         },
         {
           "from": "/scalar/scalar-sdks/getting-started",
-          "to": "/products/sdks/getting-started"
+          "to": "/products/sdk-generator/getting-started"
         },
         {
           "from": "/scalar/scalar-sdks/publishing",
-          "to": "/products/sdks/publishing/overview"
-        },
-        {
-          "from": "/products/sdks/publishing",
-          "to": "/products/sdks/publishing/overview"
+          "to": "/products/sdk-generator/publishing/overview"
         },
         {
           "from": "/scalar/scalar-sdks/configuration/typescript",
-          "to": "/products/sdks/configuration/typescript"
+          "to": "/products/sdk-generator/configuration/typescript"
         },
         {
           "from": "/scalar/scalar-sdks/configuration/python",
-          "to": "/products/sdks/configuration/python"
+          "to": "/products/sdk-generator/configuration/python"
         },
         {
           "from": "/scalar/scalar-sdks/configuration/go",
-          "to": "/products/sdks/configuration/go"
+          "to": "/products/sdk-generator/configuration/go"
         },
         {
           "from": "/scalar/scalar-sdks/configuration/java",
-          "to": "/products/sdks/configuration/java"
+          "to": "/products/sdk-generator/configuration/java"
         },
         {
           "from": "/scalar/scalar-sdks/configuration/csharp",
-          "to": "/products/sdks/configuration/csharp"
+          "to": "/products/sdk-generator/configuration/csharp"
         },
         {
           "from": "/scalar/scalar-sdks/configuration/php",
-          "to": "/products/sdks/configuration/php"
+          "to": "/products/sdk-generator/configuration/php"
         },
         {
           "from": "/scalar/scalar-sdks/configuration/ruby",
-          "to": "/products/sdks/configuration/ruby"
+          "to": "/products/sdk-generator/configuration/ruby"
         },
         {
           "from": "/scalar/scalar-sdks/configuration/swift",
-          "to": "/products/sdks/configuration/swift"
+          "to": "/products/sdk-generator/configuration/swift"
+        },
+        {
+          "from": "/products/sdks",
+          "to": "/products/sdk-generator/getting-started"
+        },
+        {
+          "from": "/products/sdks/getting-started",
+          "to": "/products/sdk-generator/getting-started"
+        },
+        {
+          "from": "/products/sdks/managing",
+          "to": "/products/sdk-generator/managing"
+        },
+        {
+          "from": "/products/sdks/custom-code",
+          "to": "/products/sdk-generator/custom-code"
+        },
+        {
+          "from": "/products/sdks/publishing",
+          "to": "/products/sdk-generator/publishing/overview"
+        },
+        {
+          "from": "/products/sdks/publishing/overview",
+          "to": "/products/sdk-generator/publishing/overview"
+        },
+        {
+          "from": "/products/sdks/publishing/github",
+          "to": "/products/sdk-generator/publishing/github"
+        },
+        {
+          "from": "/products/sdks/publishing/registries",
+          "to": "/products/sdk-generator/publishing/registries"
+        },
+        {
+          "from": "/products/sdks/publishing/typescript",
+          "to": "/products/sdk-generator/publishing/typescript"
+        },
+        {
+          "from": "/products/sdks/publishing/python",
+          "to": "/products/sdk-generator/publishing/python"
+        },
+        {
+          "from": "/products/sdks/publishing/go",
+          "to": "/products/sdk-generator/publishing/go"
+        },
+        {
+          "from": "/products/sdks/publishing/rust",
+          "to": "/products/sdk-generator/publishing/rust"
+        },
+        {
+          "from": "/products/sdks/publishing/java",
+          "to": "/products/sdk-generator/publishing/java"
+        },
+        {
+          "from": "/products/sdks/publishing/csharp",
+          "to": "/products/sdk-generator/publishing/csharp"
+        },
+        {
+          "from": "/products/sdks/publishing/ruby",
+          "to": "/products/sdk-generator/publishing/ruby"
+        },
+        {
+          "from": "/products/sdks/publishing/php",
+          "to": "/products/sdk-generator/publishing/php"
+        },
+        {
+          "from": "/products/sdks/publishing/swift",
+          "to": "/products/sdk-generator/publishing/swift"
+        },
+        {
+          "from": "/products/sdks/publishing/dart",
+          "to": "/products/sdk-generator/publishing/dart"
+        },
+        {
+          "from": "/products/sdks/publishing/cli",
+          "to": "/products/sdk-generator/publishing/cli"
+        },
+        {
+          "from": "/products/sdks/configuration",
+          "to": "/products/sdk-generator/configuration/overview"
+        },
+        {
+          "from": "/products/sdks/configuration/overview",
+          "to": "/products/sdk-generator/configuration/overview"
+        },
+        {
+          "from": "/products/sdks/configuration/typescript",
+          "to": "/products/sdk-generator/configuration/typescript"
+        },
+        {
+          "from": "/products/sdks/configuration/python",
+          "to": "/products/sdk-generator/configuration/python"
+        },
+        {
+          "from": "/products/sdks/configuration/cli",
+          "to": "/products/sdk-generator/configuration/cli"
+        },
+        {
+          "from": "/products/sdks/configuration/go",
+          "to": "/products/sdk-generator/configuration/go"
+        },
+        {
+          "from": "/products/sdks/configuration/java",
+          "to": "/products/sdk-generator/configuration/java"
+        },
+        {
+          "from": "/products/sdks/configuration/csharp",
+          "to": "/products/sdk-generator/configuration/csharp"
+        },
+        {
+          "from": "/products/sdks/configuration/php",
+          "to": "/products/sdk-generator/configuration/php"
+        },
+        {
+          "from": "/products/sdks/configuration/ruby",
+          "to": "/products/sdk-generator/configuration/ruby"
+        },
+        {
+          "from": "/products/sdks/configuration/swift",
+          "to": "/products/sdk-generator/configuration/swift"
+        },
+        {
+          "from": "/products/sdks/configuration/rust",
+          "to": "/products/sdk-generator/configuration/rust"
+        },
+        {
+          "from": "/products/sdks/configuration/kotlin",
+          "to": "/products/sdk-generator/configuration/kotlin"
+        },
+        {
+          "from": "/products/sdks/configuration/dart",
+          "to": "/products/sdk-generator/configuration/dart"
+        },
+        {
+          "from": "/products/sdks/configuration/cpp",
+          "to": "/products/sdk-generator/configuration/cpp"
+        },
+        {
+          "from": "/products/sdks/:pathMatch(.*)*",
+          "to": "/products/sdk-generator/getting-started"
         },
         {
           "from": "/scalar/scalar-registry/getting-started",
@@ -1463,8 +1599,8 @@
                   }
                 }
               },
-              "/sdks": {
-                "title": "SDKs",
+              "/sdk-generator": {
+                "title": "SDK Generator",
                 "description": "Generate production-ready SDKs and CLIs in TypeScript, Python, Go, Java, C#, PHP, Ruby, and Swift from your OpenAPI specs.",
                 "type": "group",
                 "mode": "nested",
@@ -1479,7 +1615,7 @@
                       "links": [
                         {
                           "rel": "canonical",
-                          "href": "https://scalar.com/products/sdks/getting-started"
+                          "href": "https://scalar.com/products/sdk-generator/getting-started"
                         }
                       ],
                       "meta": [

--- a/tooling/scripts/src/commands/generate-readme.ts
+++ b/tooling/scripts/src/commands/generate-readme.ts
@@ -31,7 +31,7 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 - **[API References](https://scalar.com/products/api-references/getting-started)** — Interactive API documentation from OpenAPI and AsyncAPI specs.
 - **[Developer Docs](https://scalar.com/products/docs/getting-started)** — Write in Markdown/MDX, generate API references, sync with two-way Git.
-- **[SDK Generator](https://scalar.com/products/sdks/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
+- **[SDK Generator](https://scalar.com/products/sdk-generator/getting-started)** — Type-safe SDKs and CLIs in TypeScript, Python, Go, PHP, Java, and Ruby.
 - **[API Client](https://scalar.com/products/api-client/getting-started)** — Open-source, offline-first Postman alternative built on OpenAPI.
 
 20M+ monthly npm installs · 15,500+ GitHub stars · MIT licensed · [scalar.com](https://scalar.com)


### PR DESCRIPTION
## Problem

The SDKs product pages live at `scalar.com/products/sdks/...`, but the product is branded "SDK Generator" (see the page heading on the getting-started page). The sidebar entry, the URL path, and the branding do not match.

## Solution

Rename the route group and set up redirects so no existing link breaks:

- Rename the `/products/sdks` route group to `/products/sdk-generator` in `scalar.config.json` and retitle the sidebar entry from "SDKs" to "SDK Generator".
- Add explicit redirects from every old `/products/sdks/*` page (getting-started, managing, custom-code, all publishing pages, all configuration pages, and the bare group URLs) to its new `/products/sdk-generator/*` counterpart, plus a wildcard fallback to getting-started. Explicit per-page redirects are used because wildcard redirect targets are static and cannot preserve the matched path.
- Retarget the legacy `/scalar/scalar-sdks/*` redirects to point directly at the new paths so they do not chain through a second redirect.
- Update the canonical URL on the getting-started page and all internal links: site footer, introduction/pricing/security guides, the tabs example in the navigation guide, the root README, the platform-overview block in `generate-readme.ts`, and the same block in all package/integration READMEs (regenerated the 21 the script manages; applied the identical one-line change to the rest).

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- docs/config only, no package code changes -->
- [ ] I added tests. <!-- no code behavior changed -->
- [x] I updated the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and redirect config only; no application or package runtime behavior changes.
> 
> **Overview**
> Aligns the **SDK Generator** product URL and navigation with branding by moving docs from `/products/sdks` to `/products/sdk-generator`.
> 
> **`scalar.config.json`** renames the route group to `/sdk-generator`, retitles the sidebar to **SDK Generator**, updates the getting-started canonical URL, points legacy `/scalar/scalar-sdks/*` redirects at the new paths, and adds explicit redirects for every old `/products/sdks/*` route plus a wildcard fallback to getting-started.
> 
> Across the repo, internal links now use `/products/sdk-generator/...` (site footer, intro/pricing/security guides, navigation tabs example, root README, `generate-readme.ts` platform blurb, and package/integration READMEs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5961a096c05556aeaef405b26f4302162911328a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->