### PR TITLE
feat(oas-utils): expose server and customFetch in the beforeRequest hook payload

### DIFF
--- a/.changeset/before-request-payload.md
+++ b/.changeset/before-request-payload.md
@@ -1,0 +1,9 @@
+---
+'@scalar/oas-utils': patch
+'@scalar/api-client': patch
+---
+
+Expose `server` and `customFetch` in the ClientPlugin `beforeRequest` hook
+payload (both optional, additive) so plugins can resolve relative URLs and run
+network calls — e.g. a token refresh — through the host fetch without closing
+over external state.

--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -402,6 +402,55 @@ Each handler in `responseBody` supports:
 
 Plugins can hook into the request lifecycle:
 
+### `onRequestMount`
+
+Runs when an operation view mounts, before any request is sent. Use it to warm up resources.
+
+| Field | Type | Description |
+|---|---|---|
+| `document` | `OpenApiDocument` | The current OpenAPI document. |
+| `operation` | `OperationObject` | The current operation. |
+
+### `beforeRequest`
+
+Runs before the fetch `Request` is built. Mutate `requestBuilder` to change the outgoing request.
+
+| Field | Type | Description |
+|---|---|---|
+| `requestBuilder` | `RequestFactory` | The mutable request builder. Change its method, path, query, headers, body, or security before the request is built. |
+| `document` | `OpenApiDocument` | The current OpenAPI document. |
+| `operation` | `OperationObject` | The current operation. |
+| `variablesStore?` | `VariablesStore` | The request variable store. |
+| `server?` | `ServerObject \| null` | The optional active [OpenAPI Server Object](https://spec.openapis.org/oas/v3.1.1.html#server-object) selected for the request. Its `url` can be relative or include server variables, so resolve it for the plugin's runtime before making network calls. |
+| `customFetch?` | `typeof fetch` | The optional host-provided fetch implementation configured for the API client. Use it for plugin-owned network calls so they use the same network channel as the request, including the desktop app's IPC-backed fetch. |
+
+### `requestBuilt`
+
+Runs after the fetch `Request` is built, immediately before it is sent. Outside Electron, mutate `request.headers` to change the outgoing request; its body matches the bytes sent over the wire. In Electron, Scalar sends the request payload through `customFetch` instead, so mutations to `request` do not apply and multipart body bytes can differ.
+
+| Field | Type | Description |
+|---|---|---|
+| `request` | `Request` | The request built before sending. Outside Electron it is sent as-is; Electron sends the request payload through `customFetch` instead. |
+| `requestBuilder` | `RequestFactory` | The builder used to create `request`. Mutating it at this stage does not change the outgoing request. |
+| `document` | `OpenApiDocument` | The current OpenAPI document. |
+| `operation` | `OperationObject` | The current operation. |
+| `variablesStore?` | `VariablesStore` | The request variable store. |
+
+### `responseReceived`
+
+Runs after a response is received.
+
+| Field | Type | Description |
+|---|---|---|
+| `response` | `Response` | The received response. |
+| `request` | `Request` | A request rebuilt from the sent request payload. It is not the same instance as the sent request; header mutations from `requestBuilt` are absent and multipart body bytes can differ. |
+| `requestBuilder` | `RequestFactory` | The builder used to create `request`. Mutating it does not change the already-sent request. |
+| `document` | `OpenApiDocument` | The current OpenAPI document. |
+| `operation` | `OperationObject` | The current operation. |
+| `variablesStore?` | `VariablesStore` | The request variable store. |
+
+### Example
+
 ```typescript
 const authPlugin: ClientPlugin = {
   hooks: {

--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -403,9 +403,18 @@ Each handler in `responseBody` supports:
 Plugins can hook into the request lifecycle:
 
 ```typescript
-const loggingPlugin: ClientPlugin = {
+const authPlugin: ClientPlugin = {
   hooks: {
-    beforeRequest: ({ requestBuilder }) => {
+    beforeRequest: async ({ requestBuilder, server, customFetch }) => {
+      console.log('Active server configuration:', server?.url)
+
+      if (customFetch) {
+        // Resolve an absolute URL appropriate for the plugin's runtime.
+        await customFetch('https://auth.example.com/session/refresh', {
+          method: 'POST',
+        })
+      }
+
       requestBuilder.headers.set('X-Custom-Header', 'value')
     },
     responseReceived: ({ response }) => {

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.test.ts
@@ -318,6 +318,33 @@ describe('OperationBlock', () => {
     })
   })
 
+  it('forwards server and customFetch to beforeRequest plugins', async () => {
+    const server = { url: 'https://api.example.com' }
+    const customFetch = vi.fn<typeof fetch>()
+    const received = vi.fn()
+    const plugin: ClientPlugin = {
+      hooks: {
+        beforeRequest: ({ server, customFetch }) => {
+          received({ server, customFetch })
+        },
+      },
+    }
+
+    const wrapper = mount(OperationBlock, {
+      props: {
+        ...createDefaultProps(),
+        server,
+        options: { customFetch },
+        plugins: [plugin],
+      },
+    })
+
+    await triggerExecute(wrapper)
+
+    expect(received).toHaveBeenCalledOnce()
+    expect(received).toHaveBeenCalledWith({ server, customFetch })
+  })
+
   it('persists server-set cookies into the document jar after a response', async () => {
     const mockEventBus = createMockEventBus()
     const mockResponse = {

--- a/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/operation-block/OperationBlock.vue
@@ -304,6 +304,8 @@ const handleExecute = async () => {
       document,
       operation,
       variablesStore,
+      server,
+      customFetch: toValue(options)?.customFetch,
     },
     'beforeRequest',
     plugins,

--- a/packages/oas-utils/src/helpers/client-plugins.test.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.test.ts
@@ -51,6 +51,25 @@ describe('executeHook', () => {
     expect(result.requestBuilder.headers.get('X-Custom-Header')).toBe('test-value')
   })
 
+  it('forwards server and customFetch to the beforeRequest hook', async () => {
+    const requestBuilder = createFactory()
+    const server = { url: 'https://api.example.com' } as never
+    const customFetch = fetch
+    let received: { server?: unknown; customFetch?: unknown } = {}
+    const plugin: ClientPlugin = {
+      hooks: {
+        beforeRequest: (payload) => {
+          received = { server: payload.server, customFetch: payload.customFetch }
+        },
+      },
+    }
+
+    await executeHook({ ...beforePayload(requestBuilder), server, customFetch }, 'beforeRequest', [plugin])
+
+    expect(received.server).toBe(server)
+    expect(received.customFetch).toBe(customFetch)
+  })
+
   it('chains multiple plugins in order and applies all modifications', async () => {
     const requestBuilder = createFactory()
 

--- a/packages/oas-utils/src/helpers/client-plugins.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.ts
@@ -40,9 +40,9 @@ type ClientPluginHooks = {
    * Runs before a request is sent. Receives the current document and operation so plugins can
    * modify the request before it is sent (for example, adding headers or modifying the body).
    *
-   * Mutations here happen on the request builder, before the fetch `Request` exists. Use the
-   * `requestBuilt` hook instead when you need the exact outgoing request (for example, to hash a
-   * multipart body for request signing).
+   * Mutations here happen on the request builder, before the fetch `Request` exists. Outside
+   * Electron, use the `requestBuilt` hook when you need the exact outgoing request (for example,
+   * to hash a multipart body for request signing). Electron sends the request payload instead.
    */
   beforeRequest: (payload: {
     /** Workspace-store request spec; mutable by pre-request scripts (headers, method). */
@@ -56,14 +56,13 @@ type ClientPluginHooks = {
     customFetch?: typeof fetch
   }) => void | Promise<void>
   /**
-   * Runs after the fetch `Request` has been built, right before it is sent. The request passed
-   * here is the exact object handed to fetch, so header mutations apply to the outgoing request
-   * and the body bytes match what goes over the wire (important for request signing, where a
-   * rebuilt multipart body would get a different boundary). Mutations to the request builder
-   * have no effect at this stage; use the `beforeRequest` hook for those.
+   * Runs after the fetch `Request` has been built, right before it is sent. Outside Electron, the
+   * request passed here is handed to fetch, so header mutations apply to the outgoing request and
+   * the body bytes match what goes over the wire. Electron sends the request payload instead.
+   * Mutations to the request builder have no effect at this stage; use `beforeRequest` for those.
    */
   requestBuilt: (payload: {
-    /** The exact fetch Request that will be sent. Mutate its headers to modify the outgoing request. */
+    /** The fetch Request built before sending. Electron sends the request payload instead. */
     request: Request
     /** Request builder the request was built from. Mutating it has no effect at this stage. */
     requestBuilder: RequestFactory
@@ -79,7 +78,7 @@ type ClientPluginHooks = {
     response: Response
     /** Request builder object that was used to build the request. Mutating this object will not affect the request object. */
     requestBuilder: RequestFactory
-    /** Request object that was sent to the server. */
+    /** Request rebuilt from the sent request payload, not the same instance sent to the server. */
     request: Request
     document: OpenApiDocument
     operation: OperationObject

--- a/packages/oas-utils/src/helpers/client-plugins.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.ts
@@ -158,14 +158,18 @@ type ClientPluginComponents = {
  *
  * const myPlugin: ClientPlugin = {
  *   hooks: {
- *     beforeRequest: ({ request }) => {
- *       request.headers.set('X-Custom-Header', 'foo');
- *       return { request };
+ *     beforeRequest: async ({ requestBuilder, server, customFetch }) => {
+ *       console.log('Active server configuration:', server?.url);
+ *
+ *       if (customFetch) {
+ *         await customFetch('https://auth.example.com/session/refresh', { method: 'POST' });
+ *       }
+ *
+ *       requestBuilder.headers.set('X-Custom-Header', 'foo');
  *     },
- *     responseReceived: async (response, operation) => {
+ *     responseReceived: ({ response, operation }) => {
  *       // Handle post-response logic
- *       const data = await response.json();
- *       console.log('Received:', data, 'for operation:', operation.operationId);
+ *       console.log('Received status:', response.status, 'for operation:', operation.operationId);
  *     }
  *   },
  *   components: {

--- a/packages/oas-utils/src/helpers/client-plugins.ts
+++ b/packages/oas-utils/src/helpers/client-plugins.ts
@@ -1,6 +1,6 @@
 import type { AnyEventListener, ApiReferenceEvents, WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { RequestFactory, VariablesStore } from '@scalar/workspace-store/request-example'
-import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type { OpenApiDocument, ServerObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/operation'
 import type { Component, DefineComponent } from 'vue'
 
@@ -50,6 +50,10 @@ type ClientPluginHooks = {
     document: OpenApiDocument
     operation: OperationObject
     variablesStore?: VariablesStore
+    /** Active server, so plugins can resolve relative URLs (e.g. a token endpoint). */
+    server?: ServerObject | null
+    /** Host fetch, so plugins can run network calls (e.g. a token refresh) through the same channel as the request. */
+    customFetch?: typeof fetch
   }) => void | Promise<void>
   /**
    * Runs after the fetch `Request` has been built, right before it is sent. The request passed


### PR DESCRIPTION
## What this does

Adds two optional fields to the `ClientPlugin` `beforeRequest` payload:

- `server?: ServerObject | null`: the active server, for resolving relative URLs.
- `customFetch?: typeof fetch`: the host-provided fetch implementation, including the desktop IPC-backed fetch.

`OperationBlock` forwards both values immediately before the request is built, so plugins can use them while mutating the request builder.

## Why

Plugins that inject or refresh OAuth2 bearer tokens need the active server to resolve a relative token endpoint and the host fetch to make that refresh through the same network channel as the outgoing request. Without these values, plugins must capture external state during registration, which is fragile and does not work for every host integration.

## Compatibility

This is additive. Both fields are optional, so existing client plugins continue to work unchanged.

## Verification

- Added an `OperationBlock` regression test proving both values reach a `beforeRequest` plugin.
- Retained the OAS-utils hook payload test.

## Related

Prerequisite for token-injection and auto-refresh client plugins.