### PR TITLE
docs(config): lead the site description with docs, SDKs, and MCP servers

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -38,7 +38,7 @@
       "meta": [
         {
           "name": "description",
-          "content": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve."
+          "content": "Create beautiful docs, SDKs and secure MCP servers from your API. Scalar keeps every interface in sync as your API evolves."
         },
         {
           "property": "og:site_name",
@@ -913,7 +913,7 @@
             "filepath": "documentation/guides/introduction.md",
             "title": "Introduction",
             "icon": "phosphor/regular/house",
-            "description": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve.",
+            "description": "Create beautiful docs, SDKs and secure MCP servers from your API. Scalar keeps every interface in sync as your API evolves.",
             "layout": {
               "toc": false,
               "pageTitle": false
@@ -950,7 +950,7 @@
                 },
                 {
                   "property": "og:description",
-                  "content": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve."
+                  "content": "Create beautiful docs, SDKs and secure MCP servers from your API. Scalar keeps every interface in sync as your API evolves."
                 },
                 {
                   "name": "twitter:title",
@@ -958,7 +958,7 @@
                 },
                 {
                   "name": "twitter:description",
-                  "content": "Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve."
+                  "content": "Create beautiful docs, SDKs and secure MCP servers from your API. Scalar keeps every interface in sync as your API evolves."
                 },
                 {
                   "name": "robots",


### PR DESCRIPTION
## What

Replaces the site description:

**Before**
> Industry leading Developer Docs, SDKs, API Client & Registry that your APIs deserve.

**After**
> Create beautiful docs, SDKs and secure MCP servers from your API. Scalar keeps every interface in sync as your API evolves.

## Why

This string is the HTML meta description **and** the first line of `llms.txt`, which makes it the first thing both search engines and language models read about Scalar. An AEO audit flagged the previous line as leading with unfalsifiable positioning ("industry leading", "that your APIs deserve") while omitting what Scalar actually produces.

The new copy names the three outputs and the sync story, matching the language already used on the pricing page ("Ship docs, SDKs, and MCP servers").

## The string lived in four places

All four carried the same copy and are updated together:

| Location | Feeds |
| --- | --- |
| `siteConfig.head.meta` → `description` | HTML meta description |
| `navigation.routes["/"].children[""].description` | **first line of `llms.txt`** |
| homepage route `head.meta` → `og:description` | link previews |
| homepage route `head.meta` → `twitter:description` | link previews |

Updating only the first would have left `llms.txt` and every social preview on the old copy.

## Verification

- `scalar.config.json` parses as valid JSON
- Zero remaining occurrences of the old string
- All four locations confirmed identical
- 123 characters, within meta description limits
- Prettier clean

## Notes

No changeset — `scalar.config.json` is at the repo root, outside `packages/`, `integrations/`, and `projects/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only config changes with no runtime or application logic impact.
> 
> **Overview**
> Updates the global Scalar site description in **`scalar.config.json`** from marketing-heavy copy to product-focused messaging that highlights **docs, SDKs, secure MCP servers**, and keeping interfaces in sync as the API evolves.
> 
> The same new string is applied in **four places** so SEO, LLM-facing content, and social previews stay aligned: site-wide HTML **`meta description`**, the homepage route **`description`** (including **`llms.txt`**), and homepage **`og:description`** / **`twitter:description`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f4f42c0b9910f03638122d6b148516d223a623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->