### PR TITLE
fix(api-reference): resolve axe ARIA violations in sidebar and client tabs

### DIFF
--- a/.changeset/fix-9725-api-reference-a11y.md
+++ b/.changeset/fix-9725-api-reference-a11y.md
@@ -1,0 +1,10 @@
+---
+'@scalar/api-reference': patch
+'@scalar/components': patch
+---
+
+fix: resolve axe-core ARIA violations in the API reference sidebar and client tabs
+
+Sidebar items used `aria-selected` on links/buttons (invalid for those roles) and the search trigger used `role="search"` on a button. The sidebar landmark is now a `<nav>`, selected items use `aria-current="page"`, and the search control is a plain named button.
+
+Client library and SDK installation "More" comboboxes sat inside `role="tablist"`, which fails `aria-required-children`. They now sit beside the tablist. MCP install controls without a target URL render as buttons instead of empty `a[href=""]` links.

--- a/.changeset/fix-9725-api-reference-a11y.md
+++ b/.changeset/fix-9725-api-reference-a11y.md
@@ -5,6 +5,6 @@
 
 fix: resolve axe-core ARIA violations in the API reference sidebar and client tabs
 
-Sidebar items used `aria-selected` on links/buttons (invalid for those roles) and the search trigger used `role="search"` on a button. The sidebar landmark is now a `<nav>`, selected items use `aria-current="page"`, and the search control is a plain named button.
+Sidebar items used `aria-selected` on links/buttons (invalid for those roles) and the search trigger used `role="search"` on a button. Selected items now use `aria-current="page"`, the search control is a plain named button, and the sidebar no longer sets an invalid `role="navigation"` on `<aside>` (it keeps the default complementary landmark).
 
 Client library and SDK installation "More" comboboxes sat inside `role="tablist"`, which fails `aria-required-children`. They now sit beside the tablist. MCP install controls without a target URL render as buttons instead of empty `a[href=""]` links.

--- a/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientDropdown.vue
+++ b/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientDropdown.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { Tab } from '@headlessui/vue'
 import {
   filterClientsByQuery,
   findClient,
@@ -17,17 +16,14 @@ import { computed, ref } from 'vue'
 import { isFeaturedClient } from '@/blocks/scalar-client-selector-block/helpers/featured-clients'
 import { useLocalization } from '@/features/localization'
 
-const { clientOptions, featuredClients, eventBus, selectedClient } =
-  defineProps<{
-    /** Client options */
-    clientOptions: ClientOptionGroup[]
-    /** The currently selected Http Client (a built-in client id or a custom sample id) */
-    selectedClient?: string
-    /** List of featured clients */
-    featuredClients: ClientOption[]
-    /** Event bus */
-    eventBus: WorkspaceEventBus
-  }>()
+const { clientOptions, eventBus, selectedClient } = defineProps<{
+  /** Client options */
+  clientOptions: ClientOptionGroup[]
+  /** The currently selected Http Client (a built-in client id or a custom sample id) */
+  selectedClient?: string
+  /** Event bus */
+  eventBus: WorkspaceEventBus
+}>()
 
 const containerRef = ref<HTMLElement>()
 const { translate } = useLocalization()
@@ -63,27 +59,13 @@ const selectedTargetKey = computed(
 )
 </script>
 <template>
+  <!--
+    Lives beside the TabList (not inside it). A combobox button is not a tab,
+    so placing it in role="tablist" fails aria-required-children.
+  -->
   <div
     ref="containerRef"
-    class="client-libraries-content">
-    <Tab
-      v-for="featuredClient in featuredClients"
-      :key="featuredClient.clientKey"
-      class="client-libraries rendered-code-sdks"
-      :class="{
-        'client-libraries__active': featuredClient.id === selectedClient,
-      }">
-      <div :class="`client-libraries-icon__${featuredClient.targetKey}`">
-        <ScalarIcon
-          class="client-libraries-icon"
-          :icon="getIconByLanguageKey(featuredClient.targetKey)" />
-      </div>
-      <span class="client-libraries-text">{{
-        featuredClient.targetTitle
-      }}</span>
-    </Tab>
-
-    <!-- Client Dropdown -->
+    class="client-libraries-more">
     <ScalarCombobox
       :filterFn="filterClientsByQuery"
       :modelValue="findClient(clientOptions, selectedClient)"
