### PR TITLE
fix(config): redirect /products/sdk and /api-client to their real pages

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -114,6 +114,14 @@
           "to": "/products/api-client/download"
         },
         {
+          "from": "/products/sdk",
+          "to": "/products/sdk-generator"
+        },
+        {
+          "from": "/api-client",
+          "to": "/products/api-client"
+        },
+        {
           "from": "/scalar/scalar-docs/getting-started",
           "to": "/products/docs/getting-started"
         },


### PR DESCRIPTION
## What

Adds two entries to `siteConfig.routing.redirects`:

| From | To |
| --- | --- |
| `/products/sdk` | `/products/sdk-generator` |
| `/api-client` | `/products/api-client` |

## Why

Both paths are dead ends today despite having inbound links and third-party citations pointing at them. They surfaced in an AEO/SEO audit of scalar.com as broken URLs.

`/products/sdk` targets `/products/sdk-generator` **directly** rather than `/products/sdks`, which is itself a redirect to `/products/sdk-generator/getting-started` and would create a chain.

## Verification

- `scalar.config.json` parses as valid JSON
- No duplicate `from` paths across all 201 entries
- No redirect chains — every `to` value checked against the full set of `from` values
- Both targets return HTTP 200
- Prettier clean

## Notes

No changeset — `scalar.config.json` is at the repo root, outside `packages/`, `integrations/`, and `projects/`.

Related, but intentionally separate: the underlying soft-404 behaviour (every nonexistent path currently returns HTTP 200 with a "404 Page not found" body) is a platform-level fix tracked elsewhere. These redirects are worth landing regardless, since both paths should resolve to real pages rather than 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only routing changes with no application logic; wrong targets would only affect SEO and inbound links.
> 
> **Overview**
> Adds **two site redirects** in `scalar.config.json` so legacy or shorthand URLs resolve to the live product pages instead of 404s.
> 
> `/products/sdk` now goes to **`/products/sdk-generator`** (single hop, not via `/products/sdks`). **`/api-client`** now goes to **`/products/api-client`**, matching how API Client is routed in navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22b6a1a0ff1d270fb41f234426cf0be591d13a1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->