### PR TITLE
docs(migration): add a landing page at /resources/migration

### DIFF
--- a/documentation/compare/index.md
+++ b/documentation/compare/index.md
@@ -10,4 +10,4 @@ Each guide is written by us, so read it with that in mind. We link every claim w
 <scalar-page-link filepath="documentation/compare/fern.md" title="Fern" description="A comparison of Scalar and Fern across documentation and SDK generation: licensing, self-hosting, generated code, framework integrations, and pricing">
 </scalar-page-link>
 
-Looking to move an existing setup across rather than compare? See the [migration guides](/resources/migration/swagger-ui).
+Looking to move an existing setup across rather than compare? See the [migration guides](/resources/migration).

--- a/documentation/migration/index.md
+++ b/documentation/migration/index.md
@@ -1,0 +1,25 @@
+# Migration guides
+
+Move your existing API documentation to Scalar.
+
+Every guide starts from what you already have — an OpenAPI document, a config file, a folder of Markdown — and ends with it running on Scalar. You do not need to re-author your content or convert it to a proprietary format first. Where something cannot carry across, the guide says so rather than glossing over it.
+
+<scalar-page-link filepath="documentation/migration/stainless.md" title="Stainless" description="Import your existing stainless.yml so SDK namespaces, method names, and pagination carry over unchanged">
+</scalar-page-link>
+
+<scalar-page-link filepath="documentation/migration/swagger-ui.md" title="Swagger UI" description="Replace Swagger UI with Scalar API References: keep your OpenAPI document and gain a built-in API client, search, and theming">
+</scalar-page-link>
+
+<scalar-page-link filepath="documentation/migration/stoplight.md" title="Stoplight" description="Move your Stoplight API references and Markdown guides across, with the same design-first and code-first workflows">
+</scalar-page-link>
+
+<scalar-page-link filepath="documentation/migration/api-hub.md" title="API Hub" description="Replace SmartBear API Hub (formerly SwaggerHub) Design, Portal, and Explore with a single Scalar project">
+</scalar-page-link>
+
+<scalar-page-link filepath="documentation/migration/bump.md" title="Bump.sh" description="Bring your OpenAPI documentation across from Bump.sh, including where Bump.sh still has the edge today">
+</scalar-page-link>
+
+<scalar-page-link filepath="documentation/migration/zuplo.md" title="Zuplo" description="Move your developer portal off Zuplo while leaving your API gateway exactly where it is">
+</scalar-page-link>
+
+Still deciding? The [comparison guides](/resources/compare) go through how Scalar stacks up against the alternatives, feature by feature.

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -3561,10 +3561,52 @@
               "migration": {
                 "title": "Migration",
                 "icon": "phosphor/regular/arrows-split",
-                "description": "Step-by-step guides for migrating from Swagger UI, Stoplight, API Hub, Bump.sh, and Zuplo to Scalar.",
+                "description": "Step-by-step guides for migrating from Stainless, Swagger UI, Stoplight, API Hub, Bump.sh, and Zuplo to Scalar.",
                 "type": "group",
-                "mode": "nested",
+                "mode": "folder",
+                "page": {
+                  "type": "page",
+                  "title": "Migration",
+                  "filepath": "documentation/migration/index.md",
+                  "description": "Step-by-step guides for migrating your API documentation and SDKs to Scalar.",
+                  "layout": {
+                    "toc": false
+                  },
+                  "head": {
+                    "title": "Migrate to Scalar — API Docs & SDK Migration Guides",
+                    "links": [
+                      {
+                        "rel": "canonical",
+                        "href": "https://scalar.com/resources/migration"
+                      }
+                    ],
+                    "meta": [
+                      {
+                        "name": "description",
+                        "content": "Step-by-step guides for migrating your API documentation and SDKs to Scalar."
+                      },
+                      {
+                        "property": "og:title",
+                        "content": "Migrate to Scalar - API Docs & SDK Migration Guides"
+                      },
+                      {
+                        "property": "og:description",
+                        "content": "Move your API documentation and SDKs to Scalar from Stainless, Swagger UI, Stoplight, API Hub, Bump.sh, and Zuplo."
+                      },
+                      {
+                        "name": "robots",
+                        "content": "index, follow"
+                      }
+                    ]
+                  }
+                },
                 "children": {
+                  "stainless": {
+                    "title": "Stainless",
+                    "filepath": "documentation/migration/stainless.md",
+                    "description": "Migrate from Stainless to Scalar: import your existing stainless.yml so SDK namespaces, method names, and pagination carry over.",
+                    "type": "page"
+                  },
                   "swagger-ui": {
                     "title": "Swagger UI",
                     "filepath": "documentation/migration/swagger-ui.md",
@@ -3596,12 +3638,6 @@
                         }
                       ]
                     }
-                  },
-                  "stainless": {
-                    "title": "Stainless",
-                    "filepath": "documentation/migration/stainless.md",
-                    "description": "Migrate from Stainless to Scalar: import your existing stainless.yml so SDK namespaces, method names, and pagination carry over.",
-                    "type": "page"
                   },
                   "stoplight": {
                     "title": "Stoplight",


### PR DESCRIPTION
## What

Adds a landing page for the migration guides at `/resources/migration`, mirroring the pattern `/resources/compare` already uses.

## Why

The migration guides had no hub page. The group was `mode: "nested"` with no `page`, so there was no URL for "the migration guides" as a set — the compare index had to deep-link to `/resources/migration/swagger-ui`, and there was nothing to point marketing or search traffic at.

This also fixes a sidebar inconsistency. Under Resources, Compare rendered as an expandable folder (`>`) while Migration rendered as a plain link-out (`→`), because only Compare had `mode: "folder"` and a `page`. They now render the same:

| | `mode` on main | `page` on main | after |
|---|---|---|---|
| Compare | `folder` | yes | unchanged |
| Migration | `nested` | no | `folder` + `page` |

## Changes

- New `documentation/migration/index.md` — intro plus a `<scalar-page-link>` per guide, and a cross-link back to the comparison guides
- `scalar.config.json` — migration group flipped to `mode: "folder"` with a `page` block (own canonical, description, OG tags, `toc: false`), matching the compare group
- `documentation/compare/index.md` — the forward link now points at the hub instead of `/resources/migration/swagger-ui`
- Stainless moved to the top of both the page and the sidebar. The wind-down is time-boxed, so it is the highest-intent guide in the set right now
- Added Stainless to the group description and the landing page meta, where it had been missed when that guide landed

## Reviewer notes

- **No URLs move.** `mode: "nested"` → `"folder"` changes sidebar rendering only; children keep their existing paths. Verified `/resources/migration/{swagger-ui,stainless,stoplight,api-hub,bump,zuplo}` all still resolve.
- The sidebar reorder means Stainless is first under Migration everywhere, not just on the new index. Easy to revert that one bit if you would rather keep Swagger UI leading the sidebar.
- Docs-only — no package changes, so no changeset (`pnpm changeset status` reports nothing to bump from this branch).

## Verification

Checked against `npx @scalar/cli project preview`:

- Landing page renders with the correct title, description, and page links
- Collapsed sidebar now shows Compare and Migration with identical affordances
- All six child routes return 200
- `project check-config` passes; Prettier and Biome clean via pre-commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and site navigation config only; child migration URLs are unchanged.
> 
> **Overview**
> Adds a **migration guides hub** at `/resources/migration`, following the same folder + index pattern as `/resources/compare`.
> 
> The new `documentation/migration/index.md` introduces the section and links to all six guides (with a cross-link back to compare). In `scalar.config.json`, the Migration group switches from `mode: "nested"` to **`mode: "folder"`** with a dedicated **`page`** (canonical URL, meta/OG tags, `toc: false`). **Stainless** is listed first in the index and sidebar, and group/landing copy now mentions Stainless where it was missing.
> 
> `documentation/compare/index.md` now points readers at `/resources/migration` instead of deep-linking to the Swagger UI guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97defc338603175020e4b0e153bf440191d910b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->