### PR TITLE
docs(docs): document the hidden navigation option for docs configs

### DIFF
--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -188,11 +188,39 @@ Pages render markdown content from files in your repository. They are the most c
 | `description`   | `string`  | No       | A description for SEO and metadata                        |
 | `icon`          | `string`  | No       | An icon to display next to the page                       |
 | `showInSidebar` | `boolean` | No       | Whether to show the page in the sidebar (defaults `true`) |
+| `hidden`        | `boolean` | No       | Fully hide the page: no sidebar entry, no sitemap entry, and `noindex` (defaults `false`) |
 | `layout`        | `object`  | No       | Layout configuration options                              |
 
 ### Hidden pages
 
-Set `showInSidebar` to `false` to hide a page from the sidebar navigation while keeping it accessible via its direct URL. This is useful for special pages like landing pages, promotional content, or forms that should not clutter the main navigation.
+There are two ways to keep a page out of your navigation, depending on whether the page should still be discoverable by search engines.
+
+#### Truly hidden pages with `hidden`
+
+Set `hidden` to `true` to fully hide a page. The page is:
+
+- removed from the sidebar navigation,
+- excluded from the generated `sitemap.xml`, and
+- rendered with a `<meta name="robots" content="noindex">` tag so search engines do not index it.
+
+The page stays reachable at its URL, which makes it a good fit for unlisted content like internal notes, early drafts, or pages you only want to share by direct link.
+
+```json
+"/internal-notes": {
+  "type": "page",
+  "title": "Internal Notes",
+  "filepath": "docs/internal-notes.md",
+  "hidden": true
+}
+```
+
+If you need to override the automatic `noindex` for a hidden page, an explicit `robots` meta tag in the page's `head` configuration takes precedence.
+
+Note that the site's `robots.txt` intentionally keeps allowing crawlers: they must be able to fetch the page to see the `noindex` tag, and URLs blocked by `robots.txt` can still show up in search results (title-only) when external sites link to them.
+
+#### Sidebar-only hiding with `showInSidebar`
+
+Set `showInSidebar` to `false` to hide a page from the sidebar navigation only. This is purely cosmetic: the page remains in the sitemap and stays indexable by search engines. This is useful for special pages like landing pages, promotional content, or forms that should not clutter the main navigation but should still be found through search.
 
 ```json
 "/enterprise": {
@@ -204,6 +232,8 @@ Set `showInSidebar` to `false` to hide a page from the sidebar navigation while 
 ```
 
 Users can still navigate to `/enterprise` directly, but the page will not appear in the sidebar. To make a page visible in the sidebar again, remove the `showInSidebar` property or set it to `true`.
+
+In short: use `hidden: true` when the page should be invisible to search engines, and `showInSidebar: false` when it should only be invisible in the sidebar.
 
 ### Layout Options
 
@@ -341,6 +371,7 @@ Fetch an OpenAPI document from a remote URL. The document is fetched on each pag
 | `icon`       | `string`                         | No       | An icon to display next to the reference                         |
 | `mode`       | `"flat" \| "nested" \| "folder"` | No       | How the API reference is displayed in the sidebar                |
 | `singlePage` | `boolean`                        | No       | Render all operations on a single page (defaults to `false`)     |
+| `hidden`     | `boolean`                        | No       | Fully hide the API reference and all its generated pages (defaults to `false`) |
 | `config`     | `object`                         | No       | API Reference configuration options                              |
 
 ### Display Modes
@@ -363,6 +394,19 @@ By default, Docs creates a separate page for each API operation. Set `singlePage
 ```
 
 This is useful when you want a scrollable, single-page API reference similar to traditional API documentation layouts.
