### PR TITLE
fix(api-client): allow client secret together with PKCE in oauth2

### DIFF
--- a/.changeset/oauth-pkce-client-secret.md
+++ b/.changeset/oauth-pkce-client-secret.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Allow using a client secret together with PKCE in the OAuth authorization code flow, so confidential clients can use both (as recommended by RFC 9700).

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.test.ts
@@ -561,7 +561,7 @@ describe('OAuth2', () => {
     expect(emitted).toHaveBeenCalledTimes(1)
   })
 
-  it('hides Client Secret for authorization code when PKCE uses SHA-256', async () => {
+  it('shows Client Secret for authorization code when PKCE uses SHA-256', async () => {
     const wrapper = mountWithProps({
       flows: {
         authorizationCode: {
@@ -581,10 +581,10 @@ describe('OAuth2', () => {
     await nextTick()
 
     expect(wrapper.text()).toContain('Client ID')
-    expect(wrapper.text()).not.toContain('Client Secret')
+    expect(wrapper.text()).toContain('Client Secret')
   })
 
-  it('hides Client Secret for authorization code when PKCE uses plain', async () => {
+  it('shows Client Secret for authorization code when PKCE uses plain', async () => {
     const wrapper = mountWithProps({
       flows: {
         authorizationCode: {
@@ -603,7 +603,7 @@ describe('OAuth2', () => {
 
     await nextTick()
 
-    expect(wrapper.text()).not.toContain('Client Secret')
+    expect(wrapper.text()).toContain('Client Secret')
   })
 
   it('shows Client Secret for authorization code when PKCE is disabled', async () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue
@@ -121,17 +121,13 @@ const selectedScopes = computed(() => {
 })
 
 /**
- * PKCE public clients do not use a client_secret. Hide the field when the
- * document enables PKCE so readers are not prompted for an unused secret.
+ * Show the client secret whenever the flow supports one. PKCE and a client
+ * secret are independent, so confidential clients can use both together
+ * (see RFC 9700 Section 2.1.1).
  */
-const showClientSecret = computed(() => {
-  if (!('x-scalar-secret-client-secret' in flow.value)) {
-    return false
-  }
-  const pkceMode =
-    'x-usePkce' in flow.value ? flow.value['x-usePkce'] : undefined
-  return pkceMode !== 'SHA-256' && pkceMode !== 'plain'
-})
+const showClientSecret = computed(
+  () => 'x-scalar-secret-client-secret' in flow.value,
+)
 
 const clientSecretValue = computed((): string => {
   const f = flow.value as { 'x-scalar-secret-client-secret'?: string }

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.test.ts
@@ -373,6 +373,8 @@ describe('oauth', () => {
         authorizationCode: {
           ...scheme.authorizationCode,
           'x-usePkce': 'SHA-256',
+          // Public client: no secret, so the token request relies on PKCE alone.
+          'x-scalar-secret-client-secret': '',
           'x-scalar-security-query': {
             prompt: 'login',
             audience: 'scalar',
@@ -451,6 +453,67 @@ describe('oauth', () => {
       pkceExpectedParams.set('grant_type', 'authorization_code')
       pkceExpectedParams.set('code_verifier', 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8')
       expect(pkceTokenBody.toString()).toBe(pkceExpectedParams.toString())
+    })
+
+    // PKCE with a confidential client (RFC 9700 Section 2.1.1 recommends PKCE even here).
+    it('sends both the client secret and the PKCE code verifier for confidential clients', async () => {
+      const flows = {
+        authorizationCode: {
+          ...scheme.authorizationCode,
+          'x-usePkce': 'SHA-256',
+          // Confidential client: a secret is set and should be used together with PKCE.
+          'x-scalar-secret-client-secret': clientSecret,
+        },
+      } satisfies OAuthFlowsObjectSecret
+
+      const accessToken = 'confidential_pkce_access_token'
+      const code = 'confidential_pkce_auth_code'
+
+      // Mock crypto so PKCE generation is deterministic.
+      vi.spyOn(crypto, 'getRandomValues').mockImplementation((arr) => {
+        if (arr instanceof Uint8Array) {
+          for (let i = 0; i < arr.length; i++) {
+            arr[i] = i
+          }
+        }
+        return arr
+      })
+      vi.spyOn(crypto.subtle, 'digest').mockResolvedValue(new Uint8Array([1, 2, 3, 4, 5, 6, 8, 9, 10]).buffer)
+
+      const promise = authorizeOauth2(flows, 'authorizationCode', selectedScopes, mockServer, '')
+      await flushPromises()
+
+      mockWindow.location.href = `${flows.authorizationCode['x-scalar-secret-redirect-uri']}?code=${code}&state=${state}`
+
+      global.fetch = vi.fn().mockResolvedValueOnce({
+        json: () => Promise.resolve({ access_token: accessToken }),
+      })
+
+      vi.advanceTimersByTime(200)
+
+      const [error, result] = await promise
+      expect(error).toBe(null)
+      expect(result).toEqual({ accessToken })
+
+      // The confidential client authenticates with Basic auth and still proves possession via PKCE.
+      expect(global.fetch).toHaveBeenCalledWith(tokenUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': `Basic ${secretAuth}`,
+        },
+        body: expect.any(URLSearchParams),
+      })
+
+      const tokenArgs = vi.mocked(global.fetch).mock.calls[0]
+      expect(tokenArgs).toBeDefined()
+      const tokenBody = tokenArgs![1]?.body as URLSearchParams
+      const expectedParams = new URLSearchParams()
+      expectedParams.set('redirect_uri', flows.authorizationCode['x-scalar-secret-redirect-uri'])
+      expectedParams.set('code', code)
+      expectedParams.set('grant_type', 'authorization_code')
+      expectedParams.set('code_verifier', 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8')
+      expect(tokenBody.toString()).toBe(expectedParams.toString())
     })
 
     it('should include x-scalar-security-body parameters in authorization code token request', async () => {
@@ -882,9 +945,10 @@ describe('oauth', () => {
       const callArgs = vi.mocked(global.fetch).mock.calls[0]
       expect(callArgs).toBeDefined()
       const body = callArgs![1]?.body as URLSearchParams
-      // PKCE + public client: client_id in body, no client_secret
+      // PKCE + confidential client with body credentials: client_id, client_secret, and code_verifier in body
       const expectedParams = new URLSearchParams()
       expectedParams.set('client_id', flows.authorizationCode['x-scalar-secret-client-id'])
+      expectedParams.set('client_secret', flows.authorizationCode['x-scalar-secret-client-secret'])
       expectedParams.set('redirect_uri', flows.authorizationCode['x-scalar-secret-redirect-uri'])
       expectedParams.set('code', code)
       expectedParams.set('grant_type', 'authorization_code')
@@ -2043,8 +2107,8 @@ describe('oauth', () => {
       expect(body.get('refresh_token')).toBe('refresh_token_123')
     })
 
-    it('omits client_secret on refresh when PKCE mode is SHA-256 even if a secret is stored', async () => {
-      const pkcePublicScheme = {
+    it('keeps using the client secret on refresh when PKCE mode is SHA-256', async () => {
+      const pkceConfidentialScheme = {
         authorizationCode: {
           ...refreshScheme.authorizationCode,
           'x-usePkce': 'SHA-256',
@@ -2059,14 +2123,16 @@ describe('oauth', () => {
           }),
       })
 
-      await refreshOauth2Token(pkcePublicScheme, 'authorizationCode', '', mockServer)
+      await refreshOauth2Token(pkceConfidentialScheme, 'authorizationCode', '', mockServer)
 
       const callArgs = vi.mocked(global.fetch).mock.calls[0]
       const body = callArgs![1]?.body as URLSearchParams
-      expect(body.get('client_id')).toBe(refreshScheme.authorizationCode['x-scalar-secret-client-id'])
+      // A confidential client authenticates with Basic auth, PKCE does not change that.
+      expect(body.has('client_id')).toBe(false)
       expect(body.has('client_secret')).toBe(false)
       expect(callArgs![1]?.headers).toEqual({
         'Content-Type': 'application/x-www-form-urlencoded',
+        'Authorization': `Basic ${secretAuth}`,
       })
     })
 

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth.ts
@@ -15,21 +15,6 @@ import { getOAuthCallbackData } from './oauth-callback'
 /** Oauth2 security schemes which are not implicit */
 type NonImplicitFlows = Omit<OAuthFlowsObjectSecret, 'implicit'>
 
-const authorizationCodeUsesPkcePublicClient = (
-  flowType: keyof NonImplicitFlows,
-  flow: NonImplicitFlows[keyof NonImplicitFlows],
-): boolean => {
-  if (flowType !== 'authorizationCode') {
-    return false
-  }
-  const authCode = flow as OAuthFlowsObjectSecret['authorizationCode']
-  if (!authCode) {
-    return false
-  }
-  const pkceMode = authCode['x-usePkce']
-  return pkceMode === 'SHA-256' || pkceMode === 'plain'
-}
-
 type PKCEState = {
   codeVerifier: string
   codeChallenge: string
@@ -427,8 +412,11 @@ const authorizeServers = async (
 
   /** Where to add the credentials */
   const addCredentialsToBody = flow['x-scalar-credentials-location'] === 'body'
-  const pkcePublicClient = authorizationCodeUsesPkcePublicClient(type, flow)
-  const hasClientSecret = Boolean(flow['x-scalar-secret-client-secret']) && !pkcePublicClient
+  /**
+   * PKCE and client authentication are independent: a confidential client may use both.
+   * We send the client_secret whenever one is set, regardless of PKCE (see RFC 9700 Section 2.1.1).
+   */
+  const hasClientSecret = Boolean(flow['x-scalar-secret-client-secret'])
   /**
    * Public authorization-code clients still need client_id in the token body.
    * We only send it implicitly for that case to avoid conflicting with Basic auth.
@@ -559,8 +547,8 @@ export const refreshOauth2Token = async (
   formData.set('refresh_token', refreshToken)
 
   const addCredentialsToBody = flow['x-scalar-credentials-location'] === 'body'
-  const pkcePublicClient = authorizationCodeUsesPkcePublicClient(type, flow)
-  const hasClientSecret = Boolean(flow['x-scalar-secret-client-secret']) && !pkcePublicClient
+  /** A confidential client keeps using its secret on refresh, even when PKCE is enabled. */
+  const hasClientSecret = Boolean(flow['x-scalar-secret-client-secret'])
   /**
    * Public authorization-code clients still need client_id in the refresh body per RFC 6749 Section 6.
    * We only send it implicitly for that case to avoid conflicting with Basic auth.


### PR DESCRIPTION
When you turn on PKCE in the OAuth authorization code flow, the client secret field disappears and the secret is dropped from the token request. That forces every PKCE user to be a public client.

But PKCE and a client secret are independent. A confidential client can use both, and [RFC 9700](https://datatracker.ietf.org/doc/html/rfc9700#section-2.1.1) actually recommends it.

This change keeps the client secret field visible with PKCE on, and sends the secret (Basic auth or body, depending on the credentials location) alongside the PKCE `code_verifier`. Public clients with no secret keep working exactly as before.

## Ticket

Closes #9739

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth token and refresh credential assembly, which is security-sensitive, but behavior is narrowed to matching secret presence rather than new auth modes; public PKCE paths remain covered by tests.
> 
> **Overview**
> **OAuth2 authorization code with PKCE** no longer treats PKCE as “public client only.” The **Client Secret** field stays visible when PKCE is SHA-256 or plain, and token/refresh requests include client authentication whenever a secret is configured (Basic auth or body per credentials location), **along with** the PKCE `code_verifier`.
> 
> Public clients with an empty secret are unchanged: no secret in the UI logic beyond flow support, `client_id` in the body, no Basic auth. The old `authorizationCodeUsesPkcePublicClient` gate was removed from `oauth.ts` in favor of “secret present ⇒ use it,” aligned with RFC 9700.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1549e8f84a6998260e05a0dca2c962ccd163d74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->