### PR TITLE
fix(api-client): make environment variables work in scripts

### DIFF
--- a/.changeset/script-environment-variables.md
+++ b/.changeset/script-environment-variables.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+Make environment variables work in pre-request and post-response scripts. `pm.environment.get()` (and `pm.variables.get()`) now read the active environment, and `pm.environment.set()` persists back to it so values like a bearer token survive to the next request. Previously the script variable store was created empty per request and discarded afterwards, so scripted reads returned `undefined` and writes were lost even though `{{variable}}` placeholders resolved correctly.

--- a/.changeset/script-environment-variables.md
+++ b/.changeset/script-environment-variables.md
@@ -2,4 +2,4 @@
 "@scalar/api-client": patch
 ---
 
-Make environment variables work in pre-request and post-response scripts. `pm.environment.get()` (and `pm.variables.get()`) now read the active environment, and `pm.environment.set()` persists back to it so values like a bearer token survive to the next request. Previously the script variable store was created empty per request and discarded afterwards, so scripted reads returned `undefined` and writes were lost even though `{{variable}}` placeholders resolved correctly.
+Make environment variables work in pre-request and post-response scripts. `pm.environment.get()` (and `pm.variables.get()`) now read the active environment, and `pm.environment.set()` / `pm.environment.unset()` persist back to it so values like a bearer token survive to the next request. Previously the script variable store was created empty per request and discarded afterwards, so scripted reads returned `undefined` and writes were lost even though `{{variable}}` placeholders resolved correctly.

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -728,6 +728,74 @@ describe('OperationBlock', () => {
     )
   })
 
