### PR TITLE
docs(docs): document where the logo renders

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -96,6 +96,8 @@ Links in the top bar. Use `type: "spacer"` to push items before it left and afte
 
 Properties: `title`, `type` (`"link"` | `"spacer"`), `to`, `style` (`"button"` | `"link"`), `icon`, `newTab`
 
+The header only renders when this array has at least one item, and it is where the logo goes. A lone `{ "type": "spacer" }` is enough to get a header with just the logo.
+
 ### navigation.sidebar
 
 Links at the bottom of the sidebar:
@@ -115,6 +117,8 @@ Tabs for quick access to sections:
   { "title": "API", "path": "/api", "icon": "phosphor/regular/plug" }
 ]
 ```
+
+Tabs and a header work together, and neither requires the other. With tabs but no header, the logo renders in the tab bar.
 
 ### Route Types
 
@@ -250,6 +254,8 @@ External URL:
   "lightMode": "https://example.com/logo-light.svg"
 }
 ```
+
+The logo renders on the first surface the site has: **header** (if `navigation.header` has items) → **tabs** (if `navigation.tabs` but no header) → **sidebar** (if neither). A page that hides all three via `layout` does not render it at all. With no `logo` set, `info.title` renders in the same place.
 
 **Theme** — one of: `default`, `alternate`, `moon`, `purple`, `solarized`, `bluePlanet`, `deepSpace`, `saturn`, `kepler`, `mars`, `laserwave`, `none`
 

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -27,6 +27,8 @@ All navigation is configured within the `navigation.routes` object in your `scal
 
 The `navigation.header` array defines links that appear in the top navigation bar of your documentation site. These are typically used for authentication links, external resources, or call-to-action buttons. Each item can be `type: "link"` or `type: "spacer"`. A spacer pushes items before it to the left and items after it to the right.
 
+The header only renders when this array has at least one item, and it is where your [logo](site-config.md#logo) appears. If you want the logo in the header but have no links to put there, a single spacer is enough.
+
 ### Example
 
 ```json
@@ -116,6 +118,8 @@ The `navigation.sidebar` array defines links that appear in the footer of the si
 ## Tabs
 
 The `navigation.tabs` array defines tabs that appear in the navigation area. Tabs provide a way to organize and highlight specific sections of your documentation, such as API references, that you want users to access quickly.
+
+Tabs and a header work together, and you do not need both. If you use tabs without a header, your [logo](site-config.md#logo) renders in the tab bar.
 
 ### Example
 

--- a/documentation/guides/docs/configuration/site-config.md
+++ b/documentation/guides/docs/configuration/site-config.md
@@ -20,7 +20,19 @@ All site settings are configured within the `siteConfig` object in your `scalar.
 
 ## Logo
 
-The `logo` property defines your site's logo displayed in the navigation. You can provide a single URL for all modes, or separate logos for light and dark themes.
+The `logo` property defines your site's logo. You can provide a single URL for all modes, or separate logos for light and dark themes.
+
+### Where the Logo Appears
+
+Your logo renders on the first of these surfaces your site has:
+
+1. The **header**, if `navigation.header` has any items
+2. The **tabs**, if you have `navigation.tabs` but no header
+3. The **sidebar**, if you have neither
+
+To put your logo in the header, add at least one item to [`navigation.header`](navigation.md#header) — a single spacer is enough. If a page hides all three surfaces through its [layout options](navigation.md#layout-options), the logo does not render on that page.
+
+If you do not set a `logo`, your project title from `info.title` renders in the same place instead.
 
 ### Single Logo
 


### PR DESCRIPTION
## Problem

Nothing in the docs said where the logo actually renders. The Logo section just said "displayed in the navigation", which is ambiguous — `navigation` is the name of a whole other config section covering the header, tabs *and* sidebar.

That mattered because the header only exists when `navigation.header` has items, so anyone who put their nav in tabs instead (which is what the Tabs section steers you toward) ended up with their logo in the sidebar, with no way to know why.

## Solution

The renderer now cascades the brand header → tabs → sidebar, so tabs-without-header sites get it in the tab bar rather than the sidebar. These docs catch up with that.

- `site-config.md` — new "Where the Logo Appears" section spelling out the cascade, how to force it into the header (a lone spacer is enough), and the `info.title` fallback
- `navigation.md` — the Header and Tabs sections now say where the brand lands, since their wording is what sends people to tabs in the first place
- `.agents/skills/scalar-docs/SKILL.md` — same, so agent-written configs stop reproducing the old shape

No changeset — `documentation/` and `.agents/` only, no package code.

`scalar/starter` vendors its own copy of `SKILL.md` (plus a `skills-lock.json`), so that one needs the same edit separately.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.

## Ticket

Part of DOC-5628