+
+### Hiding an API Reference
+
+Set `hidden` to `true` to fully hide an API reference. The setting cascades to every page generated from the OpenAPI document — all operation, tag, model, and webhook pages are removed from the sidebar, excluded from `sitemap.xml`, and rendered with a `noindex` meta tag. The pages stay reachable at their URLs, so you can still share them by direct link. See [Hidden pages](#hidden-pages) for details on how `hidden` compares to `showInSidebar`.
+
+```json
+"/internal-api": {
+  "type": "openapi",
+  "title": "Internal API",
+  "filepath": "docs/internal-api/openapi.yaml",
+  "hidden": true
+}
+```
 
 ### API Reference configuration
 
@@ -430,6 +474,7 @@ Groups allow you to organize related pages, API references, and links into colla
 | `icon`     | `string`                         | No       | An icon to display next to the group                             |
 | `page`     | `object`                         | No       | A page to navigate to when clicking the folder (folder mode only) |
 | `open`     | `boolean`                        | No       | Whether the folder is expanded by default (folder mode only)     |
+| `hidden`   | `boolean`                        | No       | Fully hide the group and everything nested under it (defaults to `false`) |
 
 ### Display Modes
 
@@ -438,6 +483,25 @@ Groups support three display modes:
 - **`flat`**: Shows a section title with child links directly beneath it. Ideal for top-level categories.
 - **`nested`**: Shows a sub-sidebar with breadcrumbs for deep navigation. Good for complex documentation structures.
 - **`folder`**: (default): Shows a single level of links with a folder icon. Suitable for simple groupings.
+
+### Hiding Groups
+
+Set `hidden` to `true` on a group to fully hide it along with everything nested under it — child pages, nested groups, and any API references. All affected pages are removed from the sidebar, excluded from `sitemap.xml`, and rendered with a `noindex` meta tag, while remaining reachable at their URLs. See [Hidden pages](#hidden-pages) for details on how `hidden` compares to `showInSidebar`.
+
+```json
+"/internal": {
+  "type": "group",
+  "title": "Internal",
+  "hidden": true,
+  "children": {
+    "/runbooks": {
+      "type": "page",
+      "title": "Runbooks",
+      "filepath": "docs/internal/runbooks.md"
+    }
+  }
+}
+```
 
 ### Nesting Groups
 
@@ -561,10 +625,13 @@ Links allow you to add external URLs to your navigation. Unlike pages that rende
 
 | Property | Type     | Required | Description                         |
 | -------- | -------- | -------- | ----------------------------------- |
-| `type`   | `"link"` | Yes      | Must be `"link"`                    |
-| `title`  | `string` | No       | The display text in the navigation  |
-| `url`    | `string` | Yes      | The external URL to link to         |
-| `icon`   | `string` | No       | An icon to display next to the link |
+| `type`   | `"link"`  | Yes      | Must be `"link"`                    |
+| `title`  | `string`  | No       | The display text in the navigation  |
+| `url`    | `string`  | Yes      | The external URL to link to         |
+| `icon`   | `string`  | No       | An icon to display next to the link |
+| `hidden` | `boolean` | No       | Hide the link from the sidebar (defaults to `false`) |
+
+Since a link points to an external URL, there is no page to exclude from the sitemap or deindex — on links, `hidden: true` only removes the sidebar entry. The option exists on all route types for consistency.
 
 ### Example
 

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -488,6 +488,8 @@ Groups support three display modes:
 
 Set `hidden` to `true` on a group to fully hide it along with everything nested under it — child pages, nested groups, and any API references. All affected pages are removed from the sidebar, excluded from `sitemap.xml`, and rendered with a `noindex` meta tag, while remaining reachable at their URLs. See [Hidden pages](#hidden-pages) for details on how `hidden` compares to `showInSidebar`.
 
+This works at both levels: on a top-level route section directly under `navigation.routes` and on a group nested inside another group, with the same cascade to every page underneath. Since a top-level route section has no sidebar row of its own, `hidden` there only affects indexing — and any [tabs](#tabs) or [header links](#header) pointing at that section are configured separately and are not removed automatically.
+
 ```json
 "/internal": {
   "type": "group",


### PR DESCRIPTION
## Summary

Documents the new `hidden` option for `scalar.config.json` navigation entries on the [Navigation](https://github.com/scalar/scalar/blob/claude/docs-hidden-navigation-option/documentation/guides/docs/configuration/navigation.md) configuration page:

- `hidden: true` fully hides an entry: removed from the sidebar, excluded from `sitemap.xml`, and the page renders with `<meta name="robots" content="noindex">` — while staying reachable at its URL for unlisted/internal pages shared by link.
- On `group` and `openapi` entries the option cascades to everything underneath (nested groups/pages and all generated operation, tag, model, and webhook pages).
- On `link` entries it only hides the sidebar row (there is no page to deindex); it exists for consistency.
- The revised **Hidden pages** section now contrasts this with `showInSidebar: false`, which is sidebar-only: the page stays in the sitemap and indexable (the right choice for landing pages kept out of the nav).
- Notes the escape hatch (an explicit `robots` meta in the `head` config overrides the automatic `noindex`) and why `robots.txt` keeps allowing crawlers.

## Notes

- Documents the platform feature added in scalar/scalar-org#5612 — that PR must ship before or together with merging these docs.
- Docs-only change, no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or config schema changes in this PR.
> 
> **Overview**
> Documents the **`hidden`** navigation flag on `page`, `openapi`, `group`, and `link` routes in `navigation.md`, describing behavior that goes beyond the existing **`showInSidebar`** docs.
> 
> The **Hidden pages** section is reworked into two paths: **`hidden: true`** removes sidebar entries, drops URLs from **`sitemap.xml`**, and adds **`noindex`** while URLs stay reachable; **`showInSidebar: false`** stays sidebar-only and keeps sitemap/indexing. It also covers overriding **`noindex`** via **`head`**, and why **`robots.txt`** still allows crawlers.
> 
> New sections spell out **`hidden`** on OpenAPI (cascade to generated operation/tag/model/webhook pages), groups (cascade to nested routes; top-level groups vs tabs/header links), and links (sidebar-only, for consistency).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7c90b462633fdd8eccac25ad3ac10a9dbf730e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->