### PR TITLE
docs(registry): split Registry product page from Getting Started

### DIFF
--- a/documentation/footer.html
+++ b/documentation/footer.html
@@ -89,7 +89,7 @@
         </a>
         <a
           class="text-c-2 hover:text-c-1 font-normal"
-          href="/products/registry/getting-started"
+          href="/products/registry"
           target="_blank">
           Registry
         </a>

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -274,7 +274,7 @@ You can configure the search behavior on a per-page basis:
 Scalar supports three ways to generate API references from OpenAPI documents:
 
 1. using a local file,
-2. the [Registry](../../registry/getting-started.md), or
+2. the [Registry](../../registry/index.md), or
 3. remote URLs.
 
 ### 1. Files
@@ -294,7 +294,7 @@ Reference an OpenAPI file stored in your repository by specifying a relative pat
 
 ### 2. Registry
 
-Upload your OpenAPI document to the [Registry](../../registry/getting-started.md), then reference it by namespace and slug:
+Upload your OpenAPI document to the [Registry](../../registry/index.md), then reference it by namespace and slug:
 
 ```bash
 scalar auth login

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -374,7 +374,7 @@
           Managing & versioning OpenAPI Documents with a deep Git integration.
         </div>
       </div>
-      <a class="expander-hover-link" href="/products/registry/getting-started" aria-label="Learn more about API Registry">Learn More</a>
+      <a class="expander-hover-link" href="/products/registry" aria-label="Learn more about API Registry">Learn More</a>
     </div>
   </div>
   <div class="expander-hover">

--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -763,7 +763,7 @@
           Managing & versioning OpenAPI Documents with a deep Git integration.
         </div>
       </div>
-      <a class="expander-hover-link" href="/products/registry/getting-started" aria-label="Learn more about API Registry">Learn More</a>
+      <a class="expander-hover-link" href="/products/registry" aria-label="Learn more about API Registry">Learn More</a>
     </div>
   </div>
   <div class="expander-hover">

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -1,19 +1,6 @@
-# Registry
+# Getting Started
 
-Store, version, and manage OpenAPI documents, JSON Schema, and Spectral rules in one source of truth with a deep Git integration.
-
-<div class="flex gap-2">
-  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
-  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a demo</a>
-</div>
-
-<scalar-image
-  class="registry-hero-image"
-  src="/registry-animated.svg"
-  src-dark="/registry-animated-dark.svg"
-  alt="Scalar Registry interface"
-  size="full">
-</scalar-image>
+Get your first OpenAPI document into the Registry and start powering docs, SDKs, and automation from a single source of truth.
 
 ## Create your Scalar account
 
@@ -32,128 +19,12 @@ Once authenticated, you can work with Registry from:
   size="full">
 </scalar-image>
 
-## Why a Registry?
+## Upload your first API description
 
-Managing OpenAPI can get messy fast. Teams need to know where the source of truth lives, how versions are managed, who has access, and how downstream consumers discover updates.
+From the [dashboard](https://dashboard.scalar.com), create a new API and upload an OpenAPI document, or publish one from your terminal with the [CLI](cli.md). Once the document is in Registry, docs, SDKs, and automation can all consume the same source.
 
-Registry gives your team a central place for API descriptions and the workflows around them. Once an API description is in Registry, you can power docs, SDKs, publishing, and automation from the same source.
+## Next steps
 
-## Create docs and SDKs
-
-Create API docs from Registry with just a few clicks. Your docs stay connected to OpenAPI changes, so updates move from source to published documentation without copy-paste work.
-
-<scalar-image
-  src="/api-docs-static-zoom.svg"
-  src-dark="/api-docs-static-zoom-dark.svg"
-  alt="Scalar Docs generated from Registry"
-  size="full">
-</scalar-image>
-
-Generate SDKs from the same OpenAPI documents. Keep client libraries aligned with API changes while Registry handles the connection between the source document and the generated tooling.
-
-<scalar-image
-  src="/sdk-dashboard-static.svg"
-  src-dark="/sdk-dashboard-static-dark.svg"
-  alt="Scalar SDK dashboard"
-  size="full">
-</scalar-image>
-
-## Features
-
-<div class="feature">
-  <div class="feature-container">
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/git-branch"></scalar-icon>
-        Single source of truth
-      </b>
-      <p class="leading-6">Keep API descriptions, schemas, and rules in one managed place.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/arrows-clockwise"></scalar-icon>
-        Git integration
-      </b>
-      <p class="leading-6">Connect Registry to repository workflows so updates can follow your existing review process.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
-        OpenAPI documents
-      </b>
-      <p class="leading-6">Version and publish OpenAPI documents used by docs, SDKs, and automation.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/brackets-curly"></scalar-icon>
-        JSON Schema support
-      </b>
-      <p class="leading-6">Manage shared schemas alongside the API descriptions that depend on them.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/warning-octagon"></scalar-icon>
-        Spectral rules
-      </b>
-      <p class="leading-6">Store rules for consistent API governance and validation workflows.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
-        <scalar-icon src="phosphor/bold/lock-simple"></scalar-icon>
-        Private or public
-      </b>
-      <p class="leading-6">Control whether API descriptions are internal, shared with a team, or public.</p>
-    </div>
-  </div>
-</div>
-
-## Ready to manage your APIs?
-
-We are committed to enabling developers and companies to practice the highest API industry standards.
-
-<div class="flex gap-2">
-  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
-  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a demo</a>
-</div>
-
-<style>
-  .t-editor__anchor {
-    --font-visited: none;
-  }
-
-  main.content {
-    overflow-x: clip;
-  }
-
-  .t-editor.page {
-    position: relative;
-  }
-
-  .t-doc .layout-header {
-    z-index: 10000;
-  }
-
-  .t-editor__button {
-    min-width: 160px;
-    justify-content: center;
-  }
-
-  .registry-hero-image {
-    margin-top: 32px;
-  }
-
-  .feature-container {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    column-gap: 48px;
-    row-gap: 36px;
-    margin-top: 32px;
-  }
-
-  @media screen and (max-width: 1000px) {
-    .feature-container {
-      grid-template-columns: 1fr;
-      row-gap: 28px;
-    }
-  }
-</style>
+- Publish and version documents with the [CLI](cli.md)
+- Automate updates with [GitHub Actions](github-actions.md)
+- Create [API docs](../docs/getting-started.md) and [SDKs](../sdks/getting-started.md) from your registry documents

--- a/documentation/guides/registry/index.md
+++ b/documentation/guides/registry/index.md
@@ -1,0 +1,142 @@
+# Registry
+
+Store, version, and manage OpenAPI documents, JSON Schema, and Spectral rules in one source of truth with a deep Git integration.
+
+<div class="flex gap-2">
+  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
+  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a demo</a>
+</div>
+
+<scalar-image
+  class="registry-hero-image"
+  src="/registry-animated.svg"
+  src-dark="/registry-animated-dark.svg"
+  alt="Scalar Registry interface"
+  size="full">
+</scalar-image>
+
+## Why a Registry?
+
+Managing OpenAPI can get messy fast. Teams need to know where the source of truth lives, how versions are managed, who has access, and how downstream consumers discover updates.
+
+Registry gives your team a central place for API descriptions and the workflows around them. Once an API description is in Registry, you can power docs, SDKs, publishing, and automation from the same source.
+
+## Create docs and SDKs
+
+Create API docs from Registry with just a few clicks. Your docs stay connected to OpenAPI changes, so updates move from source to published documentation without copy-paste work.
+
+<scalar-image
+  src="/api-docs-static-zoom.svg"
+  src-dark="/api-docs-static-zoom-dark.svg"
+  alt="Scalar Docs generated from Registry"
+  size="full">
+</scalar-image>
+
+Generate SDKs from the same OpenAPI documents. Keep client libraries aligned with API changes while Registry handles the connection between the source document and the generated tooling.
+
+<scalar-image
+  src="/sdk-dashboard-static.svg"
+  src-dark="/sdk-dashboard-static-dark.svg"
+  alt="Scalar SDK dashboard"
+  size="full">
+</scalar-image>
+
+## Features
+
+<div class="feature">
+  <div class="feature-container">
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/git-branch"></scalar-icon>
+        Single source of truth
+      </b>
+      <p class="leading-6">Keep API descriptions, schemas, and rules in one managed place.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/arrows-clockwise"></scalar-icon>
+        Git integration
+      </b>
+      <p class="leading-6">Connect Registry to repository workflows so updates can follow your existing review process.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
+        OpenAPI documents
+      </b>
+      <p class="leading-6">Version and publish OpenAPI documents used by docs, SDKs, and automation.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/brackets-curly"></scalar-icon>
+        JSON Schema support
+      </b>
+      <p class="leading-6">Manage shared schemas alongside the API descriptions that depend on them.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/warning-octagon"></scalar-icon>
+        Spectral rules
+      </b>
+      <p class="leading-6">Store rules for consistent API governance and validation workflows.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
+        <scalar-icon src="phosphor/bold/lock-simple"></scalar-icon>
+        Private or public
+      </b>
+      <p class="leading-6">Control whether API descriptions are internal, shared with a team, or public.</p>
+    </div>
+  </div>
+</div>
+
+## Ready to manage your APIs?
+
+Follow the [Getting Started guide](getting-started.md) to create an account and upload your first OpenAPI document.
+
+<div class="flex gap-2">
+  <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
+  <a class="t-editor__button button__secondary" href="https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a" target="_blank">Book a demo</a>
+</div>
+
+<style>
+  .t-editor__anchor {
+    --font-visited: none;
+  }
+
+  main.content {
+    overflow-x: clip;
+  }
+
+  .t-editor.page {
+    position: relative;
+  }
+
+  .t-doc .layout-header {
+    z-index: 10000;
+  }
+
+  .t-editor__button {
+    min-width: 160px;
+    justify-content: center;
+  }
+
+  .registry-hero-image {
+    margin-top: 32px;
+  }
+
+  .feature-container {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 48px;
+    row-gap: 36px;
+    margin-top: 32px;
+  }
+
+  @media screen and (max-width: 1000px) {
+    .feature-container {
+      grid-template-columns: 1fr;
+      row-gap: 28px;
+    }
+  }
+</style>

--- a/documentation/guides/sdks/managing.md
+++ b/documentation/guides/sdks/managing.md
@@ -13,14 +13,14 @@ After you [create an SDK](getting-started.md), the dashboard is where you build 
 Each SDK opens to an overview with:
 
 - **Name and description**: human-readable metadata used in generated packages. Edit them inline.
-- **Active version**: the version currently served from the [registry](../registry/getting-started.md).
+- **Active version**: the version currently served from the [registry](../registry/index.md).
 - **Namespace**: the registry namespace the SDK is published under.
 - **Targets**: every configured language, with its build and GitHub sync status.
 - **Version history**: every version and its per-target build status.
 
 ## Linking an API
 
-An SDK is generated from an OpenAPI document in your [registry](../registry/getting-started.md). The SDK stays bound to that document, so regenerating picks up the latest API changes. You can re-link the SDK to a different document, or unlink it (which pauses builds until you link one again) from the SDK settings.
+An SDK is generated from an OpenAPI document in your [registry](../registry/index.md). The SDK stays bound to that document, so regenerating picks up the latest API changes. You can re-link the SDK to a different document, or unlink it (which pauses builds until you link one again) from the SDK settings.
 
 ## Building
 

--- a/documentation/integrations/aspnetcore/build-time-generation.md
+++ b/documentation/integrations/aspnetcore/build-time-generation.md
@@ -3,7 +3,7 @@
 This guide shows you how to generate OpenAPI documents during the build process for your ASP.NET Core application. Build-time generation is useful for:
 
 - Creating OpenAPI documents that are committed to source control
-- Publishing OpenAPI documents to the [Registry](../../guides/registry/getting-started.md)
+- Publishing OpenAPI documents to the [Registry](../../guides/registry/index.md)
 
 ## Microsoft.AspNetCore.OpenApi
 
@@ -168,4 +168,4 @@ publish_to_scalar:
     - validate_openapi
 ```
 
-[Read more about publishing to the Registry.](../../guides/registry/getting-started.md).
+[Read more about publishing to the Registry.](../../guides/registry/index.md).

--- a/documentation/migration/api-hub.md
+++ b/documentation/migration/api-hub.md
@@ -93,4 +93,4 @@ Just like API Hub Explore, you can import existing API docs into the API client 
 
 ## Link APIs from Design
 
-The [Registry](../guides/registry/getting-started.md) matches the API Hub Explore's “Link APIs from Design” feature.
+The [Registry](../guides/registry/index.md) matches the API Hub Explore's “Link APIs from Design” feature.

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1927,6 +1927,38 @@
                 "mode": "nested",
                 "icon": "phosphor/regular/brackets-curly",
                 "children": {
+                  "/": {
+                    "type": "page",
+                    "title": "Registry",
+                    "filepath": "documentation/guides/registry/index.md",
+                    "description": "Centralized API registry for managing OpenAPI specifications with versioning, validation, and automated workflows.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/registry"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Centralized API registry for managing OpenAPI specifications with versioning, validation, and automated workflows."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Registry - OpenAPI Management"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Centralized API registry for managing OpenAPI specifications with versioning, validation, and automated workflows."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
                   "getting-started": {
                     "filepath": "documentation/guides/registry/getting-started.md",
                     "type": "page",


### PR DESCRIPTION
## Problem

The Registry product had no real page at `/products/registry` — the URL redirected to `/products/registry/getting-started`, which contained product marketing content (hero, "Why a Registry?", feature grid) rather than a getting started guide.

## Solution

Same restructure as #9741, applied to Registry:

- **`/products/registry`** — renamed `getting-started.md` to `index.md` and kept the product content there (hero, "Why a Registry?", "Create docs and SDKs", features, CTA).
- **`/products/registry/getting-started`** — new true getting started page: account creation (the `#create-your-scalar-account` heading is preserved because the SDK Generator guide and Private Docs guide deep-link to it), a first-upload section, and next steps. Copy is a starting point for a follow-up copy pass.
- **Config** — added a `"/"` child route on the nested group (the group `page` property only works with `mode: "folder"`), with canonical `https://scalar.com/products/registry`.
- **Links** — footer, pricing, and introduction product links now point to `/products/registry`; in-guide "the Registry" product mentions (ASP.NET Core integration, SDK managing, Docs navigation, API Hub migration) now link to `index.md`. Anchored links to `#create-your-scalar-account` are unchanged.

Verified with `npx @scalar/cli project check-config`.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed: documentation content and scalar.config.json only. -->
- [ ] I added tests. <!-- Not applicable. -->
- [x] I updated the documentation.

## Ticket

Part of #9741

🤖 Generated with [Claude Code](https://claude.com/claude-code)