### PR TITLE
fix(openapi-upgrader): keep schema properties named "example" during 3.0 to 3.1 upgrade

### DIFF
--- a/.changeset/upgrade-example-property-name.md
+++ b/.changeset/upgrade-example-property-name.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-upgrader': patch
+---
+
+fix: keep schema properties named "example" during the 3.0 to 3.1 upgrade

--- a/.changeset/upgrade-example-property-name.md
+++ b/.changeset/upgrade-example-property-name.md
@@ -2,4 +2,6 @@
 '@scalar/openapi-upgrader': patch
 ---
 
-fix: keep schema properties named "example" during the 3.0 to 3.1 upgrade
+fix: keep schema members named "example" during the 3.0 to 3.1 upgrade
+
+Members named `example` inside a map of named subschemas (`properties`, `patternProperties`, `$defs`, `definitions`, and `components/schemas`) are names, not the `example` keyword, so they are no longer rewritten into an `examples` array.

--- a/.changeset/upgrade-example-property-name.md
+++ b/.changeset/upgrade-example-property-name.md
@@ -7,5 +7,5 @@ fix: stop the 3.0 to 3.1 upgrade from mangling non-schema nodes
 The upgrade applied its schema transforms to every object node, regardless of where it sat in the document. Three cases are now handled correctly:
 
 - Members named `example` inside a map of named subschemas (`properties`, `patternProperties`, `$defs`, `definitions`, and `components/schemas`) are names, not the `example` keyword, so they are no longer rewritten into an `examples` array.
-- Data held by the `example`, `default`, `const`, and `enum` keywords is left untouched instead of being walked as if it were a schema (which turned `nullable: true` into a type array, collapsed `exclusiveMinimum`, renamed a nested `x-webhooks`, and so on).
+- Data held by the `example`, `default`, `const`, and `enum` keywords, and by an Example Object's `value`, is left untouched instead of being walked as if it were a schema (which turned `nullable: true` into a type array, collapsed `exclusiveMinimum`, renamed a nested `x-webhooks`, and so on).
 - `x-webhooks` is only renamed to `webhooks` at the document root, not wherever a key happens to share that name.

--- a/.changeset/upgrade-example-property-name.md
+++ b/.changeset/upgrade-example-property-name.md
@@ -2,6 +2,10 @@
 '@scalar/openapi-upgrader': patch
 ---
 
-fix: keep schema members named "example" during the 3.0 to 3.1 upgrade
+fix: stop the 3.0 to 3.1 upgrade from mangling non-schema nodes
 
-Members named `example` inside a map of named subschemas (`properties`, `patternProperties`, `$defs`, `definitions`, and `components/schemas`) are names, not the `example` keyword, so they are no longer rewritten into an `examples` array.
+The upgrade applied its schema transforms to every object node, regardless of where it sat in the document. Three cases are now handled correctly:
+
+- Members named `example` inside a map of named subschemas (`properties`, `patternProperties`, `$defs`, `definitions`, and `components/schemas`) are names, not the `example` keyword, so they are no longer rewritten into an `examples` array.
+- Data held by the `example`, `default`, `const`, and `enum` keywords is left untouched instead of being walked as if it were a schema (which turned `nullable: true` into a type array, collapsed `exclusiveMinimum`, renamed a nested `x-webhooks`, and so on).
+- `x-webhooks` is only renamed to `webhooks` at the document root, not wherever a key happens to share that name.

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
@@ -513,6 +513,68 @@ describe('upgradeFromThreeToThreeOne', () => {
         platform: { type: ['string', 'null'] },
       })
     })
+
+    it('does not convert a schema named "example" in components/schemas', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        components: {
+          schemas: {
+            example: { type: 'string', nullable: true },
+            other: { type: 'number' },
+          },
+        },
+      })
+
+      // The 'example' key is a schema name, so it must stay a schema entry, not become an examples array
+      expect(result.components?.schemas).toEqual({
+        example: { type: ['string', 'null'] },
+        other: { type: 'number' },
+      })
+    })
+
+    it('does not convert a "$defs" entry named "example"', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        components: {
+          schemas: {
+            MySchema: {
+              type: 'object',
+              $defs: {
+                example: { type: 'string' },
+              },
+            },
+          },
+        },
+      })
+
+      expect((result.components?.schemas?.MySchema as OpenAPIV3_1.SchemaObject)?.$defs).toEqual({
+        example: { type: 'string' },
+      })
+    })
+
+    it('still converts a real "example" keyword nested under a property named "example"', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        components: {
+          schemas: {
+            MySchema: {
+              type: 'object',
+              properties: {
+                example: { type: 'string', example: 'foo' },
+              },
+            },
+          },
+        },
+      })
+
+      // The outer 'example' stays a property; its inner 'example' keyword still becomes 'examples'
+      expect(result.components?.schemas?.MySchema?.properties).toEqual({
+        example: { type: 'string', examples: ['foo'] },
+      })
+    })
   })
 
   describe('describing File Upload Payloads', () => {

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
@@ -484,6 +484,35 @@ describe('upgradeFromThreeToThreeOne', () => {
         examples: ['John'],
       })
     })
