### PR TITLE
docs(sdks): align publishing guides with the release-please pipeline

### DIFF
--- a/documentation/guides/sdks/cli.md
+++ b/documentation/guides/sdks/cli.md
@@ -37,7 +37,7 @@ Add `cli` under `targets` to generate a command-line interface for your API.
 | `version`            | `string` | Target-specific CLI version override.                            |
 | `skip`               | `boolean` | Set to `true` to keep the config without generating this target. |
 | `destinations`       | `object` | GitHub destinations for generated output.                        |
-| `publish`            | `object` | npm, macOS, and Homebrew publishing configuration.               |
+| `publish`            | `object` | npm, standalone binary, and Homebrew publishing configuration.   |
 
 ## Method Commands
 
@@ -75,7 +75,9 @@ Use method-level `cli` settings in `resources` to enable, disable, or tune comma
 
 ## Publishing
 
-The CLI target supports `publish.npm`, `publish.macos`, and `publish.homebrew`. The CLI is a Node package, so npm (installed globally with `npm install -g`) is the primary channel; macOS attaches the tarball to the GitHub Release and Homebrew ships a tap formula. The three are independent and can be combined. See [CLI publishing](publishing/cli.md) for registry setup.
+The CLI target supports `publish.npm`, `publish.binaries`, and `publish.homebrew`. The CLI is a Node package, so npm (installed globally with `npm install -g`) is the primary channel; `binaries` attaches cross-compiled standalone executables to the GitHub Release, and Homebrew ships a tap formula that installs them. The three are independent and can be combined. See [CLI publishing](publishing/cli.md) for registry setup.
+
+`binaries` replaces the older `macos` key; configs that still set `macos` are migrated automatically.
 
 ```json
 {
@@ -85,8 +87,7 @@ The CLI target supports `publish.npm`, `publish.macos`, and `publish.homebrew`. 
         "npm": {
           "authMethod": "oidc"
         },
-        "macos": {
-          "authMethod": "oidc",
+        "binaries": {
           "releaseEnvironment": "production"
         },
         "homebrew": {

--- a/documentation/guides/sdks/cli.md
+++ b/documentation/guides/sdks/cli.md
@@ -9,7 +9,6 @@ Add `cli` under `targets` to generate a command-line interface for your API.
       "binaryName": "acme",
       "defaultFormat": "json",
       "defaultErrorFormat": "json",
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-cli"
@@ -34,7 +33,7 @@ Add `cli` under `targets` to generate a command-line interface for your API.
 | `binaryName`         | `string` | Name of the generated command-line binary.                       |
 | `defaultFormat`      | `string` | Default output format for generated commands.                    |
 | `defaultErrorFormat` | `string` | Default error output format for generated commands.              |
-| `version`            | `string` | Target-specific CLI version override.                            |
+| `shellCompletions`   | `boolean` | Ship shell completion scripts and the `completion` subcommand that prints them. Defaults to `true`. |
 | `skip`               | `boolean` | Set to `true` to keep the config without generating this target. |
 | `destinations`       | `object` | GitHub destinations for generated output.                        |
 | `publish`            | `object` | npm, standalone binary, and Homebrew publishing configuration.   |

--- a/documentation/guides/sdks/configuration.md
+++ b/documentation/guides/sdks/configuration.md
@@ -9,7 +9,6 @@ Use the config to keep SDK behavior predictable across generated targets. The to
 ```json
 {
   "name": "Acme API",
-  "version": "1.0.0",
   "environments": {
     "production": "https://api.acme.com"
   },
@@ -35,7 +34,6 @@ Use the config to keep SDK behavior predictable across generated targets. The to
 | Property           | Description                                                                 |
 | ------------------ | --------------------------------------------------------------------------- |
 | `name`             | Human-readable SDK or product name used for generated metadata and clients. |
-| `version`          | Base SDK version. Target-level versions can override this value.            |
 | `resources`        | Resource tree that defines the generated client and resource shape.         |
 | `targets`          | Per-language packaging, publishing, and emitter options.                    |
 | `environments`     | Named base URLs the generated client can switch between.                    |
@@ -250,4 +248,29 @@ Use `openapi` for SDK-specific overrides that sit next to the source API descrip
 | `streaming`         | Configure global streaming event handling hints for generated SDKs.         |
 | `settings`          | Cross-target generator behavior, such as file headers and response unwraps. |
 | `multipartSettings` | Multipart/form-data serialization preferences.                              |
+| `diagnostics`       | Gate the build on diagnostic severity, override per-rule severity, and suppress rules. |
+
+## Diagnostics
+
+Generation reports diagnostics about your OpenAPI document. Use `diagnostics` to decide which of them fail the build.
+
+```json
+{
+  "diagnostics": {
+    "failOn": "error",
+    "maxWarnings": 20,
+    "rules": {
+      "Endpoint/NotConfigured": "warn"
+    }
+  }
+}
+```
+
+| Property      | Description                                                                 |
+| ------------- | --------------------------------------------------------------------------- |
+| `failOn`      | Lowest severity that fails the build: `off`, `info`, `warn`, or `error`. Defaults to `error`; `off` disables severity gating. |
+| `maxWarnings` | Maximum allowed warnings before the build fails.                            |
+| `maxErrors`   | Maximum allowed errors before the build fails.                              |
+| `rules`       | Per-rule severity override keyed by rule id, such as `Endpoint/NotConfigured`. Set a rule to `off` to disable it. |
+| `ignored`     | Per-rule suppressions keyed by rule id.                                     |
 

--- a/documentation/guides/sdks/configuration/cpp.md
+++ b/documentation/guides/sdks/configuration/cpp.md
@@ -9,7 +9,6 @@ Add `cpp` under `targets` to generate a C++ SDK. C++ has no universal package re
 {
   "targets": {
     "cpp": {
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-cpp"
@@ -24,7 +23,6 @@ Add `cpp` under `targets` to generate a C++ SDK. C++ has no universal package re
 
 | Property       | Type      | Description                                                      |
 | -------------- | --------- | ---------------------------------------------------------------- |
-| `version`      | `string`  | Target-specific SDK version override.                            |
 | `skip`         | `boolean` | Set to `true` to keep the config without generating this target. |
 | `destinations` | `object`  | GitHub destinations for generated output.                        |
 

--- a/documentation/guides/sdks/configuration/cpp.md
+++ b/documentation/guides/sdks/configuration/cpp.md
@@ -35,4 +35,4 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |

--- a/documentation/guides/sdks/configuration/csharp.md
+++ b/documentation/guides/sdks/configuration/csharp.md
@@ -10,7 +10,6 @@ Add `csharp` under `targets` to generate a .NET SDK package.
   "targets": {
     "csharp": {
       "packageName": "Acme.Api",
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-csharp"
@@ -34,7 +33,6 @@ Add `csharp` under `targets` to generate a .NET SDK package.
 | Property        | Type              | Description                                                      |
 | --------------- | ----------------- | ---------------------------------------------------------------- |
 | `packageName`   | `string`          | .NET package name.                                               |
-| `version`       | `string`          | Target-specific SDK version override.                            |
 | `skip`          | `boolean`         | Set to `true` to keep the config without generating this target. |
 | `destinations`  | `object`          | GitHub destinations for generated output.                        |
 | `publish`       | `object`          | NuGet publishing configuration.                                  |

--- a/documentation/guides/sdks/configuration/csharp.md
+++ b/documentation/guides/sdks/configuration/csharp.md
@@ -47,7 +47,7 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
 
 ## Publishing
 

--- a/documentation/guides/sdks/configuration/dart.md
+++ b/documentation/guides/sdks/configuration/dart.md
@@ -47,7 +47,7 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
 
 ## Publishing
 

--- a/documentation/guides/sdks/configuration/dart.md
+++ b/documentation/guides/sdks/configuration/dart.md
@@ -10,7 +10,6 @@ Add `dart` under `targets` to generate a Dart SDK package.
   "targets": {
     "dart": {
       "packageName": "acme",
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-dart"
@@ -34,7 +33,6 @@ Add `dart` under `targets` to generate a Dart SDK package.
 | Property       | Type              | Description                                                      |
 | -------------- | ----------------- | ---------------------------------------------------------------- |
 | `packageName`  | `string`          | Dart package name published to pub.dev.                          |
-| `version`      | `string`          | Target-specific SDK version override.                            |
 | `skip`         | `boolean`         | Set to `true` to keep the config without generating this target. |
 | `destinations` | `object`          | GitHub destinations for generated output.                        |
 | `publish`      | `object`          | pub.dev publishing configuration.                               |

--- a/documentation/guides/sdks/configuration/go.md
+++ b/documentation/guides/sdks/configuration/go.md
@@ -6,13 +6,14 @@ Add `go` under `targets` to generate a Go SDK package.
 {
   "targets": {
     "go": {
-      "packageName": "github.com/acme/acme-go",
-      "repo": "github.com/acme/acme-go",
-      "version": "1.0.0",
+      "packageName": "acmeapi",
       "destinations": {
         "production": {
           "repo": "acme/acme-go"
         }
+      },
+      "publish": {
+        "go": true
       }
     }
   }
@@ -21,13 +22,42 @@ Add `go` under `targets` to generate a Go SDK package.
 
 ## Target Options
 
-| Property       | Type      | Description                                                      |
-| -------------- | --------- | ---------------------------------------------------------------- |
-| `packageName`  | `string`  | Go module or package name.                                       |
-| `repo`         | `string`  | Repository where the generated target is intended to be published. |
-| `version`      | `string`  | Target-specific SDK version override.                            |
-| `skip`         | `boolean` | Set to `true` to keep the config without generating this target. |
-| `destinations` | `object`  | GitHub destinations for generated output.                        |
+| Property               | Type      | Description                                                      |
+| ---------------------- | --------- | ---------------------------------------------------------------- |
+| `packageName`          | `string`  | Go module or package name.                                       |
+| `goModulePathOverride` | `string`  | Module path written to `go.mod` and every generated import, when it must differ from the one derived from the destination repository. |
+| `pointerServices`      | `boolean` | Generate a pointer-shaped client surface. Defaults to `false`.   |
+| `skip`                 | `boolean` | Set to `true` to keep the config without generating this target. |
+| `destinations`         | `object`  | GitHub destinations for generated output.                        |
+| `publish`              | `object`  | Go module publishing configuration.                              |
+
+## Module Path
+
+The module path is normally derived from `destinations.production.repo`: `acme/acme-go` becomes `github.com/acme/acme-go`. Set `goModulePathOverride` when the path consumers import differs from the repository the code is pushed to — a vanity import domain, or a module served from a subdirectory.
+
+```json
+{
+  "targets": {
+    "go": {
+      "goModulePathOverride": "go.acme.com/api"
+    }
+  }
+}
+```
+
+## Client Shape
+
+By default the generated client is value-shaped: `NewClient` returns a `Client` and service fields are plain values. Set `pointerServices` to `true` for the pointer-shaped surface instead — `NewClient` returns `*Client` and service fields are `*XService`.
+
+```json
+{
+  "targets": {
+    "go": {
+      "pointerServices": true
+    }
+  }
+}
+```
 
 ## Destinations
 
@@ -52,3 +82,24 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
 | `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
+
+## Publishing
+
+Set `publish.go` to `true` to tag each release so the Go module proxy can serve it. Go has no registry upload and needs no secrets — see [Go publishing](../publishing/go.md).
+
+```json
+{
+  "targets": {
+    "go": {
+      "publish": {
+        "go": true
+      }
+    }
+  }
+}
+```
+
+| Property             | Description                                                   |
+| -------------------- | ------------------------------------------------------------- |
+| `authMethod`         | Registry authentication mechanism, such as `oidc` or `access-token`. |
+| `releaseEnvironment` | Release environment name used by generated publishing workflows. |

--- a/documentation/guides/sdks/configuration/go.md
+++ b/documentation/guides/sdks/configuration/go.md
@@ -51,4 +51,4 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |

--- a/documentation/guides/sdks/configuration/java.md
+++ b/documentation/guides/sdks/configuration/java.md
@@ -10,7 +10,6 @@ Add `java` under `targets` to generate a Java SDK package.
   "targets": {
     "java": {
       "reverseDomain": "com.acme",
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-java"
@@ -35,7 +34,6 @@ Add `java` under `targets` to generate a Java SDK package.
 | Property        | Type              | Description                                                      |
 | --------------- | ----------------- | ---------------------------------------------------------------- |
 | `reverseDomain` | `string`          | Java base package, such as `com.acme`.                           |
-| `version`       | `string`          | Target-specific SDK version override.                            |
 | `skip`          | `boolean`         | Set to `true` to keep the config without generating this target. |
 | `destinations`  | `object`          | GitHub destinations for generated output.                        |
 | `publish`       | `object`          | Maven publishing configuration.                                  |

--- a/documentation/guides/sdks/configuration/java.md
+++ b/documentation/guides/sdks/configuration/java.md
@@ -48,7 +48,7 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
 
 ## Publishing
 

--- a/documentation/guides/sdks/configuration/kotlin.md
+++ b/documentation/guides/sdks/configuration/kotlin.md
@@ -10,7 +10,6 @@ Add `kotlin` under `targets` to generate a Kotlin SDK package. Kotlin builds wit
   "targets": {
     "kotlin": {
       "reverseDomain": "com.acme",
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-kotlin"
@@ -34,7 +33,6 @@ Add `kotlin` under `targets` to generate a Kotlin SDK package. Kotlin builds wit
 | Property        | Type              | Description                                                      |
 | --------------- | ----------------- | ---------------------------------------------------------------- |
 | `reverseDomain` | `string`          | Kotlin base package, such as `com.acme`.                         |
-| `version`       | `string`          | Target-specific SDK version override.                            |
 | `skip`          | `boolean`         | Set to `true` to keep the config without generating this target. |
 | `destinations`  | `object`          | GitHub destinations for generated output.                        |
 | `publish`       | `object`          | Maven publishing configuration.                                  |

--- a/documentation/guides/sdks/configuration/kotlin.md
+++ b/documentation/guides/sdks/configuration/kotlin.md
@@ -47,7 +47,7 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
 
 ## Publishing
 

--- a/documentation/guides/sdks/configuration/php.md
+++ b/documentation/guides/sdks/configuration/php.md
@@ -56,4 +56,4 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |

--- a/documentation/guides/sdks/configuration/php.md
+++ b/documentation/guides/sdks/configuration/php.md
@@ -12,7 +12,6 @@ Add `php` under `targets` to generate a PHP SDK package.
       "packageName": "Acme\\Api",
       "composerPackageName": "acme/api",
       "composerRepositoryUrl": "https://repo.packagist.org",
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-php"
@@ -30,9 +29,9 @@ Add `php` under `targets` to generate a PHP SDK package.
 | `packageName`           | `string`  | PHP package namespace or name.                                   |
 | `composerPackageName`   | `string`  | Composer and Packagist package name, such as `acme/api`.         |
 | `composerRepositoryUrl` | `string`  | Composer repository URL for PHP package publishing.              |
-| `version`               | `string`  | Target-specific SDK version override.                            |
 | `skip`                  | `boolean` | Set to `true` to keep the config without generating this target. |
 | `destinations`          | `object`  | GitHub destinations for generated output.                        |
+| `publish`               | `object`  | Packagist publishing configuration.                              |
 
 ## Composer Package Names
 
@@ -57,3 +56,24 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
 | `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
+
+## Publishing
+
+Set `publish.packagist` to `true` to tag each release for Packagist. Packagist serves the package from the Git tag, so there is no upload step and no secret to add — see [PHP publishing](../publishing/php.md).
+
+```json
+{
+  "targets": {
+    "php": {
+      "publish": {
+        "packagist": true
+      }
+    }
+  }
+}
+```
+
+| Property             | Description                                                   |
+| -------------------- | ------------------------------------------------------------- |
+| `authMethod`         | Registry authentication mechanism, such as `oidc` or `access-token`. |
+| `releaseEnvironment` | Release environment name used by generated publishing workflows. |

--- a/documentation/guides/sdks/configuration/python.md
+++ b/documentation/guides/sdks/configuration/python.md
@@ -8,7 +8,6 @@ Add `python` under `targets` to generate a Python SDK package.
     "python": {
       "packageName": "acme_api",
       "projectName": "acme-api",
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-python"
@@ -33,7 +32,6 @@ Add `python` under `targets` to generate a Python SDK package.
 | ------------- | ----------------- | ---------------------------------------------------------------- |
 | `packageName` | `string`          | Python import package name, such as `acme_api`.                  |
 | `projectName` | `string`          | PyPI distribution name, such as `acme-api`. Defaults to `packageName`. |
-| `version`     | `string`          | Target-specific SDK version override.                            |
 | `skip`        | `boolean`         | Set to `true` to keep the config without generating this target. |
 | `destinations` | `object`          | GitHub destinations for generated output.                        |
 | `publish`     | `object`          | PyPI publishing configuration.                                   |

--- a/documentation/guides/sdks/configuration/python.md
+++ b/documentation/guides/sdks/configuration/python.md
@@ -63,7 +63,7 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
 
 ## Publishing
 

--- a/documentation/guides/sdks/configuration/ruby.md
+++ b/documentation/guides/sdks/configuration/ruby.md
@@ -47,7 +47,7 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
 
 ## Publishing
 

--- a/documentation/guides/sdks/configuration/ruby.md
+++ b/documentation/guides/sdks/configuration/ruby.md
@@ -10,7 +10,6 @@ Add `ruby` under `targets` to generate a Ruby SDK gem.
   "targets": {
     "ruby": {
       "gemName": "acme_api",
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-ruby"
@@ -34,7 +33,6 @@ Add `ruby` under `targets` to generate a Ruby SDK gem.
 | Property           | Type              | Description                                                      |
 | ------------------ | ----------------- | ---------------------------------------------------------------- |
 | `gemName`          | `string`          | Ruby gem name.                                                   |
-| `version`          | `string`          | Target-specific SDK version override.                            |
 | `skip`             | `boolean`         | Set to `true` to keep the config without generating this target. |
 | `destinations`     | `object`          | GitHub destinations for generated output.                        |
 | `publish`          | `object`          | RubyGems publishing configuration.                               |

--- a/documentation/guides/sdks/configuration/rust.md
+++ b/documentation/guides/sdks/configuration/rust.md
@@ -47,7 +47,7 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
 
 ## Publishing
 

--- a/documentation/guides/sdks/configuration/rust.md
+++ b/documentation/guides/sdks/configuration/rust.md
@@ -10,7 +10,6 @@ Add `rust` under `targets` to generate a Rust SDK crate.
   "targets": {
     "rust": {
       "packageName": "acme",
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-rust"
@@ -34,7 +33,6 @@ Add `rust` under `targets` to generate a Rust SDK crate.
 | Property        | Type              | Description                                                      |
 | --------------- | ----------------- | ---------------------------------------------------------------- |
 | `packageName`   | `string`          | Crate name published to crates.io.                              |
-| `version`       | `string`          | Target-specific SDK version override.                            |
 | `skip`          | `boolean`         | Set to `true` to keep the config without generating this target. |
 | `destinations`  | `object`          | GitHub destinations for generated output.                        |
 | `publish`       | `object`          | crates.io publishing configuration.                             |

--- a/documentation/guides/sdks/configuration/swift.md
+++ b/documentation/guides/sdks/configuration/swift.md
@@ -53,4 +53,4 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |

--- a/documentation/guides/sdks/configuration/swift.md
+++ b/documentation/guides/sdks/configuration/swift.md
@@ -9,12 +9,15 @@ Add `swift` under `targets` to generate a Swift SDK package.
 {
   "targets": {
     "swift": {
-      "version": "1.0.0",
+      "packageName": "AcmeAPI",
       "destinations": {
         "production": {
           "repo": "acme/acme-swift",
           "branch": "main"
         }
+      },
+      "publish": {
+        "swiftpm": true
       }
     }
   }
@@ -23,13 +26,12 @@ Add `swift` under `targets` to generate a Swift SDK package.
 
 ## Target Options
 
-Swift currently uses the shared target options from the SDK Generator config.
-
 | Property       | Type      | Description                                                      |
 | -------------- | --------- | ---------------------------------------------------------------- |
-| `version`      | `string`  | Target-specific SDK version override.                            |
+| `packageName`  | `string`  | Swift package name.                                              |
 | `skip`         | `boolean` | Set to `true` to keep the config without generating this target. |
 | `destinations` | `object`  | GitHub destinations for generated output.                        |
+| `publish`      | `object`  | Swift Package Manager publishing configuration.                  |
 
 ## Destinations
 
@@ -54,3 +56,24 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
 | `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
+
+## Publishing
+
+Set `publish.swiftpm` to `true` to tag each release for Swift Package Manager. There is no registry upload and no secret to add — see [Swift publishing](../publishing/swift.md).
+
+```json
+{
+  "targets": {
+    "swift": {
+      "publish": {
+        "swiftpm": true
+      }
+    }
+  }
+}
+```
+
+| Property             | Description                                                   |
+| -------------------- | ------------------------------------------------------------- |
+| `authMethod`         | Registry authentication mechanism, such as `oidc` or `access-token`. |
+| `releaseEnvironment` | Release environment name used by generated publishing workflows. |

--- a/documentation/guides/sdks/configuration/typescript.md
+++ b/documentation/guides/sdks/configuration/typescript.md
@@ -8,7 +8,6 @@ Add `typescript` under `targets` to generate a TypeScript SDK package.
     "typescript": {
       "packageName": "@acme/api",
       "packageManager": "pnpm",
-      "version": "1.0.0",
       "destinations": {
         "production": {
           "repo": "acme/acme-typescript",
@@ -34,11 +33,51 @@ Add `typescript` under `targets` to generate a TypeScript SDK package.
 | ---------------- | ----------------- | ---------------------------------------------------------------- |
 | `packageName`    | `string`          | Import and package name for the generated TypeScript package.    |
 | `packageManager` | `string`          | Package manager preference for generated package metadata.       |
-| `version`        | `string`          | Target-specific SDK version override.                            |
 | `skip`           | `boolean`         | Set to `true` to keep the config without generating this target. |
 | `destinations`   | `object`          | GitHub destinations for generated output.                        |
 | `publish`        | `object`          | npm publishing configuration.                                    |
 | `publish.npm`    | `boolean\|object` | npm registry publishing settings.                                |
+| `options`        | `object`          | TypeScript emitter options.                                      |
+| `compatibility`  | `string`          | Emit a compatibility module reproducing another generator's public surface. |
+
+## Emitter Options
+
+`options.propertyCasing` controls how generated properties and parameters are named.
+
+```json
+{
+  "targets": {
+    "typescript": {
+      "options": {
+        "propertyCasing": "sdk"
+      }
+    }
+  }
+}
+```
+
+| Value  | Description                                                                 |
+| ------ | --------------------------------------------------------------------------- |
+| `wire` | Default. Preserves the OpenAPI wire names, so `order_by` stays `order_by`.  |
+| `sdk`  | Emits the idiomatic name for the language — camelCase in TypeScript, so `orderBy` — and generates a wire↔SDK remap so request and response bodies stay correct on the network. |
+
+## Migrating From Another Generator
+
+Set `compatibility` to also emit a module of deprecated wrapper functions that reproduce another generator's public surface and forward to the generated SDK, so existing call sites keep compiling while you migrate. Omit it to emit nothing extra.
+
+```json
+{
+  "targets": {
+    "typescript": {
+      "compatibility": "speakeasy"
+    }
+  }
+}
+```
+
+| Value       | Description                                                            |
+| ----------- | ---------------------------------------------------------------------- |
+| `speakeasy` | Emits `src/compat/speakeasy.ts` with Speakeasy-style standalone functions returning a functional `Result`, matching Speakeasy's tree-shakable `funcs/` surface. |
 
 ## Destinations
 

--- a/documentation/guides/sdks/configuration/typescript.md
+++ b/documentation/guides/sdks/configuration/typescript.md
@@ -62,7 +62,7 @@ Use `destinations.production` to push generated output to a GitHub repository.
 | Property | Description                                                                 |
 | -------- | --------------------------------------------------------------------------- |
 | `repo`   | GitHub repository in `owner/name` form.                                     |
-| `branch` | Branch to push generated output to. Defaults to the repository default.     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
 
 ## Publishing
 

--- a/documentation/guides/sdks/custom-code.md
+++ b/documentation/guides/sdks/custom-code.md
@@ -6,39 +6,39 @@ This works on any target [linked to a GitHub repository](publishing/github.md).
 
 ## How it works
 
-Each build does a three-way merge: it compares the previously generated code, the newly generated code, and your repository's current state, then opens a pull request that combines the new generation with your edits. Untouched generated files update cleanly; your edits are preserved; brand-new files you added are left alone.
+Each build does a three-way merge: it compares the previously generated code, the newly generated code, and your repository's current state, then lands the combination on the `scalar-next` branch. Untouched generated files update cleanly; your edits are preserved; brand-new files you added are left alone.
 
 <scalar-steps>
   <scalar-step id="custom-edit" title="Edit the generated code">
 
-In your SDK repository, change generated files or add new ones, the same as any other code. Commit to the default branch as usual.
+In your SDK repository, change generated files or add new ones, the same as any other code. Commit to **`scalar-next`**, the integration branch — directly or through a pull request against it. Never commit to `scalar-generated`, which holds pristine generator output.
 
   </scalar-step>
 
   <scalar-step id="custom-rebuild" title="Rebuild">
 
-The next build regenerates from the latest OpenAPI document and merges your changes into the build's pull request. Your edits ride along instead of being overwritten.
+The next build regenerates from the latest OpenAPI document and merges your changes into `scalar-next`. Your edits ride along instead of being overwritten.
 
   </scalar-step>
 
   <scalar-step id="custom-review" title="Review and merge">
 
-Review the pull request as normal. Most changes merge automatically; only real conflicts need attention.
+Review the release pull request, which Scalar keeps open from `scalar-next` against your default branch. Most changes merge automatically; only real conflicts need attention.
 
   </scalar-step>
 </scalar-steps>
 
 ## Resolving conflicts
 
-A conflict happens when a regenerated file changes the same lines you edited (for example, you customized a method whose signature then changed in the API). When that happens, the target's build is marked as having conflicts, and you can resolve them two ways:
+A conflict happens when a regenerated file changes the same lines you edited (for example, you customized a method whose signature then changed in the API). When that happens, the target's build is marked as having conflicts and the merge is parked on the `scalar-merge-conflict` branch. You can resolve it two ways:
 
 - **In the dashboard**: open the target's conflicts view and pick the generated or your version for each conflicting file.
-- **In GitHub**: resolve the conflict on the pull request like any other Git merge conflict.
+- **In GitHub**: resolve the conflict on the `scalar-merge-conflict` pull request like any other Git merge conflict.
 
-Once resolved, the build continues and the pull request reflects the merged result.
+Once resolved, the merge lands on `scalar-next` and the release pull request reflects the merged result.
 
 ## Tips
 
 - **Keep custom code separate where you can.** New files in their own paths never conflict, so prefer adding a helper file over editing deep inside a generated one.
-- **Review every build pull request.** It is the single place where generated changes and your customizations come together, so it is the natural review point before anything releases or [publishes](publishing/overview.md).
+- **Review the release pull request.** It is the single place where generated changes and your customizations come together, so it is the natural review point before anything releases or [publishes](publishing/overview.md).
 - **Custom code is per repository.** Each target keeps its own customizations in its own repository.

--- a/documentation/guides/sdks/index.md
+++ b/documentation/guides/sdks/index.md
@@ -309,7 +309,7 @@ Every target gets a preview repository, provisioned automatically. Browse the ge
 
   <scalar-step id="step-repo" title="Link your own repository">
 
-Connect the repository where the SDK should live. Scalar authors commits through a GitHub App installation, never a personal token, and every build opens a pull request against the branch you nominate.
+Connect the repository where the SDK should live. Scalar authors commits through a GitHub App installation, never a personal token. Every build pushes generated output to `scalar-generated`, merges it with your custom code on `scalar-next`, and keeps a release pull request open against the branch you nominate.
 
 <scalar-image
   src="/sdks/github-linked.png"
@@ -321,7 +321,7 @@ Connect the repository where the SDK should live. Scalar authors commits through
 
   <scalar-step id="step-publish" title="Publish from your repository">
 
-release-please cuts version and changelog pull requests. When they merge, the release workflows in your repository publish the package. Your package names, registries, and release history stay yours. See [publishing](publishing/overview.md).
+release-please versions the release pull request from your commit history and maintains the changelog. When you merge it, the workflows in your repository cut the tag and GitHub Release and publish the package. Your package names, registries, and release history stay yours. See [publishing](publishing/overview.md).
 
   </scalar-step>
 

--- a/documentation/guides/sdks/managing.md
+++ b/documentation/guides/sdks/managing.md
@@ -41,7 +41,7 @@ Each target shows a live status: **pending** while it generates, **generated** o
 
   <scalar-step id="build-sync" title="Builds sync to GitHub">
 
-If a target is [linked to a repository](publishing/github.md), the build opens or updates a pull request there. If [publishing is enabled](publishing/overview.md), merging that pull request releases the version.
+If a target is [linked to a repository](publishing/github.md), the build pushes to `scalar-generated`, merges into `scalar-next`, and updates the release pull request against your default branch. If [publishing is enabled](publishing/overview.md), merging that release pull request tags and publishes the version.
 
   </scalar-step>
 </scalar-steps>
@@ -58,7 +58,7 @@ SDK versions are explicit, so you control exactly what is built and released.
 - **Active version**: set which version is live in the registry. Consumers and code samples resolve against the active version.
 - **Discard a draft**: delete an unbuilt draft without generating it.
 
-The version that ships to a package registry is the target's `version` (falling back to the SDK version). See [Publishing](publishing/overview.md#versioning-and-releases) for how versions become releases.
+The SDK version here controls what the dashboard builds and serves from the registry. The version that ships to a *package* registry is computed separately, by release-please from the commit history of your SDK repository — or set exactly by editing the release pull request title. See [Publishing](publishing/overview.md#versioning-and-releases).
 
 ## Downloading an SDK
 

--- a/documentation/guides/sdks/publishing/cli.md
+++ b/documentation/guides/sdks/publishing/cli.md
@@ -1,14 +1,17 @@
-# CLI (npm, Homebrew, macOS)
+# CLI (npm, binaries, Homebrew)
 
-The CLI target builds a Node-based command-line tool. Because it is a normal npm package (with a `bin`), the most common way to ship it is **npm**, so users can `npm install -g`. The release workflow can also attach the built tarball to the GitHub Release and update a [Homebrew](https://brew.sh/) tap. See the [CLI configuration](../cli.md) for options.
+The CLI target ships in two forms from one source tree. The **npm** package stays a normal Node CLI (with a `bin`), so users can `npm install -g`. The release workflow can also cross-compile **standalone executables** and attach them to the GitHub Release, and update a [Homebrew](https://brew.sh/) tap that installs them. See the [CLI configuration](../cli.md) for options.
 
 These three registry keys are independent, and you can enable any combination:
 
 | Key | What it does | Auth |
 | --- | ------------ | ---- |
 | `npm` | Publishes the package to npm for `npm install -g`. | OIDC (default) or token |
-| `macos` | Attaches the built tarball to the GitHub Release. | none (uses `GITHUB_TOKEN`) |
-| `homebrew` | Regenerates a Homebrew formula in a tap repo (it installs the npm tarball). | `HOMEBREW_TAP_TOKEN` |
+| `binaries` | Cross-compiles standalone executables and attaches them to the GitHub Release. | none (uses `GITHUB_TOKEN`) |
+| `homebrew` | Regenerates a Homebrew formula in a tap repo (it installs those executables). | `HOMEBREW_TAP_TOKEN` |
+
+> [!NOTE]
+> `binaries` replaces the older `macos` key. Configs that still set `macos` keep working — it is migrated to `binaries` automatically.
 
 ## Enable publishing
 
@@ -30,7 +33,7 @@ These three registry keys are independent, and you can enable any combination:
 
 The generated CLI is published to [npm](https://www.npmjs.com/) the same way as the [TypeScript SDK](typescript.md): OIDC trusted publishing by default, with an npm token as the fallback. Authenticate one of two ways.
 
-**Trusted publishing (OIDC), recommended.** On [npmjs.com](https://www.npmjs.com/), open the package and add a **Trusted Publisher → GitHub Actions** pointing at your [linked repository](github.md) and the workflow `sdk-release.yml`. Nothing is stored in your repo.
+**Trusted publishing (OIDC), recommended.** On [npmjs.com](https://www.npmjs.com/), open the package and add a **Trusted Publisher → GitHub Actions** pointing at your [linked repository](github.md) and the workflow **`release-please.yml`** — the workflow whose inline `publish` job does the automated publish. Nothing is stored in your repo. Add `sdk-release.yml` as a second trusted publisher only if you dispatch it to re-publish a tag by hand.
 
 ```json
 { "targets": { "cli": { "publish": { "npm": true } } } }
@@ -50,9 +53,21 @@ The generated CLI is published to [npm](https://www.npmjs.com/) the same way as 
 
 The npm publish step is idempotent (skips a version already on the registry) and publishes scoped packages with `--access public`.
 
+## Standalone binaries
+
+Set `binaries` to attach cross-compiled executables to the GitHub Release. They are built with `bun build --compile`, which embeds the Bun runtime and every dependency, so they run on a machine with no Node and no `node_modules`.
+
+```json
+{ "targets": { "cli": { "publish": { "binaries": true } } } }
+```
+
+Five platforms are built from a single runner: `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, and `windows-x64`. Unix targets ship as `<binary>-<platform>.tar.gz`, Windows as a `.zip`. Asset names carry no version — the release tag in the download path already does — so `releases/latest/download/<name>` keeps resolving without rewriting your install instructions each release.
+
+The upload uses the built-in `GITHUB_TOKEN`, so no secret is needed, and runs with `--clobber`, so re-runs are idempotent.
+
 ## Homebrew
 
-Homebrew installs the tarball attached to the GitHub Release, so enabling it also attaches the asset.
+Homebrew installs the executables attached to the GitHub Release, so enabling it also builds and attaches them (the four Unix targets; Windows is only published when you enable `binaries` as well). Because each executable is self-contained, the formula declares no `depends_on` — `brew install` does not pull in Node.
 
 <scalar-steps>
   <scalar-step id="brew-tap" title="Create a tap repository">
@@ -74,12 +89,22 @@ Add the token as a repository secret named **`HOMEBREW_TAP_TOKEN`** on the **SDK
   </scalar-step>
 </scalar-steps>
 
-## macOS
-
-Set `macos` to attach the built tarball to the GitHub Release without a Homebrew formula. It uses the built-in `GITHUB_TOKEN`, so no secret is needed.
+You can override the formula's metadata from the `homebrew` entry:
 
 ```json
-{ "targets": { "cli": { "publish": { "macos": true } } } }
+{
+  "targets": {
+    "cli": {
+      "publish": {
+        "homebrew": {
+          "tapRepo": "acme/homebrew-tap",
+          "homepage": "https://acme.com/cli",
+          "description": "The Acme command-line interface"
+        }
+      }
+    }
+  }
+}
 ```
 
 ## How consumers install it
@@ -92,7 +117,9 @@ npm install -g acme
 brew install acme/tap/acme
 ```
 
+Or download the executable for their platform straight from the GitHub Release.
+
 ## Notes
 
-- The CLI release workflow is the only one that requests `contents: write`, because it can upload release assets.
-- The Homebrew formula is rewritten in full each release, so it works on the first publish and is a no-op when nothing changed. The release upload uses `--clobber`, so re-runs are idempotent.
+- The CLI is the only target whose publish job can request `contents: write`, and only when `binaries` or `homebrew` is enabled, because it uploads release assets. An npm-only CLI release stays at the read-only floor.
+- The Homebrew formula is rewritten in full each release, so it works on the first publish and is a no-op when nothing changed.

--- a/documentation/guides/sdks/publishing/csharp.md
+++ b/documentation/guides/sdks/publishing/csharp.md
@@ -27,8 +27,10 @@ Recommended. The release workflow uses the `NuGet/login` action to mint a short-
 On [nuget.org](https://www.nuget.org/), open **Account → Trusted Publishing** and add a policy for:
 
 - **Repository owner and name**: your [linked repository](github.md)
-- **Workflow file**: `sdk-release.yml`
+- **Workflow file**: `release-please.yml`
 - **Environment**: leave blank (unless you set `releaseEnvironment`)
+
+The automated publish runs as the `publish` job inside `release-please.yml`, so that is the workflow NuGet sees. If you also dispatch `sdk-release.yml` to re-publish a tag by hand, add it as a second policy.
 
   </scalar-step>
 

--- a/documentation/guides/sdks/publishing/github.md
+++ b/documentation/guides/sdks/publishing/github.md
@@ -1,6 +1,6 @@
 # GitHub Repositories
 
-Each target can be linked to its own GitHub repository. Once linked, every build syncs to that repository as a pull request, and merging it is what triggers [publishing](overview.md). Linking a repository is the prerequisite for publishing, but it is useful on its own: it gives every generated SDK a home, a review step, and a history.
+Each target can be linked to its own GitHub repository. Once linked, every build syncs to that repository, and merging the release pull request is what triggers [publishing](overview.md). Linking a repository is the prerequisite for publishing, but it is useful on its own: it gives every generated SDK a home, a review step, and a history.
 
 ## Connect a repository
 
@@ -34,7 +34,7 @@ Click **Connect repository**. From now on, every successful build pushes the gen
 
 ## How syncing works
 
-Builds never commit straight to your default branch. Each build opens (or updates) a **pull request** against the **default branch** you configure, so you always review generated changes before they land.
+Builds never commit straight to your default branch. The repository follows a three-branch flow that Scalar manages together with the generated workflows, all of which run on the default `GITHUB_TOKEN` — no extra token to provision.
 
 <scalar-image
   src="/sdks/github-linked.png"
@@ -42,15 +42,24 @@ Builds never commit straight to your default branch. Each build opens (or update
   size="full">
 </scalar-image>
 
-- **Default branch**: new builds open a pull request against this branch (`main` by default). Merging that pull request is what releases and publishes the version.
-- **Synced versions**: the target lists each SDK version next to the pull request and commit that delivered it, so you can trace a published version back to its build.
+- **`scalar-generated`** holds pristine generator output. Scalar pushes here; you never commit to it.
+- **`scalar-next`** holds that output merged with your custom code. This is where you commit your own changes, directly or through pull requests, and where Scalar merges each regeneration.
+- **The default branch** (`main` unless you configure otherwise) only ever receives released states. Scalar keeps a **release pull request** open from `scalar-next` against it, so the diff you review is the entire pending release. Merging that pull request is what releases and publishes the version.
+- **`scalar-merge-conflict`** carries a regeneration that could not be merged cleanly; it arrives as a pull request for you to resolve.
+
+**Synced versions**: the target lists each SDK version next to the pull request and commit that delivered it, so you can trace a published version back to its build.
 
 > [!NOTE]
 > Linking only controls where generated code goes. Turn on **Publish to \<registry\> on merge** (or add a `publish` block to the target) to also push the package to its registry. See [Publishing](overview.md).
 
 ## Your custom code is preserved
 
-You can edit generated files in your repository. Scalar performs a three-way merge on every regeneration, so your changes are carried forward into the next build's pull request instead of being overwritten. Review the pull request as usual; only genuine conflicts need your attention.
+You can edit generated files in your repository on `scalar-next`. Scalar performs a three-way merge on every regeneration, so your changes are carried forward into the next release pull request instead of being overwritten. Review it as usual; only genuine conflicts need your attention. See [Custom Code](../custom-code.md).
+
+## Repository prerequisites
+
+- Branch protection on `scalar-next` and the default branch must allow the Scalar app and the `github-actions` bot to push, or be left unprotected. The default branch only ever advances by merging a release pull request, and `scalar-next` receives each released state back from the release workflow.
+- No Actions settings changes are required: the generated workflows declare their own permissions and never create pull requests.
 
 ## Configuration equivalent
 
@@ -74,11 +83,11 @@ Linking from the dashboard sets the target's `destinations` in your SDK configur
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | `repo` | `string` | The `owner/repo` the generated SDK is pushed to. |
-| `branch` | `string` | The branch builds open pull requests against. Defaults to `main`. |
+| `branch` | `string` | The repository's default branch, which releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
 
 ## Adding repository secrets
 
-[OIDC trusted publishing](registries.md) needs no secrets. Token-based publishing, and Maven Central's GPG signing, store credentials as secrets on the SDK repository. The generated `sdk-release.yml` workflow reads them by exact name, so the name has to match.
+[OIDC trusted publishing](registries.md) needs no secrets. Token-based publishing, and Maven Central's GPG signing, store credentials as secrets on the SDK repository. The generated workflows read them by exact name, so the name has to match.
 
 <scalar-steps>
   <scalar-step id="secret-open" title="Open the repository's Actions secrets">

--- a/documentation/guides/sdks/publishing/go.md
+++ b/documentation/guides/sdks/publishing/go.md
@@ -2,7 +2,7 @@
 
 Go modules have no central registry. A module is "published" by tagging a version in its repository, and the [Go module proxy](https://proxy.golang.org/) serves it from there. See the [Go configuration](../configuration/go.md) for module path options.
 
-Because of this, the Go target needs **no registry account, no token, and no secrets**. There is no release workflow to set up. The `vX.Y.Z` Git tag and GitHub Release that Scalar creates when you merge a build *are* the published version.
+Because of this, the Go target needs **no registry account, no token, and no secrets**. The `vX.Y.Z` Git tag and GitHub Release cut when you merge the release pull request *are* the published version.
 
 ## Enable publishing
 
@@ -17,7 +17,9 @@ Because of this, the Go target needs **no registry account, no token, and no sec
 }
 ```
 
-This adds the `VERSIONING.md` note and ensures every merged build is tagged. The generated `sdk-ci.yml` still builds and vets the module on each pull request.
+This adds the `VERSIONING.md` note and ensures every release is tagged. The generated `sdk-ci.yml` builds and vets the module on each pull request.
+
+Go is the one tag-served target that still gets a release workflow, but it uploads nothing. After the tag is cut, the `publish` job asks the public Go module proxy for the new version so it is cached (and indexed on pkg.go.dev) immediately, instead of on the first consumer's `go get`. It reads the module path out of `go.mod` at run time and is best-effort: a private repository is invisible to the public proxy, and a failed warm-up never fails the release.
 
 ## How consumers install it
 

--- a/documentation/guides/sdks/publishing/overview.md
+++ b/documentation/guides/sdks/publishing/overview.md
@@ -1,6 +1,6 @@
 # Publishing
 
-Scalar publishes your generated SDKs to their package registries for you. Instead of running `npm publish` by hand, Scalar writes GitHub Actions workflows into your SDK repository and drives them from your SDK configuration. When you merge a build, the package goes out.
+Scalar publishes your generated SDKs to their package registries for you. Instead of running `npm publish` by hand, Scalar writes GitHub Actions workflows into your SDK repository and drives them from your SDK configuration. When you merge a release, the package goes out.
 
 Publishing is **opt-in** and **off by default**. Nothing is published until you turn it on for a target.
 
@@ -23,35 +23,44 @@ Turn on publishing for a target, either from the dashboard or in your [SDK confi
 
   <scalar-step id="step-build" title="Build the SDK">
 
-Each build generates the SDK and opens a pull request against your [linked repository's](github.md) default branch. The pull request includes the generated `.github/workflows` so the publishing logic lives in your repo, not in a black box.
+Each build generates the SDK, pushes it to the `scalar-generated` branch of your [linked repository](github.md), and merges it with your custom code on `scalar-next`. The generated `.github/workflows` land in the repository too, so the publishing logic lives in your repo, not in a black box.
 
   </scalar-step>
 
-  <scalar-step id="step-merge" title="Merge the pull request">
+  <scalar-step id="step-release-pr" title="Review the release pull request">
 
-When you merge, Scalar creates a GitHub Release tagged `vX.Y.Z` for that version.
+Scalar keeps a **release pull request** open from `scalar-next` against your default branch, titled `release: X.Y.Z`. Its diff is the full pending release: generated changes, your custom code, the changelog, and the version bump.
 
   </scalar-step>
 
-  <scalar-step id="step-publish" title="The release workflow publishes">
+  <scalar-step id="step-merge" title="Merge the release pull request">
 
-The release triggers `sdk-release.yml` in your repository, which builds the package and publishes it to the registry. The publish step is idempotent: if that version is already on the registry, it is skipped, so re-merges and re-runs never fail or double-publish.
+Merging runs `release-please.yml` on the default branch, which cuts the `vX.Y.Z` tag, updates `CHANGELOG.md`, and creates the GitHub Release.
+
+  </scalar-step>
+
+  <scalar-step id="step-publish" title="The publish job publishes">
+
+In the same workflow run, the inline `publish` job checks out the tag that was just cut and publishes the package to its registry, then the release is synced back to `scalar-next`. The publish step is idempotent: if that version is already on the registry, it is skipped, so re-runs never fail or double-publish.
 
   </scalar-step>
 </scalar-steps>
 
 ## What gets generated
 
-Every target with a linked repository gets two workflows committed alongside the SDK. They are normal, readable workflow files you can inspect (and edit) in your repo.
+Every target with a linked repository gets its release machinery committed alongside the SDK. They are normal, readable files you can inspect (and edit) in your repo.
 
 | File | Trigger | What it does |
 | ---- | ------- | ------------ |
-| `.github/workflows/sdk-ci.yml` | `push`, `pull_request` | Installs dependencies and builds the SDK so every build pull request is checked. |
-| `.github/workflows/sdk-release.yml` | `release: published` | Publishes the package to its registry. Only generated when publishing is enabled. |
-| `VERSIONING.md` | — | Notes the versioning policy for the repository. |
+| `.github/workflows/sdk-ci.yml` | `push`, `pull_request` | Installs dependencies and builds the SDK so every change is checked. |
+| `.github/workflows/release-please.yml` | `push` to the default branch | Cuts the tag, changelog, and GitHub Release when a release pull request merges, publishes from its inline `publish` job, and syncs the release back to `scalar-next`. |
+| `.github/workflows/release-title-edit.yml` | `pull_request` | Runs the `Release PR version` check and turns an edited release-pull-request title into the `Release-As` commit Scalar re-renders the pull request from. |
+| `.github/workflows/sdk-release.yml` | `workflow_dispatch` | Manually re-publishes an existing tag. Only generated when the target publishes at release time. |
+| `release-please-config.json`, `.release-please-manifest.json` | — | release-please's configuration and version state. The manifest is seeded once and then owned by your repository. |
+| `VERSIONING.md` | — | Documents the branch model, how to pick an exact version, and the repository prerequisites. |
 
 > [!NOTE]
-> Tag-served ecosystems (Go, Swift, Packagist) do not get a release workflow. For those, the `vX.Y.Z` Git tag and GitHub Release *are* the publish. See [Package Registries](registries.md).
+> Tag-served ecosystems (Swift Package Manager, Packagist) have nothing to upload, so they get no `publish` job and no `sdk-release.yml`. For those, the `vX.Y.Z` tag and GitHub Release *are* the publish. Go is tag-served too, but still gets a release workflow, which warms the public module proxy after the tag. See [Package Registries](registries.md).
 
 ## Enable publishing
 
@@ -66,7 +75,6 @@ You can enable publishing two ways. Both set the same thing.
   "targets": {
     "typescript": {
       "packageName": "demo-api",
-      "version": "0.3.1",
       "publish": {
         "npm": true
       }
@@ -83,21 +91,42 @@ You can enable publishing two ways. Both set the same thing.
 
 The registry key depends on the target (`npm`, `pypi`, `cargo`, `maven`, and so on). For the full list and per-registry options, see [Package Registries](registries.md). Each target documents its `publish` options on its [configuration page](../configuration.md).
 
+Publishing requires a [linked repository](github.md): a target with no `destinations.production` gets no workflows at all.
+
 ## Authentication
 
-By default Scalar uses **OIDC trusted publishing**. The release workflow exchanges a short-lived GitHub identity token for a registry credential at publish time, so there is **no token to create, store, or rotate**. You register your repository and the `sdk-release.yml` workflow as a trusted publisher on the registry once.
+By default Scalar uses **OIDC trusted publishing** wherever the registry supports it. The publish job exchanges a short-lived GitHub identity token for a registry credential at publish time, so there is **no token to create, store, or rotate**. You register your repository and workflow as a trusted publisher on the registry once.
 
-Registries that do not support OIDC (and Maven Central, which needs GPG signing) use repository secrets instead. Setup for each registry is covered in [Package Registries](registries.md).
+> [!IMPORTANT]
+> Register **`release-please.yml`** as the trusted publisher's workflow, not `sdk-release.yml`. The automated publish runs as a job inside `release-please.yml`, so that is the file the OIDC claims name. `sdk-release.yml` exists for manual re-publishes; register it as an *additional* trusted publisher only if you use it.
+
+Registries that do not support OIDC (RubyGems, and Maven Central, which also requires GPG signing) use repository secrets instead. Setup for each registry is covered in [Package Registries](registries.md).
 
 ## Versioning and releases
 
-Versioning is **driven by your configuration**, not inferred from commit messages. The version that ships is the target's `version` (falling back to the SDK version). Bump it when you want a new release; every merged build is tagged and released as `vX.Y.Z`.
+Versions are computed by release-please **from your commit history**, following [Conventional Commits](https://www.conventionalcommits.org). Scalar writes conventional commit messages describing what actually changed in the SDK surface, and your own commits on `scalar-next` count too. Pre-1.0, breaking changes bump the minor version instead of jumping to `1.0.0`.
 
-Scalar creates a GitHub Release for each version and maintains a `CHANGELOG.md` in the repository, so your release history lives in your repo next to the code.
+To ship an exact version instead, **edit the release pull request title**:
+
+```text
+release: 1.0.0
+```
+
+The `Release PR version` check goes red while the title and the committed version disagree, Scalar re-renders the pull request at your version, and the check goes green. Wait for green before merging. The git-native equivalent is an empty commit on `scalar-next` with a `Release-As: 1.0.0` footer.
+
+Every release gets a `vX.Y.Z` tag, a GitHub Release, and an entry in the repository's `CHANGELOG.md`, so your release history lives in your repo next to the code. The generated `VERSIONING.md` documents all of this for your maintainers.
 
 ## Permissions
 
-The generated release workflow requests only the permissions it needs:
+The generated workflows request only the permissions they need. `release-please.yml` needs to write the tag, changelog, and Release:
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+Its `publish` job then narrows that down to the publishing floor:
 
 ```yaml
 permissions:
@@ -106,14 +135,14 @@ permissions:
   packages: write
 ```
 
-`id-token: write` is what enables OIDC trusted publishing. The CLI target uses `contents: write` instead, because it uploads built binaries to the GitHub Release. Scalar never asks for organization-wide access to publish.
+`id-token: write` is what enables OIDC trusted publishing. The CLI target keeps `contents: write` on the publish job when it attaches binaries or updates a Homebrew tap, because it uploads assets to the GitHub Release. Scalar never asks for organization-wide access to publish.
 
 ## Next steps
 
 <scalar-steps>
   <scalar-step id="next-github" title="Link a GitHub repository" interactivity="none">
 
-Connect each target to a repository so builds sync as pull requests. See [GitHub Repositories](github.md).
+Connect each target to a repository so builds sync to it. See [GitHub Repositories](github.md).
 
   </scalar-step>
   <scalar-step id="next-registries" title="Set up the registry" interactivity="none">

--- a/documentation/guides/sdks/publishing/python.md
+++ b/documentation/guides/sdks/publishing/python.md
@@ -31,8 +31,10 @@ On [pypi.org](https://pypi.org/), open your project's **Publishing** tab (for a 
 
 - **Owner**: the owner of your [linked repository](github.md)
 - **Repository name**: the repository name
-- **Workflow name**: `sdk-release.yml`
+- **Workflow name**: `release-please.yml`
 - **Environment**: leave blank (unless you set `releaseEnvironment`)
+
+The automated publish runs as the `publish` job inside `release-please.yml`, so that is the workflow PyPI sees. If you also dispatch `sdk-release.yml` to re-publish a tag by hand, add it as a second publisher.
 
   </scalar-step>
 

--- a/documentation/guides/sdks/publishing/registries.md
+++ b/documentation/guides/sdks/publishing/registries.md
@@ -6,26 +6,26 @@ For how publishing works end to end, see [Publishing](overview.md).
 
 ## Quick reference
 
-| Target | Registry | Default auth | Secrets to add |
-| ------ | -------- | ------------ | -------------- |
-| [TypeScript](typescript.md) | npm | OIDC | none (OIDC) or `NPM_TOKEN` |
-| [Python](python.md) | PyPI | OIDC | none (OIDC) or `PYPI_API_TOKEN` |
-| [Go](go.md) | Go modules | Git tag | none |
-| [Rust](rust.md) | crates.io | OIDC | none (OIDC) or `CARGO_REGISTRY_TOKEN` |
-| [Java and Kotlin](java.md) | Maven Central | Token + GPG | `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `MAVEN_GPG_PRIVATE_KEY`, `MAVEN_GPG_PASSPHRASE` |
-| [C#](csharp.md) | NuGet | OIDC | `NUGET_USER` (OIDC) or `NUGET_API_KEY` |
-| [Ruby](ruby.md) | RubyGems | API key | `RUBYGEMS_API_KEY` |
-| [PHP](php.md) | Packagist | Git tag | none |
-| [Swift](swift.md) | Swift Package Manager | Git tag | none |
-| [Dart](dart.md) | pub.dev | OIDC | none (OIDC) or `PUB_TOKEN` |
-| [CLI](cli.md) | npm / Homebrew / macOS | OIDC or token | none (npm OIDC) or `NPM_TOKEN`, plus `HOMEBREW_TAP_TOKEN` for Homebrew |
-| C++ | — | — | none (built in CI, no registry) |
+| Target | `publish` key | Registry | Default auth | Secrets to add |
+| ------ | ------------- | -------- | ------------ | -------------- |
+| [TypeScript](typescript.md) | `npm` | npm | OIDC | none (OIDC) or `NPM_TOKEN` |
+| [Python](python.md) | `pypi` | PyPI | OIDC | none (OIDC) or `PYPI_API_TOKEN` |
+| [Go](go.md) | `go` | Go modules | Git tag | none |
+| [Rust](rust.md) | `cargo` | crates.io | OIDC | none (OIDC) or `CARGO_REGISTRY_TOKEN` |
+| [Java and Kotlin](java.md) | `maven` | Maven Central | Token + GPG | `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`, `MAVEN_GPG_PRIVATE_KEY`, `MAVEN_GPG_PASSPHRASE` |
+| [C#](csharp.md) | `nuget` | NuGet | OIDC | `NUGET_USER` (OIDC) or `NUGET_API_KEY` |
+| [Ruby](ruby.md) | `rubygems` | RubyGems | API key | `RUBYGEMS_API_KEY` |
+| [PHP](php.md) | `packagist` | Packagist | Git tag | none |
+| [Swift](swift.md) | `swiftpm` | Swift Package Manager | Git tag | none |
+| [Dart](dart.md) | `pub` | pub.dev | OIDC | none (OIDC) or `PUB_TOKEN` |
+| [CLI](cli.md) | `npm`, `binaries`, `homebrew` | npm / GitHub Release / Homebrew | OIDC or token | none (npm OIDC) or `NPM_TOKEN`, plus `HOMEBREW_TAP_TOKEN` for Homebrew |
+| C++ | — | — | — | none (built in CI, no registry) |
 
 ## Two ways to authenticate
 
-Most registries support both options. Pick one per target.
+Registries that support OIDC (`npm`, `pypi`, `cargo`, `nuget`, `pub`) default to it. Pick one option per target.
 
-- **OIDC trusted publishing** (recommended where available): the `sdk-release.yml` workflow proves its identity to the registry with a short-lived GitHub token, so there is **nothing to store or rotate**. You register the repository and workflow as a trusted publisher on the registry once. This is the default when you set `"<registry>": true`.
+- **OIDC trusted publishing** (the default where available): the `publish` job proves its identity to the registry with a short-lived GitHub token, so there is **nothing to store or rotate**. You register the repository and workflow as a trusted publisher on the registry once. This is what `"<registry>": true` gives you.
 - **API token / key**: you create a token on the registry and add it as a [repository secret](github.md#adding-repository-secrets). Switch a target to this with `authMethod: "access-token"`. Maven Central and RubyGems only support this style; Maven Central also requires a GPG key for signing.
 
 ```json
@@ -38,8 +38,11 @@ Most registries support both options. Pick one per target.
 }
 ```
 
+> [!IMPORTANT]
+> When you register a trusted publisher, the workflow filename is **`release-please.yml`** — the workflow whose inline `publish` job does the automated publish. `sdk-release.yml` is the manual re-publish path; add it as a second trusted publisher only if you dispatch it.
+
 > [!NOTE]
-> Tag-served ecosystems (Go, Swift, Packagist) have no upload step and no secrets. The `vX.Y.Z` Git tag and GitHub Release that Scalar creates on merge are the published version.
+> Tag-served ecosystems (Swift Package Manager, Packagist) have no upload step and no secrets. The `vX.Y.Z` Git tag and GitHub Release cut when a release pull request merges are the published version. Go is served from its tag too, but still gets a release workflow that warms the public module proxy.
 
 ## C++
 

--- a/documentation/guides/sdks/publishing/rust.md
+++ b/documentation/guides/sdks/publishing/rust.md
@@ -27,8 +27,10 @@ Recommended. The release workflow uses `rust-lang/crates-io-auth-action` to exch
 On [crates.io](https://crates.io/), open the crate's **Settings → Trusted Publishing** and add a **GitHub** publisher:
 
 - **Repository owner and name**: your [linked repository](github.md)
-- **Workflow filename**: `sdk-release.yml`
+- **Workflow filename**: `release-please.yml`
 - **Environment**: leave blank (unless you set `releaseEnvironment`)
+
+The automated publish runs as the `publish` job inside `release-please.yml`, so that is the workflow crates.io sees. If you also dispatch `sdk-release.yml` to re-publish a tag by hand, add it as a second publisher.
 
   </scalar-step>
 

--- a/documentation/guides/sdks/publishing/swift.md
+++ b/documentation/guides/sdks/publishing/swift.md
@@ -2,7 +2,7 @@
 
 Swift packages are distributed through the Swift Package Manager, which resolves them straight from a Git tag. There is no central registry to upload to. See the [Swift configuration](../configuration/swift.md) for options.
 
-Like Go, the Swift target needs **no registry account, no token, and no secrets**, and gets no release workflow. The `vX.Y.Z` Git tag and GitHub Release that Scalar creates on merge are the published version.
+The Swift target needs **no registry account, no token, and no secrets**, and gets no `publish` job or `sdk-release.yml`. The `vX.Y.Z` Git tag and GitHub Release cut when you merge the release pull request are the published version.
 
 ## Enable publishing
 
@@ -17,7 +17,7 @@ Like Go, the Swift target needs **no registry account, no token, and no secrets*
 }
 ```
 
-This adds the `VERSIONING.md` note and ensures every merged build is tagged. The generated `sdk-ci.yml` builds and tests the package on each pull request.
+This adds the `VERSIONING.md` note and ensures every release is tagged. The generated `sdk-ci.yml` builds and tests the package on each pull request.
 
 ## How consumers install it
 

--- a/documentation/guides/sdks/publishing/typescript.md
+++ b/documentation/guides/sdks/publishing/typescript.md
@@ -19,7 +19,7 @@ Turn on **Publish to npm on merge** in the target's Git settings, or add a `publ
 }
 ```
 
-With `"npm": true`, OIDC is used by default. Once enabled, merging a build publishes the package.
+With `"npm": true`, OIDC is used by default. Once enabled, merging the release pull request publishes the package.
 
 ## Trusted publishing (OIDC)
 
@@ -38,8 +38,10 @@ On [npmjs.com](https://www.npmjs.com/), open the package, then **Settings → Tr
 
 - **Organization or user**: the owner of your [linked repository](github.md)
 - **Repository**: the repository name
-- **Workflow filename**: `sdk-release.yml`
+- **Workflow filename**: `release-please.yml`
 - **Environment**: leave blank (unless you set `releaseEnvironment`)
+
+The automated publish runs as the `publish` job inside `release-please.yml`, so that is the workflow npm sees. If you also dispatch `sdk-release.yml` to re-publish a tag by hand, add it as a second trusted publisher.
 
   </scalar-step>
 


### PR DESCRIPTION
## Problem

The SDK guides drifted from the generator in two ways.

**The publishing flow was described as it worked before release-please landed**, and one gap is actively breaking: every OIDC trusted-publisher page tells you to register `sdk-release.yml`. The automated publish now runs as an inline `publish` job inside `release-please.yml`, so that is the file the OIDC claims name — following the docs means the trusted publisher never matches and every automated publish fails auth. Alongside it: builds were documented as opening a pull request per build against the default branch (they push to `scalar-generated` and merge onto `scalar-next`), `custom-code.md` told people to commit to the default branch, versioning was described as "driven by your configuration, not inferred from commit messages" (the opposite of what release-please does), and the CLI's `publish.macos` key had been renamed to `binaries`.

**The configuration pages drifted from `scalar-sdk.config.schema.json`.** All 14 pages document a `version` key that does not exist in the config at all — not top-level, not per-target, not in the IR. Go's `goModulePathOverride` and `pointerServices`, TypeScript's `options.propertyCasing` and `compatibility`, the CLI's `shellCompletions`, and the root `diagnostics` block were undocumented; Go, Swift, and PHP had no publishing section; Swift had no `packageName`; and Go's example set `repo` at the target level instead of `destinations.production.repo`.

## Solution

Checked every claim against the generator source rather than editing prose in place: `emitters/core/src/lifecycle.ts` and `release-please.ts`, the per-target `templates/*/lifecycle/*.yml`, `packages/config/src/scalar-sdk.config.schema.json`, the registry-auth defaults in `packages/ir-compiler`, and the emitted fixture snapshots.

**Publishing**

- Rewrote `publishing/overview.md`: three-branch flow, the full generated file set (`release-please.yml`, `release-title-edit.yml`, `release-please-config.json`, `.release-please-manifest.json`), conventional-commit versioning with the release-PR title override, and the real permission blocks.
- Pointed every trusted-publisher registration at `release-please.yml`, with `sdk-release.yml` reframed as the optional `workflow_dispatch` re-publish path.
- Rewrote the branch model in `publishing/github.md`, `custom-code.md`, `index.md`, and `managing.md`.
- Renamed the CLI publish key to `binaries` (noting the automatic migration) and documented the five cross-compiled targets and the Node-free Homebrew formula.
- Corrected `destinations.branch` across all target pages; noted that Go still gets a release workflow for the module-proxy warm-up, so only SwiftPM and Packagist are publish-job-free.

**Configuration** — the second commit fixes what a new drift checker found. The checker lives in the generator repo (`scalar/bane`, branch `claude/sdk-docs-updates-h3udwo`) since that is where the schema lives, and runs as `bun run check:docs-config <path-to-documentation/guides/sdks>`. It walks each guide against its schema node in both directions and validates JSON examples path-aware, so a removed key is caught while a user-named map key (a resource or method name) stays quiet. It reports 43 drifted properties against `main` and is clean against this branch.

Secret names were all verified correct as already documented (`NPM_TOKEN`, `PYPI_API_TOKEN`, `CARGO_REGISTRY_TOKEN`, `NUGET_USER`/`NUGET_API_KEY`, `RUBYGEMS_API_KEY`, `PUB_TOKEN`, the four `MAVEN_*`, `HOMEBREW_TAP_TOKEN`). Internal links and heading anchors validated across the guide.

### Two things left for someone with more context

- **Dart OIDC may be broken in the generator, not the docs.** pub.dev validates that the OIDC token's `ref` is the version tag, but `release-please.yml` triggers on a push to the default branch and only *checks out* the tag, so `github.ref` is `refs/heads/main`. If that is right the fix belongs in the emitter. Left undocumented rather than guessed at.
- **`targets.cli.packageName` is missing from the schema** even though `binaryName`'s own description refers to it and the CLI publishing page uses it. Looks like a schema gap; not fixed here.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- docs-only, no package affected -->
- [ ] I added tests. <!-- not applicable; the drift checker in scalar/bane covers the config pages -->
- [x] I updated the documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime code, but they correct OIDC setup that would otherwise block automated registry publishes.
> 
> **Overview**
> Brings SDK guides in line with the **release-please** GitHub flow and the current config schema so setup steps match what the generator actually emits.
> 
> **Publishing and GitHub sync** — Docs now describe builds pushing to `scalar-generated`, merging on `scalar-next`, and a standing **release PR** to the default branch (not one PR per build). **OIDC trusted publisher** instructions across npm, PyPI, NuGet, crates.io, and CLI now point at **`release-please.yml`** (inline `publish` job); `sdk-release.yml` is documented only as optional manual re-publish. Overview adds generated workflows (`release-title-edit.yml`, release-please manifests), **conventional-commit** package versioning with release-PR title override, and clarifies tag-served targets (Go proxy warm-up vs SwiftPM/Packagist with no upload job). CLI **`publish.macos`** is **`binaries`** (with migration note) plus standalone cross-compile/Homebrew behavior.
> 
> **Configuration** — Removes documented **`version`** keys that are not in the schema; documents root **`diagnostics`**, TypeScript **`options.propertyCasing`** / **`compatibility`**, CLI **`shellCompletions`**, Go **`goModulePathOverride`** / **`pointerServices`**, and publishing sections for Go, PHP, and Swift. **`destinations.branch`** is described as the release promotion branch, with generated output always on `scalar-generated`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4cba318ee44b34d4cfff287726da67c82dd9be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->