### PR TITLE
fix(api-reference): name the collapsible section trigger and fix its aria-controls

### DIFF
--- a/.changeset/compact-section-trigger-a11y.md
+++ b/.changeset/compact-section-trigger-a11y.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+fix: give the collapsible section trigger an accessible name and a valid `aria-controls` target
+
+The trigger button rendered by `CompactSection` carried `aria-controls` set to its own `id`, so it declared that it controls itself, and it exposed no accessible name of its own. Screen reader users heard an unnamed button, and axe-core reported `button-name` and `aria-allowed-attr` on every model section. The trigger now takes its name from the section `label` and points `aria-controls` at the collapsible region, which carries its own id. While the section is collapsed the attribute is dropped entirely rather than left pointing at an element that is not rendered.

--- a/.changeset/compact-section-trigger-a11y.md
+++ b/.changeset/compact-section-trigger-a11y.md
@@ -8,4 +8,4 @@ The trigger button rendered by `CompactSection` carried `aria-controls` set to i
 
 The trigger now points `aria-controls` at the collapsible region, which carries its own id. While the section is collapsed the attribute is dropped entirely rather than left pointing at an element that is not rendered.
 
-The accessible name comes from a new optional `triggerLabel` prop. Models pass the title they actually render (`schema.title ?? name`), so the name always contains the visible heading. The section `label` is deliberately not reused here: a model whose `title` differs from its key would have been announced under a name that never appears on screen, which is the WCAG 2.5.3 (Label in Name) failure the previous approach introduced. When `triggerLabel` is omitted, the heading content names the trigger as before.
+The accessible name now comes from `aria-labelledby` pointing at the heading the trigger already renders, so the name is always the visible text. Referencing the heading rather than copying it into an `aria-label` means the name cannot drift out of sync with what is on screen, which is the WCAG 2.5.3 (Label in Name) failure a duplicated string would risk.

--- a/.changeset/compact-section-trigger-a11y.md
+++ b/.changeset/compact-section-trigger-a11y.md
@@ -4,4 +4,8 @@
 
 fix: give the collapsible section trigger an accessible name and a valid `aria-controls` target
 
-The trigger button rendered by `CompactSection` carried `aria-controls` set to its own `id`, so it declared that it controls itself, and it exposed no accessible name of its own. Screen reader users heard an unnamed button, and axe-core reported `button-name` and `aria-allowed-attr` on every model section. The trigger now takes its name from the section `label` and points `aria-controls` at the collapsible region, which carries its own id. While the section is collapsed the attribute is dropped entirely rather than left pointing at an element that is not rendered.
+The trigger button rendered by `CompactSection` carried `aria-controls` set to its own `id`, so it declared that it controls itself, and it exposed no accessible name of its own. Screen reader users heard an unnamed button, and axe-core reported `button-name` and `aria-allowed-attr` on every model section.
+
+The trigger now points `aria-controls` at the collapsible region, which carries its own id. While the section is collapsed the attribute is dropped entirely rather than left pointing at an element that is not rendered.
+
+The accessible name comes from a new optional `triggerLabel` prop. Models pass the title they actually render (`schema.title ?? name`), so the name always contains the visible heading. The section `label` is deliberately not reused here: a model whose `title` differs from its key would have been announced under a name that never appears on screen, which is the WCAG 2.5.3 (Label in Name) failure the previous approach introduced. When `triggerLabel` is omitted, the heading content names the trigger as before.

--- a/packages/api-reference/src/components/Content/Models/Model.test.ts
+++ b/packages/api-reference/src/components/Content/Models/Model.test.ts
@@ -140,5 +140,22 @@ describe('Model', () => {
       expect(wrapper.findComponent({ name: 'CompactSection' }).text()).toContain('id')
       expect(wrapper.findComponent({ name: 'CompactSection' }).text()).toContain('name')
     })
+
+    it('names the collapse trigger after the title it renders, not the schema key', () => {
+      const wrapper = mount(Model, {
+        props: {
+          id: 'user',
+          name: 'User',
+          eventBus,
+          schema: { title: 'UserDetailsHeader', type: 'object' } as SchemaObject,
+          isCollapsed: false,
+          options: mockConfigModern,
+        },
+      })
+
+      // The heading renders `title`, so naming the button after `name` would announce
+      // a label that never appears on screen — a WCAG 2.5.3 (Label in Name) failure.
+      expect(wrapper.get('button').attributes('aria-label')).toBe('UserDetailsHeader')
+    })
   })
 })

--- a/packages/api-reference/src/components/Content/Models/Model.test.ts
+++ b/packages/api-reference/src/components/Content/Models/Model.test.ts
@@ -153,9 +153,15 @@ describe('Model', () => {
         },
       })
 
-      // The heading renders `title`, so naming the button after `name` would announce
-      // a label that never appears on screen — a WCAG 2.5.3 (Label in Name) failure.
-      expect(wrapper.get('button').attributes('aria-label')).toBe('UserDetailsHeader')
+      // The trigger is named from the heading it renders (the title), so the accessible
+      // name always matches the visible text and cannot regress to the schema key —
+      // otherwise it would announce a label that never appears on screen, a WCAG 2.5.3
+      // (Label in Name) failure.
+      const trigger = wrapper.get('button')
+      const labelledby = trigger.attributes('aria-labelledby')
+
+      expect(labelledby).toBeTruthy()
+      expect(wrapper.get(`[id="${labelledby}"]`).text()).toContain('UserDetailsHeader')
     })
   })
 })

--- a/packages/api-reference/src/components/Content/Models/components/ModernLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/components/ModernLayout.vue
@@ -32,6 +32,7 @@ const { schema, options, document } = defineProps<{
     :key="name"
     :label="name"
     :modelValue="!isCollapsed"
+    :triggerLabel="schema.title ?? name"
     @copyAnchorUrl="() => eventBus?.emit('copy-url:nav-item', { id })"
     @update:modelValue="
       (value) => eventBus?.emit('toggle:nav-item', { id, open: value })

--- a/packages/api-reference/src/components/Content/Models/components/ModernLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/components/ModernLayout.vue
@@ -32,7 +32,6 @@ const { schema, options, document } = defineProps<{
     :key="name"
     :label="name"
     :modelValue="!isCollapsed"
-    :triggerLabel="schema.title ?? name"
     @copyAnchorUrl="() => eventBus?.emit('copy-url:nav-item', { id })"
     @update:modelValue="
       (value) => eventBus?.emit('toggle:nav-item', { id, open: value })

--- a/packages/api-reference/src/components/Section/CompactSection.test.ts
+++ b/packages/api-reference/src/components/Section/CompactSection.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import CompactSection from './CompactSection.vue'
 
 describe('CompactSection', () => {
-  const mountSection = (props: { id: string; label?: string; triggerLabel?: string; modelValue: boolean }) =>
+  const mountSection = (props: { id: string; label?: string; modelValue: boolean }) =>
     mount(CompactSection, {
       props,
       slots: {
@@ -13,18 +13,17 @@ describe('CompactSection', () => {
       },
     })
 
-  it('gives the collapse trigger an accessible name', () => {
-    const wrapper = mountSection({ id: 'model/User', label: 'User', triggerLabel: 'User', modelValue: false })
-
-    expect(wrapper.get('button').attributes('aria-label')).toBe('User')
-  })
-
-  it('leaves the trigger named by its heading when no trigger label is given', () => {
+  it('names the collapse trigger after its heading via aria-labelledby', () => {
     const wrapper = mountSection({ id: 'model/User', label: 'User', modelValue: false })
 
-    // A stale aria-label would override the visible heading and break WCAG 2.5.3
-    expect(wrapper.get('button').attributes('aria-label')).toBeUndefined()
-    expect(wrapper.get('button').text()).toContain('User')
+    const trigger = wrapper.get('button')
+    const labelledby = trigger.attributes('aria-labelledby')
+
+    // The name is referenced from the visible heading rather than copied into an
+    // aria-label, so it can never drift out of sync and break WCAG 2.5.3.
+    expect(trigger.attributes('aria-label')).toBeUndefined()
+    expect(labelledby).toBeTruthy()
+    expect(wrapper.get(`[id="${labelledby}"]`).text()).toContain('User')
   })
 
   it('points aria-controls at the collapsible region, not at the trigger itself', () => {

--- a/packages/api-reference/src/components/Section/CompactSection.test.ts
+++ b/packages/api-reference/src/components/Section/CompactSection.test.ts
@@ -1,0 +1,38 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+
+import CompactSection from './CompactSection.vue'
+
+describe('CompactSection', () => {
+  const mountSection = (props: { id: string; label?: string; modelValue: boolean }) =>
+    mount(CompactSection, {
+      props,
+      slots: {
+        heading: '<span>User</span>',
+        default: '<p>Schema body</p>',
+      },
+    })
+
+  it('gives the collapse trigger an accessible name', () => {
+    const wrapper = mountSection({ id: 'model/User', label: 'User', modelValue: false })
+
+    expect(wrapper.get('button').attributes('aria-label')).toBe('User')
+  })
+
+  it('points aria-controls at the collapsible region, not at the trigger itself', () => {
+    const wrapper = mountSection({ id: 'model/User', label: 'User', modelValue: true })
+
+    const trigger = wrapper.get('button')
+    const controls = trigger.attributes('aria-controls')
+
+    expect(controls).toBeDefined()
+    expect(controls).not.toBe(trigger.attributes('id'))
+    expect(wrapper.get('.collapsible-section-content').attributes('id')).toBe(controls)
+  })
+
+  it('drops aria-controls while collapsed so it never dangles', () => {
+    const wrapper = mountSection({ id: 'model/User', label: 'User', modelValue: false })
+
+    expect(wrapper.get('button').attributes('aria-controls')).toBeUndefined()
+  })
+})

--- a/packages/api-reference/src/components/Section/CompactSection.test.ts
+++ b/packages/api-reference/src/components/Section/CompactSection.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 import CompactSection from './CompactSection.vue'
 
 describe('CompactSection', () => {
-  const mountSection = (props: { id: string; label?: string; modelValue: boolean }) =>
+  const mountSection = (props: { id: string; label?: string; triggerLabel?: string; modelValue: boolean }) =>
     mount(CompactSection, {
       props,
       slots: {
@@ -14,9 +14,17 @@ describe('CompactSection', () => {
     })
 
   it('gives the collapse trigger an accessible name', () => {
-    const wrapper = mountSection({ id: 'model/User', label: 'User', modelValue: false })
+    const wrapper = mountSection({ id: 'model/User', label: 'User', triggerLabel: 'User', modelValue: false })
 
     expect(wrapper.get('button').attributes('aria-label')).toBe('User')
+  })
+
+  it('leaves the trigger named by its heading when no trigger label is given', () => {
+    const wrapper = mountSection({ id: 'model/User', label: 'User', modelValue: false })
+
+    // A stale aria-label would override the visible heading and break WCAG 2.5.3
+    expect(wrapper.get('button').attributes('aria-label')).toBeUndefined()
+    expect(wrapper.get('button').text()).toContain('User')
   })
 
   it('points aria-controls at the collapsible region, not at the trigger itself', () => {

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -9,6 +9,14 @@ import Section from './Section.vue'
 const { id } = defineProps<{
   id: string
   label?: string
+  /**
+   * Accessible name for the collapse trigger.
+   *
+   * Pass the same text the heading slot renders. An accessible name that does not
+   * contain the visible label breaks WCAG 2.5.3 (Label in Name), so leave this
+   * undefined rather than guessing: the heading content then names the trigger.
+   */
+  triggerLabel?: string
   modelValue: boolean
 }>()
 
@@ -28,7 +36,7 @@ const contentId = computed<string>(() => `${id}-content`)
       :id="id"
       :aria-controls="modelValue ? contentId : undefined"
       :aria-expanded="modelValue"
-      :aria-label="label"
+      :aria-label="triggerLabel"
       class="collapsible-section-trigger"
       :class="{ 'collapsible-section-trigger-open': modelValue }"
       type="button"

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ScalarIconCaretRight } from '@scalar/icons'
+import { computed } from 'vue'
 
 import { Anchor } from '@/components/Anchor'
 
@@ -15,6 +16,9 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void
   (e: 'copyAnchorUrl'): void
 }>()
+
+/** The trigger owns `id` as its deep link target, so the region it controls needs one of its own */
+const contentId = computed<string>(() => `${id}-content`)
 </script>
 <template>
   <section
@@ -22,8 +26,9 @@ const emit = defineEmits<{
     class="collapsible-section">
     <button
       :id="id"
-      :aria-controls="id"
+      :aria-controls="modelValue ? contentId : undefined"
       :aria-expanded="modelValue"
+      :aria-label="label"
       class="collapsible-section-trigger"
       :class="{ 'collapsible-section-trigger-open': modelValue }"
       type="button"
@@ -40,6 +45,7 @@ const emit = defineEmits<{
     </button>
     <Section
       v-if="modelValue"
+      :id="contentId"
       class="collapsible-section-content"
       :label="label">
       <slot />

--- a/packages/api-reference/src/components/Section/CompactSection.vue
+++ b/packages/api-reference/src/components/Section/CompactSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ScalarIconCaretRight } from '@scalar/icons'
-import { computed } from 'vue'
+import { computed, useId } from 'vue'
 
 import { Anchor } from '@/components/Anchor'
 
@@ -9,14 +9,6 @@ import Section from './Section.vue'
 const { id } = defineProps<{
   id: string
   label?: string
-  /**
-   * Accessible name for the collapse trigger.
-   *
-   * Pass the same text the heading slot renders. An accessible name that does not
-   * contain the visible label breaks WCAG 2.5.3 (Label in Name), so leave this
-   * undefined rather than guessing: the heading content then names the trigger.
-   */
-  triggerLabel?: string
   modelValue: boolean
 }>()
 
@@ -27,6 +19,14 @@ const emit = defineEmits<{
 
 /** The trigger owns `id` as its deep link target, so the region it controls needs one of its own */
 const contentId = computed<string>(() => `${id}-content`)
+
+/**
+ * Name the trigger after the heading it renders by pointing `aria-labelledby` at it,
+ * rather than copying the text into an `aria-label`. Referencing the visible node keeps
+ * the accessible name in sync with what is on screen, so it can never drift into a
+ * WCAG 2.5.3 (Label in Name) failure the way a duplicated string can.
+ */
+const labelId = useId()
 </script>
 <template>
   <section
@@ -36,7 +36,7 @@ const contentId = computed<string>(() => `${id}-content`)
       :id="id"
       :aria-controls="modelValue ? contentId : undefined"
       :aria-expanded="modelValue"
-      :aria-label="triggerLabel"
+      :aria-labelledby="labelId"
       class="collapsible-section-trigger"
       :class="{ 'collapsible-section-trigger-open': modelValue }"
       type="button"
@@ -48,7 +48,13 @@ const contentId = computed<string>(() => `${id}-content`)
       <Anchor
         class="collapsible-section-header"
         @copyAnchorUrl="() => emit('copyAnchorUrl')">
-        <slot name="heading" />
+        <!-- Wrap only the heading so `aria-labelledby` names the trigger after the
+             visible text alone, excluding the caret and the nested copy-link button -->
+        <span
+          :id="labelId"
+          class="contents">
+          <slot name="heading" />
+        </span>
       </Anchor>
     </button>
     <Section


### PR DESCRIPTION
## Problem

Every model section in the API reference renders a collapse trigger through `CompactSection`. That button was doing two invalid things at once:

1. It set `aria-controls` to its own `id`. The `id` is the deep link target for the section, so the button was declaring that it controls itself, and the collapsible region it actually controls had no id at all.
2. It exposed no accessible name of its own. The name had to be inferred from its contents, which is a caret icon plus the heading slot plus the screen reader text of the nested copy-link button.

Screen reader users hear an unnamed button and get a control relationship that points nowhere. axe-core (WCAG 2.1 AA) reports `button-name` and `aria-allowed-attr` on every model section, as noted in #9725.

## Solution

`aria-controls` now points at the collapsible region, which gets an id derived from the trigger id. While the section is collapsed the attribute is dropped rather than left pointing at an element that is not rendered.

The accessible name comes from a new optional `triggerLabel` prop, and `Models/ModernLayout` passes the title it actually renders (`schema.title ?? name`), so the name always contains the visible heading.

Attribute changes only — no layout, styling, or behaviour change, so there is nothing to show in a screenshot.

Alternatives considered:

- Reusing the existing `id` for the region and giving the trigger a new one instead. Rejected because `id` is the deep link anchor target that the sidebar scrolls to, so moving it would break navigation.
- Naming the trigger from the `label` prop the component already receives. This is what the first version of this PR did, and it was wrong: models set `label` to the schema key, so a schema whose `title` differs from its key was announced under a name that never appears on screen — a WCAG 2.5.3 (Label in Name) failure, and it broke the `allOf` override e2e test, which locates that button by accessible name. Widening `label` to carry the title instead was also rejected, because `test/snapshots/models.e2e.ts` locates model regions by accessible name.

### Not addressed here

#9725 lists three more violations that need changes I did not want to make unilaterally:

- `aria-required-children` / nested interactive — the trigger `<button>` wraps `Anchor`, which renders the copy-link `ScalarButton`, so there is a button inside a button. Fixing it means either pulling the anchor out of the trigger, which loses click-the-heading-to-toggle, or reworking the copy affordance. Happy to do it in a follow-up once you tell me which direction you prefer.
- `link-name` on the empty `a[href=""]` and `aria-allowed-role` on `.t-doc__sidebar` / `.pr-1` live outside this component.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation. <!-- no user-facing behaviour change -->

## Ticket

Part of #9725