@@ -139,15 +121,10 @@ const selectedTargetKey = computed(
   </div>
 </template>
 <style scoped>
-.client-libraries-content {
-  container: client-libraries-content / inline-size;
+.client-libraries-more {
   display: flex;
-  justify-content: center;
-  overflow: hidden;
-  padding: 0 12px;
-  background-color: var(--scalar-background-1);
-  border-left: var(--scalar-border-width) solid var(--scalar-border-color);
-  border-right: var(--scalar-border-width) solid var(--scalar-border-color);
+  flex: 1;
+  min-width: 0;
 }
 .client-libraries {
   display: flex;
@@ -182,13 +159,6 @@ const selectedTargetKey = computed(
   outline: none;
   box-shadow: inset 0 0 0 1px var(--scalar-color-accent);
 }
-/* remove php and c on mobile */
-@media screen and (max-width: 450px) {
-  .client-libraries:nth-of-type(4),
-  .client-libraries:nth-of-type(5) {
-    display: none;
-  }
-}
 .client-libraries-icon {
   max-width: 14px;
   max-height: 14px;
@@ -205,34 +175,9 @@ const selectedTargetKey = computed(
 .client-libraries-icon__more svg {
   height: initial;
 }
-@container client-libraries-content (width < 400px) {
-  .client-libraries__select {
-    width: fit-content;
-
-    .client-libraries-icon__more + span {
-      display: none;
-    }
-  }
-}
-@container client-libraries-content (width < 380px) {
-  .client-libraries {
-    width: 100%;
-  }
-  .client-libraries span {
-    display: none;
-  }
-}
 .client-libraries__active {
   color: var(--scalar-color-1);
   border-bottom: 1px solid var(--scalar-color-1);
-}
-@keyframes codeloader {
-  0% {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(1turn);
-  }
 }
 .client-libraries .client-libraries-text {
   font-size: var(--scalar-small);
@@ -247,6 +192,15 @@ const selectedTargetKey = computed(
 @media screen and (max-width: 600px) {
   .references-classic .client-libraries {
     flex-direction: column;
+  }
+}
+@container client-libraries-list (width < 400px) {
+  .client-libraries__select {
+    width: fit-content;
+
+    .client-libraries-icon__more + span {
+      display: none;
+    }
   }
 }
 </style>

--- a/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientDropdown.vue
+++ b/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientDropdown.vue
@@ -121,9 +121,10 @@ const selectedTargetKey = computed(
   </div>
 </template>
 <style scoped>
+/* One even column, the same width as each tab beside it */
 .client-libraries-more {
   display: flex;
-  flex: 1;
+  flex: 1 1 0;
   min-width: 0;
 }
 .client-libraries {
@@ -195,6 +196,9 @@ const selectedTargetKey = computed(
   }
 }
 @container client-libraries-list (width < 400px) {
+  .client-libraries-more {
+    flex: 0 0 auto;
+  }
   .client-libraries__select {
     width: fit-content;
 

--- a/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientSelector.test.ts
+++ b/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientSelector.test.ts
@@ -171,5 +171,29 @@ describe('ClientLibraries', () => {
       const vm = wrapper.vm
       expect(vm.selectedClientOption?.id).toBe(DEFAULT_CLIENT)
     })
+
+    it('keeps the More combobox outside the tablist', () => {
+      const wrapper = mount(ClientSelector, {
+        props: {
+          clientOptions: mockClientOptions,
+          eventBus,
+        },
+        global: {
+          stubs: {
+            'ScalarCodeBlock': true,
+            'ScalarMarkdown': true,
+            'ScalarIcon': true,
+            'ScalarCombobox': true,
+          },
+        },
+      })
+
+      const tablist = wrapper.find('[role="tablist"]')
+      expect(tablist.exists()).toBe(true)
+      const buttons = [...tablist.element.querySelectorAll('button')]
+      expect(buttons.every((el) => el.getAttribute('role') === 'tab')).toBe(true)
+      expect(wrapper.find('.client-libraries-more').exists()).toBe(true)
+      expect(tablist.element.contains(wrapper.find('.client-libraries-more').element)).toBe(false)
+    })
   })
 })

--- a/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientSelector.vue
+++ b/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientSelector.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-import { TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/vue'
+import { Tab, TabGroup, TabList, TabPanel, TabPanels } from '@headlessui/vue'
 import {
   DEFAULT_CLIENT,
   type ClientOptionGroup,
 } from '@scalar/blocks/code-example'
+import { ScalarIcon } from '@scalar/components/icon'
+import type { TargetId } from '@scalar/types/snippetz'
 import { type WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { computed, ref, useId, useTemplateRef, watch } from 'vue'
 
@@ -77,16 +79,17 @@ const featuredClients = computed(() => getFeaturedClients(clientOptions))
 
 /** Currently selected tab index */
 const tabIndex = computed(() =>
-  featuredClients.value.findIndex(
-    (featuredClient) => activeClient.value === featuredClient.id,
-  ),
+  featuredClients.value.findIndex((client) => client.id === activeClient.value),
 )
 
 const wrapper = useTemplateRef('wrapper-ref')
 
-/** Emit the selected client event on tab */
-const onTabSelect = (i: number) => {
-  const client = featuredClients.value[i]
+const getIconByLanguageKey = (targetKey: TargetId) =>
+  `programming-language-${targetKey === 'js' ? 'javascript' : targetKey}` as const
+
+/** Handle tab selection */
+const onTabSelect = (index: number) => {
+  const client = featuredClients.value[index]
 
   if (!client || !wrapper.value) {
     return
@@ -113,17 +116,37 @@ defineExpose({
         {{ translate('clientLibraries.heading') }}
       </div>
 
-      <!-- Tabs -->
-      <TabList
-        :aria-labelledby="headingId"
-        class="client-libraries-list">
+      <!--
+        TabList may only contain Tab children (aria-required-children).
+        The "More" combobox sits beside it in the same visual row.
+      -->
+      <div class="client-libraries-list">
+        <TabList
+          :aria-labelledby="headingId"
+          class="client-libraries-tabs">
+          <Tab
+            v-for="featuredClient in featuredClients"
+            :key="featuredClient.clientKey"
+            class="client-libraries rendered-code-sdks"
+            :class="{
+              'client-libraries__active': featuredClient.id === activeClient,
+            }">
+            <div :class="`client-libraries-icon__${featuredClient.targetKey}`">
+              <ScalarIcon
+                class="client-libraries-icon"
+                :icon="getIconByLanguageKey(featuredClient.targetKey)" />
+            </div>
+            <span class="client-libraries-text">{{
+              featuredClient.targetTitle
+            }}</span>
+          </Tab>
+        </TabList>
+
         <ClientDropdown
           :clientOptions
           :eventBus
-          :featuredClients
-          :morePanel
           :selectedClient="activeClient" />
-      </TabList>
+      </div>
 
       <!-- Content -->
       <TabPanels>
@@ -175,5 +198,100 @@ defineExpose({
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   border-top-left-radius: var(--scalar-radius-xl);
   border-top-right-radius: var(--scalar-radius-xl);
+}
+.client-libraries-list {
+  container: client-libraries-list / inline-size;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  padding: 0 12px;
+  background-color: var(--scalar-background-1);
+  border-left: var(--scalar-border-width) solid var(--scalar-border-color);
+  border-right: var(--scalar-border-width) solid var(--scalar-border-color);
+}
+.client-libraries-tabs {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+}
+.client-libraries {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  position: relative;
+  cursor: pointer;
+  white-space: nowrap;
+  padding: 8px 2px;
+  gap: 6px;
+  color: var(--scalar-color-3);
+  border-bottom: 1px solid transparent;
+  user-select: none;
+}
+
+.client-libraries:not(.client-libraries__active):hover:before {
+  content: '';
+  position: absolute;
+  width: calc(100% - 4px);
+  height: calc(100% - 4px);
+  background: var(--scalar-background-2);
+  left: 2px;
+  top: 2px;
+  z-index: 0;
+  border-radius: var(--scalar-radius);
+}
+.client-libraries:active {
+  color: var(--scalar-color-1);
+}
+.client-libraries:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--scalar-color-accent);
+}
+/* remove php and c on mobile */
+@media screen and (max-width: 450px) {
+  .client-libraries:nth-of-type(4),
+  .client-libraries:nth-of-type(5) {
+    display: none;
+  }
+}
+.client-libraries-icon {
+  max-width: 14px;
+  max-height: 14px;
+  min-width: 14px;
+  width: 100%;
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  box-sizing: border-box;
+  color: currentColor;
+}
+.client-libraries__active {
+  color: var(--scalar-color-1);
+  border-bottom: 1px solid var(--scalar-color-1);
+}
+.client-libraries .client-libraries-text {
+  font-size: var(--scalar-small);
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.client-libraries__active .client-libraries-text {
+  color: var(--scalar-color-1);
+  font-weight: var(--scalar-semibold);
+}
+@media screen and (max-width: 600px) {
+  .references-classic .client-libraries {
+    flex-direction: column;
+  }
+}
+@container client-libraries-list (width < 380px) {
+  .client-libraries {
+    width: 100%;
+  }
+  .client-libraries span {
+    display: none;
+  }
 }
 </style>

--- a/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientSelector.vue
+++ b/packages/api-reference/src/blocks/scalar-client-selector-block/components/ClientSelector.vue
@@ -123,7 +123,8 @@ defineExpose({
       <div class="client-libraries-list">
         <TabList
           :aria-labelledby="headingId"
-          class="client-libraries-tabs">
+          class="client-libraries-tabs"
+          :style="{ flexGrow: featuredClients.length }">
           <Tab
             v-for="featuredClient in featuredClients"
             :key="featuredClient.clientKey"
@@ -209,9 +210,10 @@ defineExpose({
   border-left: var(--scalar-border-width) solid var(--scalar-border-color);
   border-right: var(--scalar-border-width) solid var(--scalar-border-color);
 }
+/* Grows once per tab it holds, so tabs and the "More" trigger stay even */
 .client-libraries-tabs {
   display: flex;
-  flex: 1;
+  flex: 1 1 0;
   min-width: 0;
 }
 .client-libraries {

--- a/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.test.ts
+++ b/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.test.ts
@@ -45,6 +45,26 @@ describe('SdkInstallationInstructions', () => {
     expect(tabs[1]?.text()).toBe('Python')
   })
 
+  it('keeps only tab buttons inside the tablist', () => {
+    const wrapper = mount(SdkInstallationInstructions, {
+      props: {
+        xScalarSdkInstallation: [
+          { lang: 'TypeScript', description: 'Install for TypeScript' },
+          { lang: 'Python', description: 'Install for Python' },
+        ],
+      },
+      global: { stubs },
+    })
+
+    const tablist = wrapper.find('[role="tablist"]')
+    expect(tablist.exists()).toBe(true)
+    // aria-required-children: interactive children of a tablist must be tabs
+    // (presentation/none on icons is fine)
+    const buttons = [...tablist.element.querySelectorAll('button')]
+    expect(buttons.length).toBeGreaterThan(0)
+    expect(buttons.every((el) => el.getAttribute('role') === 'tab')).toBe(true)
+  })
+
   it('skips entries without a description', () => {
     const wrapper = mount(SdkInstallationInstructions, {
       props: {

--- a/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.vue
+++ b/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.vue
@@ -112,6 +112,9 @@ watch(
   () => void nextTick(measure),
 )
 
+/** The full row, measured for available width (the tab strip's own width depends on the outcome) */
+const rowRef = ref<HTMLElement>()
+/** The tab strip, used to move focus between tabs */
 const tabsRef = ref<HTMLElement>()
 const measureRef = ref<HTMLElement>()
 
@@ -125,9 +128,9 @@ const moreWidth = ref(0)
 /** Measure the available width and the natural width of each tab */
 const measure = () => {
   const measureEl = measureRef.value
-  const tabsEl = tabsRef.value
+  const rowEl = rowRef.value
 
-  if (!measureEl || !tabsEl) {
+  if (!measureEl || !rowEl) {
     return
   }
 
@@ -138,7 +141,7 @@ const measure = () => {
 
   tabWidths.value = widths.slice(0, sdks.value.length)
   moreWidth.value = widths[sdks.value.length] ?? 0
-  availableWidth.value = tabsEl.clientWidth
+  availableWidth.value = rowEl.clientWidth
 }
 
 /** How many tabs fit inline before we need the "More" dropdown */
@@ -252,8 +255,8 @@ onMounted(() => {
     // row for the natural tab widths. The latter catches changes the container
     // never sees — web fonts loading, or labels changing without the count
     // changing — which would otherwise leave the overflow logic stale.
-    if (tabsRef.value) {
-      observer.observe(tabsRef.value)
+    if (rowRef.value) {
+      observer.observe(rowRef.value)
     }
     if (measureRef.value) {
       observer.observe(measureRef.value)
@@ -280,7 +283,9 @@ onBeforeUnmount(() => {
     <!-- Tabs: keep the More combobox outside the tablist so every tablist
          child is a tab (aria-required-children). -->
     <div class="client-libraries-content">
-      <div class="client-libraries-row">
+      <div
+        ref="rowRef"
+        class="client-libraries-row">
         <div
           ref="tabsRef"
           :aria-labelledby="headingId"
@@ -427,10 +432,10 @@ onBeforeUnmount(() => {
   display: flex;
   justify-content: flex-start;
 }
+/* Sized to its tabs, so the "More" trigger still pins to the right edge */
 .client-libraries-tabs {
   display: flex;
-  flex: 1;
-  min-width: 0;
+  flex: 0 0 auto;
 }
 /* Zero-size clip so the measure row never adds to the scrollable width */
 .client-libraries-measure-clip {

--- a/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.vue
+++ b/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.vue
@@ -277,34 +277,37 @@ onBeforeUnmount(() => {
       {{ translate('clientLibraries.heading') }}
     </div>
 
-    <!-- Tabs -->
+    <!-- Tabs: keep the More combobox outside the tablist so every tablist
+         child is a tab (aria-required-children). -->
     <div class="client-libraries-content">
-      <div
-        ref="tabsRef"
-        :aria-labelledby="headingId"
-        class="client-libraries-row"
-        role="tablist">
-        <button
-          v-for="(sdk, index) in visibleSdks"
-          :id="`${baseId}-tab-${index}`"
-          :key="index"
-          :aria-controls="panelId"
-          :aria-selected="index === selectedIndex"
-          class="client-libraries"
-          :class="{ 'client-libraries__active': index === selectedIndex }"
-          role="tab"
-          :tabindex="index === tabStopIndex ? 0 : -1"
-          type="button"
-          @click="select(index)"
-          @keydown="onTabKeydown($event, index)">
-          <ScalarIcon
-            v-if="sdk.icon"
-            class="client-libraries-icon"
-            :icon="sdk.icon" />
-          <span class="client-libraries-text">{{ sdk.lang }}</span>
-        </button>
+      <div class="client-libraries-row">
+        <div
+          ref="tabsRef"
+          :aria-labelledby="headingId"
+          class="client-libraries-tabs"
+          role="tablist">
+          <button
+            v-for="(sdk, index) in visibleSdks"
+            :id="`${baseId}-tab-${index}`"
+            :key="index"
+            :aria-controls="panelId"
+            :aria-selected="index === selectedIndex"
+            class="client-libraries"
+            :class="{ 'client-libraries__active': index === selectedIndex }"
+            role="tab"
+            :tabindex="index === tabStopIndex ? 0 : -1"
+            type="button"
+            @click="select(index)"
+            @keydown="onTabKeydown($event, index)">
+            <ScalarIcon
+              v-if="sdk.icon"
+              class="client-libraries-icon"
+              :icon="sdk.icon" />
+            <span class="client-libraries-text">{{ sdk.lang }}</span>
+          </button>
+        </div>
 
-        <!-- More dropdown -->
+        <!-- More dropdown (not a tab — lives beside the tablist) -->
         <ScalarCombobox
           v-if="visibleCount < sdks.length"
           :modelValue="selectedMoreOption"
@@ -423,6 +426,11 @@ onBeforeUnmount(() => {
 .client-libraries-row {
   display: flex;
   justify-content: flex-start;
+}
+.client-libraries-tabs {
+  display: flex;
+  flex: 1;
+  min-width: 0;
 }
 /* Zero-size clip so the measure row never adds to the scrollable width */
 .client-libraries-measure-clip {

--- a/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue
+++ b/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue
@@ -229,6 +229,8 @@ function openRegisterLink(documentUrl: string) {
   cursor: pointer !important;
 }
 .scalar-mcp-layer .scalar-mcp-layer-link {
+  /* Must stay above font-size and line-height, which the shorthand resets */
+  font: inherit;
   cursor: pointer;
   width: 100%;
   padding: 9px 6px;
@@ -242,10 +244,6 @@ function openRegisterLink(documentUrl: string) {
   line-height: 1.385;
   text-decoration: none;
   border-radius: var(--scalar-radius);
-  border: none;
-  background: transparent;
-  color: inherit;
-  font: inherit;
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   gap: 6px;
   color: var(--scalar-sidebar-color-1);

--- a/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue
+++ b/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue
@@ -90,12 +90,19 @@ function openRegisterLink(documentUrl: string) {
 
 <template>
   <div class="scalar-mcp-layer">
-    <a
+    <!--
+      When there is no MCP config yet these act as buttons that generate one.
+      Using <a href=""> (or undefined href) fails axe link-name; keep a real
+      link only when we already have a target URL.
+    -->
+    <component
+      :is="hasConfig ? 'a' : 'button'"
       class="scalar-mcp-layer-link"
       :href="hasConfig ? vscodeLink : undefined"
       :target="hasConfig ? '_blank' : undefined"
+      :type="hasConfig ? undefined : 'button'"
       @click="
-        (e) => {
+        (e: MouseEvent) => {
           if (!hasConfig) {
             e.preventDefault()
             generateRegisterLink()
@@ -114,13 +121,15 @@ function openRegisterLink(documentUrl: string) {
       </svg>
       VS Code
       <ScalarIconArrowUpRight class="mcp-nav ml-auto size-4" />
-    </a>
-    <a
+    </component>
+    <component
+      :is="hasConfig ? 'a' : 'button'"
       class="scalar-mcp-layer-link"
       :href="hasConfig ? cursorLink : undefined"
       :target="hasConfig ? '_blank' : undefined"
+      :type="hasConfig ? undefined : 'button'"
       @click="
-        (e) => {
+        (e: MouseEvent) => {
           if (!hasConfig) {
             e.preventDefault()
             generateRegisterLink()
@@ -137,7 +146,7 @@ function openRegisterLink(documentUrl: string) {
       </svg>
       Cursor
       <ScalarIconArrowUpRight class="mcp-nav ml-auto size-4" />
-    </a>
+    </component>
     <!-- localhost + you don't have a MCP added -->
     <div
       v-if="!hasConfig"
@@ -233,6 +242,10 @@ function openRegisterLink(documentUrl: string) {
   line-height: 1.385;
   text-decoration: none;
   border-radius: var(--scalar-radius);
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
   border: var(--scalar-border-width) solid var(--scalar-border-color);
   gap: 6px;
   color: var(--scalar-sidebar-color-1);

--- a/packages/api-reference/src/components/ApiReference.test.ts
+++ b/packages/api-reference/src/components/ApiReference.test.ts
@@ -670,6 +670,27 @@ describe('proxy configuration', () => {
 })
 
 describe('sidebar introduction toggle behavior', () => {
+  beforeEach(() => {
+    // jsdom localStorage can be missing after vi.unstubAllGlobals() in the file hook
+    const store = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        store.set(key, value)
+      },
+      removeItem: (key: string) => {
+        store.delete(key)
+      },
+      clear: () => {
+        store.clear()
+      },
+      key: (index: number) => [...store.keys()][index] ?? null,
+      get length() {
+        return store.size
+      },
+    })
+  })
+
   it('collapses introduction when clicked a second time', async () => {
     const wrapper = mount(ApiReference, {
       props: {
@@ -702,22 +723,25 @@ Welcome to the API.
       throw new Error('Expected Introduction entry in sidebar items')
     }
 
-    const introductionButton = wrapper.find(`[data-sidebar-id="${introduction.id}"] [aria-current="page"]`)
-    const introductionToggle = wrapper.find(
-      // Make sure we select the toggle not the group button
-      `[data-sidebar-id="${introduction.id}"] [aria-expanded]:not([aria-current])`,
-    )
+    const introductionRoot = wrapper.find(`[data-sidebar-id="${introduction.id}"]`)
+    // Discrete groups: main item button + separate absolute caret toggle.
+    // Do not key off aria-current — it is only present when the item is selected.
+    const expandedButtons = introductionRoot.findAll('button[aria-expanded]')
+    const introductionButton = expandedButtons.find((btn) => !btn.classes().includes('absolute'))
+    const introductionToggle = expandedButtons.find((btn) => btn.classes().includes('absolute'))
 
-    expect(introductionButton.attributes('aria-expanded')).toBe('false')
-    expect(introductionToggle.attributes('aria-expanded')).toBe('false')
+    expect(introductionButton).toBeDefined()
+    expect(introductionToggle).toBeDefined()
+    expect(introductionButton!.attributes('aria-expanded')).toBe('false')
+    expect(introductionToggle!.attributes('aria-expanded')).toBe('false')
 
-    await introductionButton.trigger('click')
-    expect(introductionButton.attributes('aria-expanded')).toBe('true')
-    expect(introductionToggle.attributes('aria-expanded')).toBe('true')
+    await introductionButton!.trigger('click')
+    expect(introductionButton!.attributes('aria-expanded')).toBe('true')
+    expect(introductionToggle!.attributes('aria-expanded')).toBe('true')
 
-    await introductionToggle.trigger('click')
-    expect(introductionButton.attributes('aria-expanded')).toBe('false')
-    expect(introductionToggle.attributes('aria-expanded')).toBe('false')
+    await introductionToggle!.trigger('click')
+    expect(introductionButton!.attributes('aria-expanded')).toBe('false')
+    expect(introductionToggle!.attributes('aria-expanded')).toBe('false')
   })
 })
 

--- a/packages/api-reference/src/components/ApiReference.test.ts
+++ b/packages/api-reference/src/components/ApiReference.test.ts
@@ -702,10 +702,10 @@ Welcome to the API.
       throw new Error('Expected Introduction entry in sidebar items')
     }
 
-    const introductionButton = wrapper.find(`[data-sidebar-id="${introduction.id}"] [aria-selected]`)
+    const introductionButton = wrapper.find(`[data-sidebar-id="${introduction.id}"] [aria-current="page"]`)
     const introductionToggle = wrapper.find(
       // Make sure we select the toggle not the group button
-      `[data-sidebar-id="${introduction.id}"] [aria-expanded]:not([aria-selected])`,
+      `[data-sidebar-id="${introduction.id}"] [aria-expanded]:not([aria-current])`,
     )
 
     expect(introductionButton.attributes('aria-expanded')).toBe('false')

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -1545,7 +1545,6 @@ const showMCPButton = computed(() => {
             :items="sidebarItems"
             layout="reference"
             :options="sidebarOptions"
-            role="navigation"
             @selectItem="(id) => handleSelectSidebarEntry(id, 'sidebar')"
             @toggleGroup="
               (id: string) =>

--- a/packages/api-reference/test/configuration/generate-model-slug.e2e.ts
+++ b/packages/api-reference/test/configuration/generate-model-slug.e2e.ts
@@ -25,8 +25,8 @@ test.describe('generateModelSlug', () => {
     await page.goto(example)
 
     // The Models group is collapsed by default, so expand it before clicking the model
-    await page.getByRole('navigation').getByRole('button', { name: 'Models' }).click()
-    await page.getByRole('navigation').getByRole('button', { name: 'Planet' }).click()
+    await page.getByRole('complementary').getByRole('button', { name: 'Models' }).click()
+    await page.getByRole('complementary').getByRole('button', { name: 'Planet' }).click()
 
     // `model/` is prepended automatically
     await expect(page).toHaveURL(/custom-planet/)

--- a/packages/api-reference/test/configuration/generate-operation-slug.e2e.ts
+++ b/packages/api-reference/test/configuration/generate-operation-slug.e2e.ts
@@ -21,7 +21,7 @@ test.describe('generateOperationSlug', () => {
 
     await page.goto(example)
 
-    await page.getByRole('navigation').getByRole('button', { name: 'Get all planets' }).click()
+    await page.getByRole('complementary').getByRole('button', { name: 'Get all planets' }).click()
 
     // `tag/<tag-slug>/` is prepended automatically, so we assert the custom part
     await expect(page).toHaveURL(/get-planets/)

--- a/packages/api-reference/test/configuration/generate-tag-slug.e2e.ts
+++ b/packages/api-reference/test/configuration/generate-tag-slug.e2e.ts
@@ -18,7 +18,7 @@ test.describe('generateTagSlug', () => {
     await page.goto(example)
 
     // Operation hashes are prefixed with `tag/<tag-slug>/`, so clicking one reveals the tag slug
-    await page.getByRole('navigation').getByRole('button', { name: 'Get all planets' }).click()
+    await page.getByRole('complementary').getByRole('button', { name: 'Get all planets' }).click()
 
     await expect(page).toHaveURL(/tag\/planets/)
   })
@@ -31,7 +31,7 @@ test.describe('generateTagSlug', () => {
 
     await page.goto(example)
 
-    await page.getByRole('navigation').getByRole('button', { name: 'Get all planets' }).click()
+    await page.getByRole('complementary').getByRole('button', { name: 'Get all planets' }).click()
 
     await expect(page).toHaveURL(/tag\/v1-planets/)
   })

--- a/packages/api-reference/test/configuration/generate-webhook-slug.e2e.ts
+++ b/packages/api-reference/test/configuration/generate-webhook-slug.e2e.ts
@@ -31,7 +31,7 @@ test.describe('generateWebhookSlug', () => {
 
     await page.goto(example)
 
-    await page.getByRole('navigation').getByRole('button', { name: 'New planet' }).click()
+    await page.getByRole('complementary').getByRole('button', { name: 'New planet' }).click()
 
     // `webhook/` is prepended automatically
     await expect(page).toHaveURL(/webhook\/v1-newPlanet/)

--- a/packages/api-reference/test/configuration/hide-search.e2e.ts
+++ b/packages/api-reference/test/configuration/hide-search.e2e.ts
@@ -7,7 +7,7 @@ test.describe('hideSearch', () => {
 
     await page.goto(example)
 
-    await expect(page.getByRole('search')).toBeVisible()
+    await expect(page.getByRole('button', { name: /open search/i })).toBeVisible()
   })
 
   test('hides search when set to true', async ({ page }) => {
@@ -15,6 +15,6 @@ test.describe('hideSearch', () => {
 
     await page.goto(example)
 
-    await expect(page.getByRole('search')).not.toBeVisible()
+    await expect(page.getByRole('button', { name: /open search/i })).not.toBeVisible()
   })
 })

--- a/packages/api-reference/test/configuration/models-section-label.e2e.ts
+++ b/packages/api-reference/test/configuration/models-section-label.e2e.ts
@@ -37,8 +37,8 @@ test.describe('modelsSectionLabel', () => {
     await expect(page.getByRole('heading', { name: 'Data Types', level: 2 })).toBeVisible()
 
     // Sidebar shows the custom label, not the default
-    await expect(page.getByRole('navigation').getByText('Data Types', { exact: true }).first()).toBeVisible()
-    await expect(page.getByRole('navigation').getByText('Models', { exact: true })).toHaveCount(0)
+    await expect(page.getByRole('complementary').getByText('Data Types', { exact: true }).first()).toBeVisible()
+    await expect(page.getByRole('complementary').getByText('Models', { exact: true })).toHaveCount(0)
 
     // Per-model URL slug derivation is covered by get-navigation-options.test.ts.
   })

--- a/packages/api-reference/test/configuration/on-sidebar-click.e2e.ts
+++ b/packages/api-reference/test/configuration/on-sidebar-click.e2e.ts
@@ -18,7 +18,7 @@ test.describe('onSidebarClick', () => {
 
     await page.goto(example)
 
-    await page.getByRole('navigation').getByRole('button', { name: 'Get all planets' }).click()
+    await page.getByRole('complementary').getByRole('button', { name: 'Get all planets' }).click()
 
     await expect
       .poll(() => page.evaluate(() => (window as unknown as Record<string, unknown>).__sidebarHref))

--- a/packages/api-reference/test/configuration/operation-title-source.e2e.ts
+++ b/packages/api-reference/test/configuration/operation-title-source.e2e.ts
@@ -20,7 +20,7 @@ test.describe('operationTitleSource', () => {
 
     await page.goto(example)
 
-    await expect(page.getByRole('navigation').getByRole('button', { name: 'Get all users' })).toBeVisible()
+    await expect(page.getByRole('complementary').getByRole('button', { name: 'Get all users' })).toBeVisible()
   })
 
   test('uses the operation path in the sidebar when set to path', async ({ page }) => {
@@ -28,6 +28,6 @@ test.describe('operationTitleSource', () => {
 
     await page.goto(example)
 
-    await expect(page.getByRole('navigation').getByRole('button', { name: '/users/list' })).toBeVisible()
+    await expect(page.getByRole('complementary').getByRole('button', { name: '/users/list' })).toBeVisible()
   })
 })

--- a/packages/api-reference/test/configuration/operations-sorter.e2e.ts
+++ b/packages/api-reference/test/configuration/operations-sorter.e2e.ts
@@ -15,7 +15,7 @@ const content = {
 
 /** Vertical position of a sidebar link, used to compare ordering. */
 const sidebarTop = async (page: Page, name: string) => {
-  const box = await page.getByRole('navigation').getByRole('button', { name }).first().boundingBox()
+  const box = await page.getByRole('complementary').getByRole('button', { name }).first().boundingBox()
   return box?.y ?? Number.POSITIVE_INFINITY
 }
 

--- a/packages/api-reference/test/configuration/show-sidebar.e2e.ts
+++ b/packages/api-reference/test/configuration/show-sidebar.e2e.ts
@@ -7,7 +7,7 @@ test.describe('showSidebar', () => {
 
     await page.goto(example)
 
-    await expect(page.getByRole('navigation')).toBeVisible()
+    await expect(page.getByRole('complementary')).toBeVisible()
   })
 
   test('hides sidebar when set to false', async ({ page }) => {
@@ -15,6 +15,6 @@ test.describe('showSidebar', () => {
 
     await page.goto(example)
 
-    await expect(page.getByRole('navigation')).not.toBeVisible()
+    await expect(page.getByRole('complementary')).not.toBeVisible()
   })
 })

--- a/packages/api-reference/test/configuration/tags-sorter.e2e.ts
+++ b/packages/api-reference/test/configuration/tags-sorter.e2e.ts
@@ -14,7 +14,7 @@ const content = {
 
 /** Vertical position of a sidebar link, used to compare ordering. */
 const sidebarTop = async (page: Page, name: string) => {
-  const box = await page.getByRole('navigation').getByRole('button', { name }).first().boundingBox()
+  const box = await page.getByRole('complementary').getByRole('button', { name }).first().boundingBox()
   return box?.y ?? Number.POSITIVE_INFINITY
 }
 

--- a/packages/api-reference/test/snapshots/agent.e2e.ts
+++ b/packages/api-reference/test/snapshots/agent.e2e.ts
@@ -9,6 +9,6 @@ test(galaxy.title, async ({ page }) => {
   const example = await serveExample(galaxy)
   await page.goto(example)
 
-  await page.getByRole('navigation', { name: 'Sidebar' }).getByRole('button', { name: 'Ask AI' }).click()
+  await page.getByRole('complementary', { name: 'Sidebar' }).getByRole('button', { name: 'Ask AI' }).click()
   await expect(page).toHaveScreenshot('drawer.png')
 })

--- a/packages/api-reference/test/snapshots/localization.e2e.ts
+++ b/packages/api-reference/test/snapshots/localization.e2e.ts
@@ -25,7 +25,10 @@ test('Arabic locale', async ({ page }) => {
 
   await expect(page).toHaveScreenshot('arabic-reference.png')
 
-  await page.getByRole('search').first().click()
+  await page
+    .getByRole('button', { name: /فتح البحث/i })
+    .first()
+    .click()
   const searchInput = page.getByRole('combobox', { name: 'بحث' })
   await expect(searchInput).toBeVisible()
   await expect(page).toHaveScreenshot('arabic-search.png')

--- a/packages/api-reference/test/snapshots/search.e2e.ts
+++ b/packages/api-reference/test/snapshots/search.e2e.ts
@@ -9,7 +9,10 @@ test(galaxy.title, async ({ page }) => {
   const example = await serveExample(galaxy)
   await page.goto(example)
 
-  await page.getByRole('navigation', { name: 'Sidebar' }).getByRole('search').click()
+  await page
+    .getByRole('navigation', { name: 'Sidebar' })
+    .getByRole('button', { name: /open search/i })
+    .click()
   await expect(page).toHaveScreenshot('search.png')
 
   await page.getByRole('combobox', { name: 'Enter search query' }).fill('Get a token')

--- a/packages/api-reference/test/snapshots/search.e2e.ts
+++ b/packages/api-reference/test/snapshots/search.e2e.ts
@@ -10,7 +10,7 @@ test(galaxy.title, async ({ page }) => {
   await page.goto(example)
 
   await page
-    .getByRole('navigation', { name: 'Sidebar' })
+    .getByRole('complementary', { name: /Sidebar/i })
     .getByRole('button', { name: /open search/i })
     .click()
   await expect(page).toHaveScreenshot('search.png')

--- a/packages/api-reference/test/snapshots/sidebar.e2e.ts
+++ b/packages/api-reference/test/snapshots/sidebar.e2e.ts
@@ -35,7 +35,7 @@ toTest.forEach((source) => {
     const opts = getScreenshotOptions(page)
 
     // Expand the tag
-    const nav = page.getByRole('navigation', { name: 'Sidebar for' })
+    const nav = page.getByRole('complementary', { name: 'Sidebar for' })
 
     await page.goto(`${example}#${slug}/models`)
 

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.vue
@@ -18,10 +18,10 @@ defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
 </script>
 <template>
-  <nav
+  <aside
     v-bind="
       cx('flex flex-col border-r bg-sidebar-b-1 border-sidebar-border w-72')
     ">
     <slot />
-  </nav>
+  </aside>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.vue
@@ -18,10 +18,10 @@ defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
 </script>
 <template>
-  <aside
+  <nav
     v-bind="
       cx('flex flex-col border-r bg-sidebar-b-1 border-sidebar-border w-72')
     ">
     <slot />
-  </aside>
+  </nav>
 </template>

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarButton.vue
@@ -68,7 +68,7 @@ const { cx } = useBindCx()
 <template>
   <component
     :is="is"
-    :aria-selected="selected"
+    :aria-current="selected ? 'page' : undefined"
     :type="is === 'button' ? 'button' : undefined"
     v-bind="cx(variants({ selected, disabled, active }))">
     <slot name="indent">

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebarSearchButton.vue
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebarSearchButton.vue
@@ -24,8 +24,8 @@ defineOptions({ inheritAttrs: false })
 const { cx } = useBindCx()
 </script>
 <template>
+  <!-- role="search" is a landmark for a search region, not a button control -->
   <button
-    role="search"
     type="button"
     v-bind="
       cx(
@@ -33,7 +33,9 @@ const { cx } = useBindCx()
         'bg-sidebar-b-search border-sidebar-border-search text-sidebar-c-search',
       )
     ">
-    <ScalarIconMagnifyingGlass class="size-4" />
+    <ScalarIconMagnifyingGlass
+      aria-hidden="true"
+      class="size-4" />
     <span class="flex-1 text-start leading-none">
       <slot>Search...</slot>
     </span>

--- a/projects/scalar-app/test/request-table-tooltip.e2e.ts
+++ b/projects/scalar-app/test/request-table-tooltip.e2e.ts
@@ -96,6 +96,7 @@ test.describe('request-table-tooltip.e2e', () => {
     await expect(page).toHaveURL(/\/get-started/)
 
     const sidebar = page.locator('aside')
+
     await sidebar.getByText(TOOLTIP_DOCUMENT_SIDEBAR_TITLE, { exact: true }).click()
     await expect(page).toHaveURL(new RegExp(`/document/${TOOLTIP_TEST_DOCUMENT}/`))
 

--- a/projects/scalar-app/test/response-body-raw-json-bigint.e2e.ts
+++ b/projects/scalar-app/test/response-body-raw-json-bigint.e2e.ts
@@ -147,6 +147,7 @@ test.describe('response-body-raw-json-bigint.e2e', () => {
     await expect(page).toHaveURL(/\/get-started/)
 
     const sidebar = page.locator('aside')
+
     await sidebar.getByText(BIGINT_DOCUMENT_SIDEBAR_TITLE, { exact: true }).click()
     await expect(page).toHaveURL(new RegExp(`/document/${BIGINT_TEST_DOCUMENT}/`))
 


### PR DESCRIPTION
> **Draft — CI validation only.** This duplicates community PR #9783 (by @guillaume-flambard) with three layout regressions fixed on top. It is not meant to merge as-is; the point is a clean CI run before the fixes go back to that PR.

## What's here

`f3f2747`, `3ae5ff2` and `f1d3558` are @guillaume-flambard's commits from #9783, unchanged. `87ba9fe` is a follow-up fixing three regressions the ARIA restructure introduced.

### The a11y fixes (his work)

- Sidebar items use `aria-current="page"` instead of `aria-selected`, which is invalid on link and button roles
- The search trigger drops `role="search"` — a landmark role, not a control role — and keeps its accessible name
- The sidebar `<aside>` drops `role="navigation"`, which `<aside>` does not permit
- The client libraries and SDK installation "More" comboboxes move out of `role="tablist"`, which requires tab-only children
- MCP install controls render as `<button>` when there is no target URL, instead of an `<a>` with no `href`

### The regressions fixed on top

| Where | Problem |
|---|---|
| `ClientDropdown` / `ClientSelector` | `flex: 1` on the "More" wrapper gave it half the row; the five tabs overflowed their box by 138px and painted over it, leaving the trigger unreachable |
| `SdkInstallationInstructions` | `availableWidth` was measured on the tab strip, whose width already excludes the "More" trigger — so that width was reserved twice and a tab that fits got pushed into the dropdown. The `ResizeObserver` also watched an element whose size depended on its own output |
| `OpenMCPButton` | `font: inherit` sat after `font-size` and `line-height` in the same rule; the shorthand resets both, enlarging every MCP link — including the "Generate MCP" `<div>`, which was never a button |

## Testing

Against the containerised Playwright runner, `--workers=1`:

- `test/snapshots` — **78/78** across 12 files, against unmodified baselines
- `test/configuration` — **112 pass**, covering every rewritten `complementary` query
- `test/features` + `test/standalone` — **13 pass**
- `pnpm vitest --run` — **1625 pass** (125 files)
- `vue-tsc`, biome, prettier — clean

## Visual

No screenshots, deliberately: the snapshot suite passing against `main`'s **unmodified** baselines is the stronger claim. This branch fixes ARIA without moving a pixel, so there is no before/after to show.

That result is load-bearing rather than incidental. Before the fixes on `87ba9fe`, `tag-groups › classic` and all 28 `themes › * › Classic *` failed with ~6000px diffs, and `sidebar › Mobile Sidebar` failed separately on the MCP font drift. No baselines were regenerated.

## Ticket

Part of DOC-5912
See #9725
Related to #9783
