### PR TITLE
docs(agent): split MCP & Agent product page from Getting Started

### DIFF
--- a/documentation/footer.html
+++ b/documentation/footer.html
@@ -77,7 +77,7 @@
         </a>
         <a
           class="text-c-2 hover:text-c-1 font-normal"
-          href="/products/agent/getting-started"
+          href="/products/agent"
           target="_blank">
           MCP &amp; Agent
         </a>

--- a/documentation/guides/agent/getting-started.md
+++ b/documentation/guides/agent/getting-started.md
@@ -1,78 +1,8 @@
-# MCP & Agent
+# Getting Started
 
-Connect your APIs to LLMs quickly, securely, and with minimal context.
-
-Upload your OpenAPI documents and instantly expose them as an MCP server; just-in-time tool calls, secure delegated auth, and only 0.2% of your context window no matter how many APIs you need.
-
-<div class="flex gap-2">
-  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
-  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Contact sales</a>
-</div>
-
-<div class="logowall">
-  <div class="logowall-item">
-    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-bobcat.svg"></scalar-icon>
-  </div>
-  <div class="logowall-item">
-    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-clerk.svg?v=2"></scalar-icon>
-  </div>
-  <div class="logowall-item">
-    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-partech.svg?v=2"></scalar-icon>
-  </div>
-</div>
-
-## Everything agents need
-
-<div class="feature">
-  <div class="feature-container">
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/grid-four"></scalar-icon>
-        Just-in-time tool calls
-      </b>
-      <p class="leading-6">Three tools cover any API. Operation details are retrieved when needed, not dumped into the first turn.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/shield-check"></scalar-icon>
-        Secure delegated auth
-      </b>
-      <p class="leading-6">Configure OAuth, API keys, or bearer tokens per installation. Agents never receive your upstream credentials.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/users-three"></scalar-icon>
-        Scoped access
-      </b>
-      <p class="leading-6">Decide which APIs and endpoints each MCP installation may call. Private by default; share carefully via team flows.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/arrows-out-line-horizontal"></scalar-icon>
-        Isolated execution
-      </b>
-      <p class="leading-6">Sandboxed requests so concurrent agents and automations can share the same catalog safely.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/article"></scalar-icon>
-        Markdown in MCP
-      </b>
-      <p class="leading-6">Expose guides and long-form documentation beside API tools when you want extra context in the server.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/infinity"></scalar-icon>
-        Public and internal APIs
-      </b>
-      <p class="leading-6">Works for public SaaS APIs and for large internal microservice catalogs without growing the tool list.</p>
-    </div>
-  </div>
-</div>
+Turn your OpenAPI documents into an MCP server and connect your APIs to LLMs in minutes. No custom wrappers and no token bloat—Scalar sits between your API definition and the agent runtime.
 
 ## From API to agent-ready in three steps
-
-No custom wrappers and no token bloat. Scalar sits between your API definition and the agent runtime.
 
 <scalar-steps>
   <scalar-step id="agent-step-upload" title="Upload">
