### PR TITLE
fix(api-reference): read x-enum-varnames from array items

### DIFF
--- a/.changeset/array-items-enum-varnames.md
+++ b/.changeset/array-items-enum-varnames.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: read enum metadata from array items
+
+When an enum is defined inside an array schema's `items`, the enum values were resolved from `items` but their `x-enum-varnames`, `x-enumNames`, and `x-enumDescriptions` were still read from the outer schema, so the metadata was dropped. Both the values and their metadata are now read from the same schema.

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnums.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnums.test.ts
@@ -134,6 +134,24 @@ describe('SchemaEnumValues', () => {
       expect(wrapper.text()).not.toContain(' = ')
     })
 
+    it('formats enum values with x-enum-varnames from array items', () => {
+      const wrapper = mount(SchemaEnumValues, {
+        props: {
+          value: coerceValue(SchemaObjectSchema, {
+            type: 'array',
+            items: {
+              enum: [1, 2, 3],
+              'x-enum-varnames': ['Pending', 'Approved', 'Rejected'],
+            },
+          }),
+        },
+      })
+
+      expect(wrapper.text()).toContain('1 = Pending')
+      expect(wrapper.text()).toContain('2 = Approved')
+      expect(wrapper.text()).toContain('3 = Rejected')
+    })
+
     it('handles partial varnames arrays gracefully', () => {
       const wrapper = mount(SchemaEnumValues, {
         props: {
@@ -214,6 +232,23 @@ describe('SchemaEnumValues', () => {
       // Should use regular enum list format, not special description format
       expect(wrapper.find('.property-list').exists()).toBe(false)
       expect(wrapper.find('.property-enum-values').exists()).toBe(true)
+    })
+
+    it('renders descriptions from array items', () => {
+      const wrapper = mount(SchemaEnumValues, {
+        props: {
+          value: coerceValue(SchemaObjectSchema, {
+            type: 'array',
+            items: {
+              enum: [100, 200],
+              'x-enum-descriptions': ['User is not authorized', 'Access denied'],
+            },
+          }),
+        },
+      })
+
+      expect(wrapper.text()).toContain('User is not authorized')
+      expect(wrapper.text()).toContain('Access denied')
     })
 
     it('handles missing description arrays gracefully', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaEnums.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaEnums.vue
@@ -23,19 +23,25 @@ const INITIAL_VISIBLE_COUNT = 5
 const THIN_SPACE = '\u2009'
 
 /**
+ * Resolves the schema that carries the enum values.
+ * For arrays, the enum and its x-enum-* metadata live on the items schema, so
+ * both the values and their varnames/descriptions have to be read from there.
+ */
+const enumSchema = computed(() => {
+  if (!value) {
+    return undefined
+  }
+  if (value.enum) {
+    return value
+  }
+  return isArraySchema(value) ? resolve.schema(value.items) : undefined
+})
+
+/**
  * Extracts enum values from the schema object.
  * Handles both direct enum values and nested enum arrays.
  */
-const enumValues = computed(() => {
-  if (!value) {
-    return []
-  }
-  return (
-    value.enum ||
-    (isArraySchema(value) && resolve.schema(value.items)?.enum) ||
-    []
-  )
-})
+const enumValues = computed(() => enumSchema.value?.enum ?? [])
 
 /**
  * Determines if we should show the long enum list UI.
@@ -67,8 +73,9 @@ const getEnumValueDescription = (
   enumValue: any,
   index: number,
 ): string | undefined => {
+  const schema = enumSchema.value
   const descriptions =
-    value?.['x-enumDescriptions'] ?? value?.['x-enum-descriptions']
+    schema?.['x-enumDescriptions'] ?? schema?.['x-enum-descriptions']
 
   if (!descriptions) {
     return undefined
@@ -90,7 +97,8 @@ const getEnumValueDescription = (
  * This supports both x-enum-varnames and x-enumNames extensions.
  */
 const formatEnumValueWithName = (enumValue: any, index: number): string => {
-  const varNames = value?.['x-enum-varnames'] ?? value?.['x-enumNames']
+  const varNames =
+    enumSchema.value?.['x-enum-varnames'] ?? enumSchema.value?.['x-enumNames']
   const varName = Array.isArray(varNames) ? varNames[index] : undefined
   return varName
     ? `${enumValue}${THIN_SPACE}=${THIN_SPACE}${varName}`


### PR DESCRIPTION
## Problem

`x-enum-varnames` (and `x-enumNames` / `x-enumDescriptions`) are ignored when the enum is defined inside an array schema's `items`. The enum values render, but each one shows up as a bare number instead of `1 = Pending`.

`SchemaEnums.vue` resolves the enum values from `items`, but still reads the varnames and descriptions from the outer schema, so the values and their metadata never line up.

## Solution

Resolve the schema that actually carries the enum once, and read the values, varnames, and descriptions all from it. For an array that means the `items` schema; for a scalar it stays the schema itself.

Added tests covering `x-enum-varnames` and `x-enum-descriptions` defined on array `items`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes #9722