+
+    it('does not convert a schema property named "example"', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        components: {
+          schemas: {
+            MySchema: {
+              type: 'object',
+              properties: {
+                documentation: { type: 'string', nullable: true },
+                example: { type: 'string', nullable: true },
+                platform: { type: 'string', nullable: true },
+              },
+            },
+          },
+        },
+      })
+
+      // The 'example' key is a property name, so it must stay a property, not become an examples array
+      expect(result.components?.schemas?.MySchema?.properties).toEqual({
+        documentation: { type: ['string', 'null'] },
+        example: { type: ['string', 'null'] },
+        platform: { type: ['string', 'null'] },
+      })
+    })
   })
 
   describe('describing File Upload Payloads', () => {

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
@@ -615,6 +615,62 @@ describe('upgradeFromThreeToThreeOne', () => {
         type: 'anything',
       })
     })
+
+    it('does not treat the value of an Example Object as a schema', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        paths: {
+          '/things': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: {
+                    'application/json': {
+                      schema: { type: 'object' },
+                      examples: {
+                        sample: { value: { type: 'string', nullable: true } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+
+      const mediaType = (result.paths?.['/things']?.get?.responses?.['200'] as OpenAPIV3_1.ResponseObject)?.content?.[
+        'application/json'
+      ]
+
+      // The example value is data, so it is preserved verbatim
+      expect((mediaType?.examples?.sample as OpenAPIV3_1.ExampleObject)?.value).toEqual({
+        type: 'string',
+        nullable: true,
+      })
+    })
+
+    it('still upgrades a schema property named "value" inside a schema named "examples"', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        components: {
+          schemas: {
+            examples: {
+              type: 'object',
+              properties: {
+                value: { type: 'string', nullable: true },
+              },
+            },
+          },
+        },
+      })
+
+      // This 'value' is a real schema, not Example Object data, so nullable is still upgraded
+      expect(result.components?.schemas?.examples?.properties?.value).toEqual({ type: ['string', 'null'] })
+    })
   })
 
   describe('upgrading x-webhooks', () => {

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
@@ -575,6 +575,80 @@ describe('upgradeFromThreeToThreeOne', () => {
         example: { type: 'string', examples: ['foo'] },
       })
     })
