### PR TITLE
fix(workspace-store): keep dots in webhook deep-link slugs

### DIFF
--- a/.changeset/webhook-slug-dots.md
+++ b/.changeset/webhook-slug-dots.md
@@ -1,5 +1,6 @@
 ---
 '@scalar/workspace-store': patch
+'@scalar/api-reference': patch
 ---
 
 fix: keep dots in webhook navigation deep links
@@ -7,3 +8,6 @@ fix: keep dots in webhook navigation deep links
 Webhook event names that use dots (for example `account_holder.created`) had the
 dot dropped when building the navigation id, joining adjacent words into
 `account-holdercreated`. Dots are now kept, producing `account-holder.created`.
+
+Old deep links using the dropped-dot slug are redirected to the new slug, so
+existing bookmarks keep resolving.

--- a/.changeset/webhook-slug-dots.md
+++ b/.changeset/webhook-slug-dots.md
@@ -2,9 +2,8 @@
 '@scalar/workspace-store': patch
 ---
 
-fix: keep dots in webhook navigation deep links by turning them into separators
+fix: keep dots in webhook navigation deep links
 
 Webhook event names that use dots (for example `account_holder.created`) had the
 dot dropped when building the navigation id, joining adjacent words into
-`account-holdercreated`. Dots now become separators, producing
-`account-holder-created`.
+`account-holdercreated`. Dots are now kept, producing `account-holder.created`.