+  it('resolves persistence indexes against a seed-time copy when the environment array is spliced mid-flight', async () => {
+    const mockEventBus = createMockEventBus()
+    // token sits at index 0 in the workspace scope when the request starts.
+    const environment: XScalarEnvironment = { color: 'blue', variables: [{ name: 'token', value: 'old' }] }
+
+    vi.mocked(buildRequest).mockReturnValue(
+      ok({
+        controller: new AbortController(),
+        requestPayload: ['https://api.example.com/api/users', { method: 'GET', headers: new Headers() }],
+        isUsingProxy: false,
+      }),
+    )
+
+    // Hold the request open so the environment array can be spliced before persistence runs.
+    let resolveSend!: (value: Awaited<ReturnType<typeof sendRequest>>) => void
+    vi.mocked(sendRequest).mockReturnValue(
+      new Promise<Awaited<ReturnType<typeof sendRequest>>>((resolve) => {
+        resolveSend = resolve
+      }),
+    )
+
+    const setTokenPlugin: ClientPlugin = {
+      hooks: {
+        beforeRequest: ({ variablesStore }) => {
+          variablesStore?.setEnvironment?.([{ key: 'token', value: 'new' }])
+        },
+      },
+    }
+
+    const wrapper = mount(OperationBlock, {
+      props: {
+        ...createDefaultProps(),
+        eventBus: mockEventBus,
+        plugins: [setTokenPlugin],
+        activeEnvironment: 'default',
+        environment,
+      },
+    })
+
+    wrapper.findComponent({ name: 'Header' }).vm.$emit('execute')
+    await flushPromises()
+
+    // A concurrent change prepends a variable, shifting token to index 1 in the live array.
+    environment.variables.unshift({ name: 'other', value: 'x' })
+
+    resolveSend([
+      null,
+      {
+        timestamp: Date.now(),
+        requestPayload: ['https://api.example.com/api/users', { method: 'GET', headers: new Headers() }],
+        response: {} as ResponseInstance,
+        originalResponse: createMockOriginalResponse(),
+      },
+    ])
+    await flushPromises()
+
+    // token must still resolve to its seed-time index (0), not the shifted one.
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'environment:upsert:environment-variable',
+      expect.objectContaining({
+        environmentName: 'default',
+        variable: { name: 'token', value: 'new' },
+        index: 0,
+        collectionType: 'workspace',
+      }),
+    )
+  })
+
   it('cancels request when cancelRequest is invoked via event bus', async () => {
     const mockEventBus = createMockEventBus()
     const mockController = new AbortController()

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -578,6 +578,50 @@ describe('OperationBlock', () => {
     expect(mockToast).toHaveBeenCalledWith(ERRORS.REQUEST_FAILED, 'error')
   })
 
+  it('persists a pre-request script variable even when the request fails', async () => {
+    const mockEventBus = createMockEventBus()
+
+    vi.mocked(buildRequest).mockReturnValue(
+      ok({
+        controller: new AbortController(),
+        requestPayload: ['https://api.example.com/api/users', { method: 'GET', headers: new Headers() }],
+        isUsingProxy: false,
+      }),
+    )
+
+    // The request fails, so persistence must run outside the success branch.
+    vi.mocked(sendRequest).mockResolvedValue([new Error(ERRORS.REQUEST_FAILED), null])
+
+    // A pre-request script stores a token in the active environment.
+    const setTokenPlugin: ClientPlugin = {
+      hooks: {
+        beforeRequest: ({ variablesStore }) => {
+          variablesStore?.setEnvironment?.([{ key: 'token', value: 'from-script' }])
+        },
+      },
+    }
+
+    const wrapper = mount(OperationBlock, {
+      props: {
+        ...createDefaultProps(),
+        eventBus: mockEventBus,
+        plugins: [setTokenPlugin],
+        activeEnvironment: 'default',
+      },
+    })
+
+    await triggerExecute(wrapper)
+
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'environment:upsert:environment-variable',
+      expect.objectContaining({
+        environmentName: 'default',
+        variable: { name: 'token', value: 'from-script' },
+        collectionType: 'workspace',
+      }),
+    )
+  })
+
   it('cancels request when cancelRequest is invoked via event bus', async () => {
     const mockEventBus = createMockEventBus()
     const mockController = new AbortController()

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -555,6 +555,43 @@ describe('OperationBlock', () => {
     expect(sendRequest).not.toHaveBeenCalled()
   })
 
+  it('persists a pre-request script variable when the request never builds', async () => {
+    const mockEventBus = createMockEventBus()
+
+    // The request fails to build, so the flow bails out before sending.
+    vi.mocked(buildRequest).mockReturnValue(err('BUILD_REQUEST_FAILED' as const, 'Invalid URL'))
+
+    // A pre-request script stores a token in the active environment.
+    const setTokenPlugin: ClientPlugin = {
+      hooks: {
+        beforeRequest: ({ variablesStore }) => {
+          variablesStore?.setEnvironment?.([{ key: 'token', value: 'from-script' }])
+        },
+      },
+    }
+
+    const wrapper = mount(OperationBlock, {
+      props: {
+        ...createDefaultProps(),
+        eventBus: mockEventBus,
+        plugins: [setTokenPlugin],
+        activeEnvironment: 'default',
+      },
+    })
+
+    await triggerExecute(wrapper)
+
+    expect(sendRequest).not.toHaveBeenCalled()
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'environment:upsert:environment-variable',
+      expect.objectContaining({
+        environmentName: 'default',
+        variable: { name: 'token', value: 'from-script' },
+        collectionType: 'workspace',
+      }),
+    )
+  })
+
   it('displays toast error when sendRequest fails', async () => {
     const mockController = new AbortController()
 

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -659,6 +659,75 @@ describe('OperationBlock', () => {
     )
   })
 
+  it('persists script writes to the environment active when the request started, not one switched to mid-flight', async () => {
+    const mockEventBus = createMockEventBus()
+
+    vi.mocked(buildRequest).mockReturnValue(
+      ok({
+        controller: new AbortController(),
+        requestPayload: ['https://api.example.com/api/users', { method: 'GET', headers: new Headers() }],
+        isUsingProxy: false,
+      }),
+    )
+
+    // Hold the request open so the active environment can change before persistence runs.
+    let resolveSend!: (value: Awaited<ReturnType<typeof sendRequest>>) => void
+    vi.mocked(sendRequest).mockReturnValue(
+      new Promise<Awaited<ReturnType<typeof sendRequest>>>((resolve) => {
+        resolveSend = resolve
+      }),
+    )
+
+    const setTokenPlugin: ClientPlugin = {
+      hooks: {
+        beforeRequest: ({ variablesStore }) => {
+          variablesStore?.setEnvironment?.([{ key: 'token', value: 'from-script' }])
+        },
+      },
+    }
+
+    const wrapper = mount(OperationBlock, {
+      props: {
+        ...createDefaultProps(),
+        eventBus: mockEventBus,
+        plugins: [setTokenPlugin],
+        activeEnvironment: 'default',
+      },
+    })
+
+    // Start the request; it suspends at the pending sendRequest.
+    wrapper.findComponent({ name: 'Header' }).vm.$emit('execute')
+    await flushPromises()
+
+    // The user switches environments while the request is in flight.
+    await wrapper.setProps({ activeEnvironment: 'switched' })
+
+    // Complete the request so persistence runs.
+    resolveSend([
+      null,
+      {
+        timestamp: Date.now(),
+        requestPayload: ['https://api.example.com/api/users', { method: 'GET', headers: new Headers() }],
+        response: {} as ResponseInstance,
+        originalResponse: createMockOriginalResponse(),
+      },
+    ])
+    await flushPromises()
+
+    // The write lands on the environment that was active when the request began.
+    expect(mockEventBus.emit).toHaveBeenCalledWith(
+      'environment:upsert:environment-variable',
+      expect.objectContaining({
+        environmentName: 'default',
+        variable: { name: 'token', value: 'from-script' },
+      }),
+    )
+    expect(mockEventBus.emit).not.toHaveBeenCalledWith(
+      'environment:upsert:environment-variable',
+      expect.objectContaining({ environmentName: 'switched' }),
+    )
+  })
+
   it('cancels request when cancelRequest is invoked via event bus', async () => {
     const mockEventBus = createMockEventBus()
     const mockController = new AbortController()

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -320,6 +320,46 @@ const handleExecute = async () => {
     plugins,
   )
 
+  // Persist environment variables set by scripts (pm.environment.set / unset) back to the active
+  // environment so they survive to the next request, mirroring the Environment tab. Scope and
+  // index are resolved from the merged environment so updates mutate in place. Defined here so it
+  // can run on every exit path after the pre-request scripts — including a build failure or a
+  // failed send — so a pre-request set, like a token stored before a flaky call, is not lost.
+  const persistScriptEnvironment = () => {
+    if (!activeEnvironment) {
+      return
+    }
+
+    const environmentActions = getEnvironmentPersistenceActions({
+      environmentName: activeEnvironment,
+      seededVariables: seededEnvironment,
+      scriptVariables: variablesStore.getEnvironment(),
+      mergedVariables: environment.variables,
+      documentVariables:
+        document['x-scalar-environments']?.[activeEnvironment]?.variables ?? [],
+      environmentExistsOnDocument: Boolean(
+        document['x-scalar-environments']?.[activeEnvironment],
+      ),
+    })
+
+    for (const action of environmentActions) {
+      if (action.type === 'delete') {
+        eventBus.emit('environment:delete:environment-variable', {
+          environmentName: action.environmentName,
+          index: action.index,
+          collectionType: action.collectionType,
+        })
+      } else {
+        eventBus.emit('environment:upsert:environment-variable', {
+          environmentName: action.environmentName,
+          variable: action.variable,
+          index: action.index,
+          collectionType: action.collectionType,
+        })
+      }
+    }
+  }
+
   // Resolve {{…}} placeholders from the script store so pre-request pm.environment.set() and
   // unset() take effect on this request. The store was seeded from the active environment, so
   // it already holds every value spreading seededEnvironment would add — minus the keys a script
@@ -332,6 +372,8 @@ const handleExecute = async () => {
     allowMissingRequestServerBase: layout === 'modal',
   })
   if (!built.ok) {
+    // Save any pre-request script writes before bailing out on a build failure.
+    persistScriptEnvironment()
     toast(built.message ?? built.error, 'error')
     return
   }
@@ -391,41 +433,9 @@ const handleExecute = async () => {
     )
   }
 
-  // Persist environment variables set by scripts (pm.environment.set) back to the active
-  // environment so they survive to the next request, mirroring the Environment tab. Scope
-  // and index are resolved from the merged environment so updates mutate in place. This runs
-  // even when the request fails so a pre-request set — like a token stored before a flaky
-  // call — is not lost.
-  if (activeEnvironment) {
-    const environmentActions = getEnvironmentPersistenceActions({
-      environmentName: activeEnvironment,
-      seededVariables: seededEnvironment,
-      scriptVariables: variablesStore.getEnvironment(),
-      mergedVariables: environment.variables,
-      documentVariables:
-        document['x-scalar-environments']?.[activeEnvironment]?.variables ?? [],
-      environmentExistsOnDocument: Boolean(
-        document['x-scalar-environments']?.[activeEnvironment],
-      ),
-    })
-
-    for (const action of environmentActions) {
-      if (action.type === 'delete') {
-        eventBus.emit('environment:delete:environment-variable', {
-          environmentName: action.environmentName,
-          index: action.index,
-          collectionType: action.collectionType,
-        })
-      } else {
-        eventBus.emit('environment:upsert:environment-variable', {
-          environmentName: action.environmentName,
-          variable: action.variable,
-          index: action.index,
-          collectionType: action.collectionType,
-        })
-      }
-    }
-  }
+  // Save script environment writes (pre-request and, on success, post-response) back to the
+  // active environment. Runs even when the send fails so a pre-request set is not lost.
+  persistScriptEnvironment()
 
   // Execute the hooks
   eventBus.emit('hooks:on:request:complete', {

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -306,6 +306,24 @@ const handleExecute = async () => {
     Object.entries(seededEnvironment).map(([key, value]) => ({ key, value })),
   )
 
+  // Snapshot the persistence target at request start, alongside the seed. Persistence runs after
+  // the request completes (awaits below), and the environment props are reactive — if the user
+  // switches the active environment mid-flight, reading them at persist time would apply the
+  // script's writes to the wrong environment using indexes from a different variable list. The
+  // seeded values and these targets must come from the same point in time.
+  const persistenceTarget = activeEnvironment
+    ? {
+        environmentName: activeEnvironment,
+        mergedVariables: environment.variables,
+        documentVariables:
+          document['x-scalar-environments']?.[activeEnvironment]?.variables ??
+          [],
+        environmentExistsOnDocument: Boolean(
+          document['x-scalar-environments']?.[activeEnvironment],
+        ),
+      }
+    : null
+
   // Execute the beforeRequest hook (plugins receive RequestFactory, not fetch Request)
   await executeHook(
     {
@@ -322,24 +340,18 @@ const handleExecute = async () => {
 
   // Persist environment variables set by scripts (pm.environment.set / unset) back to the active
   // environment so they survive to the next request, mirroring the Environment tab. Scope and
-  // index are resolved from the merged environment so updates mutate in place. Defined here so it
-  // can run on every exit path after the pre-request scripts — including a build failure or a
+  // index are resolved from the seed-time environment so updates mutate in place. Defined here so
+  // it can run on every exit path after the pre-request scripts — including a build failure or a
   // failed send — so a pre-request set, like a token stored before a flaky call, is not lost.
   const persistScriptEnvironment = () => {
-    if (!activeEnvironment) {
+    if (!persistenceTarget) {
       return
     }
 
     const environmentActions = getEnvironmentPersistenceActions({
-      environmentName: activeEnvironment,
+      ...persistenceTarget,
       seededVariables: seededEnvironment,
       scriptVariables: variablesStore.getEnvironment(),
-      mergedVariables: environment.variables,
-      documentVariables:
-        document['x-scalar-environments']?.[activeEnvironment]?.variables ?? [],
-      environmentExistsOnDocument: Boolean(
-        document['x-scalar-environments']?.[activeEnvironment],
-      ),
     })
 
     for (const action of environmentActions) {

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -307,17 +307,19 @@ const handleExecute = async () => {
   )
 
   // Snapshot the persistence target at request start, alongside the seed. Persistence runs after
-  // the request completes (awaits below), and the environment props are reactive — if the user
-  // switches the active environment mid-flight, reading them at persist time would apply the
-  // script's writes to the wrong environment using indexes from a different variable list. The
-  // seeded values and these targets must come from the same point in time.
+  // the request completes (awaits below), and the environment props are reactive — if the active
+  // environment is switched mid-flight, or a concurrent request splices these arrays, reading
+  // them at persist time would apply the script's writes to the wrong environment or resolve
+  // workspace/document indexes against a shifted list. Copy the arrays (not just the reference)
+  // so the seeded values and these targets stay fixed to the same point in time.
   const persistenceTarget = activeEnvironment
     ? {
         environmentName: activeEnvironment,
-        mergedVariables: environment.variables,
-        documentVariables:
-          document['x-scalar-environments']?.[activeEnvironment]?.variables ??
-          [],
+        mergedVariables: [...environment.variables],
+        documentVariables: [
+          ...(document['x-scalar-environments']?.[activeEnvironment]
+            ?.variables ?? []),
+        ],
         environmentExistsOnDocument: Boolean(
           document['x-scalar-environments']?.[activeEnvironment],
         ),

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -407,7 +407,20 @@ const handleExecute = async () => {
       })
 
       for (const action of environmentActions) {
-        eventBus.emit('environment:upsert:environment-variable', action)
+        if (action.type === 'delete') {
+          eventBus.emit('environment:delete:environment-variable', {
+            environmentName: action.environmentName,
+            index: action.index,
+            collectionType: action.collectionType,
+          })
+        } else {
+          eventBus.emit('environment:upsert:environment-variable', {
+            environmentName: action.environmentName,
+            variable: action.variable,
+            index: action.index,
+            collectionType: action.collectionType,
+          })
+        }
       }
     }
   }

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -297,6 +297,14 @@ const handleExecute = async () => {
 
   const variablesStore = createVariablesStoreForRequest()
 
+  // Seed the script variable store with the active environment so pm.environment.get()
+  // and pm.variables.get() resolve to the same values as {{…}} placeholders. Without
+  // seeding, the store starts empty and every scripted read returns undefined.
+  const seededEnvironment = getEnvironmentVariables(environment)
+  variablesStore.setEnvironment?.(
+    Object.entries(seededEnvironment).map(([key, value]) => ({ key, value })),
+  )
+
   // Execute the beforeRequest hook (plugins receive RequestFactory, not fetch Request)
   await executeHook(
     {
@@ -312,7 +320,7 @@ const handleExecute = async () => {
   )
 
   const envVariables = {
-    ...getEnvironmentVariables(environment),
+    ...seededEnvironment,
     ...variablesStore.getVariables(),
   }
 

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -135,6 +135,7 @@ import {
   getCookieRequestUrl,
   getResponseCookieActions,
 } from '@/v2/blocks/operation-block/helpers/persist-response-cookies'
+import { getEnvironmentPersistenceActions } from '@/v2/blocks/operation-block/helpers/persist-script-environment'
 import {
   getOperationExampleKey,
   isStreamingResponse,
@@ -387,6 +388,28 @@ const handleExecute = async () => {
       'responseReceived',
       plugins,
     )
+
+    // Persist environment variables set by scripts (pm.environment.set) back to the active
+    // environment so they survive to the next request, mirroring the Environment tab. Scope
+    // and index are resolved from the merged environment so updates mutate in place.
+    if (activeEnvironment) {
+      const environmentActions = getEnvironmentPersistenceActions({
+        environmentName: activeEnvironment,
+        seededVariables: seededEnvironment,
+        scriptVariables: variablesStore.getEnvironment(),
+        mergedVariables: environment.variables,
+        documentVariables:
+          document['x-scalar-environments']?.[activeEnvironment]?.variables ??
+          [],
+        environmentExistsOnDocument: Boolean(
+          document['x-scalar-environments']?.[activeEnvironment],
+        ),
+      })
+
+      for (const action of environmentActions) {
+        eventBus.emit('environment:upsert:environment-variable', action)
+      }
+    }
   }
 
   // Execute the hooks

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -320,10 +320,11 @@ const handleExecute = async () => {
     plugins,
   )
 
-  const envVariables = {
-    ...seededEnvironment,
-    ...variablesStore.getVariables(),
-  }
+  // Resolve {{…}} placeholders from the script store so pre-request pm.environment.set() and
+  // unset() take effect on this request. The store was seeded from the active environment, so
+  // it already holds every value spreading seededEnvironment would add — minus the keys a script
+  // unset, which must stay dropped (an object spread cannot remove them again).
+  const envVariables = variablesStore.getVariables()
 
   // Build the fetch Request after hooks may have mutated the factory
   const built = buildRequest(requestBuilder, {
@@ -388,39 +389,40 @@ const handleExecute = async () => {
       'responseReceived',
       plugins,
     )
+  }
 
-    // Persist environment variables set by scripts (pm.environment.set) back to the active
-    // environment so they survive to the next request, mirroring the Environment tab. Scope
-    // and index are resolved from the merged environment so updates mutate in place.
-    if (activeEnvironment) {
-      const environmentActions = getEnvironmentPersistenceActions({
-        environmentName: activeEnvironment,
-        seededVariables: seededEnvironment,
-        scriptVariables: variablesStore.getEnvironment(),
-        mergedVariables: environment.variables,
-        documentVariables:
-          document['x-scalar-environments']?.[activeEnvironment]?.variables ??
-          [],
-        environmentExistsOnDocument: Boolean(
-          document['x-scalar-environments']?.[activeEnvironment],
-        ),
-      })
+  // Persist environment variables set by scripts (pm.environment.set) back to the active
+  // environment so they survive to the next request, mirroring the Environment tab. Scope
+  // and index are resolved from the merged environment so updates mutate in place. This runs
+  // even when the request fails so a pre-request set — like a token stored before a flaky
+  // call — is not lost.
+  if (activeEnvironment) {
+    const environmentActions = getEnvironmentPersistenceActions({
+      environmentName: activeEnvironment,
+      seededVariables: seededEnvironment,
+      scriptVariables: variablesStore.getEnvironment(),
+      mergedVariables: environment.variables,
+      documentVariables:
+        document['x-scalar-environments']?.[activeEnvironment]?.variables ?? [],
+      environmentExistsOnDocument: Boolean(
+        document['x-scalar-environments']?.[activeEnvironment],
+      ),
+    })
 
-      for (const action of environmentActions) {
-        if (action.type === 'delete') {
-          eventBus.emit('environment:delete:environment-variable', {
-            environmentName: action.environmentName,
-            index: action.index,
-            collectionType: action.collectionType,
-          })
-        } else {
-          eventBus.emit('environment:upsert:environment-variable', {
-            environmentName: action.environmentName,
-            variable: action.variable,
-            index: action.index,
-            collectionType: action.collectionType,
-          })
-        }
+    for (const action of environmentActions) {
+      if (action.type === 'delete') {
+        eventBus.emit('environment:delete:environment-variable', {
+          environmentName: action.environmentName,
+          index: action.index,
+          collectionType: action.collectionType,
+        })
+      } else {
+        eventBus.emit('environment:upsert:environment-variable', {
+          environmentName: action.environmentName,
+          variable: action.variable,
+          index: action.index,
+          collectionType: action.collectionType,
+        })
       }
     }
   }

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.test.ts
@@ -30,7 +30,13 @@ describe('getEnvironmentPersistenceActions', () => {
     })
 
     expect(actions).toEqual([
-      { environmentName: 'default', variable: { name: 'token', value: 'new' }, index: 0, collectionType: 'workspace' },
+      {
+        type: 'upsert',
+        environmentName: 'default',
+        variable: { name: 'token', value: 'new' },
+        index: 0,
+        collectionType: 'workspace',
+      },
     ])
   })
 
@@ -49,7 +55,13 @@ describe('getEnvironmentPersistenceActions', () => {
     })
 
     expect(actions).toEqual([
-      { environmentName: 'default', variable: { name: 'token', value: 'new' }, index: 0, collectionType: 'document' },
+      {
+        type: 'upsert',
+        environmentName: 'default',
+        variable: { name: 'token', value: 'new' },
+        index: 0,
+        collectionType: 'document',
+      },
     ])
   })
 
@@ -64,7 +76,12 @@ describe('getEnvironmentPersistenceActions', () => {
     })
 
     expect(actions).toEqual([
-      { environmentName: 'default', variable: { name: 'token', value: 'fresh' }, collectionType: 'workspace' },
+      {
+        type: 'upsert',
+        environmentName: 'default',
+        variable: { name: 'token', value: 'fresh' },
+        collectionType: 'workspace',
+      },
     ])
   })
 
@@ -79,7 +96,12 @@ describe('getEnvironmentPersistenceActions', () => {
     })
 
     expect(actions).toEqual([
-      { environmentName: 'default', variable: { name: 'token', value: 'fresh' }, collectionType: 'document' },
+      {
+        type: 'upsert',
+        environmentName: 'default',
+        variable: { name: 'token', value: 'fresh' },
+        collectionType: 'document',
+      },
     ])
   })
 
@@ -96,6 +118,7 @@ describe('getEnvironmentPersistenceActions', () => {
 
     expect(actions).toEqual([
       {
+        type: 'upsert',
         environmentName: 'default',
         variable: { name: 'token', value: 'updated' },
         index: 0,
@@ -115,7 +138,80 @@ describe('getEnvironmentPersistenceActions', () => {
     })
 
     expect(actions).toEqual([
-      { environmentName: 'default', variable: { name: 'token', value: 'new' }, index: 0, collectionType: 'workspace' },
+      {
+        type: 'upsert',
+        environmentName: 'default',
+        variable: { name: 'token', value: 'new' },
+        index: 0,
+        collectionType: 'workspace',
+      },
+    ])
+  })
+
+  it('deletes a variable removed by the script (pm.environment.unset)', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: { token: 'abc' },
+      // The script unset token, so it is absent from the store output.
+      scriptVariables: [],
+      mergedVariables: [variable('token', 'abc')],
+      documentVariables: [],
+      environmentExistsOnDocument: false,
+    })
+
+    expect(actions).toEqual([{ type: 'delete', environmentName: 'default', index: 0, collectionType: 'workspace' }])
+  })
+
+  it('deletes a removed document variable using its document index', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: { host: 'ws', token: 'abc' },
+      scriptVariables: [{ key: 'host', value: 'ws' }],
+      mergedVariables: [variable('host', 'ws'), variable('token', 'abc')],
+      documentVariables: [variable('token', 'abc')],
+      environmentExistsOnDocument: true,
+    })
+
+    expect(actions).toEqual([{ type: 'delete', environmentName: 'default', index: 0, collectionType: 'document' }])
+  })
+
+  it('orders multiple deletes by descending index so splices stay valid', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: { a: '1', b: '2', c: '3' },
+      // Script removed a (index 0) and c (index 2), kept b.
+      scriptVariables: [{ key: 'b', value: '2' }],
+      mergedVariables: [variable('a', '1'), variable('b', '2'), variable('c', '3')],
+      documentVariables: [],
+      environmentExistsOnDocument: false,
+    })
+
+    expect(actions).toEqual([
+      { type: 'delete', environmentName: 'default', index: 2, collectionType: 'workspace' },
+      { type: 'delete', environmentName: 'default', index: 0, collectionType: 'workspace' },
+    ])
+  })
+
+  it('emits upserts before deletes so in-place updates are not shifted', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: { a: '1', b: '2' },
+      // Script removed a and changed b.
+      scriptVariables: [{ key: 'b', value: 'changed' }],
+      mergedVariables: [variable('a', '1'), variable('b', '2')],
+      documentVariables: [],
+      environmentExistsOnDocument: false,
+    })
+
+    expect(actions).toEqual([
+      {
+        type: 'upsert',
+        environmentName: 'default',
+        variable: { name: 'b', value: 'changed' },
+        index: 1,
+        collectionType: 'workspace',
+      },
+      { type: 'delete', environmentName: 'default', index: 0, collectionType: 'workspace' },
     ])
   })
 })

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.test.ts
@@ -175,6 +175,23 @@ describe('getEnvironmentPersistenceActions', () => {
     expect(actions).toEqual([{ type: 'delete', environmentName: 'default', index: 0, collectionType: 'document' }])
   })
 