+
+    it('does not treat data inside an example value as a schema', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        components: {
+          schemas: {
+            MySchema: {
+              type: 'string',
+              example: { type: 'string', nullable: true, exclusiveMinimum: true, minimum: 5, 'x-webhooks': { a: 1 } },
+            },
+          },
+        },
+      })
+
+      // The example is arbitrary data, so it is preserved verbatim inside the examples array
+      expect((result.components?.schemas?.MySchema as OpenAPIV3_1.SchemaObject)?.examples).toEqual([
+        { type: 'string', nullable: true, exclusiveMinimum: true, minimum: 5, 'x-webhooks': { a: 1 } },
+      ])
+    })
+
+    it('does not treat data inside a default value as a schema', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        components: {
+          schemas: {
+            MySchema: {
+              type: 'object',
+              default: { nullable: true, type: 'anything' },
+            },
+          },
+        },
+      })
+
+      expect((result.components?.schemas?.MySchema as OpenAPIV3_1.SchemaObject)?.default).toEqual({
+        nullable: true,
+        type: 'anything',
+      })
+    })
+  })
+
+  describe('upgrading x-webhooks', () => {
+    it('renames x-webhooks to webhooks at the document root', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        'x-webhooks': { onEvent: { post: { responses: { '200': { description: 'ok' } } } } },
+      })
+
+      expect(result.webhooks).toEqual({ onEvent: { post: { responses: { '200': { description: 'ok' } } } } })
+      expect((result as Record<string, unknown>)['x-webhooks']).toBeUndefined()
+    })
+
+    it('does not rename a schema property named x-webhooks', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        components: {
+          schemas: {
+            MySchema: {
+              type: 'object',
+              properties: {
+                'x-webhooks': { type: 'string' },
+              },
+            },
+          },
+        },
+      })
+
+      expect(result.components?.schemas?.MySchema?.properties).toEqual({
+        'x-webhooks': { type: 'string' },
+      })
+    })
   })
 
   describe('describing File Upload Payloads', () => {

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
@@ -97,7 +97,11 @@ const applyChangesToDocument = (schema: UnknownObject, path?: string[]) => {
     return false
   })
 
-  if (schema.example !== undefined && !isInsideExamplesMap) {
+  // A node whose own path ends in 'properties' is a map of named subschemas, so a
+  // key called 'example' is a property name and must not be treated as the schema keyword.
+  const isPropertiesMap = path?.[path.length - 1] === 'properties'
+
+  if (schema.example !== undefined && !isInsideExamplesMap && !isPropertiesMap) {
     if (isSchemaPath(path)) {
       schema.examples = [schema.example]
     } else {

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
@@ -40,6 +40,32 @@ export function isSchemaPath(path: string[] | undefined): boolean {
   return false
 }
 
+// Segments whose value is a map of *named* subschemas. Keys inside these maps are
+// arbitrary names (property names, definition names), never schema keywords.
+const NAMED_SCHEMA_MAP_SEGMENTS = new Set(['properties', 'patternProperties', '$defs', 'definitions'])
+
+/**
+ * Determine if the node at `path` is a map of named subschemas rather than a schema object.
+ *
+ * This matters because the 3.0 to 3.1 upgrade rewrites the `example` keyword into `examples`.
+ * A key called `example` (or `examples`) inside one of these maps is a member *name*, not the
+ * schema keyword, so it must be left untouched.
+ */
+export function isNamedSchemaMap(path: string[] | undefined): boolean {
+  const last = path?.[path.length - 1]
+
+  if (last === undefined) {
+    return false
+  }
+
+  // OpenAPI's named-schema map lives at components/schemas
+  if (last === 'schemas' && path?.[path.length - 2] === 'components') {
+    return true
+  }
+
+  return NAMED_SCHEMA_MAP_SEGMENTS.has(last)
+}
+
 /**
  * Upgrade from OpenAPI 3.0.x to 3.1.1
  *
@@ -86,22 +112,18 @@ const applyChangesToDocument = (schema: UnknownObject, path?: string[]) => {
   // 3. Handle examples
   // Skip conversion if we're already inside an examples map to avoid double nesting
   // Check if 'examples' appears as an exact path segment (not just a substring)
-  // BUT exclude cases where 'examples' is just a schema property name
+  // BUT exclude cases where 'examples' is just a named-schema-map member (e.g. a property named 'examples')
   const isInsideExamplesMap = path?.some((segment, index) => {
-    // Only consider it an examples map if 'examples' is not a schema property name
     if (segment === 'examples' && index > 0) {
-      const parent = path[index - 1]
-      // If parent is 'properties', then 'examples' is just a property name, not an examples map
-      return parent !== 'properties'
+      // If the parent node is a named-schema map, 'examples' is a member name, not an examples map
+      return !isNamedSchemaMap(path.slice(0, index))
     }
     return false
   })
 
-  // A node whose own path ends in 'properties' is a map of named subschemas, so a
-  // key called 'example' is a property name and must not be treated as the schema keyword.
-  const isPropertiesMap = path?.[path.length - 1] === 'properties'
-
-  if (schema.example !== undefined && !isInsideExamplesMap && !isPropertiesMap) {
+  // If the current node is itself a map of named subschemas, a key called 'example' is a
+  // member name (property, $defs entry, components/schemas entry) and not the schema keyword.
+  if (schema.example !== undefined && !isInsideExamplesMap && !isNamedSchemaMap(path)) {
     if (isSchemaPath(path)) {
       schema.examples = [schema.example]
     } else {

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
@@ -66,6 +66,33 @@ export function isNamedSchemaMap(path: string[] | undefined): boolean {
   return NAMED_SCHEMA_MAP_SEGMENTS.has(last)
 }
 
+// Keywords whose value is arbitrary data rather than a schema. The upgrade rules only make
+// sense for schema keywords, so nothing nested under these may be rewritten.
+const DATA_KEYWORDS = new Set(['example', 'default', 'const', 'enum'])
+
+/**
+ * Determine if the node at `path` lives inside a data value rather than a schema.
+ *
+ * The traversal visits every object node, but a value held by keywords like `example` or
+ * `default` is user data, not a schema. Applying the schema transforms to it would mangle it
+ * (turning `nullable: true` into a type array, renaming a nested `x-webhooks`, and so on).
+ */
+export function isInsideDataValue(path: string[] | undefined): boolean {
+  if (!path) {
+    return false
+  }
+
+  for (const [index, segment] of path.entries()) {
+    // Only treat it as data when the keyword is a real keyword. Inside a named-schema map the
+    // same word (e.g. a property literally called `default`) is just a member name.
+    if (DATA_KEYWORDS.has(segment) && !isNamedSchemaMap(path.slice(0, index))) {
+      return true
+    }
+  }
+
+  return false
+}
+
 /**
  * Upgrade from OpenAPI 3.0.x to 3.1.1
  *
@@ -88,6 +115,12 @@ export function upgradeFromThreeToThreeOne(originalContent: UnknownObject) {
 }
 
 const applyChangesToDocument = (schema: UnknownObject, path?: string[]) => {
+  // 0. Bail out inside data values (example, default, const, enum). These hold user data, not a
+  // schema, so none of the schema transforms below apply and running them would corrupt the data.
+  if (isInsideDataValue(path)) {
+    return schema
+  }
+
   // 1. Handle nullable types
   if (schema.type !== undefined && schema.nullable === true) {
     schema.type = [schema.type, 'null']
@@ -200,7 +233,9 @@ const applyChangesToDocument = (schema: UnknownObject, path?: string[]) => {
   }
 
   // 7. Handle x-webhooks
-  if (schema['x-webhooks'] !== undefined) {
+  // `x-webhooks` is a document-root extension, so only rename it there. Anywhere else (a schema
+  // property, an example) a key named `x-webhooks` is unrelated and must be left alone.
+  if (schema['x-webhooks'] !== undefined && (path === undefined || path.length === 0)) {
     schema.webhooks = schema['x-webhooks']
     delete schema['x-webhooks']
   }

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
@@ -88,6 +88,13 @@ export function isInsideDataValue(path: string[] | undefined): boolean {
     if (DATA_KEYWORDS.has(segment) && !isNamedSchemaMap(path.slice(0, index))) {
       return true
     }
+
+    // The `value` of an Example Object (`examples/<name>/value`) holds arbitrary data too.
+    // Require a real examples map two segments up so a property named `value` inside a schema
+    // named `examples` is not mistaken for it.
+    if (segment === 'value' && path[index - 2] === 'examples' && !isNamedSchemaMap(path.slice(0, index - 2))) {
+      return true
+    }
   }
 
   return false

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
@@ -51,7 +51,7 @@ const NAMED_SCHEMA_MAP_SEGMENTS = new Set(['properties', 'patternProperties', '$
  * A key called `example` (or `examples`) inside one of these maps is a member *name*, not the
  * schema keyword, so it must be left untouched.
  */
-export function isNamedSchemaMap(path: string[] | undefined): boolean {
+function isNamedSchemaMap(path: string[] | undefined): boolean {
   const last = path?.[path.length - 1]
 
   if (last === undefined) {
@@ -77,7 +77,7 @@ const DATA_KEYWORDS = new Set(['example', 'default', 'const', 'enum'])
  * `default` is user data, not a schema. Applying the schema transforms to it would mangle it
  * (turning `nullable: true` into a type array, renaming a nested `x-webhooks`, and so on).
  */
-export function isInsideDataValue(path: string[] | undefined): boolean {
+function isInsideDataValue(path: string[] | undefined): boolean {
   if (!path) {
     return false
   }


### PR DESCRIPTION
## Problem

The 3.0 → 3.1 upgrade applies its `example` → `examples` conversion to every object node, with no notion of what kind of node it is. So when a schema has a property literally named `example`, that property gets treated as the `example` schema keyword and rewritten into an `examples` array. A `properties` map like `{ documentation, example, platform }` loses its `example` entry, which reappears as `examples: [...]`.

Fixes #9756

## Solution

Skip the conversion when the current node is a `properties` map, since its keys are property names rather than schema keywords. The `example` keyword only lives inside a schema object, never on the map that holds the named subschemas.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.
