### PR TITLE
fix(api-reference): stop expanded content overlapping when printing

### DIFF
--- a/.changeset/print-styles-sticky-overlap.md
+++ b/.changeset/print-styles-sticky-overlap.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+Add print styles so printing (or saving to PDF) no longer renders expanded content over the text that follows it. The reference lays itself out as a fixed-viewport application, and its sticky columns were pinned to a screen measurement that is meaningless on paper. Printing now flattens that shell into ordinary document flow: navigation and floating chrome are hidden, sticky positioning and viewport-derived height caps are dropped so long examples are no longer truncated, and small units such as properties and cards avoid breaking across pages.

--- a/packages/api-reference/src/style.css
+++ b/packages/api-reference/src/style.css
@@ -18,6 +18,9 @@
 /* API Reference Tailwind Configuration */
 @import "./styles/tailwind.config.css";
 
+/* Print overrides, flattening the fixed viewport shell into a document */
+@import "./styles/print.css";
+
 /* Generate the Tailwind Utilities (scoped) */
 .scalar-app {
   @import "tailwindcss/utilities.css";

--- a/packages/api-reference/src/styles/print.css
+++ b/packages/api-reference/src/styles/print.css
@@ -1,0 +1,118 @@
+/**
+ * Print Styles
+ *
+ * The API reference renders as a fixed-viewport application: a 100dvh grid whose
+ * offsets derive from a JS-measured screen height, with sticky columns pinned to
+ * that measurement. None of that is meaningful on paper, so printing flattens the
+ * shell back into ordinary document flow.
+ *
+ * Everything here is marked !important on purpose. The declarations being
+ * overridden live in scoped <style> blocks, which compile to selectors like
+ * `.examples[data-v-hash]` and therefore tie on specificity with a two-class
+ * global selector, leaving source order to decide the winner. A print-only media
+ * block cannot affect screen rendering, so the escape hatch is cheap here.
+ *
+ * @see https://github.com/scalar/scalar/issues/9598
+ */
+@media print {
+  /* ------------------------------------------------------------------ */
+  /* Layout shell                                                        */
+
+  /*
+   * These are measured from the screen by a resize observer and are never
+   * recalculated for print, so every offset derived from them is stale by the
+   * height of the header. Zero them out so the derived values collapse.
+   *
+   * `--full-height` is written as an inline style by the resize observer, which
+   * an important declaration still outranks. It resolves to `100%` rather than
+   * `auto` so that the heights derived from it (`--refs-viewport-height`,
+   * `--refs-sidebar-height`) stay valid `calc()` expressions instead of becoming
+   * invalid at computed-value time.
+   */
+  .scalar-app {
+    --full-height: 100% !important;
+    --refs-header-height: 0px !important;
+    --refs-viewport-offset: 0px !important;
+    --refs-sidebar-width: 0px !important;
+  }
+
+  /*
+   * Collapse the application grid into normal flow. The grid-area declarations
+   * on the children become inert once the container is no longer a grid.
+   */
+  .references-layout {
+    display: block !important;
+    min-height: 0 !important;
+  }
+
+  /* Navigation and floating chrome do not belong on paper. */
+  .t-doc__sidebar,
+  .t-doc__header,
+  .references-footer,
+  .section-flare,
+  .agent-scalar,
+  .agent-scalar-overlay {
+    display: none !important;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Sticky and fixed positioning                                        */
+
+  /*
+   * Sticky boxes resolve against the page box when printing, so each of these
+   * is pinned at a stale --refs-viewport-offset instead of flowing with its
+   * siblings. The callback title additionally carries a z-index, which is what
+   * makes it paint over the content that follows rather than beside it.
+   */
+  .scalar-app .sticky,
+  .scalar-app .examples,
+  .scalar-app .operation-example-card,
+  .scalar-app .endpoints-card,
+  .scalar-app .channels-card,
+  .scalar-app .sticky-cards,
+  .scalar-app .callback-list-item-title {
+    position: static !important;
+    top: auto !important;
+    z-index: auto !important;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Height caps and scroll containers                                   */
+
+  /*
+   * Request and response examples are capped to a single screen height and
+   * scrolled. On paper that silently drops everything past the fold.
+   */
+  .scalar-app .examples > *,
+  .scalar-app .operation-example-card {
+    max-height: none !important;
+  }
+
+  /* Scroll containers clip their content instead of paginating it. */
+  .scalar-app .endpoints,
+  .scalar-app .channels,
+  .scalar-app .scalar-card-content {
+    overflow: visible !important;
+  }
+
+  /* ------------------------------------------------------------------ */
+  /* Pagination                                                          */
+
+  /*
+   * Keep small units intact across page boundaries. This is deliberately
+   * limited to leaf-ish elements: applying it to a whole operation would leave
+   * a page-sized gap whenever the operation is taller than a single page.
+   */
+  .scalar-app .property,
+  .scalar-app .parameter-item,
+  .scalar-app .scalar-card {
+    break-inside: avoid;
+  }
+
+  /* Do not strand a heading at the foot of a page. */
+  .scalar-app h1,
+  .scalar-app h2,
+  .scalar-app h3 {
+    break-after: avoid;
+  }
+}


### PR DESCRIPTION
## Problem

We have no print styles at all, so printing the reference to PDF renders expanded content over the text that follows it. The reference lays itself out as a fixed-viewport app — a `100dvh` grid with sticky columns pinned to a JS-measured screen height — and none of that means anything on paper.

## Solution

Adds a `print.css` that flattens the shell back into a document:

* Un-sticks the example columns, callback titles and list headers. Sticky resolves against the *page* box when printing, so these were getting pinned at a stale `--refs-viewport-offset` and painting over the content after them (`Callback.vue`'s title also carries a `z-index`, which is what made it overlap rather than just sit in the wrong place)
* Zeroes the viewport-derived offsets and drops the `max-height` caps, which were silently truncating long examples to one screen height
* Hides the sidebar, header, footer and `.section-flare` — fixed elements otherwise repeat on every page
* `break-inside: avoid` on small units only (properties, parameters, cards). Deliberately not on whole operations, since anything taller than a page would leave a page-sized gap

Everything in there is `!important`, which looks heavy-handed but is load-bearing: the rules it overrides live in scoped `<style>` blocks that compile to `.examples[data-v-hash]`, so they tie on specificity with a two-class selector and land in a separate stylesheet with no guaranteed load order. It's print-only, so it can't affect screen rendering.

Not a complete fix — it's a solid step, not the whole thing. `Lazy.vue` only renders sections once an `IntersectionObserver` fires and Chrome doesn't re-run those against the paginated layout, so a long document will still print blank placeholder boxes for anything you never scrolled past. CSS can't reach that one, future thing and probably its own ticket.

Before / After


<img width="49%" alt="CleanShot 2026-07-28 at 16 11 46@2x-padded" src="https://github.com/user-attachments/assets/d69a2864-b17d-40d0-89e6-c7a811f3e293" /><img width="49%" alt="CleanShot 2026-07-28 at 16 12 56@2x" src="https://github.com/user-attachments/assets/dee08c12-a410-4a35-971d-0861fbed37c5" />

## Ticket

Fixes [DOC-5894](https://linear.app/api-docs/issue/DOC-5894)
See #9598

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [ ] I added tests.
- [ ] I updated the documentation