### PR TITLE
fix(api-reference): render every oneOf/anyOf group of an allOf in place

### DIFF
--- a/.changeset/allof-multiple-oneof.md
+++ b/.changeset/allof-multiple-oneof.md
@@ -1,0 +1,6 @@
+---
+"@scalar/api-reference": patch
+"@scalar/workspace-store": patch
+---
+
+Render every `oneOf`/`anyOf` group of an `allOf` in place. Previously, when one object composed several mutually-exclusive choices as sibling `oneOf`/`anyOf` under `allOf`, only the first group was shown and the rest were silently dropped. Each choice group now renders its own selector in the position it was declared, and the generated request example stays in sync per group.

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
@@ -444,13 +444,21 @@ describe('SchemaComposition', () => {
       },
     })
 
-    // The merged schema handed to Schema keeps both the base property and the
-    // oneOf variants, so the variant selector still renders.
-    const schemaValue = wrapper.findComponent({ name: 'Schema' }).props('schema') as any
+    // The base object property is rendered by the merged Schema...
+    const baseSchema = wrapper.findComponent({ name: 'Schema' }).props('schema') as any
+    expect(baseSchema.properties).toMatchObject({ customerComment: { type: 'string' } })
 
-    expect(schemaValue.properties).toMatchObject({ customerComment: { type: 'string' } })
-    expect(schemaValue.oneOf).toHaveLength(2)
-    expect(schemaValue.oneOf[0].title).toBe('With Quote Id')
-    expect(schemaValue.oneOf[1].title).toBe('With Currency Pair')
+    // ...and the oneOf is preserved as its own composition (rendered as a sibling
+    // picker), not dropped. This is the structure that lets multiple independent
+    // oneOf groups inside one allOf each render their own selector.
+    const nestedOneOf = wrapper
+      .findAllComponents({ name: 'SchemaComposition' })
+      .find((component) => component.props('composition') === 'oneOf')
+    expect(nestedOneOf).toBeTruthy()
+
+    const oneOfSchema = nestedOneOf!.props('schema') as any
+    expect(oneOfSchema.oneOf).toHaveLength(2)
+    expect(oneOfSchema.oneOf[0].title).toBe('With Quote Id')
+    expect(oneOfSchema.oneOf[1].title).toBe('With Currency Pair')
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -21,7 +21,7 @@ import {
 } from '@/features/Operation/request-body-composition-index'
 
 import { getSchemaType } from './helpers/get-schema-type'
-import { mergeAllOfSchemas } from './helpers/merge-all-of-schemas'
+import { partitionAllOfCompositions } from './helpers/partition-all-of-compositions'
 import { type CompositionKeyword } from './helpers/schema-composition'
 import { getCycleKey } from './helpers/schema-cycle'
 import { getModelNameFromSchema } from './helpers/schema-name'
@@ -62,6 +62,18 @@ const props = withDefaults(
   },
 )
 const { translate } = useLocalization()
+
+/**
+ * Split an `allOf` into an ordered list of segments (object chunks + choice
+ * pickers) so multiple mutually-exclusive selections each render their own
+ * picker, in the position they were declared, instead of all but the first
+ * being dropped and the rest bubbling to the end.
+ */
+const allOfSegments = computed(() =>
+  props.composition === 'allOf'
+    ? partitionAllOfCompositions(props.schema).segments
+    : [],
+)
 
 /** The current composition */
 const composition = computed(() =>
@@ -203,26 +215,54 @@ if (
 
 <template>
   <div class="property-rule">
-    <!-- We merge allOf schemas into a single schema -->
-    <Schema
-      v-if="props.composition === 'allOf'"
-      :breadcrumb="breadcrumb"
-      :compact="compact"
-      :compositionPath="compositionPath"
-      :discriminator="discriminator"
-      :eventBus="eventBus"
-      :hideDescription="isRequestBodyRootComposition"
-      :hideHeading="hideHeading"
-      :hideModelNames
-      :level="level + 1"
-      :name="name"
-      :noncollapsible="true"
-      :options="options"
-      :schema="mergeAllOfSchemas(schema)"
-      :schemaContext="schemaContext" />
+    <!--
+      allOf: render the members in source order — object chunks as fields, each
+      oneOf/anyOf group as its own picker in place. Keeps every mutually-exclusive
+      selection (mergeAllOfSchemas alone drops all but the first) and preserves the
+      position of each choice group among the surrounding fields, flowing inline
+      with them as one continuous list (no extra spacing or card).
+    -->
+    <template v-if="props.composition === 'allOf'">
+      <template
+        v-for="(segment, segmentIndex) in allOfSegments"
+        :key="segmentIndex">
+        <Schema
+          v-if="segment.kind === 'object'"
+          :breadcrumb="breadcrumb"
+          :compact="compact"
+          :compositionPath="compositionPath"
+          :discriminator="discriminator"
+          :eventBus="eventBus"
+          :hideDescription="isRequestBodyRootComposition"
+          :hideHeading="hideHeading"
+          :hideModelNames
+          :level="level + 1"
+          :name="name"
+          :noncollapsible="true"
+          :options="options"
+          :schema="segment.schema"
+          :schemaContext="schemaContext" />
+        <SchemaComposition
+          v-else
+          :breadcrumb="breadcrumb"
+          :compact="compact"
+          :composition="segment.composition"
+          :compositionPath="[
+            ...(compositionPath ?? []),
+            String(segment.choiceIndex),
+          ]"
+          :eventBus="eventBus"
+          :hideHeading="hideHeading"
+          :hideModelNames
+          :level="level"
+          :options="options"
+          :schema="segment.value"
+          :schemaContext="schemaContext" />
+      </template>
+    </template>
 
     <template v-else>
-      <!-- Composition selector and panel for nested compositions -->
+      <!-- Composition selector + selected branch -->
       <ScalarListbox
         v-model="selectedOption"
         :options="listboxOptions"

--- a/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.test.ts
@@ -1,0 +1,83 @@
+import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { describe, expect, it } from 'vitest'
+
+import { partitionAllOfCompositions } from './partition-all-of-compositions'
+
+describe('partitionAllOfCompositions', () => {
+  it('returns a single object segment when there is no allOf', () => {
+    const schema = { type: 'object', properties: { id: { type: 'string' } } } as SchemaObject
+    const { segments } = partitionAllOfCompositions(schema)
+    expect(segments).toHaveLength(1)
+    expect(segments[0]).toEqual({ kind: 'object', schema })
+  })
+
+  it('keeps every oneOf group (not just the first) and interleaves them in source order', () => {
+    const schema = {
+      allOf: [
+        { type: 'object', properties: { id: { type: 'string' } } },
+        { oneOf: [{ required: ['effective_date_time'] }, { required: ['effective_period'] }] },
+        { type: 'object', properties: { issued: { type: 'string' } } },
+        { oneOf: [{ required: ['value_quantity'] }, { required: ['value_string'] }] },
+      ],
+    } as SchemaObject
+
+    const { segments } = partitionAllOfCompositions(schema)
+
+    expect(segments.map((s) => s.kind)).toEqual(['object', 'choice', 'object', 'choice'])
+    // both choice groups survive (the merge would have dropped the second)
+    expect(segments[1]).toMatchObject({ kind: 'choice', composition: 'oneOf', choiceIndex: 0 })
+    expect(segments[3]).toMatchObject({ kind: 'choice', composition: 'oneOf', choiceIndex: 1 })
+    // fields stay in place around the choices
+    expect((segments[0] as any).schema.properties).toHaveProperty('id')
+    expect((segments[2] as any).schema.properties).toHaveProperty('issued')
+  })
+
+  it('coalesces consecutive object members into one segment', () => {
+    const schema = {
+      allOf: [
+        { type: 'object', properties: { a: { type: 'string' } } },
+        { type: 'object', properties: { b: { type: 'string' } } },
+      ],
+    } as SchemaObject
+
+    const { segments } = partitionAllOfCompositions(schema)
+    expect(segments).toHaveLength(1)
+    expect(segments[0].kind).toBe('object')
+    expect((segments[0] as any).schema.properties).toEqual({ a: { type: 'string' }, b: { type: 'string' } })
+  })
+
+  it('flattens nested allOf while preserving order', () => {
+    const schema = {
+      allOf: [
+        {
+          allOf: [
+            { type: 'object', properties: { id: { type: 'string' } } },
+            { oneOf: [{ required: ['a'] }, { required: ['b'] }] },
+          ],
+        },
+        { type: 'object', properties: { context: { type: 'string' } } },
+      ],
+    } as SchemaObject
+
+    const { segments } = partitionAllOfCompositions(schema)
+    expect(segments.map((s) => s.kind)).toEqual(['object', 'choice', 'object'])
+    expect(segments[1]).toMatchObject({ choiceIndex: 0 })
+  })
+
+  it('drops pure-constraint members (not / if-then-else) from object segments', () => {
+    const schema = {
+      allOf: [
+        { type: 'object', properties: { id: { type: 'string' } } },
+        { not: { required: ['a', 'b'] } },
+        { if: { required: ['x'] }, then: { required: ['y'] } },
+      ],
+    } as SchemaObject
+
+    const { segments } = partitionAllOfCompositions(schema)
+    expect(segments).toHaveLength(1)
+    const merged = (segments[0] as any).schema
+    expect(merged.properties).toHaveProperty('id')
+    expect(merged.not).toBeUndefined()
+    expect(merged.if).toBeUndefined()
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.test.ts
@@ -38,11 +38,11 @@ describe('partitionAllOfCompositions', () => {
         { type: 'object', properties: { a: { type: 'string' } } },
         { type: 'object', properties: { b: { type: 'string' } } },
       ],
-    } as SchemaObject
+    } as unknown as SchemaObject
 
     const { segments } = partitionAllOfCompositions(schema)
     expect(segments).toHaveLength(1)
-    expect(segments[0].kind).toBe('object')
+    expect(segments[0]!.kind).toBe('object')
     expect((segments[0] as any).schema.properties).toEqual({ a: { type: 'string' }, b: { type: 'string' } })
   })
 
@@ -62,6 +62,20 @@ describe('partitionAllOfCompositions', () => {
     const { segments } = partitionAllOfCompositions(schema)
     expect(segments.map((s) => s.kind)).toEqual(['object', 'choice', 'object'])
     expect(segments[1]).toMatchObject({ choiceIndex: 0 })
+  })
+
+  it('does not recurse forever on a self-referential allOf ($ref cycle)', () => {
+    // A schema whose `allOf` references itself through a resolved `$ref`. Without
+    // a cycle guard the member walk would recurse until the stack overflows.
+    const cyclic: Record<string, unknown> = {
+      allOf: [{ type: 'object', properties: { id: { type: 'string' } } }],
+    }
+    ;(cyclic.allOf as unknown[]).push({ $ref: '#/cyclic', '$ref-value': cyclic })
+
+    const { segments } = partitionAllOfCompositions(cyclic as unknown as SchemaObject)
+
+    // Terminates and still surfaces the concrete object member.
+    expect(segments.some((segment) => segment.kind === 'object')).toBe(true)
   })
 
   it('drops pure-constraint members (not / if-then-else) from object segments', () => {

--- a/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.ts
@@ -1,0 +1,159 @@
+import { resolve } from '@scalar/workspace-store/resolve'
+import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+
+import { mergeAllOfSchemas } from './merge-all-of-schemas'
+import { type CompositionKeyword } from './schema-composition'
+
+type ChoiceKeyword = Extract<CompositionKeyword, 'oneOf' | 'anyOf'>
+
+/** An ordered piece of an `allOf`: either a merged object or a choice picker. */
+export type AllOfSegment =
+  | { kind: 'object'; schema: SchemaObject }
+  | {
+      kind: 'choice'
+      composition: ChoiceKeyword
+      /** A minimal schema carrying only this group's composition, for SchemaComposition */
+      value: SchemaObject
+      /** Ordinal among choice members, matching the request-example composition key */
+      choiceIndex: number
+    }
+
+const CHOICE_KEYWORDS: ChoiceKeyword[] = ['oneOf', 'anyOf']
+
+type Member =
+  | { kind: 'object'; schema: SchemaObject }
+  | { kind: 'choice'; composition: ChoiceKeyword; value: SchemaObject }
+
+/**
+ * Flattens a member's own (non-composition) properties and every `oneOf`/`anyOf`
+ * group it declares — recursing into nested `allOf` — into a flat, ordered list,
+ * preserving source order so choice groups stay where they were authored.
+ *
+ * Pure-constraint keywords (`not`, `if/then/else`) are dropped: they carry no
+ * visual variant and Scalar would otherwise render `not` as a bogus picker. The
+ * rule still lives in the schema (validation) and in field descriptions.
+ */
+const collectMembers = (schema: SchemaObject, out: Member[]): void => {
+  const {
+    allOf,
+    oneOf,
+    anyOf,
+    not: _not,
+    if: _if,
+    then: _then,
+    else: _else,
+    ...rest
+  } = schema as SchemaObject & {
+    allOf?: unknown[]
+    oneOf?: unknown[]
+    anyOf?: unknown[]
+    not?: unknown
+    if?: unknown
+    then?: unknown
+    else?: unknown
+  }
+
+  if (Object.keys(rest).length > 0) {
+    out.push({ kind: 'object', schema: rest as SchemaObject })
+  }
+
+  for (const keyword of CHOICE_KEYWORDS) {
+    const value = keyword === 'oneOf' ? oneOf : anyOf
+    if (Array.isArray(value) && value.length > 0) {
+      out.push({ kind: 'choice', composition: keyword, value: { [keyword]: value } as SchemaObject })
+    }
+  }
+
+  if (Array.isArray(allOf)) {
+    for (const rawMember of allOf) {
+      if (rawMember && typeof rawMember === 'object') {
+        collectMembers(resolve.schema(rawMember) as SchemaObject, out)
+      }
+    }
+  }
+}
+
+/**
+ * Splits an `allOf` schema into an ordered list of segments so the renderer can
+ * show each `oneOf`/`anyOf` group as its own picker **in the position it was
+ * declared**, with the surrounding plain fields around it.
+ *
+ * `mergeAllOfSchemas` alone keeps only the FIRST `oneOf`/`anyOf` (dropping the
+ * 2nd+ groups of an object with several independent mutually-exclusive
+ * selections) and, being a merge, also loses the ordering between fields and
+ * choices. Walking the members in order fixes both: runs of consecutive object
+ * members are merged into one object segment, and each choice member becomes its
+ * own picker segment in place.
+ */
+export const partitionAllOfCompositions = (schema: SchemaObject | undefined): { segments: AllOfSegment[] } => {
+  if (!schema) {
+    return { segments: [] }
+  }
+
+  // The schema's own (non-composition) keys, minus its top-level `oneOf`/`anyOf`
+  // — those are rendered as their own composition by the caller, not here.
+  const {
+    allOf,
+    oneOf: _oneOf,
+    anyOf: _anyOf,
+    not: _not,
+    if: _if,
+    then: _then,
+    else: _else,
+    ...rest
+  } = schema as SchemaObject & {
+    allOf?: unknown[]
+    oneOf?: unknown[]
+    anyOf?: unknown[]
+    not?: unknown
+    if?: unknown
+    then?: unknown
+    else?: unknown
+  }
+
+  if (!Array.isArray(allOf)) {
+    return { segments: [{ kind: 'object', schema: schema }] }
+  }
+
+  const members: Member[] = []
+  if (Object.keys(rest).length > 0) {
+    members.push({ kind: 'object', schema: rest as SchemaObject })
+  }
+  for (const rawMember of allOf) {
+    if (rawMember && typeof rawMember === 'object') {
+      collectMembers(resolve.schema(rawMember) as SchemaObject, members)
+    }
+  }
+
+  // Coalesce consecutive object members into a single merged object segment,
+  // keeping choice members as their own segments between them.
+  const segments: AllOfSegment[] = []
+  let objectRun: SchemaObject[] = []
+  let choiceIndex = 0
+
+  const flushObjectRun = () => {
+    if (objectRun.length === 0) {
+      return
+    }
+    const merged = objectRun.length === 1 ? objectRun[0]! : mergeAllOfSchemas({ allOf: objectRun } as SchemaObject)
+    segments.push({ kind: 'object', schema: merged })
+    objectRun = []
+  }
+
+  for (const member of members) {
+    if (member.kind === 'object') {
+      objectRun.push(member.schema)
+    } else {
+      flushObjectRun()
+      segments.push({
+        kind: 'choice',
+        composition: member.composition,
+        value: member.value,
+        choiceIndex: choiceIndex++,
+      })
+    }
+  }
+  flushObjectRun()
+
+  return { segments }
+}

--- a/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.ts
@@ -2,7 +2,7 @@ import { resolve } from '@scalar/workspace-store/resolve'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 import { mergeAllOfSchemas } from './merge-all-of-schemas'
-import { type CompositionKeyword } from './schema-composition'
+import type { CompositionKeyword } from './schema-composition'
 
 type ChoiceKeyword = Extract<CompositionKeyword, 'oneOf' | 'anyOf'>
 
@@ -33,7 +33,7 @@ type Member =
  * visual variant and Scalar would otherwise render `not` as a bogus picker. The
  * rule still lives in the schema (validation) and in field descriptions.
  */
-const collectMembers = (schema: SchemaObject, out: Member[]): void => {
+const collectMembers = (schema: SchemaObject, out: Member[], seenRefs: Set<string>): void => {
   const {
     allOf,
     oneOf,
@@ -60,14 +60,26 @@ const collectMembers = (schema: SchemaObject, out: Member[]): void => {
   for (const keyword of CHOICE_KEYWORDS) {
     const value = keyword === 'oneOf' ? oneOf : anyOf
     if (Array.isArray(value) && value.length > 0) {
-      out.push({ kind: 'choice', composition: keyword, value: { [keyword]: value } as SchemaObject })
+      out.push({ kind: 'choice', composition: keyword, value: { [keyword]: value } as unknown as SchemaObject })
     }
   }
 
   if (Array.isArray(allOf)) {
     for (const rawMember of allOf) {
       if (rawMember && typeof rawMember === 'object') {
-        collectMembers(resolve.schema(rawMember) as SchemaObject, out)
+        const resolved = resolve.schema(rawMember) as SchemaObject & { $ref?: string }
+        // Break `$ref` cycles reached through `allOf` (e.g. a member that
+        // references an ancestor). Without this guard a recursive `allOf`
+        // schema would recurse forever. `mergeAllOfSchemas` guards the same way.
+        const ref = resolved.$ref
+        if (typeof ref === 'string') {
+          if (seenRefs.has(ref)) {
+            continue
+          }
+          collectMembers(resolved, out, new Set(seenRefs).add(ref))
+        } else {
+          collectMembers(resolved, out, seenRefs)
+        }
       }
     }
   }
@@ -119,9 +131,12 @@ export const partitionAllOfCompositions = (schema: SchemaObject | undefined): { 
   if (Object.keys(rest).length > 0) {
     members.push({ kind: 'object', schema: rest as SchemaObject })
   }
+  const seenRefs = new Set<string>()
   for (const rawMember of allOf) {
     if (rawMember && typeof rawMember === 'object') {
-      collectMembers(resolve.schema(rawMember) as SchemaObject, members)
+      const resolved = resolve.schema(rawMember) as SchemaObject & { $ref?: string }
+      const ref = resolved.$ref
+      collectMembers(resolved, members, typeof ref === 'string' ? new Set(seenRefs).add(ref) : seenRefs)
     }
   }
 
@@ -145,6 +160,11 @@ export const partitionAllOfCompositions = (schema: SchemaObject | undefined): { 
       objectRun.push(member.schema)
     } else {
       flushObjectRun()
+      // `choiceIndex` is the ordinal used to build the composition-selection key
+      // that syncs each picker with the request example. It MUST stay aligned
+      // with the ordinal computed while walking `allOf` in
+      // `get-example-from-schema.ts` (`@scalar/workspace-store`), or a picker and
+      // its generated example fall out of sync.
       segments.push({
         kind: 'choice',
         composition: member.composition,

--- a/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.ts
@@ -7,7 +7,7 @@ import type { CompositionKeyword } from './schema-composition'
 type ChoiceKeyword = Extract<CompositionKeyword, 'oneOf' | 'anyOf'>
 
 /** An ordered piece of an `allOf`: either a merged object or a choice picker. */
-export type AllOfSegment =
+type AllOfSegment =
   | { kind: 'object'; schema: SchemaObject }
   | {
       kind: 'choice'

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -211,6 +211,14 @@ const shouldOmitProperty = (
  * Arrays are concatenated, objects are merged, otherwise the new value wins.
  */
 const mergeExamples = (baseValue: unknown, newValue: unknown): unknown => {
+  // A null/undefined contribution (e.g. a constraint-only allOf member such as
+  // `not` or `if/then/else`, which produce no example) must not wipe what we have.
+  if (newValue === undefined || newValue === null) {
+    return baseValue
+  }
+  if (baseValue === undefined || baseValue === null) {
+    return newValue
+  }
   if (Array.isArray(baseValue) && Array.isArray(newValue)) {
     return [...baseValue, ...newValue]
   }
@@ -522,15 +530,23 @@ const handleObjectSchema = (
       )
     }
   }
-  // allOf
+  // allOf — thread a choice-ordinal into schemaPath for each direct oneOf/anyOf
+  // member so multiple mutually-exclusive groups get distinct composition-selection
+  // keys that match the per-group pickers. Object members keep the parent path so
+  // their property-nested compositions still resolve by property name.
   else if (Array.isArray(schema.allOf) && schema.allOf.length > 0) {
     let merged: unknown = response
+    let choiceIndex = 0
     for (const item of schema.allOf) {
-      const ex = getExampleFromSchema(resolve.schema(item), options, {
+      const resolvedItem = resolve.schema(item)
+      const isChoiceMember = !!resolvedItem && (Array.isArray(resolvedItem.oneOf) || Array.isArray(resolvedItem.anyOf))
+      const memberSchemaPath = isChoiceMember ? [...schemaPath, String(choiceIndex++)] : schemaPath
+      const ex = getExampleFromSchema(resolvedItem, options, {
         level: level + 1,
         parentSchema: schema,
         seen,
         dynamicScope: childScope,
+        schemaPath: memberSchemaPath,
       })
       merged = mergeExamples(merged, ex)
     }
@@ -935,11 +951,15 @@ export const getExampleFromSchema = (
   if (Array.isArray(_schema.allOf) && _schema.allOf.length > 0) {
     let merged: unknown = undefined
     const items = _schema.allOf
+    let choiceIndex = 0
     for (const item of items) {
+      const resolvedItem = resolve.schema(item)
+      const isChoiceMember = !!resolvedItem && (Array.isArray(resolvedItem.oneOf) || Array.isArray(resolvedItem.anyOf))
+      const memberSchemaPath = isChoiceMember ? [...schemaPath, String(choiceIndex++)] : schemaPath
       const ex = getExampleFromSchema(item as SchemaObject, options, {
         level: level + 1,
         parentSchema: _schema,
-        schemaPath,
+        schemaPath: memberSchemaPath,
         seen,
         dynamicScope: childScope,
       })
@@ -947,8 +967,9 @@ export const getExampleFromSchema = (
         merged = ex
       } else if (merged && typeof merged === 'object' && ex && typeof ex === 'object') {
         merged = mergeExamples(merged, ex)
-      } else if (ex !== undefined) {
-        // Prefer the latest defined primitive value
+      } else if (ex !== undefined && ex !== null) {
+        // Prefer the latest defined primitive value (but a null contribution —
+        // e.g. a constraint-only `not`/`if-then-else` member — must not clobber).
         merged = ex
       }
     }


### PR DESCRIPTION
## What

When an object composes several mutually-exclusive choices as sibling `oneOf`/`anyOf` members under `allOf`, Scalar renders only the **first** group — the others are silently dropped (no selector, no fields), even for a valid document.

This splits the `allOf` into an ordered list of segments and renders each `oneOf`/`anyOf` group as its own selector, **in the position it was declared**, with the surrounding plain fields kept around it. The generated request example is threaded with the per-group composition selection so it stays in sync when you switch any group's variant, and constraint-only members (`not`, `if`/`then`/`else`) no longer blank the example.

Fixes #9727

## Changes

- **`partition-all-of-compositions.ts`** (new) — walk an `allOf` in source order, coalescing runs of object members and emitting each `oneOf`/`anyOf` as its own segment (so no group is dropped and ordering is preserved).
- **`SchemaComposition.vue`** — render those segments in order: a selector per choice group, in place, flowing inline with the surrounding fields.
- **`get-example-from-schema.ts`** (`@scalar/workspace-store`) — thread a per-group composition-selection key through the `allOf` example builder so switching a group updates the generated example; a `null` from a constraint-only member no longer clobbers the merged example.

## Tests

- New unit tests for the partition helper (order preserved, all groups kept, coalescing, nested `allOf`, constraint stripping).
- Updated the #5577 composition test to the new per-group-selector structure.
- `@scalar/api-reference` Schema suite (508) and `@scalar/workspace-store` request-example suite (855) pass; Prettier, Biome, and ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
