### PR TITLE
docs(hono): document publishing OpenAPI to the Scalar Registry

### DIFF
--- a/documentation/integrations/hono.md
+++ b/documentation/integrations/hono.md
@@ -130,3 +130,110 @@ app.get('/llms.txt', async (c) => {
   return c.text(markdown)
 })
 ```
+
+### Publish to the Scalar Registry
+
+If you generate your OpenAPI document from Zod OpenAPI Hono, you can publish it to the [Scalar Registry](../guides/registry/getting-started.md) to power hosted docs, share it with your team, and keep versions in sync. The nice part is that you do not need a running server to do this — the document is generated from the same Zod-driven routes, so a small script can render it to a static file.
+
+First, expose the generated document on a route as usual:
+
+```typescript
+import { OpenAPIHono } from '@hono/zod-openapi'
+
+const app = new OpenAPIHono()
+
+// Register your routes here, then expose the generated OpenAPI 3.1 document
+app.doc31('/openapi.json', (c) => ({
+  openapi: '3.1.0',
+  info: {
+    title: 'Example API',
+    version: '0.1.0',
+  },
+  servers: [{ url: c.env.BASE_URL }],
+}))
+
+export { app }
+```
+
+Then add a small script that renders that same route to a file. Because Hono apps can handle requests in memory, there is no need to boot a server:
+
+```typescript
+// scripts/dump-openapi.ts
+import { writeFileSync } from 'node:fs'
+import { app } from '../src/app'
+
+const outFile = process.argv[2] ?? 'openapi.json'
+const BASE_URL = process.env.BASE_URL ?? 'https://example.com'
+
+// Render the in-memory /openapi.json route to a static file
+const res = await app.request('/openapi.json', {}, { BASE_URL })
+
+if (!res.ok) {
+  console.error(`Failed to generate OpenAPI document: ${res.status} ${res.statusText}`)
+  process.exit(1)
+}
+
+const spec = await res.json()
+writeFileSync(outFile, `${JSON.stringify(spec, null, 2)}\n`)
+console.log(`Wrote ${outFile}`)
+```
+
+Wire it up with a couple of scripts. The [Scalar CLI](https://github.com/scalar/scalar/tree/main/packages/cli) handles validation and publishing:
+
+```json
+{
+  "scripts": {
+    "openapi:dump": "tsx scripts/dump-openapi.ts openapi.json",
+    "scalar:publish": "pnpm openapi:dump && scalar registry publish openapi.json --namespace your-namespace --slug your-api"
+  }
+}
+```
+
+To keep the registry up to date automatically, run the same steps in CI whenever a route or schema changes:
+
+```yaml
+# .github/workflows/scalar.yml
+name: Publish API docs
+
+on:
+  push:
+    branches: [main]
+    # Only republish when something that can change the document changes
+    paths:
+      - 'src/**'
+      - 'scripts/dump-openapi.ts'
+  workflow_dispatch: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          # @scalar/cli requires Node >= 24
+          node-version: 24
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate OpenAPI document
+        run: pnpm openapi:dump
+
+      - name: Validate document
+        run: pnpm dlx @scalar/cli document validate openapi.json
+
+      - name: Publish to Scalar Registry
+        env:
+          SCALAR_API_KEY: ${{ secrets.SCALAR_API_KEY }}
+        run: |
+          pnpm dlx @scalar/cli auth login --token "$SCALAR_API_KEY"
+          # Publish under the document's own info.version so a docs route can
+          # pin a stable version. --force overwrites that version on every push.
+          VERSION="$(node -p "require('./openapi.json').info.version")"
+          pnpm dlx @scalar/cli registry publish openapi.json \
+            --namespace your-namespace --slug your-api \
+            --version "$VERSION" --force
+```

--- a/documentation/integrations/hono.md
+++ b/documentation/integrations/hono.md
@@ -138,7 +138,7 @@ If you generate your OpenAPI document from Zod OpenAPI Hono, you can publish it 
 Add a small script that calls `getOpenAPI31Document()` and writes the result to a file:
 
 ```typescript
-// scripts/dump-openapi.ts
+// scripts/generate-openapi.ts
 import { writeFileSync } from 'node:fs'
 import { app } from '../src/app'
 
