### PR TITLE
ci: move integration publishes off the release critical path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,12 @@ name: Main
 # Entry workflow for pushes to the default branch. Runs the same required tests
 # as pr.yml, then — only if every required test passes — invokes the reusable
 # release.yml (npm publish, GitHub release, Scalar registry) alongside the
-# integration publishes, the ToDesktop build, and the deploys. PRs never run
-# this file: the pull_request / push:main trigger split is the boundary that
-# keeps production publish secrets out of reach of pull requests.
+# integration publishes and the ToDesktop build. The deploys are not gated the
+# same way: they run on every main push — production for release commits,
+# staging otherwise — with their exact conditions documented on each deploy
+# job below. PRs never run this file: the pull_request / push:main trigger
+# split is the boundary that keeps production publish secrets out of reach of
+# pull requests.
 
 on:
   push:
@@ -292,9 +295,11 @@ jobs:
   release:
     # Runs only on main, only when required-jobs-main passed — mirroring
     # npm-publish's old `needs: [required-jobs-main]` + `if: refs/heads/main`.
-    # `!cancelled()` lets release proceed even when non-required jobs failed or
-    # were skipped: a broken change-detection or integration build must NOT
-    # block the npm release.
+    # With required-jobs-main as the only dependency, no other job can block
+    # the npm release. `!cancelled()` is kept purely as a defensive guard so
+    # the explicit `needs.required-jobs-main.result == 'success'` check below
+    # stays the single gate, instead of relying on the implicit success()
+    # GitHub applies when an `if:` contains no status-check function.
     if: |
       !cancelled() &&
       github.ref == 'refs/heads/main' &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,10 @@ name: Main
 
 # Entry workflow for pushes to the default branch. Runs the same required tests
 # as pr.yml, then — only if every required test passes — invokes the reusable
-# release.yml which performs every production publish. PRs never run this file:
-# the pull_request / push:main trigger split is the boundary that keeps
-# production publish secrets out of reach of pull requests.
+# release.yml (npm publish, GitHub release, Scalar registry) alongside the
+# integration publishes, the ToDesktop build, and the deploys. PRs never run
+# this file: the pull_request / push:main trigger split is the boundary that
+# keeps production publish secrets out of reach of pull requests.
 
 on:
   push:
@@ -255,7 +256,7 @@ jobs:
         run: pnpm --filter scalar-app test:e2e:ci
 
   # Integration build-tests on main push that touches them — gates the matching
-  # publish job in release.yml from running against a broken tree.
+  # publish job in publish-integrations.yml from running against a broken tree.
   integration-builds:
     needs: [check-changes, build]
     uses: ./.github/workflows/integration-builds.yml
@@ -288,22 +289,17 @@ jobs:
         if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')) }}
 
   # Hand off to release.yml — only reached after required-jobs-main succeeded.
-  # release.yml is the only workflow that touches production publish secrets.
   release:
     # Runs only on main, only when required-jobs-main passed — mirroring
     # npm-publish's old `needs: [required-jobs-main]` + `if: refs/heads/main`.
-    # `!cancelled()` lets release proceed even when check-changes or
-    # integration-builds failed or were skipped: a broken change-detection or
-    # integration build must NOT block the npm release or the other publishes.
-    # check-changes stays in `needs` only to forward its outputs below; if it
-    # failed those come through empty, so each integration publish simply sees
-    # its package as unchanged. Per-integration publishes additionally gate on
-    # their own build-test result via the `*_build_passed` inputs.
+    # `!cancelled()` lets release proceed even when non-required jobs failed or
+    # were skipped: a broken change-detection or integration build must NOT
+    # block the npm release.
     if: |
       !cancelled() &&
       github.ref == 'refs/heads/main' &&
       needs.required-jobs-main.result == 'success'
-    needs: [check-changes, required-jobs-main, integration-builds]
+    needs: [required-jobs-main]
     # A reusable workflow's jobs cannot request more token permissions than the
     # calling job holds. release.yml's npm-publish and create-github-release
     # jobs need write access, so grant it on this caller job — the workflow-level
@@ -314,7 +310,27 @@ jobs:
       repository-projects: write
       id-token: write
     uses: ./.github/workflows/release.yml
+    secrets: inherit
+
+  # Fan out to every non-JS integration registry (DockerHub, NuGet, PyPI,
+  # crates.io, Maven Central). Invoked here rather than inside release.yml so
+  # the web and galaxy deploys below — which need release outputs, available
+  # only when every release.yml job has finished — do not wait behind slow
+  # integration publishes such as the multi-arch aspire Docker build.
+  # Gating matches what the job had inside release.yml: only on main, only
+  # after the npm-publish job itself succeeded. !cancelled() keeps this
+  # running when check-changes or integration-builds failed or were skipped:
+  # their outputs then come through empty, so each publish job simply sees its
+  # package as unchanged or its build-test as not passed and skips itself.
+  publish-integrations:
+    if: |
+      !cancelled() &&
+      github.ref == 'refs/heads/main' &&
+      needs.release.outputs.npm_publish_status == 'success'
+    needs: [check-changes, integration-builds, release]
+    uses: ./.github/workflows/publish-integrations.yml
     with:
+      published: ${{ needs.release.outputs.published }}
       docker_package_changed: ${{ needs.check-changes.outputs.docker_package_changed }}
       mock_server_docker_package_changed: ${{ needs.check-changes.outputs.mock_server_docker_package_changed }}
       aspnetcore_package_changed: ${{ needs.check-changes.outputs.aspnetcore_package_changed }}
@@ -324,13 +340,26 @@ jobs:
       django_ninja_package_changed: ${{ needs.check-changes.outputs.django_ninja_package_changed }}
       rust_package_changed: ${{ needs.check-changes.outputs.rust_package_changed }}
       java_package_changed: ${{ needs.check-changes.outputs.java_package_changed }}
-      # Build-test results — a publish only runs when its build-test passed.
       docker_build_passed: ${{ needs.integration-builds.outputs.docker_build_passed }}
       dotnet_build_passed: ${{ needs.integration-builds.outputs.dotnet_build_passed }}
       fastapi_build_passed: ${{ needs.integration-builds.outputs.fastapi_build_passed }}
       django_ninja_build_passed: ${{ needs.integration-builds.outputs.django_ninja_build_passed }}
       rust_build_passed: ${{ needs.integration-builds.outputs.rust_build_passed }}
       java_build_passed: ${{ needs.integration-builds.outputs.java_build_passed }}
+    secrets: inherit
+
+  # Desktop build via ToDesktop when scalar-app's version bumped on this
+  # commit. Hoisted out of release.yml for the same reason as
+  # publish-integrations above.
+  todesktop:
+    if: |
+      !cancelled() &&
+      github.ref == 'refs/heads/main' &&
+      needs.release.outputs.npm_publish_status == 'success'
+    needs: [release]
+    uses: ./.github/workflows/todesktop.yml
+    with:
+      scalar_app_released: ${{ needs.release.outputs.scalar_app_released }}
     secrets: inherit
 
   # Production Storybook deploy on every main push (independent of release).
@@ -368,10 +397,12 @@ jobs:
   # bumped scalar-app's version, staging otherwise. Runs on every main push;
   # waits for release so it can read the publish result. Gates on the
   # npm-publish job result specifically (npm_publish_status) — NOT the whole
-  # release workflow — so a failing registry push / integration publish /
-  # ToDesktop does not block the deploy. An empty value (release skipped because
-  # required tests failed) is treated like the old skipped-npm-publish case and
-  # still deploys to staging.
+  # release workflow — so a failing registry push or GitHub release does not
+  # block the deploy. Integration publishes and the ToDesktop build run as
+  # siblings of this job (see publish-integrations and todesktop above), so
+  # they can neither delay nor block it. An empty value (release skipped
+  # because required tests failed) is treated like the old skipped-npm-publish
+  # case and still deploys to staging.
   deploy-api-client:
     if: |
       !cancelled() &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -323,10 +323,17 @@ jobs:
   # only when every release.yml job has finished — do not wait behind slow
   # integration publishes such as the multi-arch aspire Docker build.
   # Gating matches what the job had inside release.yml: only on main, only
-  # after the npm-publish job itself succeeded. !cancelled() keeps this
-  # running when check-changes or integration-builds failed or were skipped:
-  # their outputs then come through empty, so each publish job simply sees its
-  # package as unchanged or its build-test as not passed and skips itself.
+  # after the npm-publish job itself succeeded. check-changes and
+  # integration-builds are in `needs` purely to forward their outputs below —
+  # NOT to gate on their success. The leading !cancelled() is what makes that
+  # safe: a status-check function in an `if:` disables GitHub's default
+  # skip-a-job-when-any-need-failed-or-was-skipped behavior, so this job is
+  # still evaluated (and runs, given a successful npm publish) even when
+  # check-changes or integration-builds failed or was skipped. Their outputs
+  # then come through empty, so each publish job simply sees its package as
+  # unchanged or its build-test as not passed and skips itself — the same
+  # degraded-input behavior release.yml had. (deploy-api-client below relies on
+  # the identical !cancelled() mechanism to run when release itself is skipped.)
   publish-integrations:
     if: |
       !cancelled() &&

--- a/.github/workflows/publish-integrations.yml
+++ b/.github/workflows/publish-integrations.yml
@@ -1,8 +1,10 @@
 name: Publish Integrations
 
 # Reusable workflow that publishes every non-JS integration to its registry
-# (DockerHub, NuGet, PyPI, crates.io, Maven Central). Only ever called from
-# release.yml after npm-publish succeeded. Each job is gated by the per-package
+# (DockerHub, NuGet, PyPI, crates.io, Maven Central). Only ever invoked from
+# main.yml on pushes to `main`, after the npm-publish job in release.yml
+# succeeded — the pr.yml / main.yml trigger split still keeps this workflow
+# unreachable from pull requests. Each job is gated by the per-package
 # `*_changed` input and the overall `published` flag, and (where applicable)
 # runs in a per-registry GitHub Environment so its credentials stay scoped.
 
@@ -40,10 +42,11 @@ on:
       java_package_changed:
         type: string
         required: true
-      # Build-test results from integration-builds.yml (forwarded via
-      # release.yml). A publish runs only when its build-test passed ('true');
-      # an empty value means the build-test was skipped or failed, which keeps
-      # the publish gated off — the cross-workflow equivalent of the old
+      # Build-test results from integration-builds.yml — main.yml passes its
+      # integration-builds job outputs in directly. A publish runs only when
+      # its build-test passed ('true'); an empty value means the build-test
+      # was skipped or failed, which keeps the publish gated off — the
+      # cross-workflow equivalent of the old
       # `needs: [<integration>-build-test]`.
       docker_build_passed:
         type: string

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,69 +1,26 @@
 name: Release
 
-# Reusable workflow that owns every production publish. Only ever invoked from
-# main.yml, after the required tests pass on a push to `main`. PRs trigger
-# pr.yml, which never references this file — that structural separation is what
-# keeps production publish secrets out of reach of pull requests.
+# Reusable workflow that owns the npm publish and its small follow-up jobs.
+# Only ever invoked from main.yml, after the required tests pass on a push to
+# `main`. PRs trigger pr.yml, which never references this file — that
+# structural separation is what keeps production publish secrets out of reach
+# of pull requests.
 #
 # Stages:
 #   1. npm-publish (changesets/action) — must run on a github-hosted runner;
 #      npm provenance via OIDC rejects self-hosted runners.
 #   2. create-github-release (only when something was published)
 #   3. push-to-scalar-registry (galaxy registry)
-#   4. publish-integrations (Docker, NuGet, PyPI, crates, Maven)
-#   5. todesktop (only when scalar-app's version bumped)
+#
+# Integration publishes (publish-integrations.yml) and the ToDesktop build
+# (todesktop.yml) are invoked from main.yml as siblings of the deploys instead
+# of from here: the deploys need this workflow's outputs, which only become
+# available once every job in this file has finished, so keeping the slow
+# fan-out workflows out of this file means the deploys do not wait behind
+# them.
 
 on:
   workflow_call:
-    inputs:
-      docker_package_changed:
-        type: string
-        required: true
-      mock_server_docker_package_changed:
-        type: string
-        required: true
-      aspnetcore_package_changed:
-        type: string
-        required: true
-      aspire_package_changed:
-        type: string
-        required: true
-      azure_functions_package_changed:
-        type: string
-        required: true
-      fastapi_package_changed:
-        type: string
-        required: true
-      django_ninja_package_changed:
-        type: string
-        required: true
-      rust_package_changed:
-        type: string
-        required: true
-      java_package_changed:
-        type: string
-        required: true
-      # Per-integration build-test results from integration-builds.yml. Each
-      # publish job gates on its own flag so it only runs when its build-test
-      # passed (empty when the build-test was skipped or failed).
-      docker_build_passed:
-        type: string
-        required: true
-      dotnet_build_passed:
-        type: string
-        required: true
-      fastapi_build_passed:
-        type: string
-        required: true
-      django_ninja_build_passed:
-        type: string
-        required: true
-      rust_build_passed:
-        type: string
-        required: true
-      java_build_passed:
-        type: string
-        required: true
     outputs:
       published:
         description: "'true' when this commit released at least one public package to npm"
@@ -74,8 +31,9 @@ on:
       npm_publish_status:
         # 'success' or 'failure' — the npm-publish JOB result on its own, so the
         # main-push deploys can gate on the publish itself rather than on the
-        # whole release workflow (a failing registry push / integration publish /
-        # ToDesktop must not block the web + galaxy deploys).
+        # whole release workflow (a failing GitHub release or registry push must
+        # not block the web + galaxy deploys). The publish-integrations and
+        # todesktop jobs in main.yml gate on this output too.
         value: ${{ jobs.npm-publish.outputs.status }}
 
 permissions:
@@ -353,34 +311,3 @@ jobs:
       - if: steps.changed-files.outputs.galaxy_any_changed == 'true'
         name: Push AsyncAPI Example to Scalar Registry
         run: npx @scalar/cli@latest registry publish --namespace scalar --slug asyncapi --version ${{ steps.package-version.outputs.VERSION }} packages/galaxy/dist/asyncapi/latest.yaml
-
-  # Fan out to every non-JS integration registry. Each job inside this reusable
-  # workflow runs in its own GitHub Environment so credentials stay scoped.
-  publish-integrations:
-    needs: [npm-publish]
-    uses: ./.github/workflows/publish-integrations.yml
-    with:
-      published: ${{ needs.npm-publish.outputs.published }}
-      docker_package_changed: ${{ inputs.docker_package_changed }}
-      mock_server_docker_package_changed: ${{ inputs.mock_server_docker_package_changed }}
-      aspnetcore_package_changed: ${{ inputs.aspnetcore_package_changed }}
-      aspire_package_changed: ${{ inputs.aspire_package_changed }}
-      azure_functions_package_changed: ${{ inputs.azure_functions_package_changed }}
-      fastapi_package_changed: ${{ inputs.fastapi_package_changed }}
-      django_ninja_package_changed: ${{ inputs.django_ninja_package_changed }}
-      rust_package_changed: ${{ inputs.rust_package_changed }}
-      java_package_changed: ${{ inputs.java_package_changed }}
-      docker_build_passed: ${{ inputs.docker_build_passed }}
-      dotnet_build_passed: ${{ inputs.dotnet_build_passed }}
-      fastapi_build_passed: ${{ inputs.fastapi_build_passed }}
-      django_ninja_build_passed: ${{ inputs.django_ninja_build_passed }}
-      rust_build_passed: ${{ inputs.rust_build_passed }}
-      java_build_passed: ${{ inputs.java_build_passed }}
-    secrets: inherit
-
-  todesktop:
-    needs: [npm-publish]
-    uses: ./.github/workflows/todesktop.yml
-    with:
-      scalar_app_released: ${{ needs.npm-publish.outputs.scalar_app_released }}
-    secrets: inherit

--- a/.github/workflows/todesktop.yml
+++ b/.github/workflows/todesktop.yml
@@ -1,9 +1,11 @@
 name: ToDesktop Build
 
 # Reusable workflow that ships a desktop build to ToDesktop's cloud. Only ever
-# called from release.yml, after npm-publish ran and scalar-app's version was
-# bumped on this commit. scalar-app is private, so we gate on the version-bump
-# signal (`scalar_app_released`) rather than the npm `published` flag.
+# invoked from main.yml on pushes to `main`, after the npm-publish job in
+# release.yml succeeded — the pr.yml / main.yml trigger split still keeps this
+# workflow unreachable from pull requests. scalar-app is private, so we gate
+# on the version-bump signal (`scalar_app_released`) rather than the npm
+# `published` flag.
 
 on:
   workflow_call:


### PR DESCRIPTION
## Motivation

Release pushes to `main` take ~18–28 min end to end versus ~13 min for ordinary pushes. Two things stack up on the critical path:

- `release / npm-publish` takes 6–9.5 min. It must run on a GitHub-hosted runner because npm provenance (OIDC) rejects self-hosted runners, so the Blacksmith stickydisk turbo cache in `.github/actions/setup-node` (gated on `startsWith(runner.name, 'blacksmith')`) never applies there and every main push rebuilds the monorepo cold — in run 29537719010 its Build step took 4m40s and its publish step 4m26s.
- The deploy jobs (`deploy-api-client` / `deploy-galaxy` / `deploy-galaxy-production`) have `needs: [release]` and read `release.yml` outputs. A reusable workflow's outputs only become available when **all** of its jobs finish. In run 29778444565 the deploys sat queued from 21:23:25 (npm-publish done) to 21:27:36 waiting for `release / publish-integrations / aspire-publish` — a ~4 min QEMU multi-arch Docker build — even though the deploys already gate on `npm_publish_status` specifically.

The cold npm-publish build is structural; the ~4 min deploy queue time behind the integration fan-out is not.

## Change

Hoist the two slow fan-out invocations out of `release.yml` into `main.yml` as sibling jobs of the deploys:

- `main.yml` gains `publish-integrations` and `todesktop` jobs, both gated on `!cancelled() && github.ref == 'refs/heads/main' && needs.release.outputs.npm_publish_status == 'success'`, with `secrets: inherit`. `publish-integrations` takes the `check-changes` / `integration-builds` outputs directly from `main.yml` instead of routing them through `release.yml` inputs.
- `release.yml` loses those two jobs and its entire `inputs:` block (all 15 inputs existed only to be forwarded to `publish-integrations.yml`). It now finishes right after `npm-publish` plus two small jobs (`create-github-release` ~20s, `push-to-scalar-registry` ~45s), so its outputs — and therefore the deploys — become available ~4 min earlier on release commits.
- The `release` caller job in `main.yml` drops its `with:` block and shrinks `needs` to `[required-jobs-main]`; its permissions block and `secrets: inherit` are unchanged.
- Header comments in `release.yml`, `publish-integrations.yml`, and `todesktop.yml` are updated to describe the new call sites, and the stale gating comments in `main.yml` are rewritten.

## Semantics preserved

- **Publish gating**: `publish-integrations` previously ran iff the `npm-publish` job succeeded (`needs: [npm-publish]`; sibling failures irrelevant). The new gate `npm_publish_status == 'success'` is equivalent — that output records the npm-publish job result via an `always()` step, and a failed or skipped release workflow leaves it `'failure'` or empty, so the publishes still skip. Same for `todesktop`.
- **Artifact flow**: the publish jobs download the `scalar-js` and `mock-server-docker-entrypoint` artifacts uploaded by `main.yml`'s `build` job. Reusable workflows share the caller's run, so the artifacts remain reachable exactly as before.
- **Degraded-input behavior**: a failed or skipped `check-changes` / `integration-builds` previously reached `publish-integrations.yml` as empty strings via `release.yml`'s inputs. The new `needs: [check-changes, integration-builds, release]` plus `!cancelled()` reproduces exactly that — empty outputs mean each publish job sees its package as unchanged or its build-test as not passed and skips itself.
- **Secrets**: both hoisted workflows receive `secrets: inherit` from `main.yml`, which is what they effectively received via `release.yml` (itself called with `secrets: inherit`). The PR-vs-main security boundary is untouched: `main.yml` still only runs on push to `main`, and `pr.yml` references none of these workflows.
- **Permissions**: every job in `publish-integrations.yml` and `todesktop.yml` requests only `contents: read`, which `main.yml`'s workflow-level default already grants to the calling jobs.
- **Outputs contract**: `release.yml`'s outputs (`published`, `scalar_app_released`, `npm_publish_status`) are unchanged, so the deploy gating expressions keep working as-is.

## Risks

- The `release` job no longer waits on `check-changes` / `integration-builds` before starting (it only forwarded their outputs), so `npm-publish` can start slightly earlier than before. Publish ordering is unaffected: `publish-integrations` still needs both jobs plus `release`.
- On the workflow-run UI, integration publishes and the ToDesktop build now appear as top-level `main` jobs instead of nested under `release` — cosmetic, but worth knowing when scanning run pages.
- Validated with Prettier and YAML parsing; `actionlint` was not available in the environment, so the expressions were reviewed manually against the previous wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restructures main-branch release and production deploy orchestration; behavior is documented as preserved but a wiring mistake could change when publishes or deploys run.
> 
> **Overview**
> **Moves slow integration registry publishes and the ToDesktop desktop build out of `release.yml` into sibling jobs on `main.yml`**, so web and Galaxy deploys can read `release` workflow outputs as soon as npm publish and the small follow-ups finish, instead of waiting behind multi-arch Docker builds (~4 minutes on release commits).
> 
> The `release` reusable workflow is narrowed to **npm publish**, GitHub release creation, and Scalar registry push; its **15 forwarded `workflow_call` inputs are removed**. `main.yml` now calls `publish-integrations.yml` and `todesktop.yml` directly (still gated on `npm_publish_status == 'success'`, with `check-changes` / `integration-builds` outputs passed in and `!cancelled()` preserving the old degraded-input skip behavior). The `release` caller job depends only on `required-jobs-main` and uses `secrets: inherit`.
> 
> Header comments in the touched workflows are updated to describe the new orchestration; **publish gating, secrets boundary (main-only), and deploy `if` expressions are intended to stay equivalent**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a3287f6b011fe58c1cc4b5475074d3c621d9295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->