### PR TITLE
fix(api-reference): stop recursive discriminator rendering for allOf variants

### DIFF
--- a/.changeset/fix-9771-discriminator-allof-recursion.md
+++ b/.changeset/fix-9771-discriminator-allof-recursion.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Stop recursive schema rendering when a discriminator variant `allOf`s back to its base type. The selected child now inherits the parent's discriminator context so the mapping is not re-inferred on every nest.

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -346,6 +346,133 @@ describe('Schema', () => {
       expect(wrapper.text()).toContain('baseInt')
     })
 
+    // https://github.com/scalar/scalar/issues/9771
+    // OpenAPI-generator inheritance: base has `discriminator.mapping`, each
+    // variant `allOf`s back to the base. Selecting a variant must flatten the
+    // inherited properties once — not re-infer the mapping and recurse.
+    it('does not re-infer the discriminator mapping when a variant allOfs back to the base', async () => {
+      const configSchema = {
+        type: 'object',
+        required: ['formatVersion'],
+        properties: {
+          formatVersion: { type: 'string' },
+        },
+        discriminator: {
+          propertyName: 'formatVersion',
+          mapping: {
+            '2.2': '#/components/schemas/Config_v2_2',
+            '2.3': '#/components/schemas/Config_v2_3',
+          },
+        },
+      }
+
+      const document = {
+        components: {
+          schemas: {
+            Config: configSchema,
+            Config_v2_2: {
+              allOf: [
+                // `$ref-value` mirrors what the workspace store attaches after
+                // resolving the document — without it the merge cannot see the
+                // base properties in this unit test.
+                { $ref: '#/components/schemas/Config', '$ref-value': configSchema },
+                { type: 'object', properties: { fieldA: { type: 'string' } } },
+              ],
+            },
+            Config_v2_3: {
+              allOf: [
+                { $ref: '#/components/schemas/Config', '$ref-value': configSchema },
+                { type: 'object', properties: { fieldB: { type: 'string' } } },
+              ],
+            },
+          },
+        },
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          name: 'Response',
+          schema: coerceValue(SchemaObjectSchema, document.components.schemas.Config),
+          options: { expandAllSchemaProperties: true, document: document as never },
+        },
+      })
+
+      // Select the Config_v2_2 variant (index 0 is already the default mapping order,
+      // but emit explicitly so the assertion does not depend on that).
+      const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+      await listbox.vm.$emit('update:modelValue', { id: '0', label: 'Config_v2_2' })
+      await wrapper.vm.$nextTick()
+
+      // Exactly one variant selector — the base's. The selected variant must not
+      // re-open another "One of" dropdown from the inherited mapping.
+      expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
+      expect(wrapper.text()).toContain('fieldA')
+      expect(wrapper.text()).toContain('formatVersion')
+      expect(wrapper.text()).not.toContain('fieldB')
+
+      // Selecting the other variant stays finite and swaps the child field.
+      await listbox.vm.$emit('update:modelValue', { id: '1', label: 'Config_v2_3' })
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
+      expect(wrapper.text()).toContain('fieldB')
+      expect(wrapper.text()).toContain('formatVersion')
+      expect(wrapper.text()).not.toContain('fieldA')
+    })
+
+    // Nested polymorphic property must keep its own discriminator context even
+    // when a parent discriminator prop is threaded through SchemaProperty (#9771).
+    it('keeps a nested property discriminator independent from a threaded parent discriminator', () => {
+      const petSchema = {
+        type: 'object',
+        discriminator: {
+          propertyName: 'petType',
+          mapping: {
+            Cat: '#/components/schemas/Cat',
+            Dog: '#/components/schemas/Dog',
+          },
+        },
+        properties: {
+          petType: { type: 'string' },
+          name: { type: 'string' },
+        },
+      }
+
+      const document = {
+        components: {
+          schemas: {
+            Cat: { type: 'object', properties: { meow: { type: 'boolean' } } },
+            Dog: { type: 'object', properties: { bark: { type: 'boolean' } } },
+          },
+        },
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          name: 'Request Body',
+          // Parent polymorphic context (different propertyName) threaded via SchemaObjectProperties.
+          discriminator: {
+            propertyName: 'formatVersion',
+            mapping: { '2.2': '#/components/schemas/Config_v2_2' },
+          },
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: { pet: petSchema },
+          }),
+          options: { expandAllSchemaProperties: true, document: document as never },
+        },
+      })
+
+      // Nested pet still gets exactly one selector from its own mapping — the
+      // threaded parent discriminator must not suppress or duplicate it.
+      expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
+      expect(wrapper.text()).toContain('One of')
+      expect(wrapper.text()).toContain('petType')
+      expect(wrapper.text()).toContain('Cat')
+    })
+
     // https://github.com/scalar/scalar/issues/7472
     // A schema that carries its own `allOf` (plus a `discriminator.mapping`) must
     // keep rendering the `allOf` members. Inference is gated to plain object

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -346,10 +346,6 @@ describe('Schema', () => {
       expect(wrapper.text()).toContain('baseInt')
     })
 