@@ -161,8 +161,8 @@ Wire it up with a couple of scripts. The [Scalar CLI](https://github.com/scalar/
 ```json
 {
   "scripts": {
-    "openapi:dump": "tsx scripts/dump-openapi.ts openapi.json",
-    "scalar:publish": "pnpm openapi:dump && scalar registry publish openapi.json --namespace your-namespace --slug your-api"
+    "openapi:generate": "tsx scripts/generate-openapi.ts openapi.json",
+    "scalar:publish": "pnpm openapi:generate && scalar registry publish openapi.json --namespace your-namespace --slug your-api"
   }
 }
 ```
@@ -179,7 +179,7 @@ on:
     # Only republish when something that can change the document changes
     paths:
       - 'src/**'
-      - 'scripts/dump-openapi.ts'
+      - 'scripts/generate-openapi.ts'
   workflow_dispatch: {}
 
 jobs:
@@ -198,7 +198,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate OpenAPI document
-        run: pnpm openapi:dump
+        run: pnpm openapi:generate
 
       - name: Validate document
         run: pnpm dlx @scalar/cli document validate openapi.json

--- a/documentation/integrations/hono.md
+++ b/documentation/integrations/hono.md
@@ -133,50 +133,28 @@ app.get('/llms.txt', async (c) => {
 
 ### Publish to the Scalar Registry
 
-If you generate your OpenAPI document from Zod OpenAPI Hono, you can publish it to the [Scalar Registry](../guides/registry/getting-started.md) to power hosted docs, share it with your team, and keep versions in sync. The nice part is that you do not need a running server to do this — the document is generated from the same Zod-driven routes, so a small script can render it to a static file.
+If you generate your OpenAPI document from Zod OpenAPI Hono, you can publish it to the [Scalar Registry](../guides/registry/getting-started.md) to power hosted docs, share it with your team, and keep versions in sync. You do not need a running server for this — `OpenAPIHono` can build the document straight from your Zod-driven routes.
 
-First, expose the generated document on a route as usual:
-
-```typescript
-import { OpenAPIHono } from '@hono/zod-openapi'
-
-const app = new OpenAPIHono()
-
-// Register your routes here, then expose the generated OpenAPI 3.1 document
-app.doc31('/openapi.json', (c) => ({
-  openapi: '3.1.0',
-  info: {
-    title: 'Example API',
-    version: '0.1.0',
-  },
-  servers: [{ url: c.env.BASE_URL }],
-}))
-
-export { app }
-```
-
-Then add a small script that renders that same route to a file. Because Hono apps can handle requests in memory, there is no need to boot a server:
+Add a small script that calls `getOpenAPI31Document()` and writes the result to a file:
 
 ```typescript
 // scripts/dump-openapi.ts
 import { writeFileSync } from 'node:fs'
 import { app } from '../src/app'
 
-const outFile = process.argv[2] ?? 'openapi.json'
-const BASE_URL = process.env.BASE_URL ?? 'https://example.com'
+const document = app.getOpenAPI31Document({
+  openapi: '3.1.0',
+  info: {
+    title: 'Example API',
+    version: '0.1.0',
+  },
+  servers: [{ url: process.env.BASE_URL ?? 'https://example.com' }],
+})
 
-// Render the in-memory /openapi.json route to a static file
-const res = await app.request('/openapi.json', {}, { BASE_URL })
-
-if (!res.ok) {
-  console.error(`Failed to generate OpenAPI document: ${res.status} ${res.statusText}`)
-  process.exit(1)
-}
-
-const spec = await res.json()
-writeFileSync(outFile, `${JSON.stringify(spec, null, 2)}\n`)
-console.log(`Wrote ${outFile}`)
+writeFileSync('openapi.json', `${JSON.stringify(document, null, 2)}\n`)
 ```
+
+Here `app` is your `OpenAPIHono` instance with all routes registered. This is the same document you would serve at runtime with `app.doc31('/openapi.json', ...)`, just written to a file instead.
 
 Wire it up with a couple of scripts. The [Scalar CLI](https://github.com/scalar/scalar/tree/main/packages/cli) handles validation and publishing:
 


### PR DESCRIPTION
Adds a section to the Hono integration docs showing how to publish a Zod OpenAPI Hono document to the Scalar Registry.

It covers three things:

- A small script that renders the OpenAPI document to a file (no running server needed)
- `package.json` scripts to dump and publish
- A GitHub Actions workflow to republish on every push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or application code impact.
> 
> **Overview**
> Adds a new **Publish to the Scalar Registry** section to `documentation/integrations/hono.md`, right after the Zod OpenAPI Hono LLM markdown example.
> 
> The section walks through exporting a Zod OpenAPI Hono spec with `getOpenAPI31Document()` (no running server), wiring `openapi:generate` / `scalar:publish` npm scripts, and a GitHub Actions workflow that regenerates `openapi.json`, validates it with `@scalar/cli`, and publishes to the registry using `info.version` and `--force`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24555834dd10359db21e7de5224fc506a171a8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->