### PR TITLE
ci: cache turbo on GitHub-hosted runners

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -54,3 +54,18 @@ runs:
         key: ${{ github.repository }}-${{ github.ref_name }}-turbo-cache-${{ steps.node-version.outputs.version }}-v1-${{ github.sha }}
         restore-keys: |
           ${{ github.repository }}-${{ github.ref_name }}-turbo-cache-${{ steps.node-version.outputs.version }}-v1-
+
+    # Keep the fallback cache bounded. Turbo never prunes ./.turbo/cache and
+    # the post-job save snapshots the whole directory under a fresh key, so
+    # without pruning the saved tarball would grow with every push to main
+    # until someone bumps the `v1` suffix. Cache restores preserve
+    # modification times and turbo does not touch entries on cache hits, so
+    # even a hot entry is pruned after two weeks — that costs one rebuild of
+    # the affected packages on the next run, never correctness.
+    - if: ${{ !startsWith(runner.name, 'blacksmith') }}
+      name: Prune stale turbo cache entries
+      shell: bash
+      run: |
+        if [ -d ./.turbo/cache ]; then
+          find ./.turbo/cache -type f -mtime +14 -delete
+        fi

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -21,7 +21,7 @@ runs:
         cache: 'pnpm'
 
     # Branch-scoped persistent turbo cache.
-    # Bump the `v1` suffix in both keys below to invalidate every cache.
+    # Bump the `v1` suffix in the cache keys below to invalidate every cache.
     - if: startsWith(runner.name, 'blacksmith')
       name: Setup persistent turbo cache
       uses: useblacksmith/stickydisk@41873b1513bb679f9c115504cbd13d3660432504 # v1
