### PR TITLE
fix(api-reference): adapt info links to container width instead of viewport

### DIFF
--- a/.changeset/info-links-narrow-container.md
+++ b/.changeset/info-links-narrow-container.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: adapt the info links to the rendered width of the reference instead of the viewport
+
+The introduction's info links (contact, license, terms of service, external docs, and `x-scalar-links`), the section header grid, and the classic-layout selector cards switched their layout based on viewport media queries, while the rest of the reference adapts to the rendered width of the reference through the `narrow-references-container` container query. They now restyle based on the container as well, through a new `narrow:` Tailwind variant.

--- a/packages/api-reference/src/blocks/scalar-info-block/components/IntroductionCard.vue
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/IntroductionCard.vue
@@ -22,38 +22,32 @@ const { row } = defineProps<{
 .introduction-card-row {
   gap: 24px;
 }
-/* Classic layout */
-@media (min-width: 600px) {
-  .introduction-card-row {
-    flex-flow: row wrap;
-  }
+/*
+ * Classic layout: a row of cards that stacks when the reference is narrow.
+ * The reference is an embeddable widget, so the cards adapt to its rendered
+ * width (see Content.vue), not to the viewport.
+ */
+.introduction-card-row {
+  flex-flow: row wrap;
 }
 .introduction-card-row > * {
   flex: 1;
+  min-width: min-content;
 }
-@media (min-width: 600px) {
-  .introduction-card-row > * {
-    min-width: min-content;
-  }
-}
-@media (max-width: 600px) {
-  .introduction-card-row > * {
-    max-width: 100%;
-  }
-}
-@container (max-width: 900px) {
+@container narrow-references-container (max-width: 900px) {
   .introduction-card-row {
     flex-direction: column;
     align-items: stretch;
-    gap: 0px;
+    gap: 0;
+  }
+  .introduction-card-row > * {
+    min-width: auto;
+    max-width: 100%;
   }
 }
 .introduction-card :deep(.security-scheme-label) {
   text-transform: uppercase;
   font-weight: var(--scalar-semibold);
-}
-.introduction-card-row :deep(.scalar-card:nth-of-type(2) .scalar-card-header) {
-  display: none;
 }
 .introduction-card-row :deep(.scalar-card:nth-of-type(2) .scalar-card-header) {
   display: none;

--- a/packages/api-reference/src/blocks/scalar-info-block/components/IntroductionLoading.vue
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/IntroductionLoading.vue
@@ -18,17 +18,18 @@ const { hasAside = true } = defineProps<{
 
 <template>
   <div
-    class="introduction-loading flex flex-col gap-5"
-    aria-hidden="true">
+    aria-hidden="true"
+    class="introduction-loading flex flex-col gap-5">
     <!-- Version and specification badges -->
     <div class="flex gap-1.5">
       <div class="introduction-skeleton h-6 w-14 rounded-full" />
       <div class="introduction-skeleton h-6 w-24 rounded-full" />
     </div>
-    <!-- Title and links (mirrors SectionHeader's two-column grid at xl) -->
-    <div class="grid grid-cols-1 gap-3 xl:grid-cols-2 xl:gap-12">
+    <!-- Title and links (mirrors SectionHeader's two-column grid on wide references) -->
+    <div class="narrow:grid-cols-1 narrow:gap-3 grid grid-cols-2 gap-12">
       <div class="introduction-skeleton h-9 w-3/5 rounded-lg" />
-      <div class="flex flex-wrap items-center gap-2 xl:justify-end">
+      <div
+        class="narrow:justify-start flex flex-wrap items-center justify-end gap-2">
         <div class="introduction-skeleton h-5 w-28 rounded" />
         <div class="introduction-skeleton h-5 w-28 rounded" />
         <div class="introduction-skeleton h-5 w-12 rounded" />
@@ -62,7 +63,7 @@ const { hasAside = true } = defineProps<{
     <!-- Classic layout: selector cards in a row below the description -->
     <div
       v-if="!hasAside"
-      class="flex flex-col gap-3 sm:flex-row sm:gap-6">
+      class="narrow:flex-col narrow:gap-3 flex gap-6">
       <div class="introduction-skeleton h-28 w-full flex-1 rounded-lg" />
       <div class="introduction-skeleton h-28 w-full flex-1 rounded-lg" />
       <div class="introduction-skeleton h-28 w-full flex-1 rounded-lg" />

--- a/packages/api-reference/src/components/LinkList/LinkList.vue
+++ b/packages/api-reference/src/components/LinkList/LinkList.vue
@@ -56,8 +56,8 @@ onUnmounted(() => {
 <template>
   <div
     ref="containerRef"
-    :class="{ 'icons-only': needsScroll }"
-    class="custom-scroll mb-3 flex h-auto min-h-8 max-w-full items-center gap-2 overflow-x-auto text-base whitespace-nowrap xl:mb-1.5">
+    class="custom-scroll narrow:mb-3 mb-1.5 flex h-auto min-h-8 max-w-full items-center gap-2 overflow-x-auto text-base whitespace-nowrap"
+    :class="{ 'icons-only': needsScroll }">
     <slot />
   </div>
 </template>

--- a/packages/api-reference/src/components/Section/SectionHeader.vue
+++ b/packages/api-reference/src/components/Section/SectionHeader.vue
@@ -6,7 +6,12 @@ const { tight, removeMargin = false } = defineProps<{
 </script>
 
 <template>
-  <div class="section-header-wrapper xl:gap-12">
+  <!-- The reference is an embeddable widget, so the header collapses based on
+       the rendered width of the reference (the narrow: variant), not the
+       viewport. The section-header-wrapper class stays as a styling hook for
+       SectionContainerAccordion. -->
+  <div
+    class="section-header-wrapper narrow:grid-cols-1 narrow:gap-0 grid grid-cols-2 gap-12">
     <div
       class="section-header"
       :class="{ tight, 'mb-3': !removeMargin }">
@@ -19,19 +24,6 @@ const { tight, removeMargin = false } = defineProps<{
 </template>
 
 <style scoped>
-@reference "@/style.css";
-
-.section-header-wrapper {
-  display: grid;
-  grid-template-columns: 1fr;
-}
-
-@variant xl {
-  .section-header-wrapper {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
 .section-header {
   font-size: var(--font-size, var(--scalar-heading-1));
   font-weight: var(--font-weight, var(--scalar-bold));

--- a/packages/api-reference/src/components/Section/SectionHeader.vue
+++ b/packages/api-reference/src/components/Section/SectionHeader.vue
@@ -5,11 +5,13 @@ const { tight, removeMargin = false } = defineProps<{
 }>()
 </script>
 
+<!--
+  The reference is an embeddable widget, so the header collapses based on the
+  rendered width of the reference (the narrow: variant), not the viewport.
+  The section-header-wrapper class stays as a styling hook for
+  SectionContainerAccordion.
+-->
 <template>
-  <!-- The reference is an embeddable widget, so the header collapses based on
-       the rendered width of the reference (the narrow: variant), not the
-       viewport. The section-header-wrapper class stays as a styling hook for
-       SectionContainerAccordion. -->
   <div
     class="section-header-wrapper narrow:grid-cols-1 narrow:gap-0 grid grid-cols-2 gap-12">
     <div

--- a/packages/api-reference/src/features/external-docs/ExternalDocs.vue
+++ b/packages/api-reference/src/features/external-docs/ExternalDocs.vue
@@ -10,23 +10,23 @@ defineProps<{
 <template>
   <template v-if="value">
     <div
-      class="group flex items-center last:border-r-0 xl:border-r xl:first:ml-auto">
+      class="group narrow:border-r-0 narrow:first:ml-0 flex items-center border-r first:ml-auto last:border-r-0">
       <a
+        class="text-c-1 hover:bg-b-2 narrow:border mr-2 flex min-h-7 min-w-7 items-center rounded-lg px-2 py-1 no-underline group-last:mr-0"
         :href="value.url"
-        class="text-c-1 hover:bg-b-2 mr-2 flex min-h-7 min-w-7 items-center rounded-lg border px-2 py-1 no-underline group-last:mr-0 xl:border-none"
-        target="_blank"
-        rel="noopener noreferrer">
+        rel="noopener noreferrer"
+        target="_blank">
         <ScalarIconBook
-          weight="bold"
-          class="size-3 text-current" />
+          class="size-3 text-current"
+          weight="bold" />
         <span
-          class="ml-1 empty:hidden"
-          v-if="value.description">
+          v-if="value.description"
+          class="ml-1 empty:hidden">
           {{ value.description }}
         </span>
         <span
-          class="ml-1 empty:hidden"
-          v-else>
+          v-else
+          class="ml-1 empty:hidden">
           {{ value.url }}
         </span>
       </a>

--- a/packages/api-reference/src/features/info-object/Contact.vue
+++ b/packages/api-reference/src/features/info-object/Contact.vue
@@ -3,18 +3,18 @@ import { ScalarIconEnvelopeSimple, ScalarIconLink } from '@scalar/icons'
 import { cva } from '@scalar/use-hooks/useBindCx'
 import type { ContactObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
+defineProps<{
+  value?: ContactObject
+}>()
+
 const variants = cva({
-  base: 'text-c-1 mr-2 flex min-h-7 min-w-7 items-center rounded-lg border px-2 py-1 group-last:mr-0 xl:border-none',
+  base: 'text-c-1 mr-2 flex min-h-7 min-w-7 items-center rounded-lg px-2 py-1 group-last:mr-0 narrow:border',
   variants: {
     link: {
       true: 'no-underline hover:bg-b-2',
     },
   },
 })
-
-defineProps<{
-  value?: ContactObject
-}>()
 </script>
 
 <template>
@@ -22,27 +22,27 @@ defineProps<{
     <!-- Each link gets its own wrapper so the dividers render between them -->
     <div
       v-if="value.email"
-      class="group flex items-center last:border-r-0 xl:border-r xl:first:ml-auto">
+      class="group narrow:border-r-0 narrow:first:ml-0 flex items-center border-r first:ml-auto last:border-r-0">
       <a
         :class="variants({ link: true })"
         :href="`mailto:${value.email}`">
         <ScalarIconEnvelopeSimple
-          weight="bold"
-          class="size-3 text-current" />
+          class="size-3 text-current"
+          weight="bold" />
         <span class="ml-1 empty:hidden">{{ value.name }}</span>
       </a>
     </div>
     <div
       v-if="value.url"
-      class="group flex items-center last:border-r-0 xl:border-r xl:first:ml-auto">
+      class="group narrow:border-r-0 narrow:first:ml-0 flex items-center border-r first:ml-auto last:border-r-0">
       <a
         :class="variants({ link: true })"
         :href="value.url"
         rel="noopener noreferrer"
         target="_blank">
         <ScalarIconLink
-          weight="bold"
-          class="size-3 text-current" />
+          class="size-3 text-current"
+          weight="bold" />
         <!-- Avoid repeating the name when the email link already shows it -->
         <span class="ml-1 empty:hidden">{{
           value.email ? '' : value.name
@@ -51,7 +51,7 @@ defineProps<{
     </div>
     <div
       v-else-if="!value.email && value.name"
-      class="group flex items-center last:border-r-0 xl:border-r xl:first:ml-auto">
+      class="group narrow:border-r-0 narrow:first:ml-0 flex items-center border-r first:ml-auto last:border-r-0">
       <span :class="variants({ link: false })">
         {{ value.name }}
       </span>

--- a/packages/api-reference/src/features/info-object/InfoLink.vue
+++ b/packages/api-reference/src/features/info-object/InfoLink.vue
@@ -9,15 +9,15 @@ defineProps<{
 
 <template>
   <div
-    class="group flex items-center last:border-r-0 xl:border-r xl:first:ml-auto">
+    class="group narrow:border-r-0 narrow:first:ml-0 flex items-center border-r first:ml-auto last:border-r-0">
     <a
-      class="text-c-1 hover:bg-b-2 mr-2 flex min-h-7 min-w-7 items-center rounded-lg border px-2 py-1 no-underline group-last:mr-0 xl:border-none"
+      class="text-c-1 hover:bg-b-2 narrow:border mr-2 flex min-h-7 min-w-7 items-center rounded-lg px-2 py-1 no-underline group-last:mr-0"
       :href="url"
-      target="_blank"
-      rel="noopener noreferrer">
+      rel="noopener noreferrer"
+      target="_blank">
       <ScalarIconLink
-        weight="bold"
-        class="size-3 text-current" />
+        class="size-3 text-current"
+        weight="bold" />
       <span class="ml-1 empty:hidden">{{ name }}</span>
     </a>
   </div>

--- a/packages/api-reference/src/features/info-object/License.vue
+++ b/packages/api-reference/src/features/info-object/License.vue
@@ -10,10 +10,10 @@ defineProps<{
 
 <template>
   <div
-    class="group flex h-fit items-center last:border-r-0 xl:border-r xl:first:ml-auto">
+    class="group narrow:border-r-0 narrow:first:ml-0 flex h-fit items-center border-r first:ml-auto last:border-r-0">
     <a
       v-if="value?.url"
-      class="text-c-1 hover:bg-b-2 mr-2 flex min-h-7 min-w-7 items-center rounded-lg border px-2 py-1 no-underline group-last:mr-0 xl:border-none"
+      class="text-c-1 hover:bg-b-2 narrow:border mr-2 flex min-h-7 min-w-7 items-center rounded-lg px-2 py-1 no-underline group-last:mr-0"
       :href="value.url"
       rel="noopener noreferrer"
       target="_blank">

--- a/packages/api-reference/src/features/info-object/TermsOfService.vue
+++ b/packages/api-reference/src/features/info-object/TermsOfService.vue
@@ -13,9 +13,9 @@ const { translate } = useLocalization()
 <template>
   <template v-if="value">
     <div
-      class="group flex items-center last:border-r-0 xl:border-r xl:first:ml-auto">
+      class="group narrow:border-r-0 narrow:first:ml-0 flex items-center border-r first:ml-auto last:border-r-0">
       <a
-        class="text-c-1 hover:bg-b-2 mr-2 flex min-h-7 min-w-7 items-center rounded-lg border px-2 py-1 no-underline group-last:mr-0 xl:border-none"
+        class="text-c-1 hover:bg-b-2 narrow:border mr-2 flex min-h-7 min-w-7 items-center rounded-lg px-2 py-1 no-underline group-last:mr-0"
         :href="value"
         rel="noopener noreferrer"
         target="_blank">

--- a/packages/api-reference/src/styles/tailwind.config.css
+++ b/packages/api-reference/src/styles/tailwind.config.css
@@ -17,3 +17,19 @@
 
 /* Search for Tailwind classes in the API Reference */
 @source "../";
+
+/**
+ * Narrow reference variant
+ *
+ * The API reference is an embeddable widget, so responsive styles must adapt
+ * to the rendered width of the reference, never to the viewport. This variant
+ * is the utility-class counterpart of the raw
+ * `@container narrow-references-container (max-width: 900px)` blocks used in
+ * scoped styles — the query is identical, so the two idioms can never
+ * disagree. The container itself is declared in Content.vue.
+ */
+@custom-variant narrow {
+  @container narrow-references-container (max-width: 900px) {
+    @slot;
+  }
+}


### PR DESCRIPTION
The reference is an embeddable widget, so everything inside it should adapt to its rendered width — the `narrow-references-container` query — not the browser window. The introduction's info links were the holdout: they restyled on viewport `xl:` breakpoints (1200px in our theme), so they never respected narrow references mode. Sidebar open on a laptop → wide inline links crammed into a narrow column; wide reference embedded in a small window → stuck in pill mode.

## Changes

- Adds a `narrow:` Tailwind variant to the api-reference tailwind config — the utility-class counterpart of the raw `@container narrow-references-container (max-width: 900px)` blocks. Identical query, so the two idioms can never disagree.
- Converts the links chain from mobile-first `xl:` to desktop-first `narrow:` overrides, matching how the rest of the reference's container CSS is written:
  - `SectionHeader.vue` — title/links grid is now `grid-cols-2 gap-12 narrow:grid-cols-1 narrow:gap-0` (the scoped `@variant xl` block is gone)
  - `ExternalDocs` / `Contact` / `License` / `TermsOfService` / `InfoLink` — pill chips when narrow, borderless inline links with dividers and right alignment when wide
  - `LinkList.vue` — row margin
  - `IntroductionLoading.vue` — skeleton mirrors, including the classic card row that previously flipped on `sm:` viewport while the real cards flipped on the container
- `IntroductionCard.vue` — the `@media 600px` rules were redundant once everything keys on the container (container > 900px implies viewport ≥ 600px), so they fold into the named `@container` block. Also drops a duplicated `:deep` rule.

The icons-only overflow collapse in `LinkList` still re-checks on window resize only — left as-is on purpose, tracked on the ticket.

## Visual

Should look the same just work better in when the references are rendered narrower than the browser window.

## Ticket

Fixes [DOC-5884](https://linear.app/api-docs/issue/DOC-5884)
