### PR TITLE
ci: build only publishable workspaces in npm-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,8 +198,12 @@ jobs:
       - name: Build
         uses: ./.github/actions/build
         with:
-          # Build everything
-          packages: './**'
+          # Build only the workspaces that can reach npm. Every public package
+          # lives under packages/ or integrations/ — projects/, examples/ and
+          # tooling/ are all private, so `pnpm -r publish` never publishes
+          # them and building them here only slowed the release down. This is
+          # the same filter the main-branch build job uses.
+          packages: './{packages,integrations}/**'
       - name: Git Status
         run: git status
       - name: Stash changes


### PR DESCRIPTION
## Motivation

Release pushes to `main` currently take ~18-28 minutes versus ~13 minutes for ordinary pushes, and the `release / npm-publish` job alone takes 6-9.5 minutes. In run 29537719010 ("Releasing 58 package(s)"), the npm-publish Build step took 4m40s and the publish step another 4m26s.

The Build step is a structural cold spot: npm provenance (OIDC) rejects self-hosted runners, so npm-publish must run on a GitHub-hosted runner. The Blacksmith stickydisk turbo cache in `.github/actions/setup-node` is gated on `startsWith(runner.name, 'blacksmith')` and therefore never runs there — every main push rebuilds cold. Building `./**` makes that cold build cover the entire monorepo, including workspaces that can never reach npm.

## Change

Narrow the npm-publish Build step in `.github/workflows/release.yml` from `./**` to `./{packages,integrations}/**`, and update the comment to explain why. This is the exact same filter the `main.yml` build job already uses, so the effective build set on a main push now matches `main.yml` exactly. `TURBO_FLAGS` (defined at the top of `release.yml`) already excludes the non-JS integrations (`java`, `rust`, `dotnet`, `docker`, `fastapi`, `django-ninja`) and the Go proxy (`projects/proxy-scalar-com`), so those were never part of the JS build either way.

## Verification that semantics are preserved

- **Everything outside the narrowed filter is private.** The `pnpm-workspace.yaml` globs outside `packages/` and `integrations/` are `examples/**`, `projects/**`, `tooling/scripts`, `tooling/changelog-generator`, and `playwright` (a stale glob — that directory no longer exists). A `find` + `jq` sweep over `examples/`, `projects/`, and `tooling/` found 14 `package.json` manifests, and every single one has `"private": true`. No public package lives outside `packages/` or `integrations/`.
- **The publish command skips private packages.** The publish command is `pnpm -r publish --access public --no-git-checks`, and `pnpm publish` refuses to publish any package marked `"private": true`. Nothing outside the narrowed build filter is ever published, so nothing that is published loses its build.
- **The version-PR path does not depend on this Build step.** `pnpm release:version` runs `changeset version && pnpm --filter @scalar/release-notes... build && pnpm --filter @scalar/release-notes start --all && pnpm format` — it builds `@scalar/release-notes` (which lives in `packages/release-notes`, so it is also covered by the narrowed filter) and its dependencies explicitly inside its own script, so it never relied on the Build step covering `tooling/` or `projects/`.

## Risks

- If a public package is ever added outside `packages/` or `integrations/` in the future, it would publish without this Build step having built it. That layout would also diverge from the `main.yml` build job and from the repository conventions documented in AGENTS.md, so it would need a deliberate workflow change anyway — the new comment on the Build step documents the assumption.
- No behavior change for any downstream job: the release-detection steps run before the Build step and only read committed `package.json` versions, and `create-github-release`, `push-to-scalar-registry`, `publish-integrations`, and `todesktop` all build or fetch what they need themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