-    // https://github.com/scalar/scalar/issues/9771
-    // OpenAPI-generator inheritance: base has `discriminator.mapping`, each
-    // variant `allOf`s back to the base. Selecting a variant must flatten the
-    // inherited properties once — not re-infer the mapping and recurse.
     it('does not re-infer the discriminator mapping when a variant allOfs back to the base', async () => {
       const configSchema = {
         type: 'object',
@@ -372,9 +368,6 @@ describe('Schema', () => {
             Config: configSchema,
             Config_v2_2: {
               allOf: [
-                // `$ref-value` mirrors what the workspace store attaches after
-                // resolving the document — without it the merge cannot see the
-                // base properties in this unit test.
                 { $ref: '#/components/schemas/Config', '$ref-value': configSchema },
                 { type: 'object', properties: { fieldA: { type: 'string' } } },
               ],
@@ -398,20 +391,15 @@ describe('Schema', () => {
         },
       })
 
-      // Select the Config_v2_2 variant (index 0 is already the default mapping order,
-      // but emit explicitly so the assertion does not depend on that).
       const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
       await listbox.vm.$emit('update:modelValue', { id: '0', label: 'Config_v2_2' })
       await wrapper.vm.$nextTick()
 
-      // Exactly one variant selector — the base's. The selected variant must not
-      // re-open another "One of" dropdown from the inherited mapping.
       expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
       expect(wrapper.text()).toContain('fieldA')
       expect(wrapper.text()).toContain('formatVersion')
       expect(wrapper.text()).not.toContain('fieldB')
 
-      // Selecting the other variant stays finite and swaps the child field.
       await listbox.vm.$emit('update:modelValue', { id: '1', label: 'Config_v2_3' })
       await wrapper.vm.$nextTick()
 
@@ -421,8 +409,6 @@ describe('Schema', () => {
       expect(wrapper.text()).not.toContain('fieldA')
     })
 
-    // Nested polymorphic property must keep its own discriminator context even
-    // when a parent discriminator prop is threaded through SchemaProperty (#9771).
     it('keeps a nested property discriminator independent from a threaded parent discriminator', () => {
       const petSchema = {
         type: 'object',
@@ -452,7 +438,6 @@ describe('Schema', () => {
         props: {
           eventBus: null,
           name: 'Request Body',
-          // Parent polymorphic context (different propertyName) threaded via SchemaObjectProperties.
           discriminator: {
             propertyName: 'formatVersion',
             mapping: { '2.2': '#/components/schemas/Config_v2_2' },
@@ -465,19 +450,71 @@ describe('Schema', () => {
         },
       })
 
-      // Nested pet still gets exactly one selector from its own mapping — the
-      // threaded parent discriminator must not suppress or duplicate it.
       expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
       expect(wrapper.text()).toContain('One of')
       expect(wrapper.text()).toContain('petType')
       expect(wrapper.text()).toContain('Cat')
     })
 
+    it('keeps nested branch discriminator mappings independent from the parent discriminator', () => {
+      const baseSchema = {
+        type: 'object',
+        discriminator: {
+          propertyName: 'rootKind',
+          mapping: { child: '#/components/schemas/Child' },
+        },
+        properties: { rootKind: { type: 'string' } },
+      }
+
+      const nestedPolymorphicSchema = {
+        type: 'object',
+        title: 'NestedPolymorphic',
+        discriminator: {
+          propertyName: 'petType',
+          mapping: { cat: '#/components/schemas/Cat' },
+        },
+        properties: { petType: { type: 'string' } },
+      }
+
+      const document = {
+        components: {
+          schemas: {
+            Base: baseSchema,
+            Child: {
+              allOf: [
+                { $ref: '#/components/schemas/Base', '$ref-value': baseSchema },
+                {
+                  type: 'object',
+                  properties: {
+                    nested: {
+                      oneOf: [
+                        nestedPolymorphicSchema,
+                        { type: 'object', title: 'OtherNested', properties: { other: { type: 'string' } } },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+            Cat: { type: 'object', title: 'Cat', properties: { meow: { type: 'boolean' } } },
+          },
+        },
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          name: 'Response',
+          schema: coerceValue(SchemaObjectSchema, baseSchema),
+          options: { expandAllSchemaProperties: true, document: document as never },
+        },
+      })
+
+      expect(wrapper.findAll('.composition-selector').length).toBe(3)
+      expect(wrapper.text()).toContain('Cat')
+    })
+
     // https://github.com/scalar/scalar/issues/7472
-    // A schema that carries its own `allOf` (plus a `discriminator.mapping`) must
-    // keep rendering the `allOf` members. Inference is gated to plain object
-    // schemas (`isTypeObject`), so the mapping does not replace the `allOf`
-    // output with a variant dropdown — the `allOf` members render as before.
     it('keeps rendering allOf members for a schema that also has a discriminator mapping', () => {
       const document = {
         components: {

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -241,18 +241,8 @@ const schemaDescription = computed(() => {
 })
 
 /**
- * Some generators (for example NSwag) describe a polymorphic base type as a
- * plain object with a `discriminator.mapping` but no explicit `oneOf`. We infer
- * the variant composition from the mapping so the selector still renders.
- *
- * The `discriminator` prop is only set when this schema is already a variant
- * being rendered inside a `SchemaComposition`; skipping the inference in that
- * case avoids re-inferring (and recursing) on a self-referential mapping.
- *
- * The inference is restricted to plain object schemas (`isTypeObject`). A schema
- * carrying its own composition keyword (`allOf`/`not`) is rendered by the
- * `SchemaProperty` branch below; inferring a selector there would replace that
- * keyword's output with the variant dropdown instead of rendering both.
+ * Infer a selector for mapped discriminators that do not declare `oneOf`.
+ * Threaded discriminators skip inference to avoid recursive allOf variants.
  */
 const inferredDiscriminatorComposition = computed(() =>
   schema && !discriminator && isTypeObject(schema)

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -401,6 +401,7 @@ const handleClick = (e: MouseEvent) => {
               :breadcrumb
               :compact
               :compositionPath="compositionPath"
+              :discriminator
               :eventBus="eventBus"
               :hideHeading
               :hideModelNames

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -29,6 +29,7 @@ import { getEnumValues } from './helpers/get-enum-values'
 import { getPropertyDescription } from './helpers/get-property-description'
 import { hasComplexArrayItems } from './helpers/has-complex-array-items'
 import { optimizeValueForDisplay } from './helpers/optimize-value-for-display'
+import type { CompositionKeyword } from './helpers/schema-composition'
 import { shouldDisplayDescription } from './helpers/should-display-description'
 import { shouldDisplayHeading } from './helpers/should-display-heading'
 import Schema from './Schema.vue'
@@ -250,6 +251,12 @@ const shouldDisplayHeadingComputed = computed(() =>
 const compositionsToRender = computed(() =>
   getCompositionsToRender(optimizedValue.value, props.options.document),
 )
+const getCompositionDiscriminator = (
+  composition: CompositionKeyword,
+): DiscriminatorObject | undefined =>
+  composition === 'allOf'
+    ? (props.schema?.discriminator ?? props.discriminator)
+    : props.schema?.discriminator
 
 /**
  * Get resolved array items for rendering (with any `$dynamicRef` bound to the concrete type).
@@ -404,13 +411,6 @@ const isDiscriminatorProperty = computed(() =>
     </div>
 
     <!-- Compositions -->
-    <!--
-      Prefer the schema's own discriminator, then the threaded parent prop.
-      Mapping variants that `allOf` back to the base (#9771) have no discriminator
-      of their own — the parent composition's must flow through so the merged base
-      does not re-infer the mapping. Preferring `schema.discriminator` first keeps
-      nested independent polymorphic properties on their own mapping context.
-    -->
     <SchemaComposition
       v-for="compositionData in compositionsToRender"
       :key="compositionData.composition"
@@ -418,7 +418,7 @@ const isDiscriminatorProperty = computed(() =>
       :compact="compact"
       :composition="compositionData.composition"
       :compositionPath="currentCompositionPath"
-      :discriminator="schema?.discriminator ?? discriminator"
+      :discriminator="getCompositionDiscriminator(compositionData.composition)"
       :eventBus="eventBus"
       :hideHeading="hideHeading"
       :hideModelNames

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -404,6 +404,13 @@ const isDiscriminatorProperty = computed(() =>
     </div>
 
     <!-- Compositions -->
+    <!--
+      Prefer the schema's own discriminator, then the threaded parent prop.
+      Mapping variants that `allOf` back to the base (#9771) have no discriminator
+      of their own — the parent composition's must flow through so the merged base
+      does not re-infer the mapping. Preferring `schema.discriminator` first keeps
+      nested independent polymorphic properties on their own mapping context.
+    -->
     <SchemaComposition
       v-for="compositionData in compositionsToRender"
       :key="compositionData.composition"
@@ -411,7 +418,7 @@ const isDiscriminatorProperty = computed(() =>
       :compact="compact"
       :composition="compositionData.composition"
       :compositionPath="currentCompositionPath"
-      :discriminator="schema?.discriminator"
+      :discriminator="schema?.discriminator ?? discriminator"
       :eventBus="eventBus"
       :hideHeading="hideHeading"
       :hideModelNames


### PR DESCRIPTION
## Problem

Schemas that use `discriminator.mapping` on a base type with variants that `allOf` back to that base (OpenAPI Generator inheritance) rendered recursively: selecting a child re-inferred the mapping from the merged base and nested another "One of" selector forever.

Repro: https://sandbox.scalar.com/e/IgFNY

## Solution

Thread the parent `discriminator` through `Schema` → `SchemaProperty` → `SchemaComposition`, preferring the schema's own discriminator when present so nested independent polymorphic properties keep their context. The merged base then skips mapping inference and flattens inherited properties once.

## Ticket

Closes #9771