### PR TITLE
docs(docs): add Redocly comparison page

### DIFF
--- a/documentation/compare/index.md
+++ b/documentation/compare/index.md
@@ -13,4 +13,7 @@ Each guide is written by us, so read it with that in mind. We link every claim w
 <scalar-page-link filepath="documentation/compare/readme.md" title="ReadMe" description="A comparison of Scalar and ReadMe for developer portals and API documentation: licensing, self-hosting, API analytics, SDK generation, and pricing">
 </scalar-page-link>
 
+<scalar-page-link filepath="documentation/compare/redocly.md" title="Redocly" description="A comparison of Scalar and Redocly for OpenAPI documentation: licensing, the try-it console, API governance, framework integrations, SDK generation, and pricing">
+</scalar-page-link>
+
 Looking to move an existing setup across rather than compare? See the [migration guides](/resources/migration).

--- a/documentation/compare/redocly.md
+++ b/documentation/compare/redocly.md
@@ -1,0 +1,82 @@
+# Scalar vs Redocly
+
+Redocly is the company behind Redoc, one of the original OpenAPI renderers — the repository dates back to [October 2015](https://github.com/Redocly/redoc) and has over 25,000 stars. A very large share of the API documentation on the internet has been rendered by Redoc at some point, and if you are evaluating OpenAPI documentation tooling, Redocly belongs on your list.
+
+This page is written by Scalar, so read it with that in mind. Every claim we make about Redocly links to their own documentation, pricing page, or public repositories. If we have something wrong, tell us and we will fix it.
+
+The short version: both companies ship an MIT-licensed OpenAPI renderer. The difference is what the open edition includes and what surrounds it. Redoc's community edition renders documentation but reserves the try-it console for the [commercial hosted product](https://github.com/Redocly/redoc#redoc-vs-hosted-redoc); Redocly's real depth is in API governance and the enterprise portal suite around the renderer. Scalar's open renderer ships with a full API client built in, mounts inside 35 web frameworks, and sits alongside SDK generation and hosted MCP servers driven by the same OpenAPI document.
+
+## At a glance
+
+| | Scalar | Redocly |
+| --- | --- | --- |
+| Docs renderer license | [MIT](https://github.com/scalar/scalar) | [MIT](https://github.com/Redocly/redoc) (Redoc community edition) |
+| Try-it console in the open renderer | Yes — a full API client | No — [commercial feature](https://github.com/Redocly/redoc#redoc-vs-hosted-redoc) |
+| API linting and governance | Spectral rules in the registry | [Redocly CLI](https://github.com/Redocly/redocly-cli), mature and configurable |
+| Framework integrations | 35 | HTML tag, React component, Docker, CLI |
+| SDK generation | Native, published pricing | [Experimental TypeScript client](https://github.com/Redocly/redocly-cli) in the CLI |
+| Standalone API client | Yes, open source | No |
+| Hosted MCP servers | Pro, $72/month | [Enterprise tier](https://redocly.com/pricing) |
+| Entry paid tier | $72/month flat | $10 per seat/month, 100-page limit |
+
+## Where Redocly is stronger
+
+We would rather you hear this from us than find out after switching.
+
+**API governance and linting.** [Redocly CLI](https://github.com/Redocly/redocly-cli) is a genuinely excellent tool — linting with configurable rulesets, bundling multi-file descriptions, and decorators for transforming documents, with support for OpenAPI 3.2 down to 2.0, AsyncAPI, and Arazzo. If your organization needs to enforce API design standards across many teams, Redocly has invested in this problem for years and it shows. Scalar's registry supports [Spectral rules](https://scalar.com/products/registry), but Redocly's governance tooling is deeper and more widely deployed.
+
+**Longevity.** Redoc has been rendering OpenAPI since 2015. It is battle-tested against a decade of real-world API descriptions, including the malformed ones. That maturity is worth something.
+
+**API contract testing.** [Respect](https://redocly.com/respect), Redocly's contract testing tool, sends real requests to your API and validates responses against your OpenAPI description and Arazzo workflows. Scalar has no direct equivalent.
+
+**The enterprise portal suite.** Redocly's commercial platform — [Realm](https://redocly.com/docs/realm), which combines Redoc, Revel (external developer hub), and Reef (internal API catalog), authored through Reunite — is a serious enterprise developer portal product with SSO, RBAC, and analytics on the [Enterprise tier](https://redocly.com/pricing).
+
+## The try-it console is the fork in the road
+
+Both renderers are MIT licensed. What differs is what the MIT edition does.
+
+Redoc's community edition renders a three-panel reference with search, code samples via vendor extension, and schema documentation. It does not let a reader send a request. Redoc's own README lists the [try-it console, automated code samples, mock server, AsyncAPI, and GraphQL](https://github.com/Redocly/redoc#redoc-vs-hosted-redoc) as features of the commercial hosted product.
+
+Scalar's open-source renderer includes an interactive client on every operation — and it is not a thin request form. It is the same open-source [API client](https://github.com/scalar/scalar) Scalar ships standalone: authentication including OAuth 2.0 flows, environments, cookie and header management, streaming responses, and code generation for 40+ HTTP clients. Your readers test the API in the docs, then keep the same tool on their desktop after they leave.
+
+If interactive documentation matters to you and you want to stay on open source, this is the clearest single difference between the two products.
+
+## Where the docs can live
+
+Redoc CE deploys as an [HTML tag, a React component, a Docker image, or static HTML from the CLI](https://redocly.com/docs/redoc/deployment/intro). These are solid options, and the zero-dependency HTML tag in particular is pleasantly simple.
+
+Scalar additionally ships 35 framework integrations — Express, Fastify, Hono, NestJS, Next.js, Nuxt, Laravel, Django, Rails, Go, Rust, ASP.NET Core, Spring Boot, and more. You mount the reference inside the application you already run, at whatever route you choose, and the docs update when your description does. If your OpenAPI document is generated by your framework, this removes an entire deployment step.
+
+**The site you are reading is the product.** scalar.com — this page, the pricing page, the guides, the API reference, and the blog — is built and hosted entirely on Scalar Docs from a single `scalar.config.json`. We do not maintain a separate marketing stack.
+
+## Beyond documentation: SDKs and MCP
+
+Redocly is a documentation and governance company, and a good one. It does not offer a production SDK generator. Redocly CLI has an [experimental `generate-client` command](https://github.com/Redocly/redocly-cli) that emits a typed TypeScript client, clearly flagged as subject to change, with no other languages and no publishing workflow.
+
+Scalar generates SDKs in TypeScript, Python, Java, C#, PHP, and Go from the same OpenAPI document that renders your docs, with package publishing, automated GitHub workflows, and webhook support. Each language target is [$100/month](https://scalar.com/pricing), published on the pricing page.
+
+The same is true for MCP. Scalar hosts an MCP server generated from your OpenAPI document on the Pro plan at $72/month, so agents can call your API with the same source of truth your docs use. Redocly lists MCP servers on their [Enterprise tier](https://redocly.com/pricing) at $24 per seat/month.
+
+If all you need is a reference page, this section does not matter. If you want docs, SDKs, and an MCP server that cannot drift apart because they come from one document in one pipeline, it is the core of the comparison.
+
+## Pricing
+
+Both companies publish their pricing, which we respect — much of this category does not.
+
+The models differ. [Redocly charges per seat](https://redocly.com/pricing): Pro is $10 per seat/month with one project and a 100-page limit; Enterprise is $24 per seat/month with 500 pages, SSO, RBAC, and MCP servers; Enterprise+ is custom, billed yearly, via sales. Revel and Reef are separate per-seat add-ons, and the full Realm bundle is $18 to $42 per seat/month on top.
+
+[Scalar Pro is $72/month flat](https://scalar.com/pricing), with editor seats and viewer seats included, custom domains, Git sync, Markdown and MDX, and hosted MCP servers. SDK languages are $100/month each. Enterprise adds SSO/SAML, RBAC, and full developer portals.
+
+To be honest about the math: a two-person team that only needs hosted reference docs is cheaper on Redocly Pro. The comparison shifts as the team grows, as page counts pass the tier limits, and as you add products — per-seat, per-product pricing compounds in a way a flat price does not. Run your own numbers for your own team size; both pricing pages give you enough to do it.
+
+## Which should you choose?
+
+**Choose Redocly if** API governance is your primary problem — you want mature linting and rulesets enforced across many teams — or you want an established enterprise portal suite with an internal API catalog, or you rely on contract testing against your OpenAPI descriptions.
+
+**Choose Scalar if** you want an open-source renderer where try-it is a real API client rather than a paid upgrade, you want docs mounted inside the framework you already run, you want SDKs and MCP servers generated from the same document as your docs, or you prefer one flat published price over per-seat, per-product tiers.
+
+Start with [Scalar Docs](https://scalar.com/products/docs), check the [pricing](https://scalar.com/pricing), and [start free](https://dashboard.scalar.com/register) — or [talk to us](https://scalar.cal.com/).
+
+---
+
+*This comparison is based on Redocly's publicly available documentation, pricing page, and public GitHub repositories as of July 2026, and on Scalar's own source. Products in this category change quickly. We have made a genuine effort to be accurate and to state where Redocly is better. If you find something wrong or out of date, please [open an issue](https://github.com/scalar/scalar/issues) and we will correct it.*

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -3685,6 +3685,39 @@
                         }
                       ]
                     }
+                  },
+                  "redocly": {
+                    "type": "page",
+                    "title": "Redocly",
+                    "filepath": "documentation/compare/redocly.md",
+                    "description": "Compare Scalar and Redocly for OpenAPI documentation: licensing, the try-it console, API governance, framework integrations, SDK generation, and pricing.",
+                    "head": {
+                      "title": "Scalar vs Redocly — OpenAPI Documentation Comparison",
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/compare/redocly"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Compare Scalar and Redocly for OpenAPI documentation: licensing, the try-it console, API governance, framework integrations, SDK generation, and pricing."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Scalar vs Redocly — OpenAPI Documentation Comparison"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "An honest comparison of Scalar and Redocly across OpenAPI documentation, open source licensing, API governance, and pricing."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
                   }
                 }
               },


### PR DESCRIPTION
## What

Adds a Scalar vs Redocly comparison page at `/resources/compare/redocly`, following the format and tone of the existing Fern and Mintlify compare pages.

- New page: `documentation/compare/redocly.md`
- Registered in `scalar.config.json` under the compare group (canonical, og tags, `robots: index, follow`)
- Linked from `documentation/compare/index.md`

## Why

Part of the AI-visibility content work: Redocly appears in AI answers for the OpenAPI and API documentation topics, and scalar.com had no citable page comparing the two.

## Notes for review

- Every Redocly claim links to their own docs, pricing page, or GitHub repos (licenses, stars, the Redoc CE vs hosted feature split, the experimental `generate-client` command all verified as of July 2026).
- The page is deliberately honest where Redocly is stronger: governance/linting via Redocly CLI, a decade of maturity, Respect contract testing, and that a small docs-only team can be cheaper on Redocly's per-seat pricing.
- Scalar-side facts (Pro $72/month, $100/month per SDK target, hosted MCP on Pro) match `documentation/guides/pricing.md`.
- Prettier compliance verified with `npx prettier --check` on all three files; no changeset needed (documentation only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and site navigation config only; no application or runtime code changes.
> 
> **Overview**
> Adds a **Scalar vs Redocly** comparison at `/resources/compare/redocly`, in the same style as the existing Fern, Mintlify, and ReadMe guides.
> 
> The new `documentation/compare/redocly.md` page covers licensing, try-it vs hosted Redoc, governance (Redocly CLI / Respect), deployment options, SDKs and MCP, and pricing, with explicit “where Redocly is stronger” sections and third-party links. The compare hub (`documentation/compare/index.md`) gets a `scalar-page-link` to the page, and `scalar.config.json` registers the route with canonical URL, meta/OG tags, and `robots: index, follow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5120d18a9809c4c209bdacd278ad48477d6b064d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->