### PR TITLE
docs(compare): add Scalar vs Mintlify comparison page

### DIFF
--- a/documentation/compare/index.md
+++ b/documentation/compare/index.md
@@ -4,6 +4,9 @@ Find out how Scalar stacks up against the alternatives.
 
 Each guide is written by us, so read it with that in mind. We link every claim we make about another product to their own documentation, pricing page, or public repositories, and we say plainly where they are stronger. If you find something wrong or out of date, [open an issue](https://github.com/scalar/scalar/issues) and we will correct it.
 
+<scalar-page-link filepath="documentation/compare/mintlify.md" title="Mintlify" description="A comparison of Scalar and Mintlify for documentation: licensing, self-hosting, customization, framework integrations, and where each fits in the wider landscape">
+</scalar-page-link>
+
 <scalar-page-link filepath="documentation/compare/fern.md" title="Fern" description="A comparison of Scalar and Fern across documentation and SDK generation: licensing, self-hosting, generated code, framework integrations, and pricing">
 </scalar-page-link>
 

--- a/documentation/compare/mintlify.md
+++ b/documentation/compare/mintlify.md
@@ -1,0 +1,111 @@
+# Scalar vs Mintlify
+
+Mintlify is the best-known documentation platform in this category, and for good reason. If you are evaluating documentation tooling, they belong on your list.
+
+This page is written by Scalar, so read it with that in mind. Every claim we make about Mintlify links to their own documentation or pricing page. If we have something wrong, tell us and we will fix it.
+
+The short version: Mintlify is a hosted documentation platform, and a very good one. Scalar is a platform where the documentation layer is open source, embeddable in the application you already run, and shipped alongside an API client and an SDK generator. Which of those matters more depends entirely on who owns your docs and where they need to live.
+
+## At a glance
+
+| | Scalar | Mintlify |
+| --- | --- | --- |
+| Docs renderer | MIT, self-hostable on any plan | Closed; self-hosting is Enterprise |
+| Entry paid tier | $72/month | $450/month billed annually |
+| Markdown and MDX | Yes | Yes |
+| Framework integrations | 35+ | None |
+| Standalone API client | Yes, open source | No |
+| SDK generation | Native | None — integrates third parties |
+| Localization | — | 30+ locales |
+| Visual editor | Yes | Yes, on every tier |
+| MCP server | Yes | Yes, on every tier |
+
+## Where Mintlify is stronger
+
+We would rather you hear this from us than find out after switching.
+
+**Unlimited seats on a flat price.** Mintlify does not charge per editor — their own documentation states you can [invite any number of members](https://www.mintlify.com/docs/dashboard/roles). For a large writing team, that pricing model is genuinely simpler than per-seat billing, and at a certain team size it wins outright.
+
+**Localization.** Thirty-plus locales with per-language navigation, banners, and footers, productized rather than bolted on. If you ship documentation in multiple languages, this is a real gap on our side.
+
+**Analytics depth.** A native dashboard plus a REST analytics API covering page views, search queries with click-through rates, assistant conversations, and per-page feedback, with sixteen third-party integrations and warehouse streaming on Enterprise. Docs-specific analytics as a first-class product surface is something few competitors match.
+
+**The agent surface is broad and shipped.** An AI writing agent that opens pull requests, scheduled and event-triggered automations, agent skills, `llms.txt` and `llms-full.txt`, and an MCP server on every tier including free. Whatever you make of the positioning, the surface area is large.
+
+**Brand and customer base.** Anthropic, Coinbase, AT&T, HubSpot, Amazon. No feature table neutralizes that, and we are not going to pretend otherwise.
+
+**Free-tier generosity in specific places.** Custom domain, API playground, Git sync, MCP server, and custom CSS and JS all at $0. They also give Pro free to non-commercial open source projects.
+
+## Two corrections
+
+Mintlify publishes two write-ups of Scalar, in their [Swagger alternatives](https://www.mintlify.com/library/best-swagger-docs-alternatives) and [enterprise developer portals](https://www.mintlify.com/library/api-developer-portals-for-enterprise) libraries. They are not hostile, and we appreciate being included. Two things in them are out of date.
+
+**"No MDX or custom component support."** Scalar supports [MDX](https://scalar.com/products/docs/content/mdx) — pages are `.mdx`, with JSX, expressions, imports, and components including `<Callout>`, `<Button>`, and `<Tabs>`. Our own pricing page lists Markdown and MDX on Pro.
+
+**"No native AI-readiness stack."** Scalar ships hosted MCP servers, an AI chat and agent surface, and `llms.txt` generation.
+
+The two pages also disagree with each other. The first says Scalar has no developer portal workflow; the second credits Scalar with SDK generation, an API registry, and an AI chat agent. We mention it only because if you are comparing the two products using their material, you are working from a stale picture of ours.
+
+## Documentation
+
+Both products render OpenAPI into a documentation site with an interactive playground, support Markdown and MDX, generate `llms.txt`, and expose an MCP server. Both have a visual editor. The differences are in ownership and placement.
+
+**Scalar's renderer is MIT licensed.** You get themes and CSS variables, arbitrary custom HTML, CSS, and JavaScript on any page, and the option to fork the renderer if you need behaviour we did not anticipate. Mintlify gives you roughly thirty built-in components and custom React components, which covers most needs — but the renderer is closed, so the ceiling is whatever they expose. Their custom CSS and JS is available on the free tier; white labeling is Enterprise.
+
+**Scalar's docs can live inside your application.** Thirty-five framework integrations — Express, Fastify, Hono, NestJS, Next.js, Nuxt, Laravel, Django, Rails, Go, Rust, ASP.NET Core, Spring Boot and more. You mount the reference inside the app you already run, at whatever route you choose.
+
+Mintlify has no framework middleware. It is a hosted documentation site, with an Astro build-time integration as the closest alternative. This is not a criticism — it is a different product shape, and if you want a standalone docs site it is the simpler one.
+
+**Self-hosting terms differ sharply.** Scalar's renderer is MIT and self-hostable on any plan. Mintlify's [self-hosting requires Enterprise](https://www.mintlify.com/docs/deploy/self-host), is scoped as an engagement with your account team rather than a self-serve install, and they document sizing at roughly 45 to 60 vCPU and 160 to 220 GB of memory.
+
+**The site you are reading is the product.** scalar.com — this page, the pricing page, the guides, the API reference, and the blog — is built and hosted entirely on Scalar Docs from a single `scalar.config.json`. We do not maintain a separate marketing stack.
+
+## The API client
+
+Scalar ships a standalone, open-source API client — desktop and web, offline-first, with environments, Postman-compatible scripting, and code generation for 40+ HTTP clients. Mintlify's playground lives inside the documentation site only; there is no separate client to download.
+
+To be precise about this: Mintlify's in-page playground is capable, and "no API client" does not mean "no API testing." The difference is whether your users get a tool they can keep using once they have left the docs.
+
+## SDKs, and the dependency question
+
+Mintlify does not generate SDKs. They render code samples produced by other vendors — [Speakeasy](https://www.mintlify.com/docs/integrations/sdks/speakeasy) and [Stainless](https://www.mintlify.com/docs/integrations/sdks/stainless).
+
+That integration model works well right up until a dependency disappears. Stainless [announced in May 2026](https://www.stainless.com/blog/stainless-is-joining-anthropic) that they are joining Anthropic and winding down their hosted products, including the SDK generator, with new signups closed. Mintlify's Stainless integration page is still live.
+
+We raise this because it is the structural difference, not to score a point. When docs and SDKs come from separate vendors, your documentation's code samples depend on a company you did not choose and cannot control. Scalar generates both from the same OpenAPI document, in the same run.
+
+If you are on Stainless today, we have a [migration guide](/resources/migration/stainless).
+
+## The wider landscape
+
+Mintlify is not your only alternative, and the category has moved considerably in the last year.
+
+| | Scalar | Mintlify | Fern | Stainless |
+| --- | --- | --- | --- | --- |
+| Status | Independent | Independent | Acquired by Postman, Jan 2026 | Winding down |
+| Docs renderer | MIT | Closed | Not public | Astro, self-hostable |
+| SDK generation | Native | None | Native, 9 languages | Winding down |
+| Self-hosting | Any plan | Enterprise | Enterprise | Yes |
+| Framework integrations | 35+ | None | None | None |
+| Standalone API client | Yes | No | No | No |
+| Entry paid tier | $72/mo | $450/mo | $150/mo | Not available |
+
+**Fern** was [acquired by Postman](https://buildwithfern.com/post/postman-acquires-fern) in January 2026. They say the product and roadmap are unchanged. Their SDK generators are genuinely Apache-2.0 and their protocol support is broader than ours — AsyncAPI, gRPC, and OpenRPC alongside OpenAPI. Their docs renderer is not public. We compare in more detail on our [Fern page](/resources/compare/fern).
+
+**Stainless** is winding down following the Anthropic acquisition. Their docs platform never left public beta. Existing customers keep the SDKs they generated; what stops is regeneration.
+
+**Mintlify versus Fern** is the comparison most buyers in this category actually run, so it is worth being straight about. Fern is cheaper at the entry tier and generates SDKs natively; Mintlify has unlimited seats where Fern caps at two and five, ships versioning and localization on lower tiers, and has the deeper analytics and agent tooling. Both are hosted-only in practice, neither offers framework middleware, and neither ships a standalone API client. Mintlify [publishes their own comparison](https://www.mintlify.com/library/mintlify-vs-fern-which-platform-should-you-choose-for-api-documentation); [so does Fern](https://buildwithfern.com/post/fern-vs-mintlify). Reading both is genuinely more useful than reading either.
+
+The pattern worth noticing: on the two things Scalar treats as core — an open documentation layer you can embed anywhere, and an API client your users keep — none of the three competes.
+
+## Which should you choose?
+
+**Choose Mintlify if** your documentation is owned by a writing or marketing team rather than engineers, you need localization across many languages, you want unlimited editors on a flat price, docs-specific analytics matter to your team, or brand recognition carries weight in your organisation.
+
+**Choose Scalar if** you want a documentation layer you own outright under MIT, you want to self-host without an enterprise contract, you want docs mounted inside your existing application rather than on a separate hosted site, you want SDKs and docs generated from the same document by the same vendor, or you want a real API client alongside your docs.
+
+[Start free](https://dashboard.scalar.com/register) or [talk to us](https://scalar.cal.com/).
+
+---
+
+*This comparison is based on Mintlify's publicly available documentation and pricing page as of July 2026, and on Scalar's own source. Products in this category change quickly. We have made a genuine effort to be accurate and to state where Mintlify is better. If you find something wrong or out of date, please [open an issue](https://github.com/scalar/scalar/issues) and we will correct it.*

--- a/documentation/compare/mintlify.md
+++ b/documentation/compare/mintlify.md
@@ -28,12 +28,6 @@ We would rather you hear this from us than find out after switching.
 
 **Localization.** Thirty-plus locales with per-language navigation, banners, and footers, productized rather than bolted on. If you ship documentation in multiple languages, this is a real gap on our side.
 
-**Analytics depth.** A native dashboard plus a REST analytics API covering page views, search queries with click-through rates, assistant conversations, and per-page feedback, with sixteen third-party integrations and warehouse streaming on Enterprise. Docs-specific analytics as a first-class product surface is something few competitors match.
-
-**The agent surface is broad and shipped.** An AI writing agent that opens pull requests, scheduled and event-triggered automations, agent skills, `llms.txt` and `llms-full.txt`, and an MCP server on every tier including free. Whatever you make of the positioning, the surface area is large.
-
-**Brand and customer base.** Anthropic, Coinbase, AT&T, HubSpot, Amazon. No feature table neutralizes that, and we are not going to pretend otherwise.
-
 **Free-tier generosity in specific places.** Custom domain, API playground, Git sync, MCP server, and custom CSS and JS all at $0. They also give Pro free to non-commercial open source projects.
 
 ## Two corrections
@@ -94,13 +88,13 @@ Mintlify is not your only alternative, and the category has moved considerably i
 
 **Stainless** is winding down following the Anthropic acquisition. Their docs platform never left public beta. Existing customers keep the SDKs they generated; what stops is regeneration.
 
-**Mintlify versus Fern** is the comparison most buyers in this category actually run, so it is worth being straight about. Fern is cheaper at the entry tier and generates SDKs natively; Mintlify has unlimited seats where Fern caps at two and five, ships versioning and localization on lower tiers, and has the deeper analytics and agent tooling. Both are hosted-only in practice, neither offers framework middleware, and neither ships a standalone API client. Mintlify [publishes their own comparison](https://www.mintlify.com/library/mintlify-vs-fern-which-platform-should-you-choose-for-api-documentation); [so does Fern](https://buildwithfern.com/post/fern-vs-mintlify). Reading both is genuinely more useful than reading either.
+**Mintlify versus Fern** is the comparison most buyers in this category actually run, so it is worth being straight about. Fern is cheaper at the entry tier and generates SDKs natively; Mintlify has unlimited seats where Fern caps at two and five, and ships versioning and localization on lower tiers. Both are hosted-only in practice, neither offers framework middleware, and neither ships a standalone API client. Mintlify [publishes their own comparison](https://www.mintlify.com/library/mintlify-vs-fern-which-platform-should-you-choose-for-api-documentation); [so does Fern](https://buildwithfern.com/post/fern-vs-mintlify). Reading both is genuinely more useful than reading either.
 
 The pattern worth noticing: on the two things Scalar treats as core — an open documentation layer you can embed anywhere, and an API client your users keep — none of the three competes.
 
 ## Which should you choose?
 
-**Choose Mintlify if** your documentation is owned by a writing or marketing team rather than engineers, you need localization across many languages, you want unlimited editors on a flat price, docs-specific analytics matter to your team, or brand recognition carries weight in your organisation.
+**Choose Mintlify if** your documentation is owned by a writing or marketing team rather than engineers, you need localization across many languages, or you want unlimited editors on a flat price.
 
 **Choose Scalar if** you want a documentation layer you own outright under MIT, you want to self-host without an enterprise contract, you want docs mounted inside your existing application rather than on a separate hosted site, you want SDKs and docs generated from the same document by the same vendor, or you want a real API client alongside your docs.
 

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -3490,6 +3490,39 @@
                   }
                 },
                 "children": {
+                  "mintlify": {
+                    "type": "page",
+                    "title": "Mintlify",
+                    "filepath": "documentation/compare/mintlify.md",
+                    "description": "Compare Scalar and Mintlify for API documentation: licensing, self-hosting, customization, framework integrations, and pricing.",
+                    "head": {
+                      "title": "Scalar vs Mintlify — API Documentation Comparison",
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/compare/mintlify"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Compare Scalar and Mintlify for API documentation: licensing, self-hosting, customization, framework integrations, and pricing."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Scalar vs Mintlify — API Documentation Comparison"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "An honest comparison of Scalar and Mintlify for API documentation, and how both compare to Fern and Stainless."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
                   "fern": {
                     "type": "page",
                     "title": "Fern",


### PR DESCRIPTION
> **Stacked on #9761.** Based on `claude/compare-fern` so the `/resources/compare` section comes with it rather than conflicting. GitHub will retarget this to `main` automatically once #9761 merges. **Merge #9761 first.**

## What

Adds `/resources/compare/mintlify` as a sibling of the Fern page, listed first on the compare index since Mintlify is the better-known platform.

- `documentation/compare/mintlify.md` (~1,470 words)
- Registered in `scalar.config.json`, listed on the compare index

## Approach

Every claim about Mintlify links to their own documentation or pricing page. All 14 cited URLs were link-checked and return 200.

The page concedes three genuine Mintlify advantages: unlimited seats on a flat price, localization across 30+ locales, and free-tier generosity (custom domain, playground, Git sync, MCP server, and custom CSS/JS at $0).

## The landscape section

This page carries the wider category mapping, since Mintlify-vs-Fern is the comparison most buyers in this category actually run. Includes a four-way table — Scalar, Mintlify, Fern, Stainless — across status, licensing, SDK generation, self-hosting, framework integrations, API client, and entry price, plus notes on where Fern and Stainless now sit after the Postman and Anthropic acquisitions.

The Mintlify-vs-Fern section links to **both** vendors' comparisons of each other and says reading both beats reading either.

## Two corrections to Mintlify's coverage of Scalar

Mintlify publishes two write-ups of Scalar. Both are out of date on the same two points, and both were updated 6 July 2026:

- **"No MDX or custom component support"** — Scalar supports MDX; pages are `.mdx` with JSX, expressions, imports, and components. Links to Scalar's own docs.
- **"No native AI-readiness stack"** — Scalar ships hosted MCP servers, an AI chat and agent surface, and `llms.txt` generation.

Their two pages also contradict each other: one says Scalar has no developer portal workflow, the other credits Scalar with SDK generation, an API registry, and an AI chat agent.

**Deliberately left alone:** Mintlify's figures on Scalar's pricing, which appear to be from an older pricing page. That is being handled directly with Mintlify rather than on this page.

## The structural argument

Mintlify does not generate SDKs — they render samples from Speakeasy and Stainless. Stainless announced in May 2026 that they are winding down, with new signups closed, and Mintlify's Stainless integration page is still live (verified 200 at time of writing).

The page states this as the structural case for generating docs and SDKs from one document by one vendor, explicitly not as a dig, and links to the Stainless migration guide in #9762.

## Worth a reviewer's eye

1. **Localization is conceded outright** as "a real gap on our side." No i18n was found in the Scalar Docs surface. If that is shipped or near, the concession and the at-a-glance row should change.
2. **The at-a-glance price row** shows Scalar Pro at $72/mo against Mintlify Pro at $450/mo without noting that Mintlify's is flat with unlimited editors. The seat difference is explained lower down, but a reader skimming only the table gets a misleading impression, and a large writing team could genuinely be cheaper on Mintlify.

## Not included

The Speakeasy quote describing Scalar's client as "Postman++" was left out despite being the best external articulation of that advantage — Speakeasy discloses a reseller relationship with Scalar, so citing it as independent validation would undercut the page's framing.

## Notes

No changeset — `documentation/` and `scalar.config.json` are outside `packages/`, `integrations/`, and `projects/`.

Carries a dated accuracy disclaimer and invites corrections via GitHub issues.

## Related

- #9761 — Scalar vs Fern, and the `/resources/compare` section this builds on
- #9762 — Stainless migration guide, linked from this page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and `scalar.config.json` navigation only; no runtime or application code changes.
> 
> **Overview**
> Adds a new **Scalar vs Mintlify** comparison at `/resources/compare/mintlify`, wired in `scalar.config.json` with canonical URL and SEO meta, and linked **first** on the compare index (ahead of Fern).
> 
> The page contrasts hosted Mintlify with Scalar’s MIT docs layer, in-app framework integrations, native SDK generation, and standalone API client. It **acknowledges Mintlify strengths** (unlimited flat-price seats, localization, free-tier features), **corrects two outdated claims** in Mintlify’s Scalar write-ups (MDX and AI/MCP), and frames **SDK dependency risk** (Speakeasy/Stainless integrations, Stainless wind-down) with a link to the Stainless migration guide.
> 
> A **wider landscape** section adds a four-way table (Scalar, Mintlify, Fern, Stainless) and short Mintlify-vs-Fern buyer context, with “which to choose” guidance at the end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 232153f3ca1003369c61ff7d2400f4182b81ca4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->