--- a/.changeset/webhook-slug-dots.md
+++ b/.changeset/webhook-slug-dots.md
@@ -1,0 +1,10 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: keep dots in webhook navigation deep links by turning them into separators
+
+Webhook event names that use dots (for example `account_holder.created`) had the
+dot dropped when building the navigation id, joining adjacent words into
+`account-holdercreated`. Dots now become separators, producing
+`account-holder-created`.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -99,6 +99,7 @@ import {
   makeUrlFromId,
   matchesBasePath,
   redirectUrl,
+  type WebhookRedirectSource,
 } from '@/helpers/id-routing'
 import {
   INTRODUCTION_ENTRY_ID_SUFFIX,
@@ -363,8 +364,24 @@ const styleContent = computed(
 // ---------------------------------------------------------------------------
 /** Navigation State Handling */
 
+// Collects every webhook entry in a navigation subtree, so old deep links can be
+// redirected from the legacy dot-dropped slug to the current one. Webhook ids are
+// only known once the document is loaded, so the redirect itself runs later, in
+// `changeSelectedDocument`.
+const collectWebhooks = (entries: TraversedEntry[]): WebhookRedirectSource[] =>
+  entries.flatMap((entry) => {
+    const nested =
+      'children' in entry && entry.children
+        ? collectWebhooks(entry.children)
+        : []
+    return entry.type === 'webhook'
+      ? [{ name: entry.name, method: entry.method, id: entry.id }, ...nested]
+      : nested
+  })
+
 // Rewrite outdated `model/` and `models/` schema URLs to the current models
-// section slug so bookmarks from before the slug changed keep resolving.
+// section slug so bookmarks from before the slug changed keep resolving. Webhook
+// deep links are handled separately once the document (and its navigation) loads.
 if (typeof window !== 'undefined') {
   const canonical = redirectUrl(
     window.location.href,
@@ -1025,6 +1042,32 @@ const changeSelectedDocument = async (
   // Always set it to active; if the document is null we show a loading state
   workspaceStore.update('x-scalar-active-document', slug)
   clientStore.update('x-scalar-active-document', slug)
+
+  // Now that the navigation is available, canonicalize a legacy webhook deep link:
+  // old ids dropped the dot in the event name (`account-holdercreated`), so rewrite
+  // the URL and the scroll target to the current slug before we scroll to it.
+  if (elementId && typeof window !== 'undefined') {
+    const canonical = redirectUrl(
+      window.location.href,
+      slugify(config.modelsSectionLabel ?? DEFAULT_MODELS_SECTION_LABEL),
+      slug,
+      isMultiDocument.value,
+      config.pathRouting?.basePath,
+      collectWebhooks(
+        workspaceStore.workspace.activeDocument?.['x-scalar-navigation']
+          ?.children ?? [],
+      ),
+    )
+    if (canonical) {
+      window.history.replaceState({}, '', canonical.toString())
+      elementId =
+        getIdFromUrl(
+          canonical.href,
+          config.pathRouting?.basePath,
+          isMultiDocument.value ? undefined : slug,
+        ) || elementId
+    }
+  }
 
   // If the document has persistence enabled we load the auth schemes from storage
   if (config.persistAuth) {

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -1008,6 +1008,82 @@ describe('redirectUrl', () => {
     })
   })
 
+  describe('webhook slug redirects', () => {
+    // Legacy webhook ids ran the event name through slugify with no options, which dropped dots.
+    // These entries carry the current (dot-keeping) id plus the raw name we rebuild the old slug from.
+    const webhooks = [
+      { name: 'account_holder.created', method: 'POST', id: 'default/webhook/POST/account-holder.created' },
+      { name: 'newPlanet', method: 'POST', id: 'default/webhook/POST/newplanet' },
+    ]
+
+    it('rewrites a legacy dot-dropped webhook slug to the current slug', () => {
+      const result = redirectUrl(
+        'https://example.com/#default/webhook/POST/account-holdercreated',
+        'models',
+        'default',
+        true,
+        undefined,
+        webhooks,
+      )
+      expect(result?.hash).toBe('#default/webhook/POST/account-holder.created')
+    })
+
+    it('rewrites a tagged legacy webhook slug', () => {
+      const result = redirectUrl(
+        'https://example.com/#default/tag/webhooks/webhook/POST/account-holdercreated',
+        'models',
+        'default',
+        true,
+        undefined,
+        webhooks,
+      )
+      expect(result?.hash).toBe('#default/tag/webhooks/webhook/POST/account-holder.created')
+    })
+
+    it('rewrites a legacy webhook pathname in path routing', () => {
+      const result = redirectUrl(
+        'https://example.com/docs/default/webhook/POST/account-holdercreated',
+        'models',
+        'default',
+        true,
+        '/docs',
+        webhooks,
+      )
+      expect(result?.pathname).toBe('/docs/default/webhook/POST/account-holder.created')
+    })
+
+    it('preserves a sub-anchor after the webhook slug', () => {
+      const result = redirectUrl(
+        'https://example.com/#default/webhook/POST/account-holdercreated/body.id',
+        'models',
+        'default',
+        true,
+        undefined,
+        webhooks,
+      )
+      expect(result?.hash).toBe('#default/webhook/POST/account-holder.created/body.id')
+    })
+
+    it('leaves a webhook whose slug did not change untouched', () => {
+      expect(
+        redirectUrl(
+          'https://example.com/#default/webhook/POST/newplanet',
+          'models',
+          'default',
+          true,
+          undefined,
+          webhooks,
+        ),
+      ).toBeNull()
+    })
+
+    it('leaves webhook urls untouched when no webhooks are passed', () => {
+      expect(
+        redirectUrl('https://example.com/#default/webhook/POST/account-holdercreated', 'models', 'default', true),
+      ).toBeNull()
+    })
+  })
+
   it('returns null when the document slug is empty', () => {
     expect(redirectUrl('https://example.com/#default/model/User', 'models', '', true)).toBeNull()
   })

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -1064,6 +1064,46 @@ describe('redirectUrl', () => {
       expect(result?.hash).toBe('#default/webhook/POST/account-holder.created/body.id')
     })
 
+    it('rewrites a legacy webhook slug followed by a dot-joined property anchor', () => {
+      // Property deep links append their breadcrumb with dots, not a `/` segment.
+      const result = redirectUrl(
+        'https://example.com/#default/webhook/POST/account-holdercreated.body.id',
+        'models',
+        'default',
+        true,
+        undefined,
+        webhooks,
+      )
+      expect(result?.hash).toBe('#default/webhook/POST/account-holder.created.body.id')
+    })
+
+    it('rewrites a legacy webhook slug followed by a response property anchor', () => {
+      const result = redirectUrl(
+        'https://example.com/#default/webhook/POST/account-holdercreated.responses.200.name',
+        'models',
+        'default',
+        true,
+        undefined,
+        webhooks,
+      )
+      expect(result?.hash).toBe('#default/webhook/POST/account-holder.created.responses.200.name')
+    })
+
+    it('leaves a dot suffix that is not a schema anchor untouched', () => {
+      // The legacy slug never contains a dot, but a current webhook slug can, so
+      // `account-holdercreated.extra` may be a different webhook's real URL.
+      expect(
+        redirectUrl(
+          'https://example.com/#default/webhook/POST/account-holdercreated.extra',
+          'models',
+          'default',
+          true,
+          undefined,
+          webhooks,
+        ),
+      ).toBeNull()
+    })
+
     it('leaves a webhook whose slug did not change untouched', () => {
       expect(
         redirectUrl(

--- a/packages/api-reference/src/helpers/id-routing.test.ts
+++ b/packages/api-reference/src/helpers/id-routing.test.ts
@@ -1082,6 +1082,44 @@ describe('redirectUrl', () => {
         redirectUrl('https://example.com/#default/webhook/POST/account-holdercreated', 'models', 'default', true),
       ).toBeNull()
     })
+
+    it('does not redirect a legacy slug that is another webhook current slug', () => {
+      // Webhook B is literally named `account-holdercreated`, so that URL is its valid current URL.
+      // Webhook A must not hijack it with its dropped-dot redirect.
+      const colliding = [
+        { name: 'account_holder.created', method: 'POST', id: 'default/webhook/POST/account-holder.created' },
+        { name: 'account-holdercreated', method: 'POST', id: 'default/webhook/POST/account-holdercreated' },
+      ]
+      expect(
+        redirectUrl(
+          'https://example.com/#default/webhook/POST/account-holdercreated',
+          'models',
+          'default',
+          true,
+          undefined,
+          colliding,
+        ),
+      ).toBeNull()
+    })
+
+    it('does not redirect an ambiguous legacy slug shared by two webhooks', () => {
+      // `user.v1.created` and `userv1.created` both collapse to the legacy slug `userv1created`,
+      // so the old bookmark is ambiguous and must fall through instead of guessing.
+      const ambiguous = [
+        { name: 'user.v1.created', method: 'POST', id: 'default/webhook/POST/user.v1.created' },
+        { name: 'userv1.created', method: 'POST', id: 'default/webhook/POST/userv1.created' },
+      ]
+      expect(
+        redirectUrl(
+          'https://example.com/#default/webhook/POST/userv1created',
+          'models',
+          'default',
+          true,
+          undefined,
+          ambiguous,
+        ),
+      ).toBeNull()
+    })
   })
 
   it('returns null when the document slug is empty', () => {

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -324,6 +324,14 @@ const buildRedirects = ({ modelsSectionSlug, documentSlug, isMultiDocument }: Re
 }
 
 /**
+ * Markers that separate an operation id from a schema path within an anchor id.
+ * `responses` mirrors the request-body/parameter markers so response property
+ * anchors (e.g. `operation.responses.200.name`) resolve back to the operation id.
+ * Without it, deep links into responses cannot find their operation.
+ */
+const SCHEMA_PARAM_MARKERS = ['.body.', '.path.', '.query.', '.header.', '.responses.']
+
+/**
  * Source data for a single webhook redirect: the raw event name, its method, and the current id.
  *
  * The current slug is read back off the id, so this layer does not need to know the (dot-keeping)
@@ -346,7 +354,10 @@ export type WebhookRedirectSource = {
  * (`account-holder.created`). That rewrite cannot be reversed generically, so we emit one exact rule
  * per webhook whose legacy slug differs from the current one. Each rule matches the invariant
  * `webhook/<METHOD>/<legacy-slug>` tail, so it applies regardless of the document/tag prefix in front
- * of it and preserves any sub-anchor after it.
+ * of it and preserves any sub-anchor after it. A sub-anchor is either a `/` segment or a dot-joined
+ * schema property anchor (e.g. `.body.id`, see {@link SCHEMA_PARAM_MARKERS}); a dot followed by
+ * anything else is not treated as a boundary, because the legacy slug never contains a dot while a
+ * current webhook slug can, so such a URL belongs to a different webhook.
  *
  * Because the legacy slug is lossy, two things can make a redirect unsafe, and both are dropped so an
  * ambiguous link falls through to normal not-found handling instead of landing on the wrong webhook:
@@ -370,6 +381,11 @@ const buildWebhookRedirects = (webhooks: WebhookRedirectSource[]): IdRedirect[] 
     }
   }
 
+  // Property deep links append their breadcrumb to the operation id with dots
+  // (`<slug>.body.id`), so the slug boundary must accept a schema-param marker
+  // alongside the end of the id and a `/` segment.
+  const boundary = `(?=$|/|${SCHEMA_PARAM_MARKERS.map(escapeRegex).join('|')})`
+
   const redirects: IdRedirect[] = []
   for (const { name, method, id } of webhooks) {
     const upperMethod = method.toUpperCase()
@@ -389,7 +405,7 @@ const buildWebhookRedirects = (webhooks: WebhookRedirectSource[]): IdRedirect[] 
     }
 
     redirects.push({
-      match: new RegExp(`(^|/)webhook/${escapeRegex(upperMethod)}/${escapeRegex(legacySlug)}(?=$|/)`),
+      match: new RegExp(`(^|/)webhook/${escapeRegex(upperMethod)}/${escapeRegex(legacySlug)}${boundary}`),
       replace: (_match, prefix) => `${prefix}webhook/${upperMethod}/${currentSlug}`,
     })
   }
@@ -443,14 +459,6 @@ export const redirectUrl = (
 
   return didRedirect ? target : null
 }
-
-/**
- * Markers that separate an operation id from a schema path within an anchor id.
- * `responses` mirrors the request-body/parameter markers so response property
- * anchors (e.g. `operation.responses.200.name`) resolve back to the operation id.
- * Without it, deep links into responses cannot find their operation.
- */
-const SCHEMA_PARAM_MARKERS = ['.body.', '.path.', '.query.', '.header.', '.responses.']
 
 /** Extracts the schema parameters from the id if they are present */
 export const getSchemaParamsFromId = (id: string): { rawId: string; params: string } => {

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -1,3 +1,5 @@
+import { slugify } from '@scalar/helpers/string/slugify'
+
 export const sanitizeBasePath = (basePath: string) => {
   return basePath.replace(/^\/+|\/+$/g, '')
 }
@@ -322,12 +324,59 @@ const buildRedirects = ({ modelsSectionSlug, documentSlug, isMultiDocument }: Re
 }
 
 /**
+ * Source data for a single webhook redirect: the raw event name, its method, and the current id.
+ *
+ * The current slug is read back off the id, so this layer does not need to know the (dot-keeping)
+ * slug rule — it only reproduces the legacy (dot-dropping) slug to match old bookmarks.
+ */
+export type WebhookRedirectSource = {
+  /** Raw webhook event name from the OpenAPI `webhooks` key, e.g. `account_holder.created`. */
+  name: string
+  /** HTTP method of the webhook operation. */
+  method: string
+  /** Current navigation id of the webhook, e.g. `default/webhook/POST/account-holder.created`. */
+  id: string
+}
+
+/**
+ * Builds redirect rules mapping each webhook's legacy dot-dropped slug to its current slug.
+ *
+ * Webhook ids used to slugify the event name with no options, which dropped dots
+ * (`account_holder.created` -> `account-holdercreated`); the current id keeps them
+ * (`account-holder.created`). That rewrite cannot be reversed generically, so we emit one exact rule
+ * per webhook whose legacy slug differs from the current one. Each rule matches the invariant
+ * `webhook/<METHOD>/<legacy-slug>` tail, so it applies regardless of the document/tag prefix in front
+ * of it and preserves any sub-anchor after it.
+ */
+const buildWebhookRedirects = (webhooks: WebhookRedirectSource[]): IdRedirect[] => {
+  const redirects: IdRedirect[] = []
+
+  for (const { name, method, id } of webhooks) {
+    const currentSlug = id.slice(id.lastIndexOf('/') + 1)
+    const legacySlug = slugify(name)
+
+    // Nothing to redirect when the slug did not change (e.g. names without dots).
+    if (!legacySlug || legacySlug === currentSlug) {
+      continue
+    }
+
+    const upperMethod = method.toUpperCase()
+    redirects.push({
+      match: new RegExp(`(^|/)webhook/${escapeRegex(upperMethod)}/${escapeRegex(legacySlug)}(?=$|/)`),
+      replace: (_match, prefix) => `${prefix}webhook/${upperMethod}/${currentSlug}`,
+    })
+  }
+
+  return redirects
+}
+
+/**
  * Rewrites navigation ids in a URL to their current form.
  *
  * The URL is reduced to its routing-agnostic id (see {@link locateIdCarriers}), each redirect rule
- * is applied in id-space (see {@link buildRedirects}), and the result is spliced back into the
- * original location. This handles hash, hash-base-path, and path routing uniformly, so a new
- * redirect only has to be added to the list once.
+ * is applied in id-space (see {@link buildRedirects} for models and {@link buildWebhookRedirects} for
+ * webhooks), and the result is spliced back into the original location. This handles hash,
+ * hash-base-path, and path routing uniformly, so a new redirect only has to be added to the list once.
  *
  * Returns the canonicalized URL when a rewrite happens, or null otherwise.
  */
@@ -337,13 +386,17 @@ export const redirectUrl = (
   documentSlug: string,
   isMultiDocument: boolean,
   basePath?: string,
+  webhooks: WebhookRedirectSource[] = [],
 ): URL | null => {
   if (!documentSlug) {
     return null
   }
 
   const target = new URL(typeof url === 'string' ? url : url.toString())
-  const redirects = buildRedirects({ modelsSectionSlug, documentSlug, isMultiDocument })
+  const redirects = [
+    ...buildRedirects({ modelsSectionSlug, documentSlug, isMultiDocument }),
+    ...buildWebhookRedirects(webhooks),
+  ]
 
   // Canonicalize every place the id might live. The carriers are distinct physical locations (the
   // pathname and the bare hash), so a single page load can carry a legacy id in more than one — for

--- a/packages/api-reference/src/helpers/id-routing.ts
+++ b/packages/api-reference/src/helpers/id-routing.ts
@@ -347,20 +347,47 @@ export type WebhookRedirectSource = {
  * per webhook whose legacy slug differs from the current one. Each rule matches the invariant
  * `webhook/<METHOD>/<legacy-slug>` tail, so it applies regardless of the document/tag prefix in front
  * of it and preserves any sub-anchor after it.
+ *
+ * Because the legacy slug is lossy, two things can make a redirect unsafe, and both are dropped so an
+ * ambiguous link falls through to normal not-found handling instead of landing on the wrong webhook:
+ * - the legacy slug is already another webhook's *current* slug (redirecting it would hijack a valid
+ *   URL), or
+ * - two webhooks collapse to the same legacy slug (the old bookmark is genuinely ambiguous).
  */
 const buildWebhookRedirects = (webhooks: WebhookRedirectSource[]): IdRedirect[] => {
-  const redirects: IdRedirect[] = []
+  const key = (method: string, slug: string) => `${method.toUpperCase()}/${slug}`
 
+  // Index current slugs so a legacy redirect never clobbers a real, current URL, and count legacy
+  // slugs so we can drop the ones two webhooks share.
+  const currentKeys = new Set<string>()
+  const legacyCounts = new Map<string, number>()
   for (const { name, method, id } of webhooks) {
+    currentKeys.add(key(method, id.slice(id.lastIndexOf('/') + 1)))
+    const legacySlug = slugify(name)
+    if (legacySlug) {
+      const legacyKey = key(method, legacySlug)
+      legacyCounts.set(legacyKey, (legacyCounts.get(legacyKey) ?? 0) + 1)
+    }
+  }
+
+  const redirects: IdRedirect[] = []
+  for (const { name, method, id } of webhooks) {
+    const upperMethod = method.toUpperCase()
     const currentSlug = id.slice(id.lastIndexOf('/') + 1)
     const legacySlug = slugify(name)
+    const legacyKey = key(method, legacySlug)
 
-    // Nothing to redirect when the slug did not change (e.g. names without dots).
-    if (!legacySlug || legacySlug === currentSlug) {
+    // Skip when the slug did not change, when the legacy slug is a real current URL, or when it is
+    // shared by more than one webhook.
+    if (
+      !legacySlug ||
+      legacySlug === currentSlug ||
+      currentKeys.has(legacyKey) ||
+      (legacyCounts.get(legacyKey) ?? 0) > 1
+    ) {
       continue
     }
 
-    const upperMethod = method.toUpperCase()
     redirects.push({
       match: new RegExp(`(^|/)webhook/${escapeRegex(upperMethod)}/${escapeRegex(legacySlug)}(?=$|/)`),
       replace: (_match, prefix) => `${prefix}webhook/${upperMethod}/${currentSlug}`,

--- a/packages/helpers/src/string/slugify.test.ts
+++ b/packages/helpers/src/string/slugify.test.ts
@@ -63,6 +63,14 @@ describe('slugify', () => {
     expect(slugify('CamelCase42', { preserveCase: true })).toBe('CamelCase42')
   })
 
+  // Pin the default dot behavior explicitly. By default a dot is not in the
+  // allow list, so it is dropped (not turned into a separator). Callers that
+  // want dots to act as separators must replace them before slugifying.
+  it('drops dots by default, joining adjacent words', () => {
+    expect(slugify('v1.2.3')).toBe('v123')
+    expect(slugify('user.created')).toBe('usercreated')
+  })
+
   it('keeps dots when "." is allowed', () => {
     expect(slugify('v1.2.3', { allowedSpecialChars: '.' })).toBe('v1.2.3')
   })

--- a/packages/workspace-store/src/navigation/get-navigation-options.test.ts
+++ b/packages/workspace-store/src/navigation/get-navigation-options.test.ts
@@ -209,17 +209,17 @@ describe('get-navigation-options', () => {
     expect(id).toBe('api/webhook/POST-orderCreated')
   })
 
-  // Event-style webhook names commonly mix underscores and dots. Both must
-  // become separators, otherwise dots get dropped and join adjacent words
-  // (e.g. "account_holder.created" -> "account-holdercreated").
+  // Event-style webhook names commonly mix underscores and dots. Dots are kept
+  // so the deep link stays close to the event name, instead of being dropped
+  // and joining adjacent words (e.g. "account_holder.created" -> "account-holdercreated").
   it.each([
-    ['account_holder.created', 'pet-store/webhook/POST/account-holder-created'],
-    ['card_transaction.updated', 'pet-store/webhook/POST/card-transaction-updated'],
+    ['account_holder.created', 'pet-store/webhook/POST/account-holder.created'],
+    ['card_transaction.updated', 'pet-store/webhook/POST/card-transaction.updated'],
     [
       'tokenization.two_factor_authentication_code',
-      'pet-store/webhook/POST/tokenization-two-factor-authentication-code',
+      'pet-store/webhook/POST/tokenization.two-factor-authentication-code',
     ],
-  ])('turns dots and underscores in webhook name %s into separators', (name, expected) => {
+  ])('keeps dots in webhook name %s while turning underscores into separators', (name, expected) => {
     const options = getNavigationOptions('Pet Store')
     const id = options.generateId({
       type: 'webhook',

--- a/packages/workspace-store/src/navigation/get-navigation-options.test.ts
+++ b/packages/workspace-store/src/navigation/get-navigation-options.test.ts
@@ -209,6 +209,27 @@ describe('get-navigation-options', () => {
     expect(id).toBe('api/webhook/POST-orderCreated')
   })
 
+  // Event-style webhook names commonly mix underscores and dots. Both must
+  // become separators, otherwise dots get dropped and join adjacent words
+  // (e.g. "account_holder.created" -> "account-holdercreated").
+  it.each([
+    ['account_holder.created', 'pet-store/webhook/POST/account-holder-created'],
+    ['card_transaction.updated', 'pet-store/webhook/POST/card-transaction-updated'],
+    [
+      'tokenization.two_factor_authentication_code',
+      'pet-store/webhook/POST/tokenization-two-factor-authentication-code',
+    ],
+  ])('turns dots and underscores in webhook name %s into separators', (name, expected) => {
+    const options = getNavigationOptions('Pet Store')
+    const id = options.generateId({
+      type: 'webhook',
+      parentId: 'pet-store',
+      name,
+      method: 'post',
+    })
+    expect(id).toBe(expected)
+  })
+
   it('generates model ID for models root when name is empty', () => {
     const options = getNavigationOptions('Pet Store')
     const id = options.generateId({

--- a/packages/workspace-store/src/navigation/get-navigation-options.ts
+++ b/packages/workspace-store/src/navigation/get-navigation-options.ts
@@ -122,9 +122,9 @@ export const getNavigationOptions = (documentName: string, options?: NavigationO
       }
 
       // Webhook events are commonly named with dots (e.g. "account_holder.created").
-      // Turn those dots into whitespace up front so slugify collapses them into a
-      // hyphen instead of dropping them and joining adjacent words ("account-holdercreated").
-      return `${prefixTag}webhook/${props.method?.toUpperCase()}/${slugify(props.name.replaceAll('.', ' '))}`
+      // Keep the dot so the deep link stays close to the event name, instead of
+      // dropping it and joining adjacent words ("account-holdercreated").
+      return `${prefixTag}webhook/${props.method?.toUpperCase()}/${slugify(props.name, { allowedSpecialChars: '.' })}`
     }
 
     // -------- Default model id generation logic --------

--- a/packages/workspace-store/src/navigation/get-navigation-options.ts
+++ b/packages/workspace-store/src/navigation/get-navigation-options.ts
@@ -121,7 +121,10 @@ export const getNavigationOptions = (documentName: string, options?: NavigationO
         })}`
       }
 
-      return `${prefixTag}webhook/${props.method?.toUpperCase()}/${slugify(props.name)}`
+      // Webhook events are commonly named with dots (e.g. "account_holder.created").
+      // Turn those dots into whitespace up front so slugify collapses them into a
+      // hyphen instead of dropping them and joining adjacent words ("account-holdercreated").
+      return `${prefixTag}webhook/${props.method?.toUpperCase()}/${slugify(props.name.replaceAll('.', ' '))}`
     }
 
     // -------- Default model id generation logic --------


### PR DESCRIPTION
Webhook event names with dots (like `account_holder.created`) had the dot deleted when building the navigation link, joining the words into `account-holdercreated`. Now the dot is kept, so the link reads `account-holder.created`.

Before / after:

| Webhook name | Before | After |
|---|---|---|
| `account_holder.created` | `account-holdercreated` | `account-holder.created` |
| `card_transaction.updated` | `card-transactionupdated` | `card-transaction.updated` |
| `tokenization.two_factor_authentication_code` | `tokenizationtwo-factor-authentication-code` | `tokenization.two-factor-authentication-code` |

Underscores still become hyphens; only the dot is preserved. The slug change only touches the webhook branch, so tag and model links are unchanged.

## Redirects

Renaming the slug would break old bookmarks (`.../webhook/POST/account-holdercreated`), so old links now redirect to the new slug. The old slug dropped the dot and cannot be rebuilt from a pattern, so the redirect is built from the real webhook names in the document (legacy slug -> current slug per webhook) in `buildWebhookRedirects` inside `packages/api-reference/src/helpers/id-routing.ts`, reusing the existing id-space redirect layer.

Verified in the browser: loading a legacy `.../webhook/POST/account-holdercreated` link rewrites the URL to `.../webhook/POST/account-holder.created` and scrolls to the webhook.

## Tests

- `get-navigation-options`: webhook slugs keep dots, underscores still become hyphens.
- `slugify`: pins what a dot does by default.
- `id-routing`: legacy webhook slug redirects to the current one (hash, path routing, tag prefix, sub-anchor, and no-op cases).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to webhook URL slug generation and client-side URL canonicalization; collision/ambiguity guards limit wrong redirects.
> 
> **Overview**
> **Webhook deep links** now keep dots when slugifying event names (e.g. `account_holder.created` → `account-holder.created` instead of `account-holdercreated`). Only the default webhook ID path in `get-navigation-options` changes; custom `generateWebhookSlug` and tag/model IDs are unchanged.
> 
> **Backward compatibility:** `redirectUrl` gains optional webhook metadata and `buildWebhookRedirects`, which maps each webhook’s old dot-stripped slug to the new one for hash, path, and tagged URLs, including property anchors (`.body.id`, `.responses.…`). Redirects are skipped when the legacy slug is ambiguous or already a valid current slug for another webhook. **ApiReference** collects webhooks from loaded navigation and runs this redirect after the document loads so the URL and scroll target update before scrolling.
> 
> Tests cover navigation ID generation, default `slugify` dot behavior, and redirect edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19bfec602237773034e3410f4f4175a57073b1b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->