### PR TITLE
fix(api-client): header params with x-disabled: false stay enabled on…

### DIFF
--- a/.changeset/fix-header-param-disabled-state.md
+++ b/.changeset/fix-header-param-disabled-state.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: header parameters with `x-disabled: false` (e.g. `x-scenario-id`) now stay enabled while editing
+
+`RequestTableRow`'s `handleUpdateRow` unconditionally ran `isDisabled.value = payload.isDisabled ?? false`. When `CodeInputLite` fired `@update:modelValue` for the name or value field it called `handleUpdateRow({ name: v })` with no `isDisabled`, which reset the row to enabled on every keystroke and overrode the correct initial state read from `x-disabled`. It now only updates `isDisabled` when it is explicitly present in the payload.

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
@@ -276,6 +276,60 @@ describe('RequestTableRow', () => {
     })
   })
 
+  it('preserves isDisabled=true when name input is updated', async () => {
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: { name: 'x-scenario-id', value: 'scenario_a', isDisabled: true },
+        environment,
+      },
+      global: { stubs: { RouterLink: true } },
+    })
+
+    const keyInput = wrapper.findAllComponents({ name: 'CodeInputLite' })[0]
+    await keyInput?.vm.$emit('update:modelValue', 'x-scenario-id')
+
+    expect(wrapper.emitted('upsertRow')?.[0]?.[0]).toMatchObject({
+      name: 'x-scenario-id',
+      isDisabled: true,
+    })
+  })
+
+  it('preserves isDisabled=true when value input is updated', async () => {
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: { name: 'x-scenario-id', value: 'scenario_a', isDisabled: true },
+        environment,
+      },
+      global: { stubs: { RouterLink: true } },
+    })
+
+    const valueInput = wrapper.findAllComponents({ name: 'CodeInputLite' })[1]
+    await valueInput?.vm.$emit('update:modelValue', 'scenario_b')
+
+    expect(wrapper.emitted('upsertRow')?.[0]?.[0]).toMatchObject({
+      value: 'scenario_b',
+      isDisabled: true,
+    })
+  })
+
+  it('preserves isDisabled=false when value input is updated', async () => {
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: { name: 'x-scenario-id', value: 'scenario_a', isDisabled: false },
+        environment,
+      },
+      global: { stubs: { RouterLink: true } },
+    })
+
+    const valueInput = wrapper.findAllComponents({ name: 'CodeInputLite' })[1]
+    await valueInput?.vm.$emit('update:modelValue', 'scenario_b')
+
+    expect(wrapper.emitted('upsertRow')?.[0]?.[0]).toMatchObject({
+      value: 'scenario_b',
+      isDisabled: false,
+    })
+  })
+
   it('disables inputs when isReadOnly is true', () => {
     const wrapper = mount(RequestTableRow, {
       props: {

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -164,8 +164,10 @@ const handleUpdateRow = (
     value.value = payload.value
   }
 
-  // Is disabled should always be false unless you explicitly set it to true
-  isDisabled.value = payload.isDisabled ?? false
+  // Is disabled should only be updated when explicitly provided in the payload
+  if (payload.isDisabled !== undefined) {
+    isDisabled.value = payload.isDisabled
+  }
 
   if (
     payload.name !== undefined &&

--- a/packages/workspace-store/src/request-example/builder/header/is-param-disabled.test.ts
+++ b/packages/workspace-store/src/request-example/builder/header/is-param-disabled.test.ts
@@ -90,4 +90,50 @@ describe('isParamDisabled', () => {
     expect(isParamDisabled(optionalPathParam, example)).toBe(false)
     expect(isParamDisabled(requiredPathParam, example)).toBe(false)
   })
+
+  it('returns false for optional non-path params when defaultDisabled is false', () => {
+    const param: ParameterObject = {
+      name: 'x-scenario-id',
+      in: 'header',
+      required: false,
+      schema: { type: 'string' },
+    }
+
+    expect(isParamDisabled(param, {}, false)).toBe(false)
+  })
+
+  it('x-disabled: false overrides defaultDisabled: true for optional header params', () => {
+    const param: ParameterObject = {
+      name: 'x-scenario-id',
+      in: 'header',
+      required: false,
+      schema: { type: 'string' },
+    }
+    const example: ExampleObject = { 'x-disabled': false }
+
+    expect(isParamDisabled(param, example, true)).toBe(false)
+  })
+
+  it('x-disabled: true overrides defaultDisabled: false', () => {
+    const param: ParameterObject = {
+      name: 'x-scenario-id',
+      in: 'header',
+      required: false,
+      schema: { type: 'string' },
+    }
+    const example: ExampleObject = { 'x-disabled': true }
+
+    expect(isParamDisabled(param, example, false)).toBe(true)
+  })
+
+  it('returns false when example is undefined and defaultDisabled is false', () => {
+    const param: ParameterObject = {
+      name: 'filter',
+      in: 'query',
+      required: false,
+      schema: { type: 'string' },
+    }
+
+    expect(isParamDisabled(param, undefined, false)).toBe(false)
+  })
 })


### PR DESCRIPTION
## Problem

Optional header parameters with `x-disabled: false` explicitly set in their OpenAPI example (e.g. `x-scenario-id`) were being reset to enabled while editing, losing their correct initial disabled state.

## Fix

`RequestTableRow`'s `handleUpdateRow` unconditionally ran:

```ts
isDisabled.value = payload.isDisabled ?? false
```

When `CodeInputLite` fires `@update:modelValue` for the name or value field it calls `handleUpdateRow({ name: v })` with no `isDisabled` in the payload, so the `?? false` fallback silently reset the row to enabled on every keystroke, overriding the state read from `x-disabled`.

Now `isDisabled` is only updated when it is explicitly present in the payload:

```ts
if (payload.isDisabled !== undefined) {
  isDisabled.value = payload.isDisabled
}
```

## Notes

An earlier revision also changed the `RequestTable` `v-for` `:key` from `index` to a `name`-based key. That was dropped: local verification could not reproduce the reported GET/DELETE staleness through it (the existing `watch(() => data.isDisabled)` already re-syncs on row reuse, and disabled optional params are never rendered as rows), and a `name`-based key remounts the row on every rename. This PR is now the `handleUpdateRow` fix only.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
