### PR TITLE
fix(api-client): truncate long multipart file names instead of overflowing

### DIFF
--- a/.changeset/multipart-file-name-overflow.md
+++ b/.changeset/multipart-file-name-overflow.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Long file names in the multipart form no longer stretch the request table past its container. The name now truncates with an ellipsis, and hovering shows the full name.

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
@@ -49,7 +49,7 @@ const emit = defineEmits<{
 
 const columns = computed(() => {
   if (showUploadButton) {
-    return ['36px', '', '', 'auto']
+    return ['36px', '', '', 'minmax(0, 1fr)']
   }
   return ['36px', '', '']
 })
@@ -107,12 +107,5 @@ const displayData = computed(() => {
 }
 :deep(.scalar-pill:not(:first-of-type)) {
   margin-left: 0.5px;
-}
-.filemask {
-  mask-image: linear-gradient(
-    to right,
-    transparent 0,
-    var(--scalar-background-2) 20px
-  );
 }
 </style>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
@@ -504,6 +504,27 @@ describe('RequestTableRow', () => {
     expect(wrapper.text()).toContain(longFileName)
   })
 
+  it('exposes the full file name as a tooltip so truncated names stay readable', () => {
+    const longFileName = 'this-is-a-very-long-file-name-that-should-still-be-displayed-correctly.txt'
+    const file = new File(['content'], longFileName, { type: 'text/plain' })
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: { name: 'file', value: file },
+        environment,
+        showUploadButton: true,
+      },
+      global: {
+        stubs: {
+          RouterLink: true,
+        },
+      },
+    })
+
+    const fileName = wrapper.find(`[title="${longFileName}"]`)
+    expect(fileName.exists()).toBe(true)
+    expect(fileName.text()).toBe(longFileName)
+  })
+
   it('emits removeFile when delete button is clicked on a file', async () => {
     const file = new File(['content'], 'test.txt', { type: 'text/plain' })
     const wrapper = mount(RequestTableRow, {

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -295,8 +295,12 @@ const handleKeyBlur = (newName: string): void => {
       class="group/upload flex items-center justify-center whitespace-nowrap">
       <template v-if="isFile">
         <div
-          class="text-c-2 filemask flex w-full max-w-[100%] items-center justify-center overflow-hidden p-1">
-          <span>{{ displayValue }}</span>
+          class="text-c-2 flex w-full max-w-[100%] items-center justify-center overflow-hidden p-1">
+          <span
+            class="truncate"
+            :title="displayValue"
+            >{{ displayValue }}</span
+          >
         </div>
         <button
           class="bg-b-2 mt-1 block rounded p-0.5 text-center text-xs font-medium md:pointer-events-none md:absolute md:inset-x-1 md:top-1/2 md:mt-0 md:-translate-y-1/2 md:opacity-0 md:group-hover/upload:pointer-events-auto md:group-hover/upload:opacity-100"


### PR DESCRIPTION
### Before

<img width="520" alt="Before: the long file name is clipped on both sides with no ellipsis" src="https://raw.githubusercontent.com/lazerg/scalar/assets-9803/before-9803.png" />

### After

<img width="520" alt="After: the file name truncates with an ellipsis" src="https://raw.githubusercontent.com/lazerg/scalar/assets-9803/after-9803.png" />

## Problem

Pick a file with a long name in a multipart form and the file column grows to fit the whole name. It runs past the request panel, so the name gets cut off at the edge. There is no ellipsis and no tooltip, so you cannot read the full name.

## Solution

The file column now shares the table width with the other columns instead of growing to its content. When the name is too long it truncates with an ellipsis, and the full name shows in a tooltip on hover.

Closes #9803
