### PR TITLE
fix(workspace-store): read x-scalar-secret extensions on apiKey and http schemes

### DIFF
--- a/.changeset/api-key-http-document-secrets.md
+++ b/.changeset/api-key-http-document-secrets.md
@@ -1,0 +1,7 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: honour document level `x-scalar-secret-*` extensions on apiKey and http security schemes
+
+OAuth flows already read their secrets from the OpenAPI document, but the apiKey and http branches only looked at the auth store and at the config input fields (`value`, `token`, `username`, `password`). A token declared as `x-scalar-secret-token` directly on the security scheme was therefore ignored, and the request kept rendering the `YOUR_SECRET_TOKEN` placeholder. Both branches now follow the same precedence as the OAuth flows: auth store, then the document extension, then the config field.

--- a/.changeset/api-key-http-document-secrets.md
+++ b/.changeset/api-key-http-document-secrets.md
@@ -2,6 +2,6 @@
 '@scalar/workspace-store': patch
 ---
 
-fix: honour document level `x-scalar-secret-*` extensions on apiKey and http security schemes
+fix: honor document level `x-scalar-secret-*` extensions on apiKey and http security schemes
 
 OAuth flows already read their secrets from the OpenAPI document, but the apiKey and http branches only looked at the auth store and at the config input fields (`value`, `token`, `username`, `password`). A token declared as `x-scalar-secret-token` directly on the security scheme was therefore ignored, and the request kept rendering the `YOUR_SECRET_TOKEN` placeholder. Both branches now follow the same precedence as the OAuth flows: auth store, then the document extension, then the config field.

--- a/packages/workspace-store/src/request-example/context/security/extract-security-scheme-secrets.test.ts
+++ b/packages/workspace-store/src/request-example/context/security/extract-security-scheme-secrets.test.ts
@@ -1812,6 +1812,21 @@ describe('extractSecuritySchemeSecrets', () => {
       expect(result['x-scalar-secret-token']).toBe('store-token')
     })
 
+    it('prioritizes the apiKey document token over the config value field', () => {
+      const authStore = createAuthStore()
+      const scheme = {
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+        'x-scalar-secret-token': 'document-token',
+        value: 'config-value',
+      } as unknown as ConfigAuthScheme
+
+      const result = extractSecuritySchemeSecrets(scheme, authStore, schemeName, documentSlug) as ApiKeyObjectSecret
+
+      expect(result['x-scalar-secret-token']).toBe('document-token')
+    })
+
     it('uses the http secrets declared on the document', () => {
       const authStore = createAuthStore()
       const scheme = {
@@ -1827,6 +1842,29 @@ describe('extractSecuritySchemeSecrets', () => {
       expect(result['x-scalar-secret-token']).toBe('document-token')
       expect(result['x-scalar-secret-username']).toBe('document-username')
       expect(result['x-scalar-secret-password']).toBe('document-password')
+    })
+
+    it('prioritizes the auth store secrets over the http document secrets', () => {
+      const authStore = createAuthStore()
+      authStore.setAuthSecrets(documentSlug, schemeName, {
+        type: 'http',
+        'x-scalar-secret-token': 'store-token',
+        'x-scalar-secret-username': 'store-username',
+        'x-scalar-secret-password': 'store-password',
+      })
+      const scheme = {
+        type: 'http',
+        scheme: 'basic',
+        'x-scalar-secret-token': 'document-token',
+        'x-scalar-secret-username': 'document-username',
+        'x-scalar-secret-password': 'document-password',
+      } as unknown as ConfigAuthScheme
+
+      const result = extractSecuritySchemeSecrets(scheme, authStore, schemeName, documentSlug) as HttpObjectSecret
+
+      expect(result['x-scalar-secret-token']).toBe('store-token')
+      expect(result['x-scalar-secret-username']).toBe('store-username')
+      expect(result['x-scalar-secret-password']).toBe('store-password')
     })
   })
 })

--- a/packages/workspace-store/src/request-example/context/security/extract-security-scheme-secrets.test.ts
+++ b/packages/workspace-store/src/request-example/context/security/extract-security-scheme-secrets.test.ts
@@ -1779,4 +1779,54 @@ describe('extractSecuritySchemeSecrets', () => {
       })
     })
   })
+  describe('document level x-scalar-secret extensions', () => {
+    it('uses the apiKey secret token declared on the document', () => {
+      const authStore = createAuthStore()
+      const scheme = {
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+        'x-scalar-secret-token': 'document-token',
+      } as unknown as ConfigAuthScheme
+
+      const result = extractSecuritySchemeSecrets(scheme, authStore, schemeName, documentSlug) as ApiKeyObjectSecret
+
+      expect(result['x-scalar-secret-token']).toBe('document-token')
+    })
+
+    it('prioritizes the auth store token over the apiKey document token', () => {
+      const authStore = createAuthStore()
+      authStore.setAuthSecrets(documentSlug, schemeName, {
+        type: 'apiKey',
+        'x-scalar-secret-token': 'store-token',
+      })
+      const scheme = {
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+        'x-scalar-secret-token': 'document-token',
+      } as unknown as ConfigAuthScheme
+
+      const result = extractSecuritySchemeSecrets(scheme, authStore, schemeName, documentSlug) as ApiKeyObjectSecret
+
+      expect(result['x-scalar-secret-token']).toBe('store-token')
+    })
+
+    it('uses the http secrets declared on the document', () => {
+      const authStore = createAuthStore()
+      const scheme = {
+        type: 'http',
+        scheme: 'basic',
+        'x-scalar-secret-token': 'document-token',
+        'x-scalar-secret-username': 'document-username',
+        'x-scalar-secret-password': 'document-password',
+      } as unknown as ConfigAuthScheme
+
+      const result = extractSecuritySchemeSecrets(scheme, authStore, schemeName, documentSlug) as HttpObjectSecret
+
+      expect(result['x-scalar-secret-token']).toBe('document-token')
+      expect(result['x-scalar-secret-username']).toBe('document-username')
+      expect(result['x-scalar-secret-password']).toBe('document-password')
+    })
+  })
 })

--- a/packages/workspace-store/src/request-example/context/security/extract-security-scheme-secrets.ts
+++ b/packages/workspace-store/src/request-example/context/security/extract-security-scheme-secrets.ts
@@ -74,6 +74,13 @@ const mergeFlowSecrets = <const T extends readonly (keyof typeof SECRET_TO_INPUT
     }),
   ) as Record<T[number], string>
 
+/** Secret extensions are not part of the strict scheme types, so they are read the same way the OAuth flows read theirs */
+const documentSecret = (scheme: SecuritySchemeObject, property: keyof typeof SECRET_TO_INPUT_FIELD_MAP): string => {
+  const value = (scheme as Record<string, unknown>)[property]
+
+  return typeof value === 'string' ? value : ''
+}
+
 const extractRefreshTokenSecret = (
   authStoreSecrets: { 'x-scalar-secret-refresh-token'?: string } = {},
 ): { 'x-scalar-secret-refresh-token'?: string } => {
@@ -227,7 +234,11 @@ export const extractSecuritySchemeSecrets = (
     const storeSecrets = secrets?.type === 'apiKey' ? secrets : undefined
     return {
       ...scheme,
-      'x-scalar-secret-token': storeSecrets?.['x-scalar-secret-token'] || scheme.value || '',
+      'x-scalar-secret-token':
+        storeSecrets?.['x-scalar-secret-token'] ||
+        documentSecret(scheme, 'x-scalar-secret-token') ||
+        scheme.value ||
+        '',
     } satisfies ApiKeyObjectSecret
   }
 
@@ -236,9 +247,21 @@ export const extractSecuritySchemeSecrets = (
     const storeSecrets = secrets?.type === 'http' ? secrets : undefined
     return {
       ...scheme,
-      'x-scalar-secret-token': storeSecrets?.['x-scalar-secret-token'] || scheme.token || '',
-      'x-scalar-secret-username': storeSecrets?.['x-scalar-secret-username'] || scheme.username || '',
-      'x-scalar-secret-password': storeSecrets?.['x-scalar-secret-password'] || scheme.password || '',
+      'x-scalar-secret-token':
+        storeSecrets?.['x-scalar-secret-token'] ||
+        documentSecret(scheme, 'x-scalar-secret-token') ||
+        scheme.token ||
+        '',
+      'x-scalar-secret-username':
+        storeSecrets?.['x-scalar-secret-username'] ||
+        documentSecret(scheme, 'x-scalar-secret-username') ||
+        scheme.username ||
+        '',
+      'x-scalar-secret-password':
+        storeSecrets?.['x-scalar-secret-password'] ||
+        documentSecret(scheme, 'x-scalar-secret-password') ||
+        scheme.password ||
+        '',
     } satisfies HttpObjectSecret
   }
 


### PR DESCRIPTION
## Problem

A secret declared directly on an `apiKey` security scheme is ignored:

```yaml
components:
  securitySchemes:
    apiKeyAuth:
      type: apiKey
      in: query
      name: token
      x-scalar-secret-token: my-token
```

The request keeps rendering the `YOUR_SECRET_TOKEN` placeholder instead of the value from the document (#9724).

The cause is a gap in `extractSecuritySchemeSecrets`. The OAuth flows resolve their secrets from three sources, in order: the auth store, the `x-scalar-secret-*` extension on the document, then the config input field — that is what `mergeFlowSecrets` does with its `configSecrets` argument. The `apiKey` and `http` branches only consult two of them, the auth store and the config field (`value`, `token`, `username`, `password`). Whatever the document declares is never read, so it cannot win over an empty store.

`http` has the same defect as `apiKey`, on all three of its secrets. I fixed both because it is one cause, not two.

## Solution

The `apiKey` and `http` branches now follow the same precedence as the OAuth flows: auth store, then document extension, then config field.

The extension is read through a small `documentSecret` helper that mirrors how `mergeFlowSecrets` reads flow secrets, via an index on the object rather than a declared property. That keeps the strict `ApiKeyObject` / `HttpObject` schema types untouched — the alternative was adding `x-scalar-secret-*` to those schemas, which would turn the extension into published API surface and is a bigger decision than this bug warrants. Happy to switch to that if you would rather have the extensions declared.

Three tests cover it: the document value is used for `apiKey` and for all three `http` secrets, and the auth store still wins over the document.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation. <!-- extension already documented, this makes it work as documented -->

## Ticket

Closes #9724
