### PR TITLE
docs(sdk-generator): split SDK Generator product page from Getting Started

### DIFF
--- a/documentation/footer.html
+++ b/documentation/footer.html
@@ -83,7 +83,7 @@
         </a>
         <a
           class="text-c-2 hover:text-c-1 font-normal"
-          href="/products/sdk-generator/getting-started"
+          href="/products/sdk-generator"
           target="_blank">
           SDKs
         </a>

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -206,7 +206,7 @@
           File Streaming Support
         </b>
       </div>
-      <a class="mt-3 t-editor__anchor" href="/products/sdk-generator/getting-started" aria-label="Generate your first SDK with Scalar">Generate your first SDK →</a>
+      <a class="mt-3 t-editor__anchor" href="/products/sdk-generator" aria-label="Generate your first SDK with Scalar">Generate your first SDK →</a>
     </div>
     <div class="product-image">
       <div class="product-image-transform">
@@ -355,7 +355,7 @@
           Bring your OpenAPI document and get type-safe client libraries for TypeScript, Python and more.
         </div>
       </div>
-      <a class="expander-hover-link" href="/products/sdk-generator/getting-started" aria-label="Learn more about SDKs">Learn More</a>
+      <a class="expander-hover-link" href="/products/sdk-generator" aria-label="Learn more about SDKs">Learn More</a>
     </div>
   </div>
   <div class="expander-hover">

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -744,7 +744,7 @@
           Bring your OpenAPI document and get type-safe client libraries across supported languages.
         </div>
       </div>
-      <a class="expander-hover-link" href="/products/sdk-generator/getting-started" aria-label="Learn more about SDKs">Learn More</a>
+      <a class="expander-hover-link" href="/products/sdk-generator" aria-label="Learn more about SDKs">Learn More</a>
     </div>
   </div>
   <div class="expander-hover">

--- a/documentation/guides/sdks/getting-started.md
+++ b/documentation/guides/sdks/getting-started.md
@@ -1,19 +1,6 @@
-# SDK Generator
+# Getting Started
 
-Generate type-safe SDKs and CLIs from OpenAPI in minutes. Build clients for TypeScript, Python, CLI targets, and more without maintaining generator infrastructure.
-
-<div class="flex gap-2">
-  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
-  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a demo</a>
-</div>
-
-<scalar-image
-  class="sdks-hero-image"
-  src="/sdks-animated.svg"
-  src-dark="/sdks-animated-dark.svg"
-  alt="Scalar SDK generation interface"
-  size="full">
-</scalar-image>
+Generate your first type-safe SDK or CLI from an OpenAPI document in minutes, straight from the Scalar dashboard.
 
 > [!NOTE]
 > SDK generation is part of our paid plans and costs $100 per month per target. Keep this in mind when selecting what you want to generate.
@@ -56,102 +43,9 @@ Once created, you will be redirected to the SDK overview page. From there you ca
   size="full">
 </scalar-image>
 
-## Features
+## Next steps
 
-<div class="feature">
-  <div class="feature-container">
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
-        OpenAPI-first
-      </b>
-      <p class="leading-6">Generate SDKs and CLIs from the OpenAPI documents your team already maintains.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/brackets-square"></scalar-icon>
-        Custom code
-      </b>
-      <p class="leading-6">Customize clients without forking the generated SDK or losing future updates.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/code"></scalar-icon>
-        Code samples
-      </b>
-      <p class="leading-6">Keep SDK usage examples close to your API reference and developer docs.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/fingerprint"></scalar-icon>
-        OpenAPI authentication
-      </b>
-      <p class="leading-6">Generate clients that understand the authentication patterns in your API description.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/terminal-window"></scalar-icon>
-        CLI targets
-      </b>
-      <p class="leading-6">Generate command-line tools alongside SDKs when your API needs terminal workflows.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/file-cloud"></scalar-icon>
-        File streaming support
-      </b>
-      <p class="leading-6">Handle file uploads and streaming responses in generated clients.</p>
-    </div>
-  </div>
-</div>
-
-## Ready to generate SDKs and CLIs?
-
-We are committed to enabling developers and companies to practice the highest API industry standards.
-
-<div class="flex gap-2">
-  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
-  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a demo</a>
-</div>
-
-<style>
-  .t-editor__anchor {
-    --font-visited: none;
-  }
-
-  main.content {
-    overflow-x: clip;
-  }
-
-  .t-editor.page {
-    position: relative;
-  }
-
-  .t-doc .layout-header {
-    z-index: 10000;
-  }
-
-  .t-editor__button {
-    min-width: 160px;
-    justify-content: center;
-  }
-
-  .sdks-hero-image {
-    margin-top: 32px;
-  }
-
-  .feature-container {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    column-gap: 48px;
-    row-gap: 36px;
-    margin-top: 32px;
-  }
-
-  @media screen and (max-width: 1000px) {
-    .feature-container {
-      grid-template-columns: 1fr;
-      row-gap: 28px;
-    }
-  }
-</style>
+- [Build, version, and download](managing.md) your targets
+- [Configure](configuration.md) each SDK or CLI
+- [Publish to a package registry](publishing/overview.md)
+- [Add custom code](custom-code.md) that survives regeneration

--- a/documentation/guides/sdks/index.md
+++ b/documentation/guides/sdks/index.md
@@ -1,0 +1,116 @@
+# SDK Generator
+
+Generate type-safe SDKs and CLIs from OpenAPI in minutes. Build clients for TypeScript, Python, CLI targets, and more without maintaining generator infrastructure.
+
+<div class="flex gap-2">
+  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
+  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a demo</a>
+</div>
+
+<scalar-image
+  class="sdks-hero-image"
+  src="/sdks-animated.svg"
+  src-dark="/sdks-animated-dark.svg"
+  alt="Scalar SDK generation interface"
+  size="full">
+</scalar-image>
+
+## Features
+
+<div class="feature">
+  <div class="feature-container">
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
+        OpenAPI-first
+      </b>
+      <p class="leading-6">Generate SDKs and CLIs from the OpenAPI documents your team already maintains.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/brackets-square"></scalar-icon>
+        Custom code
+      </b>
+      <p class="leading-6">Customize clients without forking the generated SDK or losing future updates.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/code"></scalar-icon>
+        Code samples
+      </b>
+      <p class="leading-6">Keep SDK usage examples close to your API reference and developer docs.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/fingerprint"></scalar-icon>
+        OpenAPI authentication
+      </b>
+      <p class="leading-6">Generate clients that understand the authentication patterns in your API description.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/terminal-window"></scalar-icon>
+        CLI targets
+      </b>
+      <p class="leading-6">Generate command-line tools alongside SDKs when your API needs terminal workflows.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/file-cloud"></scalar-icon>
+        File streaming support
+      </b>
+      <p class="leading-6">Handle file uploads and streaming responses in generated clients.</p>
+    </div>
+  </div>
+</div>
+
+## Ready to generate SDKs and CLIs?
+
+Follow the [Getting Started guide](getting-started.md) to generate your first target from the dashboard.
+
+<div class="flex gap-2">
+  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
+  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a demo</a>
+</div>
+
+<style>
+  .t-editor__anchor {
+    --font-visited: none;
+  }
+
+  main.content {
+    overflow-x: clip;
+  }
+
+  .t-editor.page {
+    position: relative;
+  }
+
+  .t-doc .layout-header {
+    z-index: 10000;
+  }
+
+  .t-editor__button {
+    min-width: 160px;
+    justify-content: center;
+  }
+
+  .sdks-hero-image {
+    margin-top: 32px;
+  }
+
+  .feature-container {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 48px;
+    row-gap: 36px;
+    margin-top: 32px;
+  }
+
+  @media screen and (max-width: 1000px) {
+    .feature-container {
+      grid-template-columns: 1fr;
+      row-gap: 28px;
+    }
+  }
+</style>

--- a/documentation/guides/security.md
+++ b/documentation/guides/security.md
@@ -39,7 +39,7 @@ Scalar treats OpenAPI as a source of truth for developer docs, API clients, gene
 
 - **Auth-aware API descriptions:** Model API keys, bearer tokens, OAuth flows, and other security schemes directly in your OpenAPI document.
 - **Rules and validation:** Add review gates and linting so API changes are caught before they reach consumers.
-- **SDK generation:** Generate production-ready SDKs and CLIs from reviewed API descriptions. See the [SDK Generator](/products/sdk-generator/getting-started).
+- **SDK generation:** Generate production-ready SDKs and CLIs from reviewed API descriptions. See the [SDK Generator](/products/sdk-generator).
 - **MCP guardrails:** Choose which endpoints become tools, decide search versus execute modes, and apply API auth per installation. See [MCP & Agent](/products/agent/getting-started).
 - **Self-hostable foundation:** Run Scalar's open-source tooling in your own environment when your architecture requires it.
 

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1690,6 +1690,38 @@
                 "mode": "nested",
                 "icon": "phosphor/regular/package",
                 "children": {
+                  "/": {
+                    "type": "page",
+                    "title": "SDK Generator",
+                    "filepath": "documentation/guides/sdks/index.md",
+                    "description": "Generate production-ready SDKs and CLIs in TypeScript, Python, Go, Java, C#, PHP, Ruby, and Swift from your OpenAPI specs.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/sdk-generator"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Generate production-ready SDKs and CLIs in TypeScript, Python, Go, Java, C#, PHP, Ruby, and Swift from your OpenAPI specs."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "SDK Generator - Generate Client Libraries from OpenAPI"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Generate production-ready SDKs and CLIs in TypeScript, Python, Go, Java, C#, PHP, Ruby, and Swift from your OpenAPI specs."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
                   "getting-started": {
                     "filepath": "documentation/guides/sdks/getting-started.md",
                     "type": "page",


### PR DESCRIPTION
## Problem

The SDK Generator product had no real page at `/products/sdk-generator` — the URL redirected to `/products/sdk-generator/getting-started`, which contained product marketing content (hero, feature grid) rather than a getting started guide.

## Solution

Same restructure as #9741, applied to SDK Generator:

- **`/products/sdk-generator`** — renamed `getting-started.md` to `index.md` and kept the product content there (hero, features, CTA).
- **`/products/sdk-generator/getting-started`** — new true getting started page with the pricing note, account prerequisite, the "Generate your first target" steps, and next steps. Copy is a starting point for a follow-up copy pass.
- **Config** — added a `"/"` child route on the nested group (the group `page` property only works with `mode: "folder"`), with canonical `https://scalar.com/products/sdk-generator`.
- **Links** — footer, introduction, pricing, and security product links now point to `/products/sdk-generator`.

Verified with `npx @scalar/cli project check-config`.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed: documentation content and scalar.config.json only. -->
- [ ] I added tests. <!-- Not applicable. -->
- [x] I updated the documentation.

## Ticket

Part of #9741

🤖 Generated with [Claude Code](https://claude.com/claude-code)