### PR TITLE
fix(api-client): checkbox aria labels

### DIFF
--- a/.changeset/fix-checkbox-aria-labels.md
+++ b/.changeset/fix-checkbox-aria-labels.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix missing accessible names on request/scopes table checkboxes and their row delete buttons. `DataTableCheckbox` now accepts an `ariaLabel` prop, and `RequestTableRow`/`OAuthScopesInput` pass row-specific labels (e.g. "Include x-api-key in request", "Select read:users scope") so screen reader users can tell which row a control acts on.

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
@@ -87,6 +87,45 @@ describe('RequestTableRow', () => {
     })
   })
 
+  it('gives the checkbox a row-specific accessible name', () => {
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: { name: 'x-api-key', value: 'value' },
+        environment,
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    const checkbox = wrapper.findComponent(DataTableCheckbox)
+    expect(checkbox.props('ariaLabel')).toBe('Include x-api-key in request')
+  })
+
+  it('gives the delete row button a row-specific accessible name', () => {
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: { name: 'x-api-key', value: 'value' },
+        environment,
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    const deleteButtons = wrapper.findAllComponents({ name: 'ScalarButton' })
+    const deleteRowButton = deleteButtons.find((btn) => {
+      const iconComponent = btn.findComponent({ name: 'ScalarIconTrash' })
+      return iconComponent.exists()
+    })
+
+    expect(deleteRowButton?.attributes('aria-label')).toBe('Delete x-api-key')
+  })
+
   it('disables checkbox when hasCheckboxDisabled is true', () => {
     const wrapper = mount(RequestTableRow, {
       props: {

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
@@ -100,8 +100,8 @@ describe('RequestTableRow', () => {
       },
     })
 
-    const checkbox = wrapper.findComponent(DataTableCheckbox)
-    expect(checkbox.props('ariaLabel')).toBe('Include x-api-key in request')
+    const checkbox = wrapper.find('input[type="checkbox"]')
+    expect(checkbox.attributes('aria-label')).toBe('Include x-api-key in request')
   })
 
   it('gives the delete row button a row-specific accessible name', () => {

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -212,6 +212,7 @@ const handleKeyBlur = (newName: string): void => {
       error: validationResult.ok === false && invalidParams?.has(data.name),
     }">
     <DataTableCheckbox
+      :ariaLabel="`Include ${data.name} in request`"
       class="!border-r"
       :disabled="hasCheckboxDisabled ?? false"
       :modelValue="!isDisabled"
@@ -257,6 +258,7 @@ const handleKeyBlur = (newName: string): void => {
               !data.isRequired &&
               data.isReadonly !== true
             "
+            :aria-label="`Delete ${data.name || 'row'}`"
             class="text-c-2 hover:text-c-1 hover:bg-b-2 z-context -mr-0.5 hidden h-fit rounded p-1 group-hover:flex group-has-[.code-input-lite__editor:focus]:flex"
             size="sm"
             variant="ghost"

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -212,7 +212,7 @@ const handleKeyBlur = (newName: string): void => {
       error: validationResult.ok === false && invalidParams?.has(data.name),
     }">
     <DataTableCheckbox
-      :ariaLabel="`Include ${data.name} in request`"
+      :ariaLabel="`Include ${data.name || 'row'} in request`"
       class="!border-r"
       :disabled="hasCheckboxDisabled ?? false"
       :modelValue="!isDisabled"

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.test.ts
@@ -137,6 +137,17 @@ describe('OAuthScopesInput', () => {
     expect(wrapper.text()).toContain('0 / 2')
   })
 
+  it('gives each scope checkbox a scope-specific accessible name', async () => {
+    const wrapper = mountComponent()
+    await openDisclosure(wrapper)
+
+    const checkboxes = wrapper.findAll('input[type="checkbox"]')
+    expect(checkboxes.map((checkbox) => checkbox.attributes('aria-label'))).toEqual([
+      'Select read:items scope',
+      'Select write:items scope',
+    ])
+  })
+
   it('updates via checkbox change event', async () => {
     const wrapper = mountComponent()
     await openDisclosure(wrapper)

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuthScopesInput.vue
@@ -311,6 +311,7 @@ const handleDeleteScope = (scopeKey: string) => {
                   letting the row fire too would toggle the scope a second time.
                 -->
                 <DataTableCheckbox
+                  :ariaLabel="`Select ${label} scope`"
                   :modelValue="selectedScopes.includes(id)"
                   @click.stop
                   @update:modelValue="setScope(id, $event)" />

--- a/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
+++ b/packages/api-client/src/v2/components/data-table/DataTableCheckbox.vue
@@ -9,9 +9,11 @@ withDefaults(
     modelValue: boolean
     disabled?: boolean
     align?: 'left' | 'center'
+    ariaLabel?: string
   }>(),
   {
     align: 'center',
+    ariaLabel: 'Toggle',
   },
 )
 
@@ -32,6 +34,7 @@ const variants = cva({
 <template>
   <DataTableCell class="group/cell relative flex min-w-8">
     <input
+      :aria-label="ariaLabel"
       :checked="modelValue"
       class="peer absolute inset-0 size-full cursor-pointer opacity-0 disabled:cursor-default"
       :disabled="Boolean(disabled)"


### PR DESCRIPTION
Problem
Checkboxes in the request/scopes tables and their row delete buttons had no accessible name, so screen reader users couldn't tell which row a control acted on.

DataTableCheckbox renders a bare <input type="checkbox"> with no aria-label, and it's reused across the request params table, the OAuth scopes table, and elsewhere — so the gap affects every table built on it. Its row delete ScalarButton (icon-only, trash icon) had the same problem: no accessible name at all.

Solution
Added an optional ariaLabel prop to DataTableCheckbox (defaults to "Toggle", preserving current behavior for any callers not yet updated) and bound it to the checkbox's aria-label. Updated the two call sites that had row-specific data available to pass a descriptive label:

RequestTableRow.vue: Include ${name} in request on the checkbox, Delete ${name} on the delete button.
OAuthScopesInput.vue: Select ${label} scope on the checkbox.
Considered labelling generically (e.g. just "Toggle" everywhere) but that doesn't help a screen reader user distinguish rows in a table with many similar controls, so per-row labels were used instead.

Checklist

- [x] -   I explained why the change is needed.
- [x]  -  I added a changeset.
- [x] -  I added tests.
- [ ] -  I updated the documentation.