### PR TITLE
feat(api-client): add date and time picker for date/date-time/time fields

### DIFF
--- a/.changeset/date-time-picker.md
+++ b/.changeset/date-time-picker.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+Add a date and time picker for request fields with `format: date`, `date-time`, or `time`. A calendar/clock icon opens an accessible picker (built on radix-vue's Calendar) that writes a correctly formatted value back into the field. For `date-time` fields, the picker also offers shortcuts to insert faker variables like `{{$isoTimestamp}}` and `{{$randomDateFuture}}`. Free-text entry and `{{variables}}` keep working, so you can still type invalid data on purpose.

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -307,6 +307,7 @@
   "dependencies": {
     "@headlessui/tailwindcss": "catalog:*",
     "@headlessui/vue": "catalog:*",
+    "@internationalized/date": "catalog:*",
     "@scalar/blocks": "workspace:*",
     "@scalar/components": "workspace:*",
     "@scalar/helpers": "workspace:*",

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -21,6 +21,7 @@ import {
   DataTableCheckbox,
   DataTableRow,
 } from '@/v2/components/data-table'
+import { DatePicker, type DatePickerType } from '@/v2/components/date-picker'
 
 import RequestTableTooltip from './RequestTableTooltip.vue'
 
@@ -146,6 +147,21 @@ const enumValue = computed<string[]>(() => {
 const typeValue = computed(() =>
   data.schema && 'type' in data.schema ? data.schema.type : undefined,
 )
+
+/**
+ * Which date/time picker (if any) this value should offer, based on the
+ * schema `format`. Free-text entry and `{{variables}}` keep working — the
+ * picker is an optional shortcut that writes a formatted value back into the
+ * same input.
+ */
+const dateFormat = computed<DatePickerType | undefined>(() => {
+  const format =
+    data.schema && 'format' in data.schema ? data.schema.format : undefined
+  const pickerFormats: DatePickerType[] = ['date', 'date-time', 'time']
+  return pickerFormats.includes(format as DatePickerType)
+    ? (format as DatePickerType)
+    : undefined
+})
 
 const validationResult = computed(() =>
   validateParameter(data.schema, value.value),
@@ -273,6 +289,12 @@ const handleKeyBlur = (newName: string): void => {
             tooltip="top"
             variant="ghost"
             @click="emit('navigate', data.globalRoute)" />
+
+          <DatePicker
+            v-if="dateFormat && data.isReadonly !== true"
+            :modelValue="displayValue"
+            :type="dateFormat"
+            @update:modelValue="(v) => handleUpdateRow({ value: v })" />
 
           <RequestTableTooltip
             v-if="data.isReadonly"

--- a/packages/api-client/src/v2/blocks/request-block/helpers/validate-parameter.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/validate-parameter.test.ts
@@ -35,6 +35,8 @@ describe('validateParameter', () => {
 
   it.each([
     [{ schema: { type: 'string', format: 'date' }, value: 'some random value' }],
+    [{ schema: { type: 'string', format: 'date-time' }, value: '2025-05-15' }],
+    [{ schema: { type: 'string', format: 'time' }, value: 'some random value' }],
     [{ schema: { type: 'string', format: 'email' }, value: 'some random value' }],
     [{ schema: { type: 'string', format: 'uri' }, value: 'some random value' }],
   ])('validates different string formats', ({ schema, value }) => {
@@ -47,6 +49,8 @@ describe('validateParameter', () => {
 
   it.each([
     [{ schema: { type: 'string', format: 'date' }, value: '2025-05-15' }],
+    [{ schema: { type: 'string', format: 'date-time' }, value: '2024-03-20T13:45:30Z' }],
+    [{ schema: { type: 'string', format: 'time' }, value: '13:45:30' }],
     [{ schema: { type: 'string', format: 'email' }, value: 'someone@gmail.com' }],
     [{ schema: { type: 'string', format: 'uri' }, value: 'http://example.co' }],
   ])('validates different string formats to true', ({ schema, value }) => {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/validate-parameter.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/validate-parameter.ts
@@ -45,6 +45,12 @@ export const validateParameter = (
         message: 'Please enter a valid date and time in RFC 3339 format (e.g., 2024-03-20T13:45:30Z)',
       }
     }
+    if (schema.format === 'time' && !/^\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$/.test(value ?? '')) {
+      return {
+        ok: false,
+        message: 'Please enter a valid time in HH:MM:SS format (e.g., 13:45:30)',
+      }
+    }
     if (schema.format === 'email' && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value ?? '')) {
       return { ok: false, message: 'Please enter a valid email address (e.g., user@example.com)' }
     }

--- a/packages/api-client/src/v2/components/date-picker/DatePicker.vue
+++ b/packages/api-client/src/v2/components/date-picker/DatePicker.vue
@@ -1,0 +1,327 @@
+<script setup lang="ts">
+import {
+  CalendarDate,
+  CalendarDateTime,
+  type DateValue,
+} from '@internationalized/date'
+import { ScalarButton } from '@scalar/components/button'
+import { ScalarPopover } from '@scalar/components/popover'
+import {
+  ScalarIconCalendarBlank,
+  ScalarIconCaretLeft,
+  ScalarIconCaretRight,
+  ScalarIconClock,
+} from '@scalar/icons'
+import {
+  CalendarCell,
+  CalendarCellTrigger,
+  CalendarGrid,
+  CalendarGridBody,
+  CalendarGridHead,
+  CalendarGridRow,
+  CalendarHeadCell,
+  CalendarHeader,
+  CalendarHeading,
+  CalendarNext,
+  CalendarPrev,
+  CalendarRoot,
+  DateFieldInput,
+  DateFieldRoot,
+} from 'radix-vue'
+import { computed, ref, watch } from 'vue'
+
+import {
+  formatValue,
+  getLocalTimezoneOffset,
+  parseValue,
+  partsFromDate,
+  type DateParts,
+  type DatePickerType,
+} from './date-parts'
+
+const { modelValue, type } = defineProps<{
+  /** The current field value; may be a formatted value, free text, or a variable. */
+  modelValue: string
+  /** Which OpenAPI string format this field carries. */
+  type: DatePickerType
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: string): void
+}>()
+
+/** Locale for the calendar's weekday/month labels; falls back to English. */
+const locale =
+  typeof navigator !== 'undefined' ? navigator.language || 'en' : 'en'
+
+/** Whether the calendar grid is shown (everything except the time-only picker). */
+const showCalendar = computed(() => type !== 'time')
+
+/** Whether the time controls are shown. */
+const showTime = computed(() => type !== 'date')
+
+/**
+ * The currently committed selection parsed from `modelValue`, or `null` when
+ * the field holds free text or a variable. Drives both the highlighted day and
+ * the time input, and lets us leave the field untouched until the user picks.
+ */
+const selection = computed<DateParts | null>(() => parseValue(modelValue, type))
+
+/**
+ * Working fields. Seeded from the current value when it is a valid date/time,
+ * otherwise from "now" so the calendar opens on a sensible month.
+ */
+const draft = ref<DateParts>(selection.value ?? partsFromDate(new Date()))
+
+/** The month the calendar shows before a date is chosen. */
+const placeholder = ref<DateValue>(
+  new CalendarDate(draft.value.year, draft.value.month, draft.value.day),
+)
+
+/** Keep the working fields and calendar view in sync with the field. */
+watch(
+  () => modelValue,
+  () => {
+    draft.value = selection.value ?? partsFromDate(new Date())
+    placeholder.value = new CalendarDate(
+      draft.value.year,
+      draft.value.month,
+      draft.value.day,
+    )
+  },
+)
+
+/** The selected day as a calendar value, or `undefined` when nothing is selected. */
+const calendarValue = computed<DateValue | undefined>(() =>
+  selection.value
+    ? new CalendarDate(
+        selection.value.year,
+        selection.value.month,
+        selection.value.day,
+      )
+    : undefined,
+)
+
+/**
+ * The time bound to the segmented time field. radix-vue has no standalone time
+ * field in this version, so we back it with a `CalendarDateTime` and only render
+ * its hour/minute/second segments; the date part is ignored. A writable computed
+ * (rather than a one-way `:modelValue`) is what keeps the segments prefilled with
+ * the current time — DateField only populates from `modelValue` via `v-model`.
+ */
+const timeModel = computed<DateValue | undefined>({
+  get: () =>
+    new CalendarDateTime(
+      draft.value.year || 2000,
+      draft.value.month || 1,
+      draft.value.day || 1,
+      draft.value.hour,
+      draft.value.minute,
+      draft.value.second,
+    ),
+  set: (value) => {
+    // Only `CalendarDateTime`/`ZonedDateTime` carry time parts; ignore bare dates.
+    if (!value || !('hour' in value)) {
+      return
+    }
+    commit({
+      ...draft.value,
+      hour: value.hour,
+      minute: value.minute,
+      second: value.second,
+    })
+  },
+})
+
+/** The faker variables offered as shortcuts, contextual to the format. */
+const fakerOptions = computed<{ name: string; label: string }[]>(() =>
+  type === 'date-time'
+    ? [
+        { name: '$isoTimestamp', label: 'Current timestamp' },
+        { name: '$randomDateFuture', label: 'Random future date' },
+        { name: '$randomDatePast', label: 'Random past date' },
+        { name: '$randomDateRecent', label: 'Random recent date' },
+      ]
+    : [],
+)
+
+/** Emit a value built from the working fields, filling a local offset for `date-time`. */
+const commit = (next: DateParts): void => {
+  const resolved =
+    type === 'date-time' && !next.offset
+      ? { ...next, offset: getLocalTimezoneOffset(new Date()) }
+      : next
+  draft.value = resolved
+  emit('update:modelValue', formatValue(resolved, type))
+}
+
+const handleCalendarSelect = (
+  value: DateValue | undefined,
+  close: () => void,
+): void => {
+  if (!value) {
+    return
+  }
+  commit({
+    ...draft.value,
+    year: value.year,
+    month: value.month,
+    day: value.day,
+  })
+  // A date has nothing left to pick, so close; date-time keeps the time controls open.
+  if (type === 'date') {
+    close()
+  }
+}
+
+/** Seed the picker with the current date/time. */
+const selectNow = (close: () => void): void => {
+  commit(partsFromDate(new Date()))
+  if (type === 'date') {
+    close()
+  }
+}
+
+/** Insert a faker variable so the value is generated fresh at send time. */
+const selectFaker = (name: string, close: () => void): void => {
+  emit('update:modelValue', `{{${name}}}`)
+  close()
+}
+
+/**
+ * Keep only the time-related segments (hour/minute/second and the `:` literals
+ * between them). The backing value is a `CalendarDateTime`, so radix also yields
+ * date segments we do not want to show — we slice from the first time part. The
+ * generic preserves radix's `SegmentPart` type so it stays assignable to `part`.
+ */
+const timeSegments = <T extends { part: string }>(segments: T[]): T[] => {
+  const start = segments.findIndex((segment) => segment.part === 'hour')
+  return start === -1 ? segments : segments.slice(start)
+}
+</script>
+
+<template>
+  <ScalarPopover
+    placement="bottom-end"
+    teleport>
+    <button
+      :aria-label="type === 'time' ? 'Pick a time' : 'Pick a date'"
+      class="text-c-2 hover:text-c-1 hover:bg-b-2 -mr-0.5 rounded p-1"
+      type="button">
+      <component
+        :is="type === 'time' ? ScalarIconClock : ScalarIconCalendarBlank"
+        class="size-3.5" />
+    </button>
+    <template #popover="{ close }">
+      <div class="flex w-64 flex-col gap-2 py-1">
+        <!-- Calendar (accessible grid from radix-vue) -->
+        <CalendarRoot
+          v-if="showCalendar"
+          v-slot="{ weekDays, grid }"
+          class="px-2"
+          :locale="locale"
+          :modelValue="calendarValue as DateValue | undefined"
+          :placeholder="placeholder as DateValue"
+          @update:modelValue="(v) => handleCalendarSelect(v, close)"
+          @update:placeholder="(v) => (placeholder = v)">
+          <CalendarHeader class="flex items-center justify-between">
+            <CalendarPrev
+              aria-label="Previous month"
+              class="text-c-2 hover:text-c-1 hover:bg-b-2 flex size-6 items-center justify-center rounded">
+              <ScalarIconCaretLeft class="size-4" />
+            </CalendarPrev>
+            <CalendarHeading class="text-c-1 text-sm font-medium" />
+            <CalendarNext
+              aria-label="Next month"
+              class="text-c-2 hover:text-c-1 hover:bg-b-2 flex size-6 items-center justify-center rounded">
+              <ScalarIconCaretRight class="size-4" />
+            </CalendarNext>
+          </CalendarHeader>
+          <CalendarGrid
+            v-for="month in grid"
+            :key="month.value.toString()"
+            class="w-full border-collapse">
+            <CalendarGridHead>
+              <CalendarGridRow class="grid grid-cols-7">
+                <CalendarHeadCell
+                  v-for="day in weekDays"
+                  :key="day"
+                  class="text-c-3 flex h-6 items-center justify-center text-xs font-normal">
+                  {{ day }}
+                </CalendarHeadCell>
+              </CalendarGridRow>
+            </CalendarGridHead>
+            <CalendarGridBody>
+              <CalendarGridRow
+                v-for="(weekDates, index) in month.rows"
+                :key="index"
+                class="grid grid-cols-7">
+                <CalendarCell
+                  v-for="weekDate in weekDates"
+                  :key="weekDate.toString()"
+                  :date="weekDate"
+                  class="text-center text-sm">
+                  <CalendarCellTrigger
+                    :day="weekDate"
+                    :month="month.value"
+                    class="text-c-1 hover:bg-b-2 data-[selected]:bg-c-accent data-[selected]:text-b-1 data-[outside-view]:text-c-3 mx-auto flex size-7 cursor-pointer items-center justify-center rounded text-sm outline-offset-2 data-[today]:font-bold" />
+                </CalendarCell>
+              </CalendarGridRow>
+            </CalendarGridBody>
+          </CalendarGrid>
+        </CalendarRoot>
+
+        <!-- Time: a themed segmented field (radix-vue has no standalone time field here) -->
+        <div
+          v-if="showTime"
+          class="flex items-center justify-between gap-2 px-2 text-sm">
+          <span class="text-c-2">Time</span>
+          <DateFieldRoot
+            v-slot="{ segments }"
+            v-model="timeModel"
+            aria-label="Time"
+            class="bg-b-2 text-c-1 flex items-center rounded px-2 py-1 tabular-nums"
+            granularity="second"
+            :hourCycle="24"
+            :locale="locale">
+            <DateFieldInput
+              v-for="(item, index) in timeSegments(segments)"
+              :key="index"
+              :class="
+                item.part === 'literal'
+                  ? 'text-c-3'
+                  : 'data-[placeholder]:text-c-3 focus:bg-c-accent focus:text-b-1 rounded px-px focus:outline-none'
+              "
+              :part="item.part">
+              {{ item.value }}
+            </DateFieldInput>
+          </DateFieldRoot>
+        </div>
+
+        <ScalarButton
+          class="mx-2 h-fit"
+          size="sm"
+          variant="outlined"
+          @click="selectNow(close)">
+          {{ type === 'time' ? 'Now' : 'Today' }}
+        </ScalarButton>
+
+        <!-- Faker shortcuts (date-time only) -->
+        <template v-if="fakerOptions.length">
+          <div class="bg-b-3 -mx-0.75 h-px" />
+          <span class="text-c-3 px-2 text-xs">Variables</span>
+          <div class="flex flex-col">
+            <button
+              v-for="option in fakerOptions"
+              :key="option.name"
+              class="text-c-1 hover:bg-b-2 flex items-center rounded px-2 py-1 text-left text-sm"
+              type="button"
+              @click="selectFaker(option.name, close)">
+              {{ option.label }}
+            </button>
+          </div>
+        </template>
+      </div>
+    </template>
+  </ScalarPopover>
+</template>

--- a/packages/api-client/src/v2/components/date-picker/date-parts.test.ts
+++ b/packages/api-client/src/v2/components/date-picker/date-parts.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  type DateParts,
+  formatDate,
+  formatTime,
+  formatValue,
+  getLocalTimezoneOffset,
+  parseValue,
+  partsFromDate,
+} from './date-parts'
+
+const parts = (overrides: Partial<DateParts> = {}): DateParts => ({
+  year: 2024,
+  month: 3,
+  day: 20,
+  hour: 13,
+  minute: 45,
+  second: 30,
+  offset: 'Z',
+  ...overrides,
+})
+
+describe('parseValue', () => {
+  it('parses a date value', () => {
+    expect(parseValue('2024-03-20', 'date')).toMatchObject({
+      year: 2024,
+      month: 3,
+      day: 20,
+    })
+  })
+
+  it('parses a time value with seconds', () => {
+    expect(parseValue('13:45:30', 'time')).toMatchObject({
+      hour: 13,
+      minute: 45,
+      second: 30,
+    })
+  })
+
+  it('parses a time value without seconds', () => {
+    expect(parseValue('09:05', 'time')).toMatchObject({
+      hour: 9,
+      minute: 5,
+      second: 0,
+    })
+  })
+
+  it('parses a date-time value and keeps the offset', () => {
+    expect(parseValue('2024-03-20T13:45:30+02:00', 'date-time')).toMatchObject({
+      year: 2024,
+      month: 3,
+      day: 20,
+      hour: 13,
+      minute: 45,
+      second: 30,
+      offset: '+02:00',
+    })
+  })
+
+  it('parses a date-time value with a Z offset and fractional seconds', () => {
+    expect(parseValue('2024-03-20T13:45:30.123Z', 'date-time')).toMatchObject({
+      hour: 13,
+      minute: 45,
+      second: 30,
+      offset: 'Z',
+    })
+  })
+
+  it('returns null for free-text or variable values', () => {
+    expect(parseValue('not a date', 'date')).toBeNull()
+    expect(parseValue('{{myDate}}', 'date-time')).toBeNull()
+    expect(parseValue('', 'time')).toBeNull()
+  })
+
+  it('does not treat a bare date as a date-time', () => {
+    expect(parseValue('2024-03-20', 'date-time')).toBeNull()
+  })
+})
+
+describe('formatValue', () => {
+  it('formats a date', () => {
+    expect(formatValue(parts(), 'date')).toBe('2024-03-20')
+  })
+
+  it('formats a time', () => {
+    expect(formatValue(parts(), 'time')).toBe('13:45:30')
+  })
+
+  it('formats a date-time with the supplied offset', () => {
+    expect(formatValue(parts({ offset: '+02:00' }), 'date-time')).toBe('2024-03-20T13:45:30+02:00')
+  })
+
+  it('zero-pads single-digit fields', () => {
+    expect(formatValue(parts({ month: 1, day: 5, hour: 9 }), 'date-time')).toBe('2024-01-05T09:45:30Z')
+  })
+
+  it('round-trips a parsed date-time', () => {
+    const value = '2024-03-20T13:45:30+02:00'
+    const parsed = parseValue(value, 'date-time')
+    expect(parsed).not.toBeNull()
+    expect(formatValue(parsed!, 'date-time')).toBe(value)
+  })
+})
+
+describe('formatDate / formatTime', () => {
+  it('formats the date portion', () => {
+    expect(formatDate(parts())).toBe('2024-03-20')
+  })
+
+  it('formats the time portion', () => {
+    expect(formatTime(parts())).toBe('13:45:30')
+  })
+})
+
+describe('getLocalTimezoneOffset', () => {
+  it('formats a positive offset', () => {
+    // -120 minutes reported → UTC+02:00
+    const date = { getTimezoneOffset: () => -120 } as Date
+    expect(getLocalTimezoneOffset(date)).toBe('+02:00')
+  })
+
+  it('formats a negative offset', () => {
+    const date = { getTimezoneOffset: () => 300 } as Date
+    expect(getLocalTimezoneOffset(date)).toBe('-05:00')
+  })
+
+  it('formats UTC as +00:00', () => {
+    const date = { getTimezoneOffset: () => 0 } as Date
+    expect(getLocalTimezoneOffset(date)).toBe('+00:00')
+  })
+})
+
+describe('partsFromDate', () => {
+  it('reads the local fields from a date', () => {
+    const date = new Date(2024, 2, 20, 13, 45, 30)
+    expect(partsFromDate(date)).toMatchObject({
+      year: 2024,
+      month: 3,
+      day: 20,
+      hour: 13,
+      minute: 45,
+      second: 30,
+    })
+  })
+})

--- a/packages/api-client/src/v2/components/date-picker/date-parts.ts
+++ b/packages/api-client/src/v2/components/date-picker/date-parts.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure date/time helpers for the {@link DatePicker}.
+ *
+ * The picker edits three OpenAPI string formats — `date`, `date-time`, and
+ * `time` — as a small bag of integer fields. Keeping the parse/format logic
+ * here (free of Vue and, where possible, of the ambient timezone) makes it
+ * straightforward to unit test the exact strings we hand back to the request.
+ */
+
+/** The OpenAPI string formats the picker knows how to edit. */
+export type DatePickerType = 'date' | 'date-time' | 'time'
+
+/**
+ * A date/time broken into its editable fields.
+ *
+ * `offset` only matters for `date-time` values: it holds the timezone
+ * designator (`Z` or `±HH:MM`) so a round-trip preserves whatever the user
+ * originally typed instead of silently rewriting it to the local zone.
+ */
+export type DateParts = {
+  year: number
+  /** 1-12 (human month, not the 0-based `Date` month) */
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+  /** Timezone designator for `date-time`, e.g. `Z` or `+02:00`. Empty otherwise. */
+  offset: string
+}
+
+/** Zero-pad a number to two digits. */
+const pad2 = (value: number): string => String(Math.abs(value)).padStart(2, '0')
+
+/** Zero-pad a year to four digits. */
+const pad4 = (value: number): string => String(value).padStart(4, '0')
+
+const DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/
+const TIME_RE = /^(\d{2}):(\d{2})(?::(\d{2}))?$/
+const DATE_TIME_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d+)?(Z|[+-]\d{2}:\d{2})?$/
+
+/**
+ * Parse a formatted value into editable fields, or return `null` when it does
+ * not match the given format. A `null` result is how the picker recognizes
+ * free-text or `{{variable}}` values it should not try to interpret — it just
+ * falls back to "now" for its initial view without touching the field.
+ */
+export const parseValue = (value: string, type: DatePickerType): DateParts | null => {
+  const trimmed = value.trim()
+
+  if (type === 'date') {
+    const match = DATE_RE.exec(trimmed)
+    if (!match) {
+      return null
+    }
+    return {
+      year: Number(match[1]),
+      month: Number(match[2]),
+      day: Number(match[3]),
+      hour: 0,
+      minute: 0,
+      second: 0,
+      offset: '',
+    }
+  }
+
+  if (type === 'time') {
+    const match = TIME_RE.exec(trimmed)
+    if (!match) {
+      return null
+    }
+    return {
+      year: 0,
+      month: 0,
+      day: 0,
+      hour: Number(match[1]),
+      minute: Number(match[2]),
+      second: Number(match[3] ?? 0),
+      offset: '',
+    }
+  }
+
+  const match = DATE_TIME_RE.exec(trimmed)
+  if (!match) {
+    return null
+  }
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+    hour: Number(match[4]),
+    minute: Number(match[5]),
+    second: Number(match[6] ?? 0),
+    offset: match[7] ?? '',
+  }
+}
+
+/** Format the date portion as `YYYY-MM-DD`. */
+export const formatDate = (parts: DateParts): string => `${pad4(parts.year)}-${pad2(parts.month)}-${pad2(parts.day)}`
+
+/** Format the time portion as `HH:MM:SS`. */
+export const formatTime = (parts: DateParts): string =>
+  `${pad2(parts.hour)}:${pad2(parts.minute)}:${pad2(parts.second)}`
+
+/**
+ * Format editable fields back into the string the request expects.
+ *
+ * For `date-time` the caller is responsible for supplying a non-empty
+ * `offset`; use {@link getLocalTimezoneOffset} to derive one when the original
+ * value had none.
+ */
+export const formatValue = (parts: DateParts, type: DatePickerType): string => {
+  if (type === 'date') {
+    return formatDate(parts)
+  }
+  if (type === 'time') {
+    return formatTime(parts)
+  }
+  return `${formatDate(parts)}T${formatTime(parts)}${parts.offset}`
+}
+
+/**
+ * Read the current fields from a `Date`, in the host's local timezone. Used to
+ * seed the picker with "now"/"today" and to fill in an offset when a
+ * `date-time` value arrives without one.
+ */
+export const partsFromDate = (date: Date): DateParts => ({
+  year: date.getFullYear(),
+  month: date.getMonth() + 1,
+  day: date.getDate(),
+  hour: date.getHours(),
+  minute: date.getMinutes(),
+  second: date.getSeconds(),
+  offset: getLocalTimezoneOffset(date),
+})
+
+/**
+ * The host's UTC offset for the given date as an RFC 3339 designator
+ * (`+02:00`, `-05:00`, or `+00:00`). `Date.getTimezoneOffset` reports minutes
+ * *behind* UTC, so the sign is inverted here.
+ */
+export const getLocalTimezoneOffset = (date: Date): string => {
+  const offsetMinutes = -date.getTimezoneOffset()
+  const sign = offsetMinutes >= 0 ? '+' : '-'
+  return `${sign}${pad2(Math.floor(Math.abs(offsetMinutes) / 60))}:${pad2(Math.abs(offsetMinutes) % 60)}`
+}

--- a/packages/api-client/src/v2/components/date-picker/index.ts
+++ b/packages/api-client/src/v2/components/date-picker/index.ts
@@ -1,0 +1,2 @@
+export { default as DatePicker } from './DatePicker.vue'
+export type { DatePickerType } from './date-parts'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ catalogs:
     '@hono/node-ws':
       specifier: ^1.2.0
       version: 1.3.1
+    '@internationalized/date':
+      specifier: 3.5.4
+      version: 3.5.4
     '@nestjs/cli':
       specifier: ^11.0.14
       version: 11.0.14
@@ -1208,6 +1211,9 @@ importers:
       '@headlessui/vue':
         specifier: catalog:*
         version: 1.7.23(vue@3.5.30(typescript@5.9.3))
+      '@internationalized/date':
+        specifier: catalog:*
+        version: 3.5.4
       '@scalar/blocks':
         specifier: workspace:*
         version: link:../blocks
@@ -18678,8 +18684,8 @@ packages:
   vue-component-type-helpers@3.3.3:
     resolution: {integrity: sha512-x4nsFpy5Pe8fqPzp/5vkTPeTTDBpAx4WVtV47Ejt0+2FQrq4pRRsJs7JmYRqMFzTu/LW+pCWEjQ3YVCkPV7f9g==}
 
-  vue-component-type-helpers@3.3.5:
-    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
+  vue-component-type-helpers@3.3.7:
+    resolution: {integrity: sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -25715,7 +25721,7 @@ snapshots:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       type-fest: 2.19.0
       vue: 3.5.30(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.5
+      vue-component-type-helpers: 3.3.7
 
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.16.0)':
     dependencies:
@@ -38569,7 +38575,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.3: {}
 
-  vue-component-type-helpers@3.3.5: {}
+  vue-component-type-helpers@3.3.7: {}
 
   vue-demi@0.14.10(vue@3.5.30(typescript@5.9.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,6 +25,7 @@ catalogs:
     '@headlessui/vue': 1.7.23
     '@hono/node-server': ^1.19.10
     '@hono/node-ws': ^1.2.0
+    '@internationalized/date': 3.5.4
     '@modelcontextprotocol/sdk': 1.26.0
     '@nestjs/cli': '^11.0.14'
     '@nestjs/common': '^11.1.11'


### PR DESCRIPTION
Adds an accessible date/time picker to API Client fields with `date`, `date-time`, or `time` formats. Free-text and variable entry remain available. Date-time fields also offer faker shortcuts.

The picker uses themed controls, a Done action, and an expandable variable section. Edits preserve fractional seconds and explicit offsets; an empty date-time field uses the selected date’s local timezone offset.

For example, this API description previously required typing each value. Its query fields now offer calendar or time controls alongside text entry:

```yaml
openapi: 3.1.0
info:
  title: Event search
  version: 1.0.0
paths:
  /events:
    get:
      parameters:
        - name: day
          in: query
          schema: { type: string, format: date }
        - name: starts_at
          in: query
          schema: { type: string, format: date-time }
          example: '2026-09-22T13:45:30.123+02:00'
        - name: time
          in: query
          schema: { type: string, format: time }
      responses:
        '200':
          description: Event results
```

## Visual

Screenshots of the date/time controls in the API Client have been captured; attachment is pending.

## Ticket

Closes #9749
