### PR TITLE
feat(components): add ScalarDialog native dialog component

### DIFF
--- a/.changeset/doc-3107-scalar-dialog.md
+++ b/.changeset/doc-3107-scalar-dialog.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': minor
+---
+
+Add `ScalarDialog`, a modal dialog built on the native `<dialog>` element and `showModal()`. Control it with `v-model:open` and compose its contents with the default slot. Focus trapping, focus restore, background inert, Escape-to-close, and top-layer stacking come from the platform; backdrop-click dismissal is handled by a small, tested composable that ignores text-selection drags and keyboard-activated controls.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -76,6 +76,11 @@
       "import": "./dist/components/ScalarCopy/index.js",
       "default": "./dist/components/ScalarCopy/index.js"
     },
+    "./dialog": {
+      "types": "./dist/components/ScalarDialog/index.d.ts",
+      "import": "./dist/components/ScalarDialog/index.js",
+      "default": "./dist/components/ScalarDialog/index.js"
+    },
     "./dropdown": {
       "types": "./dist/components/ScalarDropdown/index.d.ts",
       "import": "./dist/components/ScalarDropdown/index.js",

--- a/packages/components/src/components/ScalarDialog/ScalarDialog.stories.ts
+++ b/packages/components/src/components/ScalarDialog/ScalarDialog.stories.ts
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { ref } from 'vue'
+
+import { ScalarButton } from '../ScalarButton'
+import ScalarDialog from './ScalarDialog.vue'
+
+/**
+ * Control the dialog with `v-model:open` (a plain `ref`) and compose its contents
+ * with the default slot. There are no size or variant props — restyle or resize by
+ * passing your own `class`.
+ */
+const meta = {
+  component: ScalarDialog,
+  tags: ['autodocs'],
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof ScalarDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Base: Story = {
+  render: (args) => ({
+    components: { ScalarButton, ScalarDialog },
+    setup() {
+      const open = ref(false)
+      return { args, open }
+    },
+    template: `
+      <div class="flex h-dvh items-center justify-center">
+        <ScalarButton @click="open = true">Open dialog</ScalarButton>
+      </div>
+      <ScalarDialog
+        v-model:open="open"
+        aria-label="Example dialog"
+        v-bind="args">
+        <div class="flex flex-col gap-4">
+          <h2 class="text-sm font-medium">Example dialog</h2>
+          <p class="text-c-2">
+            Compose whatever you want in here — there are no size or variant props,
+            just the slot and class overrides.
+          </p>
+          <div class="flex gap-2 *:flex-1">
+            <ScalarButton variant="outlined" @click="open = false">Cancel</ScalarButton>
+            <ScalarButton @click="open = false">Confirm</ScalarButton>
+          </div>
+        </div>
+      </ScalarDialog>
+    `,
+  }),
+}
+
+/**
+ * Opening a dialog from within another stacks them in the top layer: the browser
+ * inerts the dialog underneath, Escape closes the topmost first, and focus returns
+ * down the stack — all without any bookkeeping on our side.
+ */
+export const Nested: Story = {
+  render: () => ({
+    components: { ScalarButton, ScalarDialog },
+    setup() {
+      const open = ref(false)
+      const nested = ref(false)
+      return { open, nested }
+    },
+    template: `
+      <div class="flex h-dvh items-center justify-center">
+        <ScalarButton @click="open = true">Open dialog</ScalarButton>
+      </div>
+      <ScalarDialog
+        v-model:open="open"
+        aria-label="First dialog">
+        <div class="flex flex-col gap-4">
+          <h2 class="text-sm font-medium">First dialog</h2>
+          <p class="text-c-2">Open another dialog on top — the browser stacks and inerts this one.</p>
+          <div class="flex gap-2 *:flex-1">
+            <ScalarButton variant="outlined" @click="open = false">Close</ScalarButton>
+            <ScalarButton @click="nested = true">Open nested</ScalarButton>
+          </div>
+        </div>
+      </ScalarDialog>
+      <ScalarDialog
+        v-model:open="nested"
+        aria-label="Nested dialog"
+        class="max-w-sm">
+        <div class="flex flex-col gap-4">
+          <h2 class="text-sm font-medium">Nested dialog</h2>
+          <p class="text-c-2">Escape closes me first, then the dialog underneath.</p>
+          <ScalarButton @click="nested = false">Close</ScalarButton>
+        </div>
+      </ScalarDialog>
+    `,
+  }),
+}
+
+/** The dialog caps its height and scrolls long content rather than the page. */
+export const Scrolling: Story = {
+  render: () => ({
+    components: { ScalarButton, ScalarDialog },
+    setup() {
+      const open = ref(false)
+      const paragraphs = Array.from({ length: 12 }, (_, i) => i + 1)
+      return { open, paragraphs }
+    },
+    template: `
+      <div class="flex h-dvh items-center justify-center">
+        <ScalarButton @click="open = true">Open dialog</ScalarButton>
+      </div>
+      <ScalarDialog
+        v-model:open="open"
+        aria-label="Scrolling dialog">
+        <div class="flex flex-col gap-3">
+          <h2 class="text-sm font-medium">Lots of content</h2>
+          <p
+            v-for="n in paragraphs"
+            :key="n"
+            class="text-c-2">
+            Paragraph {{ n }} — the dialog caps its height and scrolls the overflow.
+          </p>
+        </div>
+      </ScalarDialog>
+    `,
+  }),
+}

--- a/packages/components/src/components/ScalarDialog/ScalarDialog.vue
+++ b/packages/components/src/components/ScalarDialog/ScalarDialog.vue
@@ -1,0 +1,115 @@
+<script lang="ts">
+/**
+ * Scalar Dialog
+ *
+ * A modal dialog built on the native `<dialog>` element. It calls `showModal()`
+ * under the hood, so the dialog is promoted to the browser top layer (escaping
+ * ancestor stacking, overflow, and transform contexts), traps and restores focus,
+ * makes the rest of the page inert, and closes on Escape — all natively, with no
+ * teleport and no extra wrapper elements.
+ *
+ * Control it with `v-model:open` and compose the contents with the default slot.
+ * Restyle or resize it by passing your own `class`; the defaults are intentionally
+ * minimal so consumers compose rather than configure.
+ *
+ * @example
+ * <ScalarDialog v-model:open="open">
+ *   <h2>Title</h2>
+ *   <p>Some content</p>
+ * </ScalarDialog>
+ */
+export default {}
+</script>
+
+<script setup lang="ts">
+import { cva, useBindCx } from '@scalar/use-hooks/useBindCx'
+import { ref, watchPostEffect } from 'vue'
+
+import type { ScalarDialogProps } from './types'
+import { useBackdropClick } from './useBackdropClick'
+
+const { unmount = true, closeOnBackdrop = true } =
+  defineProps<ScalarDialogProps>()
+
+const emit = defineEmits<{
+  /** Emitted whenever the dialog closes, whether via Escape, a backdrop click, or `open` being set to false. */
+  (e: 'close'): void
+}>()
+
+defineSlots<{
+  /** The dialog contents. Compose your own header, body, and footer here. */
+  default(): unknown
+}>()
+
+/** Whether the dialog is open. Drives the native `showModal()` and `close()` calls. */
+const open = defineModel<boolean>('open', { default: false })
+
+const dialog = cva({
+  base: [
+    // Reset the native dialog chrome and center it within the top layer
+    'scalar-dialog m-auto rounded-lg border-0 p-3 shadow-lg',
+    // Surface colors
+    'bg-b-1 text-c-1',
+    // Theme the native ::backdrop via Tailwind's backdrop variant
+    'backdrop:bg-backdrop dark:backdrop:bg-backdrop-dark',
+    // Constrain the size and let long content scroll
+    'custom-scroll max-h-[85svh] w-[calc(100dvw-2rem)] max-w-md overflow-auto',
+  ],
+})
+
+defineOptions({ inheritAttrs: false })
+const { cx } = useBindCx()
+
+const dialogRef = ref<HTMLDialogElement | null>(null)
+
+/**
+ * Puppet the native dialog from the reactive `open` model.
+ *
+ * `watchPostEffect` runs after the DOM updates, so the slotted content (and any
+ * `autofocus` target) is mounted before `showModal()` moves focus into it. The
+ * guards against `dialog.open` avoid the `InvalidStateError` the browser throws
+ * when `showModal()` is called on an already-open dialog.
+ */
+watchPostEffect(() => {
+  const element = dialogRef.value
+  if (!element) {
+    return
+  }
+
+  if (open.value && !element.open) {
+    element.showModal()
+  } else if (!open.value && element.open) {
+    element.close()
+  }
+})
+
+/** Mirror native closes (Escape, form submit, programmatic) back into the model. */
+const handleClose = () => {
+  open.value = false
+  emit('close')
+}
+
+/**
+ * Close when the backdrop is clicked. The composable ignores text-selection drags
+ * and keyboard-activated controls; setting `open` to false lets the puppet bridge
+ * run the native `close()` so the flow matches Escape and programmatic closes.
+ */
+const { handlePointerDown, handleClick } = useBackdropClick(dialogRef, () => {
+  if (closeOnBackdrop) {
+    open.value = false
+  }
+})
+</script>
+
+<template>
+  <dialog
+    ref="dialogRef"
+    v-bind="cx(dialog())"
+    @close="handleClose"
+    @pointerdown="handlePointerDown"
+    @click="handleClick">
+    <template v-if="!unmount || open">
+      <slot />
+    </template>
+  </dialog>
+</template>

--- a/packages/components/src/components/ScalarDialog/ScalarDialog.vue
+++ b/packages/components/src/components/ScalarDialog/ScalarDialog.vue
@@ -28,8 +28,7 @@ import { ref, watchPostEffect } from 'vue'
 import type { ScalarDialogProps } from './types'
 import { useBackdropClick } from './useBackdropClick'
 
-const { unmount = true, closeOnBackdrop = true } =
-  defineProps<ScalarDialogProps>()
+const { persist = false } = defineProps<ScalarDialogProps>()
 
 const emit = defineEmits<{
   /** Emitted whenever the dialog closes, whether via Escape, a backdrop click, or `open` being set to false. */
@@ -95,9 +94,7 @@ const handleClose = () => {
  * run the native `close()` so the flow matches Escape and programmatic closes.
  */
 const { handlePointerDown, handleClick } = useBackdropClick(dialogRef, () => {
-  if (closeOnBackdrop) {
-    open.value = false
-  }
+  open.value = false
 })
 </script>
 
@@ -108,7 +105,7 @@ const { handlePointerDown, handleClick } = useBackdropClick(dialogRef, () => {
     @close="handleClose"
     @pointerdown="handlePointerDown"
     @click="handleClick">
-    <template v-if="!unmount || open">
+    <template v-if="persist || open">
       <slot />
     </template>
   </dialog>

--- a/packages/components/src/components/ScalarDialog/index.ts
+++ b/packages/components/src/components/ScalarDialog/index.ts
@@ -1,0 +1,5 @@
+import { default as ScalarDialog } from './ScalarDialog.vue'
+
+export { ScalarDialog }
+
+export type { ScalarDialogProps } from './types'

--- a/packages/components/src/components/ScalarDialog/types.ts
+++ b/packages/components/src/components/ScalarDialog/types.ts
@@ -1,0 +1,20 @@
+/** Props for the ScalarDialog component */
+export type ScalarDialogProps = {
+  /**
+   * Controls whether the dialog contents are torn down when the dialog closes.
+   *
+   * When true (the default) the contents are unmounted on close, so child
+   * components mount fresh on each open and their lifecycle hooks fire in step
+   * with the dialog's open state. Set it to false to keep the contents mounted
+   * and preserve their state across open and close.
+   *
+   * @default true
+   */
+  unmount?: boolean
+  /**
+   * Whether clicking the backdrop (outside the dialog) closes it.
+   *
+   * @default true
+   */
+  closeOnBackdrop?: boolean
+}

--- a/packages/components/src/components/ScalarDialog/types.ts
+++ b/packages/components/src/components/ScalarDialog/types.ts
@@ -1,20 +1,14 @@
 /** Props for the ScalarDialog component */
 export type ScalarDialogProps = {
   /**
-   * Controls whether the dialog contents are torn down when the dialog closes.
+   * Keeps the dialog contents mounted while it is closed.
    *
-   * When true (the default) the contents are unmounted on close, so child
-   * components mount fresh on each open and their lifecycle hooks fire in step
-   * with the dialog's open state. Set it to false to keep the contents mounted
-   * and preserve their state across open and close.
+   * By default the contents are torn down on close, so child components mount
+   * fresh on each open and their lifecycle hooks fire in step with the dialog's
+   * open state. Set this to keep the contents mounted and preserve their state
+   * across open and close.
    *
-   * @default true
+   * @default false
    */
-  unmount?: boolean
-  /**
-   * Whether clicking the backdrop (outside the dialog) closes it.
-   *
-   * @default true
-   */
-  closeOnBackdrop?: boolean
+  persist?: boolean
 }

--- a/packages/components/src/components/ScalarDialog/useBackdropClick.test.ts
+++ b/packages/components/src/components/ScalarDialog/useBackdropClick.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { isPointerOutsideBox, useBackdropClick } from './useBackdropClick'
+
+/** A dialog box centered away from the origin, matching a real centered dialog. */
+const BOX = { top: 100, right: 300, bottom: 300, left: 100 }
+
+/** Build a fake dialog element whose `getBoundingClientRect` returns {@link BOX}. */
+const dialogWith = (box = BOX) =>
+  ref({ getBoundingClientRect: () => box }) as unknown as Parameters<typeof useBackdropClick>[0]
+
+/** Build a pointer event with sensible defaults for the fields the composable reads. */
+const pointer = (overrides: Partial<PointerEvent> = {}) =>
+  ({ button: 0, clientX: 0, clientY: 0, ...overrides }) as PointerEvent
+
+/** Build a click event; a real mouse click reports `detail >= 1`. */
+const click = (overrides: Partial<MouseEvent> = {}) =>
+  ({ detail: 1, clientX: 0, clientY: 0, ...overrides }) as MouseEvent
+
+describe('isPointerOutsideBox', () => {
+  it('is false for a point inside the box', () => {
+    expect(isPointerOutsideBox({ clientX: 200, clientY: 200 }, BOX)).toBe(false)
+  })
+
+  it('is false on the edges (padding counts as inside)', () => {
+    expect(isPointerOutsideBox({ clientX: 100, clientY: 100 }, BOX)).toBe(false)
+    expect(isPointerOutsideBox({ clientX: 300, clientY: 300 }, BOX)).toBe(false)
+  })
+
+  it('is true to the left, right, above, and below', () => {
+    expect(isPointerOutsideBox({ clientX: 99, clientY: 200 }, BOX)).toBe(true)
+    expect(isPointerOutsideBox({ clientX: 301, clientY: 200 }, BOX)).toBe(true)
+    expect(isPointerOutsideBox({ clientX: 200, clientY: 99 }, BOX)).toBe(true)
+    expect(isPointerOutsideBox({ clientX: 200, clientY: 301 }, BOX)).toBe(true)
+  })
+
+  it('treats the origin as outside a centered box', () => {
+    expect(isPointerOutsideBox({ clientX: 0, clientY: 0 }, BOX)).toBe(true)
+  })
+})
+
+describe('useBackdropClick', () => {
+  it('dismisses when the pointer is pressed and released on the backdrop', () => {
+    const onDismiss = vi.fn()
+    const { handlePointerDown, handleClick } = useBackdropClick(dialogWith(), onDismiss)
+
+    handlePointerDown(pointer({ clientX: 10, clientY: 10 }))
+    handleClick(click({ clientX: 10, clientY: 10 }))
+
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+
+  it('does not dismiss for a click inside the dialog', () => {
+    const onDismiss = vi.fn()
+    const { handlePointerDown, handleClick } = useBackdropClick(dialogWith(), onDismiss)
+
+    handlePointerDown(pointer({ clientX: 200, clientY: 200 }))
+    handleClick(click({ clientX: 200, clientY: 200 }))
+
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('does not dismiss a text-selection drag that starts inside and ends outside', () => {
+    const onDismiss = vi.fn()
+    const { handlePointerDown, handleClick } = useBackdropClick(dialogWith(), onDismiss)
+
+    // Press on the content, then release out on the backdrop.
+    handlePointerDown(pointer({ clientX: 200, clientY: 200 }))
+    handleClick(click({ clientX: 10, clientY: 10 }))
+
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('does not dismiss when a press on the backdrop is released inside the dialog', () => {
+    const onDismiss = vi.fn()
+    const { handlePointerDown, handleClick } = useBackdropClick(dialogWith(), onDismiss)
+
+    handlePointerDown(pointer({ clientX: 10, clientY: 10 }))
+    handleClick(click({ clientX: 200, clientY: 200 }))
+
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('ignores keyboard-synthesized clicks (detail 0 at the origin)', () => {
+    const onDismiss = vi.fn()
+    const { handleClick } = useBackdropClick(dialogWith(), onDismiss)
+
+    // Activating a button with Enter/Space dispatches a click with no prior pointerdown.
+    handleClick(click({ detail: 0, clientX: 0, clientY: 0 }))
+
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-primary button presses', () => {
+    const onDismiss = vi.fn()
+    const { handlePointerDown, handleClick } = useBackdropClick(dialogWith(), onDismiss)
+
+    handlePointerDown(pointer({ button: 2, clientX: 10, clientY: 10 }))
+    handleClick(click({ clientX: 10, clientY: 10 }))
+
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('resets between interactions so a stale backdrop press cannot leak into a later click', () => {
+    const onDismiss = vi.fn()
+    const { handlePointerDown, handleClick } = useBackdropClick(dialogWith(), onDismiss)
+
+    // A backdrop press that never produced a matching outside click (released inside).
+    handlePointerDown(pointer({ clientX: 10, clientY: 10 }))
+    handleClick(click({ clientX: 200, clientY: 200 }))
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    // A later inside click must not inherit the earlier backdrop press.
+    handleClick(click({ clientX: 200, clientY: 200 }))
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the dialog ref is not set', () => {
+    const onDismiss = vi.fn()
+    const dialogRef = ref(null)
+    const { handlePointerDown, handleClick } = useBackdropClick(dialogRef, onDismiss)
+
+    handlePointerDown(pointer({ clientX: 10, clientY: 10 }))
+    handleClick(click({ clientX: 10, clientY: 10 }))
+
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+})

--- a/packages/components/src/components/ScalarDialog/useBackdropClick.ts
+++ b/packages/components/src/components/ScalarDialog/useBackdropClick.ts
@@ -1,0 +1,76 @@
+import type { Ref } from 'vue'
+
+/** The pointer coordinates we compare against the dialog's box. */
+type PointerPosition = Pick<MouseEvent, 'clientX' | 'clientY'>
+
+/** A rectangle we can test a pointer position against (a subset of `DOMRect`). */
+type Box = Pick<DOMRect, 'top' | 'right' | 'bottom' | 'left'>
+
+/**
+ * Whether a pointer position falls outside a box.
+ *
+ * A native `<dialog>` renders its `::backdrop` as part of the dialog element, so a
+ * click on the backdrop targets the dialog itself. That is why `onClickOutside` (and
+ * any "is the event target inside my element" check) cannot detect a backdrop click —
+ * the target is the dialog. Comparing the pointer position against the dialog's box is
+ * the reliable way to tell a backdrop click from a click on the dialog surface. The box
+ * comes from `getBoundingClientRect()`, so it already includes padding and border: a
+ * click in the dialog's padding counts as inside and keeps the dialog open.
+ */
+export const isPointerOutsideBox = (
+  { clientX, clientY }: PointerPosition,
+  { top, right, bottom, left }: Box,
+): boolean => clientX < left || clientX > right || clientY < top || clientY > bottom
+
+/**
+ * Dismiss a native `<dialog>` when the backdrop is clicked.
+ *
+ * Returns `pointerdown` and `click` handlers to bind on the `<dialog>`. A click only
+ * counts as a backdrop dismissal when the pointer was both pressed and released on the
+ * backdrop, which avoids two failure modes a naive click-position check has:
+ *
+ * - **Text-selection drags** — pressing inside the dialog, dragging to select text, and
+ *   releasing outside would otherwise fire a `click` with outside coordinates and close
+ *   the dialog. Requiring the press to also be outside keeps it open.
+ * - **Keyboard-activated controls** — pressing Enter or Space on a focused button
+ *   dispatches a synthetic `click` with `detail === 0` and coordinates of `(0, 0)`, which
+ *   sit outside the centered dialog. Ignoring `detail === 0` clicks keeps the dialog open
+ *   when a control inside it is used from the keyboard.
+ *
+ * @param dialogRef - Template ref to the native `<dialog>` element.
+ * @param onDismiss - Called when a genuine backdrop click is detected.
+ */
+export const useBackdropClick = (
+  dialogRef: Ref<HTMLDialogElement | null>,
+  onDismiss: () => void,
+): {
+  handlePointerDown: (event: PointerEvent) => void
+  handleClick: (event: MouseEvent) => void
+} => {
+  /** Whether the most recent primary press landed on the backdrop. */
+  let pressedOnBackdrop = false
+
+  const handlePointerDown = (event: PointerEvent): void => {
+    const element = dialogRef.value
+    // Only the primary (left) button can lead to a `click`, so ignore the rest.
+    pressedOnBackdrop = event.button === 0 && !!element && isPointerOutsideBox(event, element.getBoundingClientRect())
+  }
+
+  const handleClick = (event: MouseEvent): void => {
+    const element = dialogRef.value
+    const pressed = pressedOnBackdrop
+    // Reset for the next interaction before any early return.
+    pressedOnBackdrop = false
+
+    // Ignore keyboard-synthesized clicks: they report `detail === 0` and `(0, 0)`.
+    if (!element || event.detail === 0) {
+      return
+    }
+
+    if (pressed && isPointerOutsideBox(event, element.getBoundingClientRect())) {
+      onDismiss()
+    }
+  }
+
+  return { handlePointerDown, handleClick }
+}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -24,6 +24,8 @@ export type {
 } from './components/ScalarCombobox'
 export { ScalarCombobox, ScalarComboboxMultiselect, isScalarComboboxGroups } from './components/ScalarCombobox'
 export { ScalarCopy, ScalarCopyBackdrop, ScalarCopyButton } from './components/ScalarCopy'
+export type { ScalarDialogProps } from './components/ScalarDialog'
+export { ScalarDialog } from './components/ScalarDialog'
 export {
   ScalarDropdown,
   ScalarDropdownButton,


### PR DESCRIPTION
> WIP — first piece of the dialog overhaul. Migrating call sites + the command palette are separate follow-ups.

Adds `ScalarDialog`, a new modal built on the native `<dialog>` element + `showModal()`, shipped alongside the existing `ScalarModal`. Going native means the platform handles focus trap/restore, background inert, Escape, top-layer stacking, and nesting for free — so we can eventually drop the HeadlessUI workarounds `ScalarModal` still carries.

- `v-model:open` + default slot, composition-first (no `size`/`variant` — restyle via `class`)
- `watchPostEffect` puppet bridge drives `showModal()`/`close()` and mirrors native closes back to state
- `useBackdropClick` composable for backdrop dismissal (VueUse's `onClickOutside` can't — the `::backdrop` click targets the dialog itself); handles text-selection drags + keyboard clicks
- Storybook stories + 12 unit tests

## Visual

Storybook: `pnpm --filter @scalar/components dev` → **Components/ScalarDialog**. _(screenshots to follow)_

## Ticket

Part of DOC-3107
