### PR TITLE
docs(sdks): correct publish ordering and tag-served publish options

### DIFF
--- a/documentation/guides/sdks/configuration/go.md
+++ b/documentation/guides/sdks/configuration/go.md
@@ -101,5 +101,7 @@ Set `publish.go` to `true` to tag each release so the Go module proxy can serve 
 
 | Property             | Description                                                   |
 | -------------------- | ------------------------------------------------------------- |
-| `authMethod`         | Registry authentication mechanism, such as `oidc` or `access-token`. |
-| `releaseEnvironment` | Release environment name used by generated publishing workflows. |
+| `go`                 | Set to `true` to tag each release and warm the Go module proxy. |
+| `releaseEnvironment` | Release environment the generated publish job runs in.        |
+
+Go publishes through the Git tag, so there is nothing to authenticate against: the release workflow only warms the public module proxy, using the built-in `GITHUB_TOKEN`. The shared `authMethod` option has nothing to act on here and is ignored.

--- a/documentation/guides/sdks/configuration/php.md
+++ b/documentation/guides/sdks/configuration/php.md
@@ -75,5 +75,6 @@ Set `publish.packagist` to `true` to tag each release for Packagist. Packagist s
 
 | Property             | Description                                                   |
 | -------------------- | ------------------------------------------------------------- |
-| `authMethod`         | Registry authentication mechanism, such as `oidc` or `access-token`. |
-| `releaseEnvironment` | Release environment name used by generated publishing workflows. |
+| `packagist`          | Set to `true` to tag each release for Packagist.              |
+
+Packagist serves the package from the Git tag, so no publish job is generated for this target. The shared `authMethod` and `releaseEnvironment` publish options have nothing to act on here and are ignored.

--- a/documentation/guides/sdks/configuration/swift.md
+++ b/documentation/guides/sdks/configuration/swift.md
@@ -75,5 +75,6 @@ Set `publish.swiftpm` to `true` to tag each release for Swift Package Manager. T
 
 | Property             | Description                                                   |
 | -------------------- | ------------------------------------------------------------- |
-| `authMethod`         | Registry authentication mechanism, such as `oidc` or `access-token`. |
-| `releaseEnvironment` | Release environment name used by generated publishing workflows. |
+| `swiftpm`            | Set to `true` to tag each release for Swift Package Manager.  |
+
+Swift Package Manager resolves packages straight from the Git tag, so no publish job is generated for this target. The shared `authMethod` and `releaseEnvironment` publish options have nothing to act on here and are ignored.

--- a/documentation/guides/sdks/publishing/overview.md
+++ b/documentation/guides/sdks/publishing/overview.md
@@ -41,7 +41,7 @@ Merging runs `release-please.yml` on the default branch, which cuts the `vX.Y.Z`
 
   <scalar-step id="step-publish" title="The publish job publishes">
 
-In the same workflow run, the inline `publish` job checks out the tag that was just cut and publishes the package to its registry, then the release is synced back to `scalar-next`. The publish step is idempotent: if that version is already on the registry, it is skipped, so re-runs never fail or double-publish.
+In the same workflow run, the release is synced back to `scalar-next`, and the inline `publish` job then checks out the tag that was just cut and publishes the package to its registry. The publish step is idempotent: if that version is already on the registry, it is skipped, so re-runs never fail or double-publish.
 
   </scalar-step>
 </scalar-steps>


### PR DESCRIPTION
## Problem

Review follow-ups on #9813, both checked against the generator source rather than read off the prose. This PR is **stacked on `claude/sdk-docs-updates-h3udwo`** because the lines it corrects only exist on that branch — it should merge into #9813 before #9813 merges to `main`.

**The publish and sync steps are described in the wrong order.** `publishing/overview.md` says the inline `publish` job "publishes the package to its registry, then the release is synced back to `scalar-next`." In `emitters/core/templates/lifecycle/release-please.yml` the `Sync release back to scalar-next` step is the last step of the `release-please` job, and `release-please-publish-job.yml` declares `needs: release-please`. The sync runs first.

**The tag-served publishing tables document options that do nothing.** The new Publishing sections on `configuration/go.md`, `php.md`, and `swift.md` list the shared `authMethod` and `releaseEnvironment` registry options, immediately below text explaining these targets have no registry upload and no secrets. Per `TAG_SERVED` in `packages/ir-compiler/src/compile/metadata.ts`, SwiftPM and Packagist get no publish job at all, so neither option has anything to act on. Go does get a publish job (the module-proxy warm-up), so `releaseEnvironment` applies there, but the warm-up authenticates against nothing, so `authMethod` still does not.

## Solution

- Reordered the `step-publish` prose to match the job graph: sync, then checkout-at-tag and publish.
- Replaced the three publishing tables with the target's own registry key, plus a sentence naming which shared options are ignored and why. Swift and PHP drop both; Go keeps `releaseEnvironment` and drops `authMethod`.

Re-ran the config drift checker from `scalar/bane@claude/sdk-docs-updates-h3udwo` against the result — still `✓ 14 pages match the config schema`, so the clean state #9813 established is preserved.

No changeset: documentation only, nothing under `packages/`, `integrations/`, or `projects/`. Markdown is in `.prettierignore`, so no formatting step applies.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset.
- [ ] I added tests.
- [x] I updated the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcXvV1Jf4C1UvcfnCy8F4k

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcXvV1Jf4C1UvcfnCy8F4k)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes under `documentation/guides/sdks/`; no runtime, auth, or generator code paths are modified.
> 
> **Overview**
> **Reframes SDK publishing and GitHub sync** to match what the generator emits today: builds land on `scalar-generated` and merge into `scalar-next`, a standing release PR targets your default branch, and merging runs `release-please.yml` (tag, changelog, GitHub Release) before the inline **`publish`** job checks out that tag. The publish step prose now puts **sync back to `scalar-next` first**, then registry publish—matching `needs: release-please` in the templates. Trusted-publisher setup across registries now names **`release-please.yml`** as the automated workflow (with `sdk-release.yml` as optional manual re-publish).
> 
> **Updates configuration and target docs**: drops `version` from required/minimal examples; clarifies `destinations.branch` as the release promotion branch (generated output always on `scalar-generated`); documents **`diagnostics`**; CLI **`publish.binaries`** (replacing `macos`) and **`shellCompletions`**; expanded Go, TypeScript emitter options, and tag-served **`publish`** keys for Go/PHP/Swift—with explicit notes that **`authMethod` / `releaseEnvironment` are ignored** where there is no real registry upload (PHP/Swift entirely; Go keeps `releaseEnvironment` only).
> 
> **Touches custom-code, managing, index, and registry quick-reference** so versioning is split between dashboard SDK versions and release-please package versions, and tag-served vs registry publish paths stay consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b016de5ff2fd0914a201e879be070fb3f35194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->