### PR TITLE
feat(api-client): show request timing waterfall for proxied requests

### DIFF
--- a/.changeset/proxy-request-timing.md
+++ b/.changeset/proxy-request-timing.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': minor
+---
+
+feat: show a request timing waterfall for proxied requests
+
+Proxied requests now surface a **Timing** tab in the response view with a DNS lookup, initial connection, TLS handshake, and waiting-for-server-response breakdown. The Scalar proxy measures these network phases between the proxy and the target server and reports them via a `Server-Timing` header, since browsers do not expose per-phase timing for cross-origin requests. The tab only appears for requests sent through the proxy.

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
@@ -11,6 +11,7 @@ import type { RequestPayload } from '@scalar/workspace-store/request-example'
 import { parseSetCookie } from 'set-cookie-parser'
 
 import { getCookieHeaderKeys } from '@/v2/blocks/operation-block/helpers/get-cookie-header-keys'
+import { type RequestTiming, parseServerTiming } from '@/v2/blocks/response-block/helpers/parse-server-timing'
 import { resolveResponseBodyHandler } from '@/v2/blocks/response-block/helpers/resolve-response-body-handler'
 import {
   resolveResponseContentType,
@@ -27,6 +28,12 @@ export type ResponseInstance = Omit<Response, 'headers'> & {
   cookieHeaderKeys: string[]
   /** Time in ms the request took */
   duration: number
+  /**
+   * Detailed network phase timings (DNS, connect, TLS, TTFB) parsed from the
+   * proxy's `Server-Timing` header. Only present for proxied requests, since
+   * browsers do not expose these phases for direct cross-origin requests.
+   */
+  timing?: RequestTiming
   /** The response status */
   status: number
   /** The response status text */
@@ -110,6 +117,9 @@ export const sendRequest = async ({
     // Extract response metadata early for reuse
     const contentType = response.headers.get('content-type')
     const responseHeaders = normalizeHeaders(response.headers, isUsingProxy)
+    // The proxy reports detailed network phases via Server-Timing. Direct
+    // requests will not carry this header, leaving timing undefined.
+    const timing = parseServerTiming(response.headers.get('server-timing')) ?? undefined
     const responseUrl = new URL(response.url)
     const fullPath = responseUrl.pathname + responseUrl.search
     const statusText = response.statusText || httpStatusCodes[response.status]?.name || ''
@@ -127,6 +137,7 @@ export const sendRequest = async ({
         requestPayload,
         timestamp,
         duration,
+        timing,
         responseHeaders,
         statusText,
         method,
@@ -139,6 +150,7 @@ export const sendRequest = async ({
       requestPayload,
       timestamp,
       duration,
+      timing,
       responseHeaders,
       statusText,
       method,
@@ -183,6 +195,7 @@ const buildStreamingResponse = ({
   requestPayload,
   timestamp,
   duration,
+  timing,
   responseHeaders,
   statusText,
   method,
@@ -192,6 +205,7 @@ const buildStreamingResponse = ({
   requestPayload: RequestPayload
   timestamp: number
   duration: number
+  timing?: RequestTiming
   responseHeaders: Record<string, string>
   statusText: string
   method: HttpMethod
@@ -222,6 +236,7 @@ const buildStreamingResponse = ({
         cookieHeaderKeys,
         reader: response.body!.getReader(),
         duration,
+        timing,
         method,
         path: fullPath,
       },
@@ -239,6 +254,7 @@ const buildStandardResponse = async ({
   requestPayload,
   timestamp,
   duration,
+  timing,
   responseHeaders,
   statusText,
   method,
@@ -251,6 +267,7 @@ const buildStandardResponse = async ({
   requestPayload: RequestPayload
   timestamp: number
   duration: number
+  timing?: RequestTiming
   responseHeaders: Record<string, string>
   statusText: string
   method: HttpMethod
@@ -302,6 +319,7 @@ const buildStandardResponse = async ({
         data: responseData,
         size: arrayBuffer.byteLength,
         duration,
+        timing,
         method,
         status: response.status,
         path: fullPath,

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
@@ -11,6 +11,7 @@ import type { RequestPayload } from '@scalar/workspace-store/request-example'
 import { parseSetCookie } from 'set-cookie-parser'
 
 import { getCookieHeaderKeys } from '@/v2/blocks/operation-block/helpers/get-cookie-header-keys'
+import { type RequestTiming, parseServerTiming } from '@/v2/blocks/response-block/helpers/parse-server-timing'
 import { resolveResponseBodyHandler } from '@/v2/blocks/response-block/helpers/resolve-response-body-handler'
 import {
   resolveResponseContentType,
@@ -27,6 +28,12 @@ export type ResponseInstance = Omit<Response, 'headers'> & {
   cookieHeaderKeys: string[]
   /** Time in ms the request took */
   duration: number
+  /**
+   * Detailed network phase timings (DNS, connect, TLS, TTFB) parsed from the
+   * proxy's `Server-Timing` header. Only present for proxied requests, since
+   * browsers do not expose these phases for direct cross-origin requests.
+   */
+  timing?: RequestTiming
   /** The response status */
   status: number
   /** The response status text */
@@ -110,6 +117,9 @@ export const sendRequest = async ({
     // Extract response metadata early for reuse
     const contentType = response.headers.get('content-type')
     const responseHeaders = normalizeHeaders(response.headers, isUsingProxy)
+    // The proxy reports detailed network phases via Server-Timing. Direct
+    // requests will not carry this header, leaving timing undefined.
+    const timing = parseServerTiming(response.headers.get('server-timing')) ?? undefined
     // A Response built with the Response constructor has an empty url, so fall back to the requested one
     const responseUrl = new URL(response.url || requestPayload[0])
     const fullPath = responseUrl.pathname + responseUrl.search
@@ -128,6 +138,7 @@ export const sendRequest = async ({
         requestPayload,
         timestamp,
         duration,
+        timing,
         responseHeaders,
         statusText,
         method,
@@ -140,6 +151,7 @@ export const sendRequest = async ({
       requestPayload,
       timestamp,
       duration,
+      timing,
       responseHeaders,
       statusText,
       method,
@@ -184,6 +196,7 @@ const buildStreamingResponse = ({
   requestPayload,
   timestamp,
   duration,
+  timing,
   responseHeaders,
   statusText,
   method,
@@ -193,6 +206,7 @@ const buildStreamingResponse = ({
   requestPayload: RequestPayload
   timestamp: number
   duration: number
+  timing?: RequestTiming
   responseHeaders: Record<string, string>
   statusText: string
   method: HttpMethod
@@ -223,6 +237,7 @@ const buildStreamingResponse = ({
         cookieHeaderKeys,
         reader: response.body!.getReader(),
         duration,
+        timing,
         method,
         path: fullPath,
       },
@@ -240,6 +255,7 @@ const buildStandardResponse = async ({
   requestPayload,
   timestamp,
   duration,
+  timing,
   responseHeaders,
   statusText,
   method,
@@ -252,6 +268,7 @@ const buildStandardResponse = async ({
   requestPayload: RequestPayload
   timestamp: number
   duration: number
+  timing?: RequestTiming
   responseHeaders: Record<string, string>
   statusText: string
   method: HttpMethod
@@ -303,6 +320,7 @@ const buildStandardResponse = async ({
         data: responseData,
         size: arrayBuffer.byteLength,
         duration,
+        timing,
         method,
         status: response.status,
         path: fullPath,

--- a/packages/api-client/src/v2/blocks/response-block/ResponseBlock.vue
+++ b/packages/api-client/src/v2/blocks/response-block/ResponseBlock.vue
@@ -17,6 +17,7 @@ import ResponseCookies from '@/v2/blocks/response-block/components/ResponseCooki
 import ResponseEmpty from '@/v2/blocks/response-block/components/ResponseEmpty.vue'
 import ResponseLoadingOverlay from '@/v2/blocks/response-block/components/ResponseLoadingOverlay.vue'
 import ResponseMetaInformation from '@/v2/blocks/response-block/components/ResponseMetaInformation.vue'
+import ResponseTiming from '@/v2/blocks/response-block/components/ResponseTiming.vue'
 import { textMediaTypes } from '@/v2/blocks/response-block/helpers/media-types'
 import { parseSetCookie } from '@/v2/blocks/response-block/helpers/parse-set-cookie'
 import type { ClientLayout } from '@/v2/types/layout'
@@ -59,11 +60,17 @@ const responseCookies = computed(
       .filter(isDefined) ?? [],
 )
 
-const responseSections = ['Cookies', 'Headers', 'Body'] as const
+const responseSections = ['Cookies', 'Headers', 'Body', 'Timing'] as const
 type Filter = 'All' | (typeof responseSections)[number]
 const activeFilter = ref<Filter>('All')
 
-const filters = computed<Filter[]>(() => ['All', ...responseSections])
+// Timing is only meaningful for proxied requests, which carry Server-Timing.
+const filters = computed<Filter[]>(() => [
+  'All',
+  ...responseSections.filter(
+    (section) => section !== 'Timing' || response?.timing,
+  ),
+])
 
 const filterIds = computed(
   () =>
@@ -201,6 +208,14 @@ defineExpose({
           :role="activeFilter === 'All' ? 'none' : 'tabpanel'">
           <template #title>Response Headers</template>
         </HeadersComponent>
+
+        <!-- Timing waterfall, available for proxied requests -->
+        <ResponseTiming
+          v-if="response.timing && isSectionVisible('Timing')"
+          :id="filterIds.Timing"
+          class="response-section-content-timing"
+          :role="activeFilter === 'All' ? 'none' : 'tabpanel'"
+          :timing="response.timing" />
 
         <!-- Inject response section plugin components -->
         <ScalarErrorBoundary

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseTiming.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseTiming.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import prettyMilliseconds from 'pretty-ms'
+import { computed } from 'vue'
+
+import type { RequestTiming } from '@/v2/blocks/response-block/helpers/parse-server-timing'
+import { CollapsibleSection } from '@/v2/components/layout'
+
+const { timing } = defineProps<{
+  timing: RequestTiming
+}>()
+
+/**
+ * Human-readable labels and colors for the known proxy phases. Unknown phase
+ * names fall back to their raw name and a neutral color, so new metrics from
+ * the proxy still render without a code change.
+ */
+const PHASE_META: Record<string, { label: string; color: string }> = {
+  dns: { label: 'DNS Lookup', color: 'var(--scalar-color-purple)' },
+  connect: { label: 'Initial Connection', color: 'var(--scalar-color-orange)' },
+  tls: { label: 'TLS Handshake', color: 'var(--scalar-color-blue)' },
+  ttfb: {
+    label: 'Waiting for Server Response',
+    color: 'var(--scalar-color-green)',
+  },
+}
+
+/** The total measured time across all reported phases. */
+const total = computed(() =>
+  timing.phases.reduce((sum, phase) => sum + phase.duration, 0),
+)
+
+/**
+ * Lay the phases out as a waterfall: each bar starts where the previous one
+ * ended, so the segments read left to right like the browser dev tools.
+ */
+const segments = computed(() => {
+  let offset = 0
+
+  return timing.phases.map((phase) => {
+    const meta = PHASE_META[phase.name] ?? {
+      label: phase.name,
+      color: 'var(--scalar-color-3)',
+    }
+    const widthPercent =
+      total.value > 0 ? (phase.duration / total.value) * 100 : 0
+    const offsetPercent = total.value > 0 ? (offset / total.value) * 100 : 0
+
+    offset += phase.duration
+
+    return {
+      key: phase.name,
+      label: meta.label,
+      color: meta.color,
+      duration: phase.duration,
+      widthPercent,
+      offsetPercent,
+    }
+  })
+})
+
+/** Format a millisecond value with the same helper used across the response UI. */
+const format = (ms: number) =>
+  prettyMilliseconds(ms, { millisecondsDecimalDigits: 2 })
+</script>
+<template>
+  <CollapsibleSection
+    class="overflow-auto"
+    :itemCount="timing.phases.length">
+    <template #title>Timing</template>
+    <div class="bg-b-1 flex flex-col gap-2.5 border-t p-4 text-sm">
+      <div
+        v-for="segment in segments"
+        :key="segment.key"
+        class="grid grid-cols-[minmax(0,10rem)_1fr_auto] items-center gap-3">
+        <span class="text-c-2 truncate">{{ segment.label }}</span>
+        <!-- Waterfall track -->
+        <div class="bg-b-2 relative h-2 min-w-16 rounded-full">
+          <div
+            class="absolute top-0 h-full min-w-0.5 rounded-full"
+            :style="{
+              left: `${segment.offsetPercent}%`,
+              width: `${segment.widthPercent}%`,
+              backgroundColor: segment.color,
+            }" />
+        </div>
+        <span class="text-c-1 tabular-nums">{{
+          format(segment.duration)
+        }}</span>
+      </div>
+
+      <!-- Total -->
+      <div
+        class="text-c-1 mt-1 flex items-center justify-between border-t pt-2.5 font-medium">
+        <span>Total</span>
+        <span class="tabular-nums">{{ format(total) }}</span>
+      </div>
+
+      <p class="text-c-3 text-xs">
+        <template v-if="timing.reused">
+          Connection reused, so DNS, connection, and TLS were skipped.
+        </template>
+        Measured by the proxy between the proxy and the target server.
+      </p>
+    </div>
+  </CollapsibleSection>
+</template>

--- a/packages/api-client/src/v2/blocks/response-block/helpers/parse-server-timing.test.ts
+++ b/packages/api-client/src/v2/blocks/response-block/helpers/parse-server-timing.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseServerTiming } from './parse-server-timing'
+
+describe('parse-server-timing', () => {
+  it('returns null for an empty or missing header', () => {
+    expect(parseServerTiming(null)).toBeNull()
+    expect(parseServerTiming(undefined)).toBeNull()
+    expect(parseServerTiming('')).toBeNull()
+  })
+
+  it('parses named phases with durations', () => {
+    const result = parseServerTiming('dns;dur=1.56, connect;dur=12.69, tls;dur=95.03, ttfb;dur=148.93')
+
+    expect(result).toEqual({
+      reused: false,
+      phases: [
+        { name: 'dns', duration: 1.56 },
+        { name: 'connect', duration: 12.69 },
+        { name: 'tls', duration: 95.03 },
+        { name: 'ttfb', duration: 148.93 },
+      ],
+    })
+  })
+
+  it('marks reused connections and keeps their phases', () => {
+    const result = parseServerTiming('ttfb;dur=29.99, reused')
+
+    expect(result).toEqual({
+      reused: true,
+      phases: [{ name: 'ttfb', duration: 29.99 }],
+    })
+  })
+
+  it('captures descriptions and ignores phases without a duration', () => {
+    const result = parseServerTiming('cache;desc="HIT", ttfb;dur=10')
+
+    expect(result).toEqual({
+      reused: false,
+      phases: [{ name: 'ttfb', duration: 10 }],
+    })
+  })
+
+  it('ignores malformed durations', () => {
+    expect(parseServerTiming('ttfb;dur=not-a-number')).toBeNull()
+  })
+})

--- a/packages/api-client/src/v2/blocks/response-block/helpers/parse-server-timing.ts
+++ b/packages/api-client/src/v2/blocks/response-block/helpers/parse-server-timing.ts
@@ -1,0 +1,103 @@
+/**
+ * A single named phase reported by the server via the `Server-Timing` header.
+ */
+export type RequestTimingPhase = {
+  /** The metric name, for example `dns`, `connect`, `tls`, or `ttfb`. */
+  name: string
+  /** The phase duration in milliseconds. */
+  duration: number
+  /** An optional human-readable description sent by the server. */
+  description?: string
+}
+
+/**
+ * Structured request timing parsed from a `Server-Timing` header.
+ *
+ * The Scalar proxy measures the network phases (DNS, connect, TLS, time to
+ * first byte) between the proxy and the target server, because browsers do not
+ * expose these for cross-origin requests. It reports them here so the client
+ * can draw a request timing waterfall.
+ */
+export type RequestTiming = {
+  /** The named phases, in the order the server reported them. */
+  phases: RequestTimingPhase[]
+  /**
+   * Whether an existing connection was reused. When true, the DNS, connect,
+   * and TLS phases legitimately did not happen and are absent.
+   */
+  reused: boolean
+}
+
+/**
+ * Parse a `Server-Timing` header value into structured timing phases.
+ *
+ * The header follows the format `name;dur=123.4;desc="text", name2;dur=5.6`.
+ * Bare tokens without a `dur` (such as the proxy's `reused` marker) are treated
+ * as flags rather than measured phases.
+ *
+ * @param header - The raw `Server-Timing` header value, or null when absent.
+ * @returns Structured timing, or null when there is nothing usable to show.
+ */
+export const parseServerTiming = (header: string | null | undefined): RequestTiming | null => {
+  if (!header) {
+    return null
+  }
+
+  const phases: RequestTimingPhase[] = []
+  let reused = false
+
+  // Each metric is comma-separated; its parameters are semicolon-separated.
+  for (const entry of header.split(',')) {
+    const parts = entry.split(';')
+    const name = parts[0]?.trim()
+
+    if (!name) {
+      continue
+    }
+
+    // The `reused` marker is a bare flag with no duration.
+    if (name === 'reused') {
+      reused = true
+      continue
+    }
+
+    let duration: number | undefined
+    let description: string | undefined
+
+    for (const param of parts.slice(1)) {
+      const separatorIndex = param.indexOf('=')
+
+      if (separatorIndex === -1) {
+        continue
+      }
+
+      const key = param.slice(0, separatorIndex).trim()
+      // Strip surrounding quotes that descriptions may carry.
+      const value = param
+        .slice(separatorIndex + 1)
+        .trim()
+        .replace(/^"|"$/g, '')
+
+      if (key === 'dur') {
+        const parsed = Number.parseFloat(value)
+
+        if (Number.isFinite(parsed)) {
+          duration = parsed
+        }
+      } else if (key === 'desc') {
+        description = value
+      }
+    }
+
+    // Only keep entries that carry a measured duration.
+    if (duration !== undefined) {
+      phases.push({ name, duration, ...(description ? { description } : {}) })
+    }
+  }
+
+  if (phases.length === 0 && !reused) {
+    return null
+  }
+
+  return { phases, reused }
+}

--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -8,8 +8,10 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -178,6 +180,72 @@ func (s streamingResponseWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
+// timingsContextKeyType is a private type for the context key so it cannot
+// collide with keys set elsewhere.
+type timingsContextKeyType struct{}
+
+// timingsContextKey carries the per-request proxyTimings through the request
+// context so the custom DialContext can record the DNS lookup it performs.
+var timingsContextKey = timingsContextKeyType{}
+
+// proxyTimings collects the network phase durations for a single upstream
+// request, measured from the proxy to the target server. These map to the
+// phases a browser cannot observe for cross-origin requests, which is why we
+// measure them here and report them back via the Server-Timing header.
+type proxyTimings struct {
+	// start marks the moment just before the outbound request is sent.
+	start time.Time
+	// dnsDuration is the time spent resolving the target hostname.
+	dnsDuration time.Duration
+	// connectDuration is the time spent establishing the TCP connection.
+	connectDuration time.Duration
+	// tlsDuration is the time spent on the TLS handshake.
+	tlsDuration time.Duration
+	// ttfb is the "waiting for server response" phase: the time from finishing
+	// sending the request to receiving the first response byte. It excludes the
+	// DNS, connect, and TLS phases so the phases can be shown side by side.
+	ttfb time.Duration
+	// reused reports whether an existing pooled connection was reused, in
+	// which case the DNS, connect, and TLS phases legitimately did not happen.
+	reused bool
+}
+
+// serverTimingHeader renders the collected timings as a Server-Timing header
+// value. Browsers surface this natively and the Scalar API client parses it to
+// draw a request timing waterfall. Only phases that actually happened are
+// included, plus a reused marker so pooled connections are not misread.
+func (t *proxyTimings) serverTimingHeader() string {
+	// Format a duration as fractional milliseconds, matching the Server-Timing spec.
+	ms := func(d time.Duration) string {
+		return strconv.FormatFloat(float64(d.Microseconds())/1000.0, 'f', 2, 64)
+	}
+
+	parts := []string{}
+
+	if t.dnsDuration > 0 {
+		parts = append(parts, "dns;dur="+ms(t.dnsDuration))
+	}
+
+	if t.connectDuration > 0 {
+		parts = append(parts, "connect;dur="+ms(t.connectDuration))
+	}
+
+	if t.tlsDuration > 0 {
+		parts = append(parts, "tls;dur="+ms(t.tlsDuration))
+	}
+
+	if t.ttfb > 0 {
+		parts = append(parts, "ttfb;dur="+ms(t.ttfb))
+	}
+
+	// A zero-duration description flag lets clients label reused connections.
+	if t.reused {
+		parts = append(parts, "reused")
+	}
+
+	return strings.Join(parts, ", ")
+}
+
 // NewProxyServer creates a new proxy server instance
 func NewProxyServer(bypassCidr bool) *ProxyServer {
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
@@ -221,8 +289,15 @@ func NewProxyServer(bypassCidr bool) *ProxyServer {
 					return dialer.DialContext(ctx, network, chosen)
 				}
 
-				// Re-resolve hostname on every dial
+				// Re-resolve hostname on every dial. Time the lookup so we can
+				// report it via Server-Timing. The custom DialContext resolves
+				// manually, so httptrace's DNS hooks never fire for us.
+				dnsStart := time.Now()
 				ips, err := net.LookupIP(host)
+
+				if timings, ok := ctx.Value(timingsContextKey).(*proxyTimings); ok {
+					timings.dnsDuration = time.Since(dnsStart)
+				}
 
 				if err != nil {
 					return nil, err
@@ -412,7 +487,55 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	// Collect network phase timings (DNS, connect, TLS, TTFB) so we can report
+	// them back to the client via Server-Timing. Browsers cannot observe these
+	// for cross-origin requests, so measuring here is the only reliable source.
+	timings := &proxyTimings{}
+
+	var connectStart, tlsStart, wroteRequest time.Time
+
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			// A reused connection skips DNS, connect, and TLS entirely.
+			timings.reused = info.Reused
+		},
+		ConnectStart: func(_, _ string) {
+			connectStart = time.Now()
+		},
+		ConnectDone: func(_, _ string, _ error) {
+			if !connectStart.IsZero() {
+				// Accumulate across redirects, which may dial more than once.
+				timings.connectDuration += time.Since(connectStart)
+			}
+		},
+		TLSHandshakeStart: func() {
+			tlsStart = time.Now()
+		},
+		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
+			if !tlsStart.IsZero() {
+				timings.tlsDuration += time.Since(tlsStart)
+			}
+		},
+		WroteRequest: func(_ httptrace.WroteRequestInfo) {
+			// Marks the end of sending the request; TTFB is measured from here.
+			// The last write in a redirect chain wins, giving the final leg.
+			wroteRequest = time.Now()
+		},
+		GotFirstResponseByte: func() {
+			// Isolated "waiting for server response" phase for the final response.
+			if !wroteRequest.IsZero() {
+				timings.ttfb = time.Since(wroteRequest)
+			} else {
+				timings.ttfb = time.Since(timings.start)
+			}
+		},
+	}
+
+	ctx := httptrace.WithClientTrace(context.WithValue(outreq.Context(), timingsContextKey, timings), trace)
+	outreq = outreq.WithContext(ctx)
+
 	// Make the request
+	timings.start = time.Now()
 	resp, err := client.Do(outreq)
 
 	if err != nil {
@@ -455,6 +578,13 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 
 	// Add the final URL as a header
 	w.Header().Set("X-Forwarded-Host", resp.Request.URL.String())
+
+	// Expose the proxy-to-target network timings so the client can draw a
+	// request timing waterfall. Content download is intentionally omitted: it
+	// happens after the headers are flushed, and the client measures it itself.
+	if serverTiming := timings.serverTimingHeader(); serverTiming != "" {
+		w.Header().Set("Server-Timing", serverTiming)
+	}
 
 	// Copy the status code from the proxied response
 	w.WriteHeader(resp.StatusCode)

--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -8,8 +8,10 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -271,6 +273,72 @@ func (s streamingResponseWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
+// timingsContextKeyType is a private type for the context key so it cannot
+// collide with keys set elsewhere.
+type timingsContextKeyType struct{}
+
+// timingsContextKey carries the per-request proxyTimings through the request
+// context so the custom DialContext can record the DNS lookup it performs.
+var timingsContextKey = timingsContextKeyType{}
+
+// proxyTimings collects the network phase durations for a single upstream
+// request, measured from the proxy to the target server. These map to the
+// phases a browser cannot observe for cross-origin requests, which is why we
+// measure them here and report them back via the Server-Timing header.
+type proxyTimings struct {
+	// start marks the moment just before the outbound request is sent.
+	start time.Time
+	// dnsDuration is the time spent resolving the target hostname.
+	dnsDuration time.Duration
+	// connectDuration is the time spent establishing the TCP connection.
+	connectDuration time.Duration
+	// tlsDuration is the time spent on the TLS handshake.
+	tlsDuration time.Duration
+	// ttfb is the "waiting for server response" phase: the time from finishing
+	// sending the request to receiving the first response byte. It excludes the
+	// DNS, connect, and TLS phases so the phases can be shown side by side.
+	ttfb time.Duration
+	// reused reports whether an existing pooled connection was reused, in
+	// which case the DNS, connect, and TLS phases legitimately did not happen.
+	reused bool
+}
+
+// serverTimingHeader renders the collected timings as a Server-Timing header
+// value. Browsers surface this natively and the Scalar API client parses it to
+// draw a request timing waterfall. Only phases that actually happened are
+// included, plus a reused marker so pooled connections are not misread.
+func (t *proxyTimings) serverTimingHeader() string {
+	// Format a duration as fractional milliseconds, matching the Server-Timing spec.
+	ms := func(d time.Duration) string {
+		return strconv.FormatFloat(float64(d.Microseconds())/1000.0, 'f', 2, 64)
+	}
+
+	parts := []string{}
+
+	if t.dnsDuration > 0 {
+		parts = append(parts, "dns;dur="+ms(t.dnsDuration))
+	}
+
+	if t.connectDuration > 0 {
+		parts = append(parts, "connect;dur="+ms(t.connectDuration))
+	}
+
+	if t.tlsDuration > 0 {
+		parts = append(parts, "tls;dur="+ms(t.tlsDuration))
+	}
+
+	if t.ttfb > 0 {
+		parts = append(parts, "ttfb;dur="+ms(t.ttfb))
+	}
+
+	// A zero-duration description flag lets clients label reused connections.
+	if t.reused {
+		parts = append(parts, "reused")
+	}
+
+	return strings.Join(parts, ", ")
+}
+
 // NewProxyServer creates a new proxy server instance
 func NewProxyServer(bypassCidr bool) *ProxyServer {
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
@@ -299,8 +367,15 @@ func NewProxyServer(bypassCidr bool) *ProxyServer {
 					return dialer.DialContext(ctx, network, dialAddr(ip, port))
 				}
 
-				// Re-resolve hostname on every dial
+				// Re-resolve hostname on every dial. Time the lookup so we can
+				// report it via Server-Timing. The custom DialContext resolves
+				// manually, so httptrace's DNS hooks never fire for us.
+				dnsStart := time.Now()
 				ips, err := net.LookupIP(host)
+
+				if timings, ok := ctx.Value(timingsContextKey).(*proxyTimings); ok {
+					timings.dnsDuration = time.Since(dnsStart)
+				}
 
 				if err != nil {
 					return nil, err
@@ -489,7 +564,55 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	// Collect network phase timings (DNS, connect, TLS, TTFB) so we can report
+	// them back to the client via Server-Timing. Browsers cannot observe these
+	// for cross-origin requests, so measuring here is the only reliable source.
+	timings := &proxyTimings{}
+
+	var connectStart, tlsStart, wroteRequest time.Time
+
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			// A reused connection skips DNS, connect, and TLS entirely.
+			timings.reused = info.Reused
+		},
+		ConnectStart: func(_, _ string) {
+			connectStart = time.Now()
+		},
+		ConnectDone: func(_, _ string, _ error) {
+			if !connectStart.IsZero() {
+				// Accumulate across redirects, which may dial more than once.
+				timings.connectDuration += time.Since(connectStart)
+			}
+		},
+		TLSHandshakeStart: func() {
+			tlsStart = time.Now()
+		},
+		TLSHandshakeDone: func(_ tls.ConnectionState, _ error) {
+			if !tlsStart.IsZero() {
+				timings.tlsDuration += time.Since(tlsStart)
+			}
+		},
+		WroteRequest: func(_ httptrace.WroteRequestInfo) {
+			// Marks the end of sending the request; TTFB is measured from here.
+			// The last write in a redirect chain wins, giving the final leg.
+			wroteRequest = time.Now()
+		},
+		GotFirstResponseByte: func() {
+			// Isolated "waiting for server response" phase for the final response.
+			if !wroteRequest.IsZero() {
+				timings.ttfb = time.Since(wroteRequest)
+			} else {
+				timings.ttfb = time.Since(timings.start)
+			}
+		},
+	}
+
+	ctx := httptrace.WithClientTrace(context.WithValue(outreq.Context(), timingsContextKey, timings), trace)
+	outreq = outreq.WithContext(ctx)
+
 	// Make the request
+	timings.start = time.Now()
 	resp, err := client.Do(outreq)
 
 	if err != nil {
@@ -544,6 +667,13 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 
 	// Add the final URL as a header
 	w.Header().Set("X-Forwarded-Host", resp.Request.URL.String())
+
+	// Expose the proxy-to-target network timings so the client can draw a
+	// request timing waterfall. Content download is intentionally omitted: it
+	// happens after the headers are flushed, and the client measures it itself.
+	if serverTiming := timings.serverTimingHeader(); serverTiming != "" {
+		w.Header().Set("Server-Timing", serverTiming)
+	}
 
 	// Copy the status code from the proxied response
 	w.WriteHeader(resp.StatusCode)

--- a/projects/proxy-scalar-com/main_test.go
+++ b/projects/proxy-scalar-com/main_test.go
@@ -723,6 +723,60 @@ func TestProxyBehavior(t *testing.T) {
 	})
 }
 
+func TestServerTiming(t *testing.T) {
+	proxyServer := NewProxyServer(true)
+
+	t.Run("Reports a ttfb phase via the Server-Timing header", func(t *testing.T) {
+		// A small delay guarantees a measurable time to first byte.
+		targetServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(20 * time.Millisecond)
+			w.Write([]byte("slow response"))
+		})
+		defer targetServer.server.Close()
+
+		req := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetServer.url, nil)
+		w := httptest.NewRecorder()
+
+		proxyServer.handleRequest(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected status code %d, got %d", http.StatusOK, w.Code)
+		}
+
+		serverTiming := w.Header().Get("Server-Timing")
+		if serverTiming == "" {
+			t.Fatal("Expected a Server-Timing header, got none")
+		}
+
+		if !strings.Contains(serverTiming, "ttfb;dur=") {
+			t.Errorf("Expected Server-Timing to include a ttfb phase, got '%s'", serverTiming)
+		}
+	})
+
+	t.Run("Marks reused connections", func(t *testing.T) {
+		targetServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("ok"))
+		})
+		defer targetServer.server.Close()
+
+		// The first request primes the connection pool for the shared transport.
+		firstReq := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetServer.url, nil)
+		firstRes := httptest.NewRecorder()
+		proxyServer.handleRequest(firstRes, firstReq)
+
+		// Drain the body so the connection is returned to the pool for reuse.
+		io.ReadAll(firstRes.Result().Body)
+
+		secondReq := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetServer.url, nil)
+		secondRes := httptest.NewRecorder()
+		proxyServer.handleRequest(secondRes, secondReq)
+
+		if serverTiming := secondRes.Header().Get("Server-Timing"); !strings.Contains(serverTiming, "reused") {
+			t.Errorf("Expected reused marker on the second request, got '%s'", serverTiming)
+		}
+	})
+}
+
 func readSSEEvent(reader *bufio.Reader) (string, error) {
 	lines := []string{}
 

--- a/projects/proxy-scalar-com/main_test.go
+++ b/projects/proxy-scalar-com/main_test.go
@@ -774,6 +774,60 @@ func TestProxyBehavior(t *testing.T) {
 	})
 }
 
+func TestServerTiming(t *testing.T) {
+	proxyServer := NewProxyServer(true)
+
+	t.Run("Reports a ttfb phase via the Server-Timing header", func(t *testing.T) {
+		// A small delay guarantees a measurable time to first byte.
+		targetServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(20 * time.Millisecond)
+			w.Write([]byte("slow response"))
+		})
+		defer targetServer.server.Close()
+
+		req := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetServer.url, nil)
+		w := httptest.NewRecorder()
+
+		proxyServer.handleRequest(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected status code %d, got %d", http.StatusOK, w.Code)
+		}
+
+		serverTiming := w.Header().Get("Server-Timing")
+		if serverTiming == "" {
+			t.Fatal("Expected a Server-Timing header, got none")
+		}
+
+		if !strings.Contains(serverTiming, "ttfb;dur=") {
+			t.Errorf("Expected Server-Timing to include a ttfb phase, got '%s'", serverTiming)
+		}
+	})
+
+	t.Run("Marks reused connections", func(t *testing.T) {
+		targetServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("ok"))
+		})
+		defer targetServer.server.Close()
+
+		// The first request primes the connection pool for the shared transport.
+		firstReq := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetServer.url, nil)
+		firstRes := httptest.NewRecorder()
+		proxyServer.handleRequest(firstRes, firstReq)
+
+		// Drain the body so the connection is returned to the pool for reuse.
+		io.ReadAll(firstRes.Result().Body)
+
+		secondReq := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetServer.url, nil)
+		secondRes := httptest.NewRecorder()
+		proxyServer.handleRequest(secondRes, secondReq)
+
+		if serverTiming := secondRes.Header().Get("Server-Timing"); !strings.Contains(serverTiming, "reused") {
+			t.Errorf("Expected reused marker on the second request, got '%s'", serverTiming)
+		}
+	})
+}
+
 func readSSEEvent(reader *bufio.Reader) (string, error) {
 	lines := []string{}
 


### PR DESCRIPTION
WIP

- [ ] needs love
- [ ] check how it's working with SSE

Adds a **Timing** tab to the API client response view that shows how long each network phase took: DNS lookup, connection, TLS, and waiting for the server.

Browsers hide these details for cross-origin requests, so the proxy measures them and sends them back in a `Server-Timing` header. The client reads that header and draws the waterfall. The tab only appears for requests that go through the proxy.

**Preview**

<img width="1446" height="1152" alt="image" src="https://github.com/user-attachments/assets/76c182b1-2da1-45b4-bc9b-90869fcd8c40" />
