### PR TITLE
docs(api-client): split API Client product page from Getting Started

### DIFF
--- a/documentation/footer.html
+++ b/documentation/footer.html
@@ -101,7 +101,7 @@
         </a>
         <a
           class="text-c-2 hover:text-c-1 font-normal"
-          href="/products/api-client/getting-started"
+          href="/products/api-client"
           target="_blank">
           API Client
         </a>

--- a/documentation/guides/app/getting-started.md
+++ b/documentation/guides/app/getting-started.md
@@ -1,23 +1,8 @@
-# API Client
+# Getting Started
 
-A modern, open-source API client built on the OpenAPI standard. Send requests, organize collections, and test your APIs from a beautiful, offline-first interface available on every platform.
+Send your first request with API Client in minutes. [Download the app](./download.md) for macOS, Windows, or Linux, or jump straight into the [browser version](https://client.scalar.com).
 
-<div class="flex gap-2">
-  <a class="t-editor__button button__primary" href="https://client.scalar.com/" target="_blank">Try in browser</a>
-  <a class="t-editor__button button__secondary" href="/products/api-client/download">Download</a>
-</div>
-
-<scalar-image
-  class="api-client-hero-image"
-  src="/api-client-static.svg"
-  src-dark="/api-client-static-dark.svg"
-  alt="Scalar API Client interface"
-  size="full">
-</scalar-image>
-
-## Get started
-
-[Download the app](./download.md) for macOS, Windows, or Linux, or jump straight into the [browser version](https://client.scalar.com).
+## Send your first request
 
 <scalar-steps>
   <scalar-step id="step-1" title="Open API Client">
@@ -63,102 +48,8 @@ API Client supports request scripts and response tests, so you can automate setu
 
 Start with [Scripts](./scripts.md) for pre-request and post-response workflows, then use [Testing](./testing.md) to validate status codes, headers, and response bodies.
 
-## Features
+## Next steps
 
-<div class="feature">
-  <div class="feature-container">
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
-        <scalar-icon src="phosphor/bold/wifi-slash"></scalar-icon>
-        Offline-first
-      </b>
-      <p class="leading-6">Work locally with requests and collections without waiting on cloud sync.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
-        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
-        OpenAPI-native
-      </b>
-      <p class="leading-6">Generate collections from OpenAPI descriptions and keep them close to your source of truth.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
-        <scalar-icon src="phosphor/bold/desktop-tower"></scalar-icon>
-        Cross-platform
-      </b>
-      <p class="leading-6">Use API Client in the browser or on macOS, Windows, and Linux.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
-        <scalar-icon src="phosphor/bold/globe"></scalar-icon>
-        Environments
-      </b>
-      <p class="leading-6">Manage variables for local, staging, and production without duplicating requests.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
-        <scalar-icon src="phosphor/bold/file-code"></scalar-icon>
-        Scripts and tests
-      </b>
-      <p class="leading-6">Automate setup and validate responses with request scripts and test assertions.</p>
-    </div>
-    <div class="feature-item">
-      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
-        <scalar-icon src="phosphor/bold/lock-simple-open"></scalar-icon>
-        No vendor lock-in
-      </b>
-      <p class="leading-6">Build on open standards with an open-source client that keeps your API work portable.</p>
-    </div>
-  </div>
-</div>
-
-## Ready to send your first request?
-
-Start in the browser or download the desktop app for your platform.
-
-<div class="flex gap-2">
-  <a class="t-editor__button button__primary" href="https://client.scalar.com/" target="_blank">Try in browser</a>
-  <a class="t-editor__button button__secondary" href="/products/api-client/download">Download</a>
-</div>
-
-<style>
-  .t-editor__anchor {
-    --font-visited: none;
-  }
-
-  main.content {
-    overflow-x: clip;
-  }
-
-  .t-editor.page {
-    position: relative;
-  }
-
-  .t-doc .layout-header {
-    z-index: 10000;
-  }
-
-  .t-editor__button {
-    min-width: 160px;
-    justify-content: center;
-  }
-
-  .api-client-hero-image {
-    margin-top: 32px;
-  }
-
-  .feature-container {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    column-gap: 48px;
-    row-gap: 36px;
-    margin-top: 32px;
-  }
-
-  @media screen and (max-width: 1000px) {
-    .feature-container {
-      grid-template-columns: 1fr;
-      row-gap: 28px;
-    }
-  }
-</style>
+- Configure [authentication](./authentication.md) for your APIs
+- Speed up your workflow with [keyboard shortcuts](./keyboard-shortcuts.md)
+- Generate code snippets with [code generation](./code-generation.md)

--- a/documentation/guides/app/index.md
+++ b/documentation/guides/app/index.md
@@ -1,0 +1,116 @@
+# API Client
+
+A modern, open-source API client built on the OpenAPI standard. Send requests, organize collections, and test your APIs from a beautiful, offline-first interface available on every platform.
+
+<div class="flex gap-2">
+  <a class="t-editor__button button__primary" href="https://client.scalar.com/" target="_blank">Try in browser</a>
+  <a class="t-editor__button button__secondary" href="/products/api-client/download">Download</a>
+</div>
+
+<scalar-image
+  class="api-client-hero-image"
+  src="/api-client-static.svg"
+  src-dark="/api-client-static-dark.svg"
+  alt="Scalar API Client interface"
+  size="full">
+</scalar-image>
+
+## Features
+
+<div class="feature">
+  <div class="feature-container">
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
+        <scalar-icon src="phosphor/bold/wifi-slash"></scalar-icon>
+        Offline-first
+      </b>
+      <p class="leading-6">Work locally with requests and collections without waiting on cloud sync.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
+        <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
+        OpenAPI-native
+      </b>
+      <p class="leading-6">Generate collections from OpenAPI descriptions and keep them close to your source of truth.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
+        <scalar-icon src="phosphor/bold/desktop-tower"></scalar-icon>
+        Cross-platform
+      </b>
+      <p class="leading-6">Use API Client in the browser or on macOS, Windows, and Linux.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
+        <scalar-icon src="phosphor/bold/globe"></scalar-icon>
+        Environments
+      </b>
+      <p class="leading-6">Manage variables for local, staging, and production without duplicating requests.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
+        <scalar-icon src="phosphor/bold/file-code"></scalar-icon>
+        Scripts and tests
+      </b>
+      <p class="leading-6">Automate setup and validate responses with request scripts and test assertions.</p>
+    </div>
+    <div class="feature-item">
+      <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">
+        <scalar-icon src="phosphor/bold/lock-simple-open"></scalar-icon>
+        No vendor lock-in
+      </b>
+      <p class="leading-6">Build on open standards with an open-source client that keeps your API work portable.</p>
+    </div>
+  </div>
+</div>
+
+## Ready to send your first request?
+
+Start in the browser or download the desktop app for your platform, then follow the [Getting Started guide](getting-started.md).
+
+<div class="flex gap-2">
+  <a class="t-editor__button button__primary" href="https://client.scalar.com/" target="_blank">Try in browser</a>
+  <a class="t-editor__button button__secondary" href="/products/api-client/download">Download</a>
+</div>
+
+<style>
+  .t-editor__anchor {
+    --font-visited: none;
+  }
+
+  main.content {
+    overflow-x: clip;
+  }
+
+  .t-editor.page {
+    position: relative;
+  }
+
+  .t-doc .layout-header {
+    z-index: 10000;
+  }
+
+  .t-editor__button {
+    min-width: 160px;
+    justify-content: center;
+  }
+
+  .api-client-hero-image {
+    margin-top: 32px;
+  }
+
+  .feature-container {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 48px;
+    row-gap: 36px;
+    margin-top: 32px;
+  }
+
+  @media screen and (max-width: 1000px) {
+    .feature-container {
+      grid-template-columns: 1fr;
+      row-gap: 28px;
+    }
+  }
+</style>

--- a/documentation/guides/introduction.md
+++ b/documentation/guides/introduction.md
@@ -253,7 +253,7 @@
           Linux, Windows, macOS
         </b>
       </div>
-      <a class="mt-3 t-editor__anchor" href="/products/api-client/getting-started" aria-label="Send your first API request with Scalar">Send Your First Request →</a>
+      <a class="mt-3 t-editor__anchor" href="/products/api-client" aria-label="Send your first API request with Scalar">Send Your First Request →</a>
     </div>
     <div class="product-image">
       <div class="product-image-transform">

--- a/documentation/migration/api-hub.md
+++ b/documentation/migration/api-hub.md
@@ -85,7 +85,7 @@ Configure automatic deployment (publish when a branch is merged into your main b
 
 ## How to migrate from API Hub Explore to Scalar
 
-Scalar's API client is a direct replacement for API Hub Explore. Both you and your end users can get a version of it by clicking **Test Request** in the API reference or by going to the [API client page](https://client.scalar.com/). You can also [download a desktop version](../guides/app/getting-started.md).
+Scalar's API client is a direct replacement for API Hub Explore. Both you and your end users can get a version of it by clicking **Test Request** in the API reference or by going to the [API client page](https://client.scalar.com/). You can also [download a desktop version](../guides/app/download.md).
 
 Just like API Hub Explore, you can import existing API docs into the API client to get all the endpoints set up for testing. Once you have these, you can modify and send requests, add new routes, and much more to help explore and debug APIs.
 

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -2548,6 +2548,38 @@
                 "mode": "nested",
                 "icon": "phosphor/regular/paper-plane-tilt",
                 "children": {
+                  "/": {
+                    "type": "page",
+                    "title": "API Client",
+                    "filepath": "documentation/guides/app/index.md",
+                    "description": "Modern, open-source API testing client with OpenAPI integration, collections, and a beautiful interface.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/products/api-client"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Modern, open-source API testing client with OpenAPI integration, collections, and a beautiful interface."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "API Client - Open-Source API Testing"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Modern, open-source API testing client with OpenAPI integration, collections, and a beautiful interface."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
                   "getting-started": {
                     "filepath": "documentation/guides/app/getting-started.md",
                     "type": "page",


### PR DESCRIPTION
## Problem

The API Client product had no real page at `/products/api-client` — the URL redirected to `/products/api-client/getting-started`, which contained product marketing content (hero, feature grid) rather than a getting started guide.

## Solution

Same restructure as #9741, applied to API Client:

- **`/products/api-client`** — renamed `getting-started.md` (in `documentation/guides/app/`) to `index.md` and kept the product content there (hero, features, CTA).
- **`/products/api-client/getting-started`** — new true getting started page with the five-step first-request walkthrough, "Import and sync OpenAPI", "Test and automate responses", and next steps. Copy is a starting point for a follow-up copy pass.
- **Config** — added a `"/"` child route on the nested group (the group `page` property only works with `mode: "folder"`), with canonical `https://scalar.com/products/api-client`.
- **Links** — footer and introduction product links now point to `/products/api-client`; the API Hub migration guide's "download a desktop version" link now points at the Download page directly.

Verified with `npx @scalar/cli project check-config`.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not needed: documentation content and scalar.config.json only. -->
- [ ] I added tests. <!-- Not applicable. -->
- [x] I updated the documentation.

## Ticket

Part of #9741

🤖 Generated with [Claude Code](https://claude.com/claude-code)