@@ -147,71 +77,15 @@ Configure auth once in the Scalar dashboard—OAuth 2.0, API keys, bearer tokens
 
 Read more: [API Authentication](./mcp.md#api-authentication) on the MCP page.
 
-## Ready to connect your APIs?
+## Next steps
 
-Spin up your first MCP server in under a minute—no boilerplate servers to maintain.
-
-<div class="flex gap-2">
-  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
-  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Contact sales</a>
-</div>
+- Create and manage [MCP installations](./mcp.md)
+- Connect from your runtime with the [Agent SDK](./sdk.md)
+- Try the hosted chat at [agent.scalar.com](https://agent.scalar.com)
 
 <style>
   .t-editor__anchor {
     --font-visited: none;
-  }
-
-  main.content {
-    overflow-x: clip;
-  }
-
-  .t-editor.page {
-    position: relative;
-  }
-
-  .t-doc .layout-header {
-    z-index: 10000;
-  }
-
-  .t-editor__button {
-    min-width: 160px;
-    justify-content: center;
-  }
-
-  .feature-container {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    column-gap: 48px;
-    row-gap: 36px;
-    margin-top: 32px;
-  }
-
-  .logowall.logowall {
-    margin-top: 48px;
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    align-items: center;
-    gap: 40px;
-  }
-
-  .logowall-item {
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-  }
-
-  .logowall-item svg {
-    width: fit-content;
-    height: auto;
-    max-height: 24px;
-  }
-
-  .ign-logo__fill {
-    fill: var(--scalar-color-1);
-  }
-
-  .fill-current-bg {
-    fill: var(--scalar-background-1);
   }
 
   .connect-platforms {
@@ -255,28 +129,5 @@ Spin up your first MCP server in under a minute—no boilerplate servers to main
 
   .dark-mode .connect-platform__logo {
     filter: invert(1);
-  }
-
-  @media screen and (max-width: 1000px) {
-    .logowall.logowall {
-      grid-template-columns: repeat(2, 1fr);
-      column-gap: 20px;
-      row-gap: 40px;
-    }
-
-    .logowall-item {
-      justify-content: start;
-    }
-
-    .logowall-item svg {
-      max-width: 100%;
-      height: 100%;
-      max-height: 20px;
-    }
-
-    .feature-container {
-      grid-template-columns: 1fr;
-      row-gap: 28px;
-    }
   }
 </style>

--- a/documentation/guides/agent/index.md
+++ b/documentation/guides/agent/index.md
@@ -1,0 +1,163 @@
+# MCP & Agent
+
+Connect your APIs to LLMs quickly, securely, and with minimal context.
+
+Upload your OpenAPI documents and instantly expose them as an MCP server; just-in-time tool calls, secure delegated auth, and only 0.2% of your context window no matter how many APIs you need.
+
+<div class="flex gap-2">
+  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
+  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Contact sales</a>
+</div>
+
+<div class="logowall">
+  <div class="logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-bobcat.svg"></scalar-icon>
+  </div>
+  <div class="logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-clerk.svg?v=2"></scalar-icon>
+  </div>
+  <div class="logowall-item">
+    <scalar-icon src="https://cdn.scalar.com/marketing/landing/logo-partech.svg?v=2"></scalar-icon>
+  </div>
+</div>
+
+## Everything agents need
+
+<div class="feature">
+  <div class="feature-container">
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/grid-four"></scalar-icon>
+        Just-in-time tool calls
+      </b>
+      <p class="leading-6">Three tools cover any API. Operation details are retrieved when needed, not dumped into the first turn.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/shield-check"></scalar-icon>
+        Secure delegated auth
+      </b>
+      <p class="leading-6">Configure OAuth, API keys, or bearer tokens per installation. Agents never receive your upstream credentials.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/users-three"></scalar-icon>
+        Scoped access
+      </b>
+      <p class="leading-6">Decide which APIs and endpoints each MCP installation may call. Private by default; share carefully via team flows.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/arrows-out-line-horizontal"></scalar-icon>
+        Isolated execution
+      </b>
+      <p class="leading-6">Sandboxed requests so concurrent agents and automations can share the same catalog safely.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/article"></scalar-icon>
+        Markdown in MCP
+      </b>
+      <p class="leading-6">Expose guides and long-form documentation beside API tools when you want extra context in the server.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/infinity"></scalar-icon>
+        Public and internal APIs
+      </b>
+      <p class="leading-6">Works for public SaaS APIs and for large internal microservice catalogs without growing the tool list.</p>
+    </div>
+  </div>
+</div>
+
+## Ready to connect your APIs?
+
+Spin up your first MCP server in under a minute—no boilerplate servers to maintain. Follow the [Getting Started guide](getting-started.md) to upload a spec, configure access, and connect your agent.
+
+<div class="flex gap-2">
+  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
+  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Contact sales</a>
+</div>
+
+<style>
+  .t-editor__anchor {
+    --font-visited: none;
+  }
+
+  main.content {
+    overflow-x: clip;
+  }
+
+  .t-editor.page {
+    position: relative;
+  }
+
+  .t-doc .layout-header {
+    z-index: 10000;
+  }
+
+  .t-editor__button {
+    min-width: 160px;
+    justify-content: center;
+  }
+
+  .feature-container {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 48px;
+    row-gap: 36px;
+    margin-top: 32px;
+  }
+
+  .logowall.logowall {
+    margin-top: 48px;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    align-items: center;
+    gap: 40px;
+  }
+
+  .logowall-item {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  .logowall-item svg {
+    width: fit-content;
+    height: auto;
+    max-height: 24px;
+  }
+
+  .ign-logo__fill {
+    fill: var(--scalar-color-1);
+  }
+
+  .fill-current-bg {
+    fill: var(--scalar-background-1);
+  }
+
+
+  @media screen and (max-width: 1000px) {
+    .logowall.logowall {
+      grid-template-columns: repeat(2, 1fr);
+      column-gap: 20px;
+      row-gap: 40px;
+    }
+
+    .logowall-item {
+      justify-content: start;
+    }
+
+    .logowall-item svg {
+      max-width: 100%;
+      height: 100%;
+      max-height: 20px;
+    }
+
+    .feature-container {
+      grid-template-columns: 1fr;
+      row-gap: 28px;
+    }
+  }
+</style>

--- a/documentation/guides/security.md
+++ b/documentation/guides/security.md
@@ -40,7 +40,7 @@ Scalar treats OpenAPI as a source of truth for developer docs, API clients, gene
 - **Auth-aware API descriptions:** Model API keys, bearer tokens, OAuth flows, and other security schemes directly in your OpenAPI document.
 - **Rules and validation:** Add review gates and linting so API changes are caught before they reach consumers.
 - **SDK generation:** Generate production-ready SDKs and CLIs from reviewed API descriptions. See the [SDK Generator](/products/sdk-generator).
-- **MCP guardrails:** Choose which endpoints become tools, decide search versus execute modes, and apply API auth per installation. See [MCP & Agent](/products/agent/getting-started).
+- **MCP guardrails:** Choose which endpoints become tools, decide search versus execute modes, and apply API auth per installation. See [MCP & Agent](/products/agent).
 - **Self-hostable foundation:** Run Scalar's open-source tooling in your own environment when your architecture requires it.
 
 ## Responsible disclosure

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1601,6 +1601,38 @@
                 "mode": "nested",
                 "icon": "phosphor/regular/sparkle",
                 "children": {
+                  "/": {
+                    "type": "page",
+                    "title": "MCP & Agent",
+                    "filepath": "documentation/guides/agent/index.md",
+                    "description": "OpenAPI-backed MCP servers and SDKs that connect your APIs to LLMs with just-in-time tools and delegated authentication.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/agent"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "OpenAPI-backed MCP servers and SDKs that connect your APIs to LLMs with just-in-time tools and delegated authentication."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "MCP & Agent — OpenAPI to MCP for LLMs"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "OpenAPI-backed MCP servers and SDKs that connect your APIs to LLMs with just-in-time tools and delegated authentication."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
                   "getting-started": {
                     "title": "Getting Started",
                     "type": "page",


### PR DESCRIPTION
## Problem

The MCP & Agent product had no real page at `/products/agent` — the URL redirected to `/products/agent/getting-started`, which contained product marketing content (hero, logo wall, feature grid) rather than a getting started guide.

## Solution

Same restructure as #9741, applied to MCP & Agent:

- **`/products/agent`** — renamed `getting-started.md` to `index.md` and kept the product content there (hero, logo wall, "Everything agents need" features, CTA).
- **`/products/agent/getting-started`** — new true getting started page with "From API to agent-ready in three steps", "Connect from anywhere" (platform links and the Python example), "Authentication and access", and next steps. Copy is a starting point for a follow-up copy pass.
- **Config** — added a `"/"` child route on the nested group (the group `page` property only works with `mode: "folder"`), with canonical `https://scalar.com/products/agent`.
- **Links** — footer and security page product links now point to `/products/agent`.

Verified with `npx @scalar/cli project check-config`.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed: documentation content and scalar.config.json only. -->
- [ ] I added tests. <!-- Not applicable. -->
- [x] I updated the documentation.

## Ticket

Part of #9741

🤖 Generated with [Claude Code](https://claude.com/claude-code)