### PR TITLE
fix(api-reference): give badge base styles real specificity

### DIFF
--- a/.changeset/badge-specificity.md
+++ b/.changeset/badge-specificity.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: badge base styles no longer rely on zero specificity
+
+The badge base rule was written with `:where(.badge)`, which the scoped-style compiler collapsed to zero specificity, letting any late-loading reset clobber the badge font size, padding, and colors. The base styles now carry real specificity, and consumers that intentionally override them (the download-link json/yaml badges and the webhook badge) keep winning through tailwind-merge and higher-specificity variant rules.

--- a/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.vue
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/DownloadLink.vue
@@ -181,7 +181,8 @@ const handleDownloadClick = (format: 'json' | 'yaml') => {
   top: 42px;
 }
 
-.extension {
+/* Scoped to `.badge.extension` so the accent colors override the badge base styles. */
+.badge.extension {
   z-index: 1;
   background: var(--scalar-link-color, var(--scalar-color-accent));
   color: var(--scalar-background-1);

--- a/packages/api-reference/src/components/Badge/Badge.vue
+++ b/packages/api-reference/src/components/Badge/Badge.vue
@@ -1,56 +1,57 @@
 <script setup lang="ts">
+import { useBindCx } from '@scalar/use-hooks/useBindCx'
 import { computed } from 'vue'
 
 const { color } = defineProps<{
   color?: string
 }>()
 
+// Merge fallthrough classes via `cx` so consumer classes can override the base styles.
+defineOptions({ inheritAttrs: false })
+
+const { cx } = useBindCx()
+
 const badgeStyle = computed(() =>
   color
     ? {
-        '--badge-background-color': color,
-        '--badge-text-color': `color-mix(in srgb, ${color}, black 40%)`,
+        backgroundColor: color,
+        color: `color-mix(in srgb, ${color}, black 40%)`,
       }
-    : {},
+    : undefined,
 )
 </script>
 
 <template>
   <div
-    class="badge"
+    v-bind="
+      cx(
+        'badge inline-block rounded-2xl border bg-b-2 px-1.5 py-0.5 text-c-2 text-sm',
+      )
+    "
     :style="badgeStyle">
     <slot />
   </div>
 </template>
 
 <style scoped>
-:where(.badge) {
-  color: var(--badge-text-color, var(--scalar-color-2));
-  font-size: var(--scalar-mini);
-  background: var(--badge-background-color, var(--scalar-background-2));
-  border: var(--scalar-border-width) solid
-    var(--badge-border-color, var(--scalar-border-color));
-  padding: 2px 6px;
-  border-radius: 12px;
-  display: inline-block;
-}
-:where(.badge).text-orange {
+/* Colour variants are keyed on the `text-*` class a consumer passes in. */
+.badge.text-orange {
   background: color-mix(in srgb, var(--scalar-color-orange), transparent 90%);
   border: transparent;
 }
-:where(.badge).text-yellow {
+.badge.text-yellow {
   background: color-mix(in srgb, var(--scalar-color-yellow), transparent 90%);
   border: transparent;
 }
-:where(.badge).text-red {
+.badge.text-red {
   background: color-mix(in srgb, var(--scalar-color-red), transparent 90%);
   border: transparent;
 }
-:where(.badge).text-purple {
+.badge.text-purple {
   background: color-mix(in srgb, var(--scalar-color-purple), transparent 90%);
   border: transparent;
 }
-:where(.badge).text-green {
+.badge.text-green {
   background: color-mix(in srgb, var(--scalar-color-green), transparent 90%);
   border: transparent;
 }


### PR DESCRIPTION
The badge base styles were written as `:where(.badge) { … }`. The intent was `(0,1,0)`, but Vue's scoped-style compiler hoists the scope attribute *inside* the `:where()`, so it actually resolves to **zero specificity** — meaning any late-loading reset or matching rule clobbers the badge's font size, padding, and colors. That's what surfaced in the dashboard editor, where badges rendered at ~16px.

## What changed

- **`Badge.vue`** — rewrote the base styles onto the element as Tailwind utilities via `useBindCx`, so they carry real specificity *and* consumers can override them cleanly through tailwind-merge (no cascade war). The base is now `inline-block rounded-2xl border bg-b-2 px-1.5 py-0.5 text-c-2 text-sm` — each maps to the exact original value.
- The `--badge-*` CSS-var indirection is gone (nothing else referenced it); the `color` prop now sets `background-color`/`color` directly via inline style.
- The five `.text-*` colour variants stay in scoped CSS but are now `.badge.text-*` `(0,3,0)`, since they react to a class the *consumer* passes and can't be plain utilities.
- **`DownloadLink.vue`** — one-line bump so the json/yaml badge's accent colors (`.badge.extension`) keep winning over the base.

No consumer template changes needed — the webhook badge (`flex`) and download badges (`hidden group-hover:flex`) keep working because tailwind-merge collapses the conflicting `display` utility instead of fighting it in the cascade.

## Visual

*No visible change intended — badges render identically.*

## Ticket

Fixes [DOC-5883](https://linear.app/api-docs/issue/DOC-5883)