### PR TITLE
docs(api-references): add API References product page at /products/api-references

### DIFF
--- a/documentation/footer.html
+++ b/documentation/footer.html
@@ -95,7 +95,7 @@
         </a>
         <a
           class="text-c-2 hover:text-c-1 font-normal"
-          href="/products/api-references/getting-started"
+          href="/products/api-references"
           target="_blank">
           API References
         </a>

--- a/documentation/guides/api-references/getting-started.md
+++ b/documentation/guides/api-references/getting-started.md
@@ -1,9 +1,4 @@
-# API References
-<div class="flex gap-2">
-<a href="https://www.npmjs.com/@scalar/api-reference" aria-label="View @scalar/api-reference on NPM"><img alt="NPM Version" src="https://img.shields.io/npm/v/@scalar/api-reference"></a>
-<a href="https://www.npmjs.com/@scalar/api-reference" aria-label="View NPM downloads for @scalar/api-reference"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@scalar/api-reference"></a>
-<a href="https://discord.gg/scalar" aria-label="Join Scalar community on Discord"><img alt="Discord" src="https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2"></a>
-</div>
+# Getting Started
 
 The API Reference renders a modern documentation for your OpenAPI/Swagger documents and all you need is a few lines of code.
 

--- a/documentation/guides/api-references/index.md
+++ b/documentation/guides/api-references/index.md
@@ -1,0 +1,19 @@
+# API References
+
+<div class="flex gap-2">
+<a href="https://www.npmjs.com/@scalar/api-reference" aria-label="View @scalar/api-reference on NPM"><img alt="NPM Version" src="https://img.shields.io/npm/v/@scalar/api-reference"></a>
+<a href="https://www.npmjs.com/@scalar/api-reference" aria-label="View NPM downloads for @scalar/api-reference"><img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@scalar/api-reference"></a>
+<a href="https://discord.gg/scalar" aria-label="Join Scalar community on Discord"><img alt="Discord" src="https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2"></a>
+</div>
+
+Generate beautiful, interactive API documentation from OpenAPI and AsyncAPI documents. The API Reference is open source, free, and renders modern documentation with built-in request testing from just a few lines of code.
+
+It works from a single HTML page, a CDN script, or one of the many framework integrations for Express, Fastify, Hono, NestJS, Next.js, Nuxt, ASP.NET Core, FastAPI, and more.
+
+Ready to render your first reference? Follow the [Getting Started guide](getting-started.md).
+
+## Go further
+
+- [Configuration](../../configuration.md) — customize behavior, authentication, and layout
+- [Themes](../../themes.md) — match the reference to your brand
+- [Plugins](../../plugins.md) — extend the reference with custom features

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -2004,6 +2004,38 @@
                 "mode": "nested",
                 "icon": "phosphor/regular/notebook",
                 "children": {
+                  "/": {
+                    "type": "page",
+                    "title": "API References",
+                    "filepath": "documentation/guides/api-references/index.md",
+                    "description": "Generate beautiful, interactive API documentation from OpenAPI and AsyncAPI specifications with customizable themes.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/api-references"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Generate beautiful, interactive API documentation from OpenAPI and AsyncAPI specifications with customizable themes."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "API References - OpenAPI Documentation"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Generate beautiful, interactive API documentation from OpenAPI and AsyncAPI specifications with customizable themes."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
                   "getting-started": {
                     "title": "Getting Started",
                     "filepath": "documentation/guides/api-references/getting-started.md",


### PR DESCRIPTION
## Problem

The API References product had no page at `/products/api-references` — the URL redirected to `/products/api-references/getting-started`. Unlike the other products (see #9741), that page was already a genuine quick start rather than marketing content, but there was still no product page at the root.

## Solution

- **`/products/api-references`** — new `index.md` product page: npm/Discord badges (moved from the quick start), a product description, and links onward to Getting Started, Configuration, Themes, and Plugins. Copy is a starting point for a follow-up copy pass.
- **`/products/api-references/getting-started`** — kept as-is, retitled from "API References" to "Getting Started" and badges removed since they now live on the product page.
- **Config** — added a `"/"` child route on the nested group (the group `page` property only works with `mode: "folder"`), with canonical `https://scalar.com/products/api-references`.
- **Links** — the footer product link now points to `/products/api-references`.

Verified with `npx @scalar/cli project check-config`.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed: documentation content and scalar.config.json only. -->
- [ ] I added tests. <!-- Not applicable. -->
- [x] I updated the documentation.

## Ticket

Part of #9741

🤖 Generated with [Claude Code](https://claude.com/claude-code)