### PR TITLE
docs(docs): tighten Docs product page intro

### DIFF
--- a/documentation/guides/docs/index.md
+++ b/documentation/guides/docs/index.md
@@ -1,8 +1,6 @@
 # Scalar Docs
 
-Documentation that stays in sync with your API and code. Pull content from GitHub, get previews on every pull request, deploy on merge, or publish from anywhere with the CLI.
-
-The site you are reading was built with Docs. Teams use it to combine product guides, API references, OpenAPI-powered search, and release-ready developer portals in one place.
+Product guides and API references in one developer portal. Write in Markdown or MDX, pull content from GitHub, preview every pull request, and deploy on merge or from anywhere with the CLI, so your docs stay in sync with your code. All of scalar.com is fully built with Scalar Docs.
 
 <div class="flex gap-2">
   <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get Started</a>


### PR DESCRIPTION
Merges the two intro paragraphs on `/products/docs` into one.

- Leads with what you get — product guides and API references in one developer portal
- Mentions MDX alongside Markdown, since the Docs guides cover it extensively (`content/mdx.mdx` plus the whole `components/` set)
- Drops the "OpenAPI-powered search" claim — search isn't powered by OpenAPI
- Moves "stays in sync with your code" onto the GitHub → preview → deploy sentence, where it's the payoff rather than an abstract opener
- Replaces "the site you are reading was built with Docs" with the stronger "All of scalar.com is fully built with Scalar Docs"

### Before

> Documentation that stays in sync with your API and code. Pull content from GitHub, get previews on every pull request, deploy on merge, or publish from anywhere with the CLI.
>
> The site you are reading was built with Docs. Teams use it to combine product guides, API references, OpenAPI-powered search, and release-ready developer portals in one place.

### After

> Product guides and API references in one developer portal. Write in Markdown or MDX, pull content from GitHub, preview every pull request, and deploy on merge or from anywhere with the CLI, so your docs stay in sync with your code. All of scalar.com is fully built with Scalar Docs.

Copy-only change to `documentation/`, so no changeset — nothing published ships from this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation copy only under `documentation/`; no runtime, API, or published package changes.
> 
> **Overview**
> **Copy-only update** to the Scalar Docs product intro in `documentation/guides/docs/index.md`: two opening paragraphs are merged into one tighter block.
> 
> The new lead emphasizes **product guides and API references in one developer portal**, adds **Markdown or MDX**, and keeps the GitHub → PR preview → deploy/CLI flow with **“stays in sync with your code”** as the closing payoff. It **drops the inaccurate “OpenAPI-powered search”** line and swaps the softer “site you are reading” wording for **“All of scalar.com is fully built with Scalar Docs.”** Hero CTAs and the rest of the page are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 967a1b1bf78130803422f350fb035cc297ddfc2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->