+  it('deletes a removed variable from both scopes when the name is shadowed', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: { token: 'doc' },
+      // The script unset token, which exists on both the workspace and the document.
+      scriptVariables: [],
+      mergedVariables: [variable('token', 'ws'), variable('token', 'doc')],
+      documentVariables: [variable('token', 'doc')],
+      environmentExistsOnDocument: true,
+    })
+
+    expect(actions).toEqual([
+      { type: 'delete', environmentName: 'default', index: 0, collectionType: 'document' },
+      { type: 'delete', environmentName: 'default', index: 0, collectionType: 'workspace' },
+    ])
+  })
+
   it('orders multiple deletes by descending index so splices stay valid', () => {
     const actions = getEnvironmentPersistenceActions({
       environmentName: 'default',

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.test.ts
@@ -1,0 +1,121 @@
+import type { XScalarEnvVar } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
+import { describe, expect, it } from 'vitest'
+
+import { getEnvironmentPersistenceActions } from './persist-script-environment'
+
+const variable = (name: string, value: string): XScalarEnvVar => ({ name, value })
+
+describe('getEnvironmentPersistenceActions', () => {
+  it('returns no actions when nothing changed', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: { token: 'abc' },
+      scriptVariables: [{ key: 'token', value: 'abc' }],
+      mergedVariables: [variable('token', 'abc')],
+      documentVariables: [],
+      environmentExistsOnDocument: false,
+    })
+
+    expect(actions).toEqual([])
+  })
+
+  it('updates an existing workspace variable in place by index', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: { token: 'old' },
+      scriptVariables: [{ key: 'token', value: 'new' }],
+      mergedVariables: [variable('token', 'old')],
+      documentVariables: [],
+      environmentExistsOnDocument: false,
+    })
+
+    expect(actions).toEqual([
+      { environmentName: 'default', variable: { name: 'token', value: 'new' }, index: 0, collectionType: 'workspace' },
+    ])
+  })
+
+  it('updates an existing document variable in place by its document index', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: { host: 'ws', token: 'old' },
+      scriptVariables: [
+        { key: 'host', value: 'ws' },
+        { key: 'token', value: 'new' },
+      ],
+      // Merged order is [...workspace, ...document]; token lives on the document.
+      mergedVariables: [variable('host', 'ws'), variable('token', 'old')],
+      documentVariables: [variable('token', 'old')],
+      environmentExistsOnDocument: true,
+    })
+
+    expect(actions).toEqual([
+      { environmentName: 'default', variable: { name: 'token', value: 'new' }, index: 0, collectionType: 'document' },
+    ])
+  })
+
+  it('adds a new variable to the workspace when the environment lives on the workspace', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: {},
+      scriptVariables: [{ key: 'token', value: 'fresh' }],
+      mergedVariables: [],
+      documentVariables: [],
+      environmentExistsOnDocument: false,
+    })
+
+    expect(actions).toEqual([
+      { environmentName: 'default', variable: { name: 'token', value: 'fresh' }, collectionType: 'workspace' },
+    ])
+  })
+
+  it('adds a new variable to the document when the environment lives on the document', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: {},
+      scriptVariables: [{ key: 'token', value: 'fresh' }],
+      mergedVariables: [],
+      documentVariables: [],
+      environmentExistsOnDocument: true,
+    })
+
+    expect(actions).toEqual([
+      { environmentName: 'default', variable: { name: 'token', value: 'fresh' }, collectionType: 'document' },
+    ])
+  })
+
+  it('prefers the document scope when a name exists in both collections', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: { token: 'doc' },
+      scriptVariables: [{ key: 'token', value: 'updated' }],
+      // Same name on both scopes: workspace copy first, document copy appended.
+      mergedVariables: [variable('token', 'ws'), variable('token', 'doc')],
+      documentVariables: [variable('token', 'doc')],
+      environmentExistsOnDocument: true,
+    })
+
+    expect(actions).toEqual([
+      {
+        environmentName: 'default',
+        variable: { name: 'token', value: 'updated' },
+        index: 0,
+        collectionType: 'document',
+      },
+    ])
+  })
+
+  it('accepts the store scope as a record', () => {
+    const actions = getEnvironmentPersistenceActions({
+      environmentName: 'default',
+      seededVariables: { token: 'old' },
+      scriptVariables: { token: 'new' },
+      mergedVariables: [variable('token', 'old')],
+      documentVariables: [],
+      environmentExistsOnDocument: false,
+    })
+
+    expect(actions).toEqual([
+      { environmentName: 'default', variable: { name: 'token', value: 'new' }, index: 0, collectionType: 'workspace' },
+    ])
+  })
+})

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.ts
@@ -105,13 +105,19 @@ export const getEnvironmentPersistenceActions = ({
   }
 
   // Removals: keys present before the scripts ran but absent afterwards (pm.environment.unset).
+  // Delete from every scope that defines the name — not just the one that wins on reads. A copy
+  // left behind in another scope would resurface on the next seed, so the unset would not stick.
   for (const key of Object.keys(seededVariables)) {
     if (scriptKeys.has(key)) {
       continue
     }
-    const existing = findExisting(key)
-    if (existing) {
-      deletes.push({ type: 'delete', environmentName, index: existing.index, collectionType: existing.collectionType })
+    const documentIndex = documentIndexByName.get(key)
+    if (documentIndex !== undefined) {
+      deletes.push({ type: 'delete', environmentName, index: documentIndex, collectionType: 'document' })
+    }
+    const workspaceIndex = workspaceIndexByName.get(key)
+    if (workspaceIndex !== undefined) {
+      deletes.push({ type: 'delete', environmentName, index: workspaceIndex, collectionType: 'workspace' })
     }
   }
 

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.ts
@@ -1,0 +1,101 @@
+import type { CollectionType } from '@scalar/workspace-store/events'
+import type { VariableEntry } from '@scalar/workspace-store/request-example'
+import type { XScalarEnvVar } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
+
+/**
+ * A single `environment:upsert:environment-variable` event needed to persist a value
+ * that a script set via `pm.environment.set()`. The shape mirrors what the workspace
+ * event bus expects, so the caller can emit it directly.
+ */
+type EnvironmentUpsertAction = {
+  environmentName: string
+  variable: { name: string; value: string }
+  /** Index of the existing variable to update, or undefined to add a new one. */
+  index?: number
+} & CollectionType
+
+/** Normalize the store's environment scope, which may be an array or a plain record. */
+const toEntries = (variables: VariableEntry[] | Record<string, string>): VariableEntry[] =>
+  Array.isArray(variables) ? variables : Object.entries(variables).map(([key, value]) => ({ key, value }))
+
+/**
+ * Resolve which environment variables a script changed and where to persist them.
+ *
+ * The active environment is a merge of workspace- and document-scoped variables:
+ * `getActiveEnvironment` concatenates them as `[...workspaceVariables, ...documentVariables]`.
+ * We use that ordering to map each changed variable back to the scope and index it came
+ * from, so updates mutate the correct collection in place instead of creating duplicates.
+ * New variables are added to whichever scope actually defines the active environment, so the
+ * upsert target exists (the mutator no-ops when the environment is missing from a collection).
+ */
+export const getEnvironmentPersistenceActions = ({
+  environmentName,
+  seededVariables,
+  scriptVariables,
+  mergedVariables,
+  documentVariables,
+  environmentExistsOnDocument,
+}: {
+  /** Name of the active environment being written to. */
+  environmentName: string
+  /** Environment values seeded into the store before the scripts ran. */
+  seededVariables: Record<string, string>
+  /** Environment scope read back from the store after the scripts ran. */
+  scriptVariables: VariableEntry[] | Record<string, string>
+  /** The merged (workspace + document) variables of the active environment. */
+  mergedVariables: XScalarEnvVar[]
+  /** The document-scoped variables of the active environment (appended last in the merge). */
+  documentVariables: XScalarEnvVar[]
+  /** Whether the active environment is defined on the document (vs. the workspace). */
+  environmentExistsOnDocument: boolean
+}): EnvironmentUpsertAction[] => {
+  // Workspace variables occupy the front of the merged array; document variables the tail.
+  const workspaceCount = Math.max(0, mergedVariables.length - documentVariables.length)
+
+  const documentIndexByName = new Map(documentVariables.map((variable, index) => [variable.name, index]))
+  const workspaceIndexByName = new Map(
+    mergedVariables.slice(0, workspaceCount).map((variable, index) => [variable.name, index]),
+  )
+
+  const actions: EnvironmentUpsertAction[] = []
+
+  for (const { key, value } of toEntries(scriptVariables)) {
+    // Skip values the script did not touch.
+    if (seededVariables[key] === value) {
+      continue
+    }
+
+    // Update an existing variable in place, preferring the document scope on name
+    // collisions since document values win when the environment is merged for reads.
+    const documentIndex = documentIndexByName.get(key)
+    if (documentIndex !== undefined) {
+      actions.push({
+        environmentName,
+        variable: { name: key, value },
+        index: documentIndex,
+        collectionType: 'document',
+      })
+      continue
+    }
+
+    const workspaceIndex = workspaceIndexByName.get(key)
+    if (workspaceIndex !== undefined) {
+      actions.push({
+        environmentName,
+        variable: { name: key, value },
+        index: workspaceIndex,
+        collectionType: 'workspace',
+      })
+      continue
+    }
+
+    // New variable — add it to whichever scope holds the active environment.
+    actions.push({
+      environmentName,
+      variable: { name: key, value },
+      collectionType: environmentExistsOnDocument ? 'document' : 'workspace',
+    })
+  }
+
+  return actions
+}

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/persist-script-environment.ts
@@ -3,16 +3,13 @@ import type { VariableEntry } from '@scalar/workspace-store/request-example'
 import type { XScalarEnvVar } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 
 /**
- * A single `environment:upsert:environment-variable` event needed to persist a value
- * that a script set via `pm.environment.set()`. The shape mirrors what the workspace
- * event bus expects, so the caller can emit it directly.
+ * A single change to persist to the active environment in response to a script's
+ * `pm.environment.set()` / `pm.environment.unset()`. Shapes mirror the workspace event
+ * bus payloads (`environment:upsert:environment-variable` / `:delete:environment-variable`)
+ * so the caller can emit each action directly.
  */
-type EnvironmentUpsertAction = {
-  environmentName: string
-  variable: { name: string; value: string }
-  /** Index of the existing variable to update, or undefined to add a new one. */
-  index?: number
-} & CollectionType
+type EnvironmentPersistenceAction = { environmentName: string } & CollectionType &
+  ({ type: 'upsert'; variable: { name: string; value: string }; index?: number } | { type: 'delete'; index: number })
 
 /** Normalize the store's environment scope, which may be an array or a plain record. */
 const toEntries = (variables: VariableEntry[] | Record<string, string>): VariableEntry[] =>
@@ -27,6 +24,11 @@ const toEntries = (variables: VariableEntry[] | Record<string, string>): Variabl
  * from, so updates mutate the correct collection in place instead of creating duplicates.
  * New variables are added to whichever scope actually defines the active environment, so the
  * upsert target exists (the mutator no-ops when the environment is missing from a collection).
+ *
+ * Variables present before the scripts ran but gone afterwards were removed via
+ * `pm.environment.unset()` and are emitted as deletes. Deletes splice the underlying array,
+ * so they are ordered last and by descending index — an earlier splice must not invalidate the
+ * index of a later one. Upserts run first because they replace in place without shifting.
  */
 export const getEnvironmentPersistenceActions = ({
   environmentName,
@@ -48,7 +50,7 @@ export const getEnvironmentPersistenceActions = ({
   documentVariables: XScalarEnvVar[]
   /** Whether the active environment is defined on the document (vs. the workspace). */
   environmentExistsOnDocument: boolean
-}): EnvironmentUpsertAction[] => {
+}): EnvironmentPersistenceAction[] => {
   // Workspace variables occupy the front of the merged array; document variables the tail.
   const workspaceCount = Math.max(0, mergedVariables.length - documentVariables.length)
 
@@ -57,45 +59,65 @@ export const getEnvironmentPersistenceActions = ({
     mergedVariables.slice(0, workspaceCount).map((variable, index) => [variable.name, index]),
   )
 
-  const actions: EnvironmentUpsertAction[] = []
+  /**
+   * Locate an existing variable by name, preferring the document scope on collisions since
+   * document values win when the environment is merged for reads.
+   */
+  const findExisting = (
+    key: string,
+  ): { collectionType: CollectionType['collectionType']; index: number } | undefined => {
+    const documentIndex = documentIndexByName.get(key)
+    if (documentIndex !== undefined) {
+      return { collectionType: 'document', index: documentIndex }
+    }
+    const workspaceIndex = workspaceIndexByName.get(key)
+    if (workspaceIndex !== undefined) {
+      return { collectionType: 'workspace', index: workspaceIndex }
+    }
+    return undefined
+  }
+
+  const upserts: EnvironmentPersistenceAction[] = []
+  const deletes: Array<Extract<EnvironmentPersistenceAction, { type: 'delete' }>> = []
+  const scriptKeys = new Set<string>()
 
   for (const { key, value } of toEntries(scriptVariables)) {
+    scriptKeys.add(key)
+
     // Skip values the script did not touch.
     if (seededVariables[key] === value) {
       continue
     }
 
-    // Update an existing variable in place, preferring the document scope on name
-    // collisions since document values win when the environment is merged for reads.
-    const documentIndex = documentIndexByName.get(key)
-    if (documentIndex !== undefined) {
-      actions.push({
+    const existing = findExisting(key)
+    if (existing) {
+      // Update an existing variable in place.
+      upserts.push({ type: 'upsert', environmentName, variable: { name: key, value }, ...existing })
+    } else {
+      // New variable — add it to whichever scope holds the active environment.
+      upserts.push({
+        type: 'upsert',
         environmentName,
         variable: { name: key, value },
-        index: documentIndex,
-        collectionType: 'document',
+        collectionType: environmentExistsOnDocument ? 'document' : 'workspace',
       })
-      continue
     }
-
-    const workspaceIndex = workspaceIndexByName.get(key)
-    if (workspaceIndex !== undefined) {
-      actions.push({
-        environmentName,
-        variable: { name: key, value },
-        index: workspaceIndex,
-        collectionType: 'workspace',
-      })
-      continue
-    }
-
-    // New variable — add it to whichever scope holds the active environment.
-    actions.push({
-      environmentName,
-      variable: { name: key, value },
-      collectionType: environmentExistsOnDocument ? 'document' : 'workspace',
-    })
   }
 
-  return actions
+  // Removals: keys present before the scripts ran but absent afterwards (pm.environment.unset).
+  for (const key of Object.keys(seededVariables)) {
+    if (scriptKeys.has(key)) {
+      continue
+    }
+    const existing = findExisting(key)
+    if (existing) {
+      deletes.push({ type: 'delete', environmentName, index: existing.index, collectionType: existing.collectionType })
+    }
+  }
+
+  // Highest index first so each splice leaves lower indices — including cross-scope ones,
+  // which live in independent arrays — valid for the deletes that follow.
+  deletes.sort((a, b) => b.index - a.index)
+
+  return [...upserts, ...deletes]
 }


### PR DESCRIPTION
Environment variables did not work in scripts. `pm.environment.get()` always returned `undefined`, and `pm.environment.set()` did not save anything — even though `{{variable}}` worked fine in request fields.

A user hit this trying to save a bearer token from a login response and reuse it on the next request.

## Why

When a request runs, scripts get a variable store that was created empty and thrown away afterwards. So reads found nothing, and writes were lost. `{{variable}}` worked because it reads the environment directly, skipping that store.

## Fix

- Fill the store with the active environment before scripts run, so reads work.
- After the response, save any variables the script set back to the active environment, so they stick for the next request.

Covers `pm.environment` (the Environment tab). `pm.globals` / `pm.collectionVariables` are a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request execution and workspace event emissions for environment data; behavior is well-covered by new unit and integration tests but wrong persistence could affect tokens and shared env state across requests.
> 
> **Overview**
> Pre-request and post-response scripts now see and can update the **active environment** the same way `{{variable}}` placeholders do.
> 
> **OperationBlock** seeds the per-request script store from the active environment before hooks run, so `pm.environment.get()` / `pm.variables.get()` return real values. Placeholder resolution for the outgoing request uses the store (including script `set`/`unset`) instead of only merging static env into the store. After scripts run—and on **build failure** or **failed sends** as well as success—script changes are written back via `environment:upsert:environment-variable` and `environment:delete:environment-variable`. A **request-start snapshot** of the active environment name and variable arrays keeps persistence on the correct environment and indexes if the user switches environments or the variable list changes mid-flight.
> 
> **`getEnvironmentPersistenceActions`** (new helper) diffs seeded vs post-script state, routes updates to workspace vs document scope (document wins on name collisions), and orders upserts before descending-index deletes for `unset`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 751454ae8f907b315fe1ffd0168943277af049fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->