@@ -37,3 +37,20 @@ runs:
       with:
         key: ${{ github.repository }}-${{ github.ref_name }}-pnpm-store-${{ steps.node-version.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}-v1
         path: ~/.local/share/pnpm/store
+
+    # Fallback turbo cache for GitHub-hosted runners, where the Blacksmith
+    # stickydisk steps above never run. The npm-publish job in release.yml
+    # must stay on a GitHub-hosted runner (npm provenance rejects the OIDC
+    # issuer of self-hosted runners) and previously rebuilt the whole
+    # monorepo cold on every push to main. GitHub's cache isolation already
+    # prevents a pull request branch from writing to the main-branch cache,
+    # mirroring the branch scoping the stickydisk keys encode with
+    # github.ref_name.
+    - if: ${{ !startsWith(runner.name, 'blacksmith') }}
+      name: Setup turbo cache (GitHub-hosted fallback)
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
+      with:
+        path: ./.turbo
+        key: ${{ github.repository }}-${{ github.ref_name }}-turbo-cache-${{ steps.node-version.outputs.version }}-v1-${{ github.sha }}
+        restore-keys: |
+          ${{ github.repository }}-${{ github.ref_name }}-turbo-cache-${{ steps.node-version.outputs.version }}-v1-

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -38,14 +38,9 @@ runs:
         key: ${{ github.repository }}-${{ github.ref_name }}-pnpm-store-${{ steps.node-version.outputs.version }}-${{ hashFiles('pnpm-lock.yaml') }}-v1
         path: ~/.local/share/pnpm/store
 
-    # Fallback turbo cache for GitHub-hosted runners, where the Blacksmith
-    # stickydisk steps above never run. The npm-publish job in release.yml
-    # must stay on a GitHub-hosted runner (npm provenance rejects the OIDC
-    # issuer of self-hosted runners) and previously rebuilt the whole
-    # monorepo cold on every push to main. GitHub's cache isolation already
-    # prevents a pull request branch from writing to the main-branch cache,
-    # mirroring the branch scoping the stickydisk keys encode with
-    # github.ref_name.
+    # Fallback turbo cache for GitHub-hosted runners, where the stickydisk
+    # steps never run — notably npm-publish, which must stay GitHub-hosted
+    # (npm provenance rejects self-hosted OIDC) and otherwise rebuilds cold.
     - if: ${{ !startsWith(runner.name, 'blacksmith') }}
       name: Setup turbo cache (GitHub-hosted fallback)
       uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
@@ -55,13 +50,9 @@ runs:
         restore-keys: |
           ${{ github.repository }}-${{ github.ref_name }}-turbo-cache-${{ steps.node-version.outputs.version }}-v1-
 
-    # Keep the fallback cache bounded. Turbo never prunes ./.turbo/cache and
-    # the post-job save snapshots the whole directory under a fresh key, so
-    # without pruning the saved tarball would grow with every push to main
-    # until someone bumps the `v1` suffix. Cache restores preserve
-    # modification times and turbo does not touch entries on cache hits, so
-    # even a hot entry is pruned after two weeks — that costs one rebuild of
-    # the affected packages on the next run, never correctness.
+    # Turbo never prunes ./.turbo/cache, so drop entries untouched for two
+    # weeks to keep the saved tarball bounded. A pruned-but-hot entry just
+    # rebuilds once on the next run.
     - if: ${{ !startsWith(runner.name, 'blacksmith') }}
       name: Prune stale turbo cache entries
       shell: bash


### PR DESCRIPTION
## Motivation

Release pushes to main take ~18-28 minutes versus ~13 minutes for ordinary pushes. A big chunk of that is the `release / npm-publish` job (6-9.5 minutes): in run 29537719010 its Build step alone took 4m40s and the publish step 4m26s.

`npm-publish` must run on a GitHub-hosted runner because npm provenance (OIDC) rejects the OIDC issuer of self-hosted runners. The Blacksmith stickydisk turbo cache in `.github/actions/setup-node` is gated on `startsWith(runner.name, 'blacksmith')`, so it never runs there — every push to main rebuilds the monorepo completely cold.

## Change

Adds a fallback turbo cache step to `.github/actions/setup-node/action.yml`, gated on `${{ !startsWith(runner.name, 'blacksmith') }}`, using `actions/cache` pinned to the same commit SHA already used in `.github/workflows/publish-integrations.yml`:

- **path**: `./.turbo` (same as the stickydisk step)
- **key**: `${{ github.repository }}-${{ github.ref_name }}-turbo-cache-${{ steps.node-version.outputs.version }}-v1-${{ github.sha }}`
- **restore-keys**: the same key without the trailing SHA

The key ends with `github.sha` because `actions/cache` entries are immutable per key — suffixing the SHA means every push to main saves an updated cache, and the `restore-keys` prefix matches the most recent one on the next run.

The existing "bump the v1 suffix" comment was updated to cover all cache keys in the file, and the new step's `if` is wrapped in `${{ }}` because a bare leading `!` would be parsed as a YAML tag.

## Semantics preserved

- Blacksmith runners are unaffected: the stickydisk steps still run there, and the new step is skipped.
- Branch scoping is preserved: the key includes `github.ref_name`, mirroring the stickydisk keys, and GitHub's cache isolation already prevents a pull request branch from writing to the main-branch cache.
- The documented `v1` suffix bump remains the single invalidation lever for every cache key in the file.

## Expected effect

The npm-publish Build step should drop from ~4m40s to roughly a minute on a warm cache, on every push to main — both the release path and the release-PR-update path. For context, in run 29778444565 the deploy jobs also sat queued for ~4 minutes behind `publish-integrations / aspire-publish` because a reusable workflow's outputs only become available when all of its jobs finish; shrinking npm-publish shortens the overall critical path even though that queueing behavior is unchanged.

## Risks

- Cache growth: one new entry per push to main (plus branch-scoped entries for non-Blacksmith PR jobs, which are rare). Old cache *entries* are handled by GitHub's per-repo eviction (LRU plus 7-day unused expiry). The *contents* of the restored `.turbo` directory would still grow monotonically (turbo never prunes its own cache), so a follow-up step deletes cache files untouched for 14 days before each save — a pruned-but-hot entry just rebuilds once on the next run. The documented `v1` key-suffix bump remains the full-invalidation lever.
- A stale or corrupt cache would at worst cause turbo to rebuild affected tasks; bumping the `v1` suffix invalidates everything if that ever becomes necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only caching and local pruning in the setup-node composite; worst case is a cold turbo rebuild or a manual `v1` bump, with no application or auth impact.
> 
> **Overview**
> **GitHub-hosted JS jobs** (especially `npm-publish`, which cannot use Blacksmith stickydisk) now restore and save `./.turbo` via `actions/cache`, using branch-scoped keys aligned with the existing stickydisk naming plus a per-commit suffix and prefix `restore-keys` so each push can publish an updated cache while the next run reuses the latest match.
> 
> Blacksmith runners are unchanged: stickydisk steps still own turbo caching there, and the new steps are skipped when `runner.name` starts with `blacksmith`.
> 
> Before saving on GitHub-hosted runners, a composite step **deletes turbo cache files older than 14 days** under `./.turbo/cache` so restored directories do not grow without bound. The shared comment now says bumping the `v1` suffix invalidates all cache keys in the action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d95c5ffd80e9b0306d25ea840daa083734b388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->