### PR TITLE
fix(api-reference): keep sibling properties when flattening single-member allOf

### DIFF
--- a/.changeset/allof-sibling-properties.md
+++ b/.changeset/allof-sibling-properties.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-reference": patch
+---
+
+Keep sibling `properties` when flattening a single-member `allOf`. Previously, a schema declaring its own `properties` next to an `allOf` holding a single `$ref` lost those sibling properties: the referenced schema's `properties` overwrote them instead of being combined, and the referenced schema's `title`/`description` replaced the parent's. Sibling and inherited properties now render together, `required` lists are unioned, and the parent schema's own annotations win over the base it extends.

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
@@ -550,4 +550,88 @@ describe('optimizeValueForDisplay', () => {
       ],
     })
   })
+
+  it('unions sibling properties with a single-member allOf instead of dropping them', () => {
+    // Mirrors the reported schema: an object declares its own `properties`
+    // next to an `allOf` holding a single `$ref` base. The sibling properties
+    // (`assetIds`) must survive the flattening, and the root's own annotations
+    // (title, description) must win over the base schema's.
+    const input = {
+      title: 'Geofence Update Payload',
+      description: 'Geofence data to update in Equipment Monitoring table.',
+      type: 'object',
+      properties: {
+        assetIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Geofence assigned asset ids',
+        },
+      },
+      allOf: [
+        {
+          '$ref': '#/components/schemas/GeofencePayloadWithoutAssetIds',
+          '$ref-value': {
+            title: 'Geofence Payload without asset ids',
+            description: 'Geofence data to save in Equipment Monitoring table',
+            type: 'object',
+            properties: {
+              updatedBy: { type: 'string' },
+              name: { type: 'string' },
+            },
+            required: ['updatedBy'],
+          },
+        },
+      ],
+    } as unknown as SchemaObject
+
+    const result = optimizeValueForDisplay(input)
+
+    expect(result).toEqual({
+      // The resolved node keeps its `$ref` so model names still render
+      '$ref': '#/components/schemas/GeofencePayloadWithoutAssetIds',
+      title: 'Geofence Update Payload',
+      description: 'Geofence data to update in Equipment Monitoring table.',
+      type: 'object',
+      properties: {
+        assetIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Geofence assigned asset ids',
+        },
+        updatedBy: { type: 'string' },
+        name: { type: 'string' },
+      },
+      required: ['updatedBy'],
+    })
+  })
+
+  it('lets a sibling property redefinition win over the single-member allOf base', () => {
+    // When the root redeclares a property the base also defines, the root's
+    // definition is the more specific one and should be the one rendered.
+    const input = {
+      type: 'object',
+      properties: {
+        updatedBy: { type: 'string', description: 'Name of the updating user' },
+      },
+      allOf: [
+        {
+          type: 'object',
+          properties: {
+            updatedBy: { type: 'string' },
+            name: { type: 'string' },
+          },
+        },
+      ],
+    } as unknown as SchemaObject
+
+    const result = optimizeValueForDisplay(input)
+
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        updatedBy: { type: 'string', description: 'Name of the updating user' },
+        name: { type: 'string' },
+      },
+    })
+  })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
@@ -97,10 +97,16 @@ export function optimizeValueForDisplay(value: SchemaObject | undefined): Schema
   // Determine if nullable should be set
   const shouldBeNullable = hasNullSchema || originalNullable === true
 
-  // If only one schema remains after filtering, merge with root properties
+  // If only one schema remains after filtering, merge with root properties.
+  // `properties`/`required` are unioned so sibling properties declared next to
+  // the composition (e.g. `properties` alongside a single-`$ref` `allOf`) are
+  // kept instead of being overwritten by the member schema's own `properties`.
+  // Root-level annotations (title, description, …) win over the member's: they
+  // describe the combined schema, not the base it extends.
   if (filteredSchemas.length === 1) {
-    const mergedSchema = { ...rootProperties, ...filteredSchemas[0] }
+    const mergedSchema = mergeSchemaProperties(filteredSchemas[0], rootProperties) as SchemaObject
     if (shouldBeNullable) {
+      // @ts-expect-error We use nullable
       mergedSchema.nullable = true
     }
     return mergedSchema


### PR DESCRIPTION
## What changed

A schema that declares its own `properties` next to an `allOf` holding a single member (typically a `$ref`) lost those sibling properties in the rendered reference. `optimizeValueForDisplay` flattened the composition with a shallow spread, so the member schema's `properties` object completely replaced the parent's, and the member's `title`/`description` replaced the parent's annotations.

Reported by a customer with this shape (abridged):

```json
"GeofenceUpdatePayload": {
  "title": "Geofence Update Payload",
  "type": "object",
  "properties": {
    "assetIds": { "type": "array", "items": { "type": "string" } },
    "updatedBy": { "type": "string" }
  },
  "allOf": [
    { "$ref": "#/components/schemas/GeofencePayloadWithoutAssetIds" }
  ]
}
```

`assetIds` never rendered, and the request body section was titled "Geofence Payload without asset ids" instead of "Geofence Update Payload". Redoc renders the merged set.

## How

The single-member branch now reuses `mergeSchemaProperties` (introduced in #9664 for the multi-branch `oneOf`/`anyOf` path), which unions `properties` and `required` instead of overwriting. The root schema is merged last so its own annotations (`title`, `description`) and property redefinitions win over the base it extends — matching JSON Schema intent (sibling keywords and `allOf` members all apply; the parent's annotations describe the combined schema).

#9664 fixed this exact clobbering for multi-branch compositions but left the `filteredSchemas.length === 1` path on the old shallow spread.

## Tests

- New: sibling `properties` + single-`$ref` `allOf` renders the union, keeps `required`, and keeps the parent's `title`/`description` (the customer's schema shape).
- New: a sibling property redefinition wins over the base's definition of the same property.
- All 26 existing Schema test files pass (515 tests), plus `vue-tsc` type check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display-time schema merge in api-reference with targeted tests; no auth, API, or persistence changes.
> 
> **Overview**
> Fixes API reference rendering when an object schema has **sibling `properties` (or `required`) next to a single-member `allOf`**—often a lone `$ref` base. That path used a shallow object spread when flattening, so the member’s `properties` replaced the parent’s and inherited `title`/`description` could override the parent’s.
> 
> **`optimizeValueForDisplay`** now uses **`mergeSchemaProperties`** on the `filteredSchemas.length === 1` branch (same helper as multi-branch `oneOf`/`anyOf` in #9664). **`properties` and `required` are unioned**; the root is merged last so **parent annotations and redefined fields win** over the base. Tests cover the reported geofence payload shape and sibling property overrides. Patch changeset for `@scalar/api-reference`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41d1aa57d36defcbb59478398ab23573914abe65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->