### PR TITLE
docs(docs): add Postman comparison page

### DIFF
--- a/documentation/compare/index.md
+++ b/documentation/compare/index.md
@@ -16,4 +16,7 @@ Each guide is written by us, so read it with that in mind. We link every claim w
 <scalar-page-link filepath="documentation/compare/redocly.md" title="Redocly" description="A comparison of Scalar and Redocly for OpenAPI documentation: licensing, the try-it console, API governance, framework integrations, SDK generation, and pricing">
 </scalar-page-link>
 
+<scalar-page-link filepath="documentation/compare/postman.md" title="Postman" description="A comparison of Scalar and Postman across API clients and documentation: licensing, offline use, OpenAPI support, vendor lock-in, and pricing">
+</scalar-page-link>
+
 Looking to move an existing setup across rather than compare? See the [migration guides](/resources/migration).

--- a/documentation/compare/postman.md
+++ b/documentation/compare/postman.md
@@ -1,0 +1,97 @@
+# Scalar vs Postman
+
+Postman is the default API client for millions of developers, and it earned that position. If you are evaluating API tooling, it is almost certainly already on your list — it may be the tool you are using right now.
+
+This page is written by Scalar, so read it with that in mind. Every claim we make about Postman links to Postman's own documentation, pricing page, or public repositories. If we have something wrong, tell us and we will fix it.
+
+The short version: Postman is a large collaboration platform built around its own collection format, with your work synced to Postman's cloud. Scalar is built around OpenAPI — an open standard you already maintain — with an [API client](/products/api-client) that is MIT licensed, offline-first, and works without an account, on the same platform that renders your documentation and generates your SDKs.
+
+**One thing to know up front:** Postman [acquired Fern in January 2026](https://blog.postman.com/postman-acquires-fern/). We compare against Fern [on its own page](/resources/compare/fern); the acquisition matters here because it signals where Postman is heading — deeper into documentation and SDKs, the territory this page compares.
+
+## At a glance
+
+| | Scalar | Postman |
+| --- | --- | --- |
+| API client license | MIT, fully open source | Closed source; Newman and the collection schema are open |
+| Native format | OpenAPI | Postman Collection Format |
+| Works without an account | Yes, the full client | [Lightweight client](https://learning.postman.com/docs/getting-started/basics/using-api-client/) only; collections require sign-in |
+| Where your work lives | Local, offline-first | Synced to Postman's cloud when signed in |
+| OpenAPI | The working format itself | [Imported and converted](https://learning.postman.com/docs/design-apis/specifications/import-a-specification/) to collections |
+| Documentation | Same platform, same OpenAPI document | [Generated from collections](https://learning.postman.com/docs/publishing-your-api/api-documentation-overview/); full sites via Fern |
+| SDK generation | Native — TypeScript, Python, C#, Java, PHP, Go | Code snippets in the client; SDKs via Fern |
+| Client pricing | Free on every plan | [Free tier; paid from $9/month](https://www.postman.com/pricing/) |
+| Platforms | Web, macOS, Windows, Linux | [Web, macOS, Windows, Linux](https://www.postman.com/downloads/) |
+
+## Where Postman is stronger
+
+We would rather you hear this from us than find out after switching.
+
+**Ecosystem and reach.** Postman says it serves [more than 500,000 companies worldwide, including 98% of the Fortune 500](https://blog.postman.com/postman-acquires-fern/). The [Public API Network](https://www.postman.com/explore) is a genuine discovery channel where companies publish workspaces and collections for their public APIs. Nothing else in the category has this gravity, and if your users expect to find your API on Postman, that expectation is itself a reason to be there.
+
+**Protocol breadth today.** Postman's client handles [HTTP, gRPC, GraphQL, and WebSocket requests](https://learning.postman.com/docs/getting-started/basics/using-api-client/). Scalar's client is HTTP-first; gRPC, GraphQL, WebSocket, and SOAP clients are [on our roadmap](/pricing) but not shipped. If you need to test non-HTTP protocols this week, Postman does it and we do not yet.
+
+**Team collaboration in the cloud.** Shared workspaces, commenting, role-based access control, and cloud sync across devices are mature and central to Postman. Scalar's client stores your work locally, and cloud sync is [coming soon](/pricing) — which means teams that want a synced, shared workspace get one from Postman today and not from us.
+
+**Platform breadth.** [Scheduled monitors](https://learning.postman.com/docs/monitoring-your-api/intro-monitors/), [mock servers](https://learning.postman.com/docs/design-apis/mock-apis/set-up-mock-servers/), and a [large integration directory](https://learning.postman.com/docs/integrations/intro-integrations/) covering CI, APM, and messaging tools. Scalar has a [mock server](https://github.com/scalar/scalar/tree/main/packages/mock-server) and CI workflows, but Postman's breadth here is real.
+
+**Switching friction is real.** If your team has years of collections, monitors, mock servers, and workspace history in Postman, migrating is work. Our importer brings your collections across, but it does not bring your monitors, your mocks, or your history. Anyone who tells you switching is free is selling something.
+
+## The format question
+
+This is the structural difference between the two products, so it is worth being precise.
+
+Postman's working artifact is the [Postman Collection Format](https://schema.postman.com/collection/json/v2.1.0/draft-07/docs/index.html) — a JSON format that describes requests, folders, scripts, and tests. To Postman's credit, the [schema is publicly documented](https://github.com/postmanlabs/schemas) and [Newman](https://github.com/postmanlabs/newman), the command-line collection runner, is open source. Postman [imports OpenAPI documents](https://learning.postman.com/docs/design-apis/specifications/import-a-specification/) by generating a collection from them, and can keep a specification and its generated collection in sync.
+
+But the direction of travel matters. Everything you author inside Postman — tests, scripts, examples, organization — accumulates in the collection, not in your OpenAPI document. Over time the collection becomes the thing your team actually maintains, and it is a format only Postman tooling fully understands.
+
+Scalar does not have a native format, because OpenAPI is the native format. The [API client generates collections directly from your OpenAPI document](/products/api-client/import), can watch it for changes, and keeps requests, authentication, and servers aligned with it. The same document drives your documentation, your SDKs, and your client. There is no second artifact to drift.
+
+## Offline, accounts, and where your work lives
+
+In 2023 Postman [sunset the offline Scratch Pad](https://blog.postman.com/announcing-new-lightweight-postman-api-client/). Signed out, you now get the [lightweight API client](https://learning.postman.com/docs/getting-started/basics/using-api-client/): you can send requests, but per Postman's own documentation you need to sign in to save requests to collections, use environments and variables, or use workspaces. Signed in, your work syncs to Postman's cloud.
+
+For plenty of teams that trade-off is fine. For teams testing internal APIs with credentials that are not supposed to leave the building, it is the reason they went looking for an alternative.
+
+Scalar's client is offline-first. The full client — collections, environments, scripting, the collection runner — works without an account, and your requests and credentials stay on your machine. The client is [MIT licensed](https://github.com/scalar/scalar), so you can read exactly what it does with your data, and it runs [in the browser](https://client.scalar.com) or as a desktop app on macOS, Windows, and Linux.
+
+The honest flip side, stated plainly: because nothing syncs, there is no cross-device or team sync today. If that is a dealbreaker, Postman wins this one for now.
+
+## Documentation
+
+Postman [generates documentation from collections](https://learning.postman.com/docs/publishing-your-api/api-documentation-overview/) — request details, authorization, and sample code, publishable to the web and editable in a built-in editor. It is genuinely convenient, and for a quick public reference on a collection you already maintain, it works.
+
+For full documentation sites, Postman's own documentation now points to the Fern integration. In other words, the comprehensive answer is a separately acquired product with its own stack.
+
+Documentation is not an add-on for Scalar; it is half the company. The API reference renderer is MIT licensed, themeable down to CSS variables, and ships with 35 framework integrations — Express, Fastify, Hono, NestJS, Next.js, Nuxt, Laravel, Django, Rails, ASP.NET Core, Spring Boot, and more — so the docs can live inside the application you already run. Guides, landing pages, MDX, `llms.txt`, and hosted MCP servers are part of the same platform, driven by the same OpenAPI document as the client and the SDKs. scalar.com itself, including this page, is built on Scalar Docs.
+
+And because the reference embeds the client, every operation in your docs has a working **Test Request** button. Your documentation is not a description of your API next to a screenshot of a client — it is the client.
+
+## SDKs
+
+Postman's client generates [code snippets](https://github.com/postmanlabs/postman-code-generators) for a request in a wide range of languages — open source, and genuinely useful for copy-paste. But a snippet is not a client library. For SDK generation proper, Postman's answer is now Fern: since the [acquisition](https://blog.postman.com/postman-acquires-fern/), publishing client libraries from Postman means adopting Fern's stack, where the free tier [caps at 50 endpoints](https://buildwithfern.com/pricing) and most SDK capability is Enterprise, priced per SDK and billed annually with no published rate. We compare Fern's generated output in detail [on its own page](/resources/compare/fern).
+
+Scalar generates SDKs natively — TypeScript, Python, C#, Java, PHP, and Go — from the same OpenAPI document that renders your reference and drives the client, in the same generation run, so your docs, your client, and your libraries cannot describe different APIs. Custom code survives regeneration through a three-way merge, and each language target is a published [$100/month add-on](/pricing). You can work out what it costs without talking to sales.
+
+## Scripting, tests, and moving over
+
+Scalar's client supports [pre-request scripts and post-response tests using a Postman-compatible syntax](/products/api-client/testing) — `pm.test()`, `pm.expect()`, `pm.response` — so existing test scripts largely carry over, and so does your muscle memory.
+
+The client [imports Postman Collections](/products/api-client/import) (v2.0 and v2.1), converting requests, folders, and basic authentication settings into an OpenAPI-based collection. It also imports OpenAPI 3.x, upgrades Swagger 2.0 documents automatically, and parses pasted cURL commands. To repeat the honest caveat from above: monitors, mock servers, and workspace history do not come across.
+
+## Pricing
+
+Postman's [pricing](https://www.postman.com/pricing/) at the time of writing: a free tier for one user, then Solo at $9/month, Team at $19 per user per month, and Enterprise at $49 per user per month, billed annually. The free tier is genuinely usable, and the paid tiers are reasonable for what the platform does — but the cost scales with every seat, and the features that make Postman sticky (shared workspaces, RBAC, higher API call limits) are the ones that add seats.
+
+Scalar's API client is free and open source for everyone, on every plan, with no per-seat fee, because it is not where we make money. The [docs platform](/pricing) starts free and is $72/month on Pro — a flat price, not per user.
+
+## Which should you choose?
+
+**Choose Postman if** your team needs gRPC, GraphQL, or WebSocket testing today, depends on monitors and mock servers at scale, wants cloud-synced team workspaces right now, or benefits from publishing to the Public API Network.
+
+**Choose Scalar if** OpenAPI is your source of truth and you want it to stay that way, you want an API client you can read and fork under MIT, you want your requests and credentials to stay on your machine, you do not want per-seat pricing for an API client, or you want documentation, SDKs, and the client generated from the same document on one platform.
+
+[Try the API client](/products/api-client), [start free](https://dashboard.scalar.com/register), or [talk to us](https://scalar.cal.com/).
+
+---
+
+*This comparison is based on Postman's publicly available documentation, pricing page, and public repositories as of July 2026, and on Scalar's own source. Postman ships quickly and their platform may change. We have made a genuine effort to be accurate and to state where Postman is better. If you find something wrong or out of date, please [open an issue](https://github.com/scalar/scalar/issues) and we will correct it.*

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -3755,6 +3755,39 @@
                         }
                       ]
                     }
+                  },
+                  "postman": {
+                    "type": "page",
+                    "title": "Postman",
+                    "filepath": "documentation/compare/postman.md",
+                    "description": "Compare Scalar and Postman for API clients and documentation: licensing, offline use, OpenAPI support, vendor lock-in, and pricing.",
+                    "head": {
+                      "title": "Scalar vs Postman — API Client and Documentation Comparison",
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/compare/postman"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Compare Scalar and Postman for API clients and documentation: licensing, offline use, OpenAPI support, vendor lock-in, and pricing."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Scalar vs Postman — API Client and Documentation Comparison"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "An honest comparison of Scalar and Postman across API clients, OpenAPI support, offline use, documentation, and pricing."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
                   }
                 }
               },


### PR DESCRIPTION
## What

Adds a Scalar vs Postman comparison page at `/resources/compare/postman`, following the format and tone of the existing Fern and Mintlify compare pages. This puts a citable page behind the homepage's "Postman alternative" positioning.

- New page: `documentation/compare/postman.md`
- Registered in `scalar.config.json` under the compare group (canonical, og tags, `robots: index, follow`)
- Linked from `documentation/compare/index.md`

## Notes for review

- Every Postman claim links to Postman's own docs, blog, or pricing (all 14 external URLs verified returning 200): the 2023 Scratch Pad sunset, lightweight-client sign-in limits, collection format schema, pricing tiers, and the Fern acquisition.
- Honest where Postman is stronger: ecosystem reach, gRPC/GraphQL/WebSocket support today (Scalar's are roadmap), cloud team collaboration, monitors/mocks — and it plainly states Scalar has no cloud sync yet.
- Includes an SDKs section: Postman's snippet generators + Fern's enterprise SDK pricing vs Scalar's native six-language generation at a published $100/month per target.
- Prettier-checked; no changeset needed (documentation only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and site navigation/SEO config only; no application or runtime code changes.
> 
> **Overview**
> Adds a **Scalar vs Postman** comparison at `/resources/compare/postman`, in the same style as the other compare guides.
> 
> The new `documentation/compare/postman.md` page covers licensing, OpenAPI vs collections, offline/account requirements, docs/SDKs, migration (including Postman collection import), pricing, and when to pick each tool—with explicit “where Postman is stronger” sections. The compare index gets a new `scalar-page-link`, and `scalar.config.json` registers the page under **Resources → Compare** with canonical URL, description, Open Graph tags, and `robots: index, follow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f42b60623011003ac0d112a590c93e2e4e3febe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->