### PR TITLE
fix(themes): render hairline borders in Firefox on standard-DPI screens

### DIFF
--- a/.changeset/firefox-hairline-borders.md
+++ b/.changeset/firefox-hairline-borders.md
@@ -1,0 +1,7 @@
+---
+'@scalar/themes': patch
+---
+
+fix: render hairline borders in Firefox on standard-DPI screens
+
+Firefox rounds the 0.5px `--scalar-border-width` down to zero device pixels on non-retina displays, which makes `shadow-border` outlines invisible. The border width now falls back to 1px in Firefox below retina density, matching what other engines effectively render.

--- a/packages/themes/src/base/variables.css
+++ b/packages/themes/src/base/variables.css
@@ -137,3 +137,17 @@
     --scalar-page-description: 20px;
   }
 }
+
+/**
+ * Firefox snaps box-shadow geometry to whole device pixels, so on standard-DPI screens the 0.5px
+ * hairline rounds down to zero and shadow-border outlines disappear entirely. Use a full pixel in
+ * Firefox below retina density. The -moz-appearance supports query only matches in Gecko, so other
+ * engines (which antialias the half pixel into a faint line) keep the hairline everywhere.
+ */
+@media (max-resolution: 1.5dppx) {
+  @supports (-moz-appearance: none) {
+    :root {
+      --scalar-border-width: 1px;
+    }
+  }
+}


### PR DESCRIPTION
## What

Firefox does not render the theme's 0.5px hairline borders on standard-DPI (non-retina) displays. `--scalar-border-width` is `0.5px`, and the `shadow-border` utility draws outlines via `inset 0 0 0 var(--scalar-border-width) var(--scalar-border-color)`. Firefox snaps box-shadow geometry to whole device pixels, so at `devicePixelRatio: 1` the 0.5px spread rounds down to zero and outlined buttons, inputs, and similar `shadow-border` elements lose their borders entirely (occasionally a single horizontal edge survives the rounding, which looks even more broken). Chromium and WebKit antialias the half pixel into a faint ~1px line instead, so they are unaffected.

## Fix

Fall back to `--scalar-border-width: 1px` in exactly the broken environment, leaving everything else untouched:

- `@supports (-moz-appearance: none)` only matches in Gecko, so Chromium/WebKit are unaffected everywhere.
- `@media (max-resolution: 1.5dppx)` excludes retina/HiDPI displays, where 0.5px is a whole device pixel and Firefox already renders it correctly.

The result in low-DPI Firefox visually matches what other engines already effectively render (a ~1px antialiased line).

## Visual

Reproduced on the dashboard login page in Firefox at `devicePixelRatio: 1`: the outlined login buttons render with no visible borders. With this change they render with the same outline Chrome shows. To reproduce in this repo, view any outlined `ScalarButton` in Storybook in Firefox on a standard-DPI display (or set `layout.css.devPixelsPerPx` to `1`).