### PR TITLE
fix(blocks): stop vendoring the themes reset in style.css

### DIFF
--- a/.changeset/blocks-non-vendored-styles.md
+++ b/.changeset/blocks-non-vendored-styles.md
@@ -1,0 +1,7 @@
+---
+'@scalar/blocks': patch
+---
+
+fix: stop vendoring a second copy of the themes reset in the standalone stylesheet
+
+The blocks `style.css` build pulled in `@scalar/components/style.css`, which re-imports `@scalar/themes/style.css` — so the published stylesheet shipped two unlayered copies of the universal reset. Loaded after the other Scalar packages, the late duplicate clobbered component font sizes, padding, and colors. Blocks now composes the lean `@scalar/components/vue-styles.css` instead, matching how `@scalar/api-reference` and `@scalar/components` build their stylesheets, and exposes `./vue-styles.css` alongside `./style.css` and `./tailwind.config.css`.

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -32,16 +32,7 @@
   "exports": {
     "./style.css": "./dist/style.css",
     "./tailwind.config.css": "./dist/styles/tailwind.config.css",
-    "./*.css": {
-      "import": "./dist/*.css",
-      "require": "./dist/*.css",
-      "default": "./dist/*.css"
-    },
-    "./css/*.css": {
-      "import": "./dist/css/*.css",
-      "require": "./dist/css/*.css",
-      "default": "./dist/css/*.css"
-    },
+    "./vue-styles.css": "./dist/vue-styles.css",
     "./code-example": {
       "import": "./dist/code-example/index.js",
       "types": "./dist/code-example/index.d.ts",

--- a/packages/blocks/src/style.css
+++ b/packages/blocks/src/style.css
@@ -1,14 +1,20 @@
 /**
- * Blocks Styles
+ * Blocks Style Generation
+ *
+ * This file is used to generate the Tailwind style
+ * sheet for Scalar Blocks.
  */
 
-@import "@scalar/themes/style.css";
-@import "@scalar/themes/tailwind.css";
+@import "@scalar/themes/style.css"; /* Theme Base Styles and Reset */
+@import "@scalar/themes/tailwind.css"; /* Tailwind Theme + Config */
 
+/* Dependency Vue SFC styles */
+@import "@scalar/components/vue-styles.css";
+
+/* Blocks Tailwind Configuration */
 @import "./styles/tailwind.config.css";
 
+/* Generate the Tailwind Utilities (scoped) */
 .scalar-app {
   @import "tailwindcss/utilities.css";
 }
-
-@import "@scalar/components/style.css";


### PR DESCRIPTION
## What

`@scalar/blocks` shipped its `style.css` as a fat standalone bundle that imported `@scalar/components/style.css` — which itself re-imports `@scalar/themes/style.css`. So the published stylesheet ended up with **two** unlayered copies of the themes universal reset (`:where(.scalar-app) * { font-size: inherit; padding: unset; … }`).

When an app loads blocks' `style.css` *after* the other Scalar packages' `vue-styles.css` (like the Org dashboard's new editor does), the late duplicate reset ties every zero-specificity component rule at (0,0,0) and wins on source order — clobbering font-size, padding, border, and color across api-reference, api-client, and components. That's the root cause of the oversized reference badges in [DOC-5878](https://linear.app/api-docs/issue/DOC-5878).

## The fix

Align blocks with how `@scalar/api-reference` and `@scalar/components` already build their styles — no new machinery, just stop being the odd one out:

- `src/style.css` now composes the **lean** `@scalar/components/vue-styles.css` instead of the fat `@scalar/components/style.css`, so `@scalar/themes` is vendored exactly once.
- Exports now match the siblings' three-CSS shape: `./vue-styles.css` is a first-class export (it was only reachable via a loose `./*.css` wildcard before), alongside `./style.css` (full) and `./tailwind.config.css` (lean). Dropped the `./*.css` / `./css/*.css` wildcards.

The full `style.css` still renders a block standalone — themes (once now), the `ScalarCodeBlock`/hljs highlighting, and the component styles are all still in there.

## Verified

Built `@scalar/blocks` and checked `dist/style.css`:

- universal reset appears **once** (was twice in `0.1.8`)
- `code.hljs` highlighting + component styles still present
- lean `vue-styles.css` (727 B) and `tailwind.config.css` (336 B) both shipped, neither carrying a themes copy

## Ticket

Fixes [DOC-5882](https://linear.app/api-docs/issue/DOC-5882)
Related to [DOC-5878](https://linear.app/api-docs/issue/DOC-5878) — org-side dashboard fix handled separately