### PR TITLE
fix(ci): build changelog generator in the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,12 +198,13 @@ jobs:
       - name: Build
         uses: ./.github/actions/build
         with:
-          # Build only the workspaces that can reach npm. Every public package
-          # lives under packages/ or integrations/ — projects/, examples/ and
-          # tooling/ are all private, so `pnpm -r publish` never publishes
-          # them and building them here only slowed the release down. This is
-          # the same filter the main-branch build job uses.
-          packages: './{packages,integrations}/**'
+          # Every public package lives under packages/ or integrations/, so
+          # those are all `pnpm -r publish` can reach. We also build tooling/
+          # because it holds @scalar-internal/changelog-generator, which
+          # `changeset version` imports to write changelogs — skip it and
+          # versioning fails with MODULE_NOT_FOUND. projects/ and examples/
+          # stay out: they are private and only slow the release down.
+          packages: './{packages,integrations,tooling}/**'
       - name: Git Status
         run: git status
       - name: Stash changes


### PR DESCRIPTION
The release job builds only `packages/` and `integrations/` (#9735), which skips `tooling/changelog-generator`. But `changeset version` uses that package to write changelogs, so it crashed with `MODULE_NOT_FOUND` and the release failed.

This adds the changelog generator to the release build filter so it gets built too.

Fixes the failing `release / npm-publish` job on `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the release build scope; no runtime product or auth/data logic affected.
> 
> **Overview**
> Fixes **release** failures where `pnpm release:version` / `changeset version` could not load **`@scalar-internal/changelog-generator`** (`MODULE_NOT_FOUND`).
> 
> The **npm-publish** build step now filters **`./{packages,integrations,tooling}/**`** instead of only `packages` and `integrations`, so the internal changelog package under `tooling/` is built before versioning. Comments in the workflow explain why `tooling/` is required and why `projects/` and `examples/` stay excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e52c2a9c6bbf7140f0874b726a3a6fe455f673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->