### PR TITLE
fix(api-reference): keep even heading-to-description spacing in narrow layout

### DIFF
--- a/.changeset/operation-title-narrow-spacing.md
+++ b/.changeset/operation-title-narrow-spacing.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: keep even heading-to-description spacing on the operation title in narrow layouts
+
+The narrow (single-column) operation layout bumped the operation title's bottom margin to 24px, so the gap between the heading and its description no longer matched the 12px used on wider screens. The override is removed so the title keeps the shared 12px spacing at every width.

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -390,10 +390,6 @@ provide(REQUEST_BODY_COMPOSITION_INDEX_SYMBOL, requestBodyCompositionSelection)
     margin-bottom: 4px;
   }
 
-  .operation-title {
-    margin-bottom: 24px;
-  }
-
   .operation-description {
     margin-bottom: 24px;
   }


### PR DESCRIPTION
Cam flagged that the gap between an operation heading and its markdown description looks uneven in the reference. Turns out the narrow (single-column) operation layout was overriding the title's bottom margin up to `24px`, while wide screens use `12px` — so the spacing jumped as soon as the layout collapsed.

This removes that narrow-only override so the operation title keeps the shared `12px` bottom margin at every width.

## Changes

- Drop the `.operation-title { margin-bottom: 24px }` override from the `narrow-references-container` query in `ModernLayout.vue`. The base rule's `12px` now applies everywhere.

Before / After

<img width="49%" alt="CleanShot 2026-07-24 at 14 37 54@2x" src="https://github.com/user-attachments/assets/7fc34a78-2304-442a-b772-d243c0f5f875" />
<img width="49%" alt="CleanShot 2026-07-24 at 14 38 02@2x" src="https://github.com/user-attachments/assets/6677d24b-f753-4209-9b26-f73ce53fb533" />


## Ticket

Fixes [DOC-5879](https://linear.app/api-docs/issue/DOC-5879)
