### PR TITLE
feat(api-reference): export SdkInstallationInstructions from blocks

### DIFF
--- a/.changeset/export-sdk-installation-instructions.md
+++ b/.changeset/export-sdk-installation-instructions.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat: export `SdkInstallationInstructions` and `getRenderableSdks` from `@scalar/api-reference/blocks`, so consumers that compose their own reference layout can render `x-scalar-sdk-installation` again

--- a/packages/api-reference/src/blocks/index.ts
+++ b/packages/api-reference/src/blocks/index.ts
@@ -1,4 +1,5 @@
 export { AsyncApiServerSelector } from './scalar-asyncapi-server-selector-block'
 export { ClientSelector } from './scalar-client-selector-block'
 export { InfoBlock, IntroductionCardItem } from './scalar-info-block'
+export { SdkInstallationInstructions, getRenderableSdks } from './scalar-sdk-installation-instructions'
 export { ServerSelector } from './scalar-server-selector-block'


### PR DESCRIPTION
PR #9399 removed the `xScalarSdkInstallation` prop from the `ClientSelector` block and introduced a dedicated `SdkInstallationInstructions` component, but the new component was only wired up internally in `Content.vue`. Consumers that compose their own introduction card from `@scalar/api-reference/blocks` lost the ability to render `x-scalar-sdk-installation` entirely.

This exports `SdkInstallationInstructions` and `getRenderableSdks` from the public `@scalar/api-reference/blocks` entry point so downstream layouts can render SDK installation instructions again.

## Changes

- Re-export `SdkInstallationInstructions` and `getRenderableSdks` from `packages/api-reference/src/blocks/index.ts`
- Add a minor changeset for `@scalar/api-reference`

## Checks

- Verified the build emits both exports into `dist/blocks/index.d.ts`
- `pnpm vitest src/blocks --run` in `packages/api-reference`: 19 files, 196 tests passing
- `pnpm --filter @scalar/api-reference types:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Barrel export and changeset only; no runtime or behavioral changes to the reference package.
> 
> **Overview**
> **Restores public access** to SDK installation UI for custom `@scalar/api-reference/blocks` layouts by re-exporting `SdkInstallationInstructions` and `getRenderableSdks` from `packages/api-reference/src/blocks/index.ts`.
> 
> That surfaces the component and helper that already exist internally (after `xScalarSdkInstallation` was removed from `ClientSelector`), so consumers can render `x-scalar-sdk-installation` again without duplicating logic. A **minor** changeset documents the `@scalar/api-reference` API addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b3da342b705c00a2058272d67c8c0dcce383f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->