### PR TITLE
fix(workspace-store): resolve relative externalValue URLs

### DIFF
--- a/.changeset/external-value-relative-urls.md
+++ b/.changeset/external-value-relative-urls.md
@@ -1,0 +1,6 @@
+---
+'@scalar/json-magic': patch
+'@scalar/workspace-store': patch
+---
+
+Resolve relative `externalValue` URLs on example objects against the document origin, so external request and response examples load even when referenced with a relative path

--- a/packages/json-magic/src/bundle/bundle.test.ts
+++ b/packages/json-magic/src/bundle/bundle.test.ts
@@ -2612,6 +2612,7 @@ describe('bundle', () => {
             },
           },
           loaders: [],
+          origin: '/',
         },
       )
       expect(onBeforeNodeProcess).toHaveBeenNthCalledWith(
@@ -2633,6 +2634,7 @@ describe('bundle', () => {
             },
           },
           loaders: [],
+          origin: '/',
         },
       )
 
@@ -2656,6 +2658,7 @@ describe('bundle', () => {
             },
           },
           loaders: [],
+          origin: '/',
         },
       )
       expect(onAfterNodeProcess).toHaveBeenNthCalledWith(
@@ -2675,6 +2678,7 @@ describe('bundle', () => {
             },
           },
           loaders: [],
+          origin: '/',
         },
       )
     })

--- a/packages/json-magic/src/bundle/bundle.ts
+++ b/packages/json-magic/src/bundle/bundle.ts
@@ -259,6 +259,8 @@ export type LoaderPlugin = {
  *
  * - `path`: The JSON pointer path (as an array of strings) from the document root to the current node.
  * - `resolutionCache`: A cache for storing promises of resolved references.
+ * - `origin`: The origin (URL or file path) of the document this node lives in. Lifecycle plugins can
+ *   use it to resolve relative references (for example an example's `externalValue`) into absolute URLs.
  */
 type NodeProcessContext = {
   path: readonly string[]
@@ -266,6 +268,7 @@ type NodeProcessContext = {
   parentNode: UnknownObject | null
   rootNode: UnknownObject
   loaders: LoaderPlugin[]
+  origin: string
 }
 
 /**
@@ -639,17 +642,20 @@ export async function bundle(input: UnknownObject | string, config: Config) {
     // Mark this node as processed before continuing
     processedNodes.add(root)
 
+    // A node with its own `$id` establishes a new base for resolving relative references within it.
+    // Fall back to the origin inherited from the parent document otherwise.
+    const id = getId(root)
+
     const context = {
       path: currentPath,
       resolutionCache: cache,
       parentNode: parent,
       rootNode: documentRoot as UnknownObject,
       loaders: loaderPlugins,
+      origin: id ?? origin,
     }
 
     await executeHooks('onBeforeNodeProcess', root as UnknownObject, context)
-
-    const id = getId(root)
 
     if (hasRef(root)) {
       const ref = root['$ref']

--- a/packages/json-magic/src/bundle/index.ts
+++ b/packages/json-magic/src/bundle/index.ts
@@ -1,2 +1,4 @@
+export { resolveReferencePath } from '@/helpers/resolve-reference-path'
+
 export type { LifecyclePlugin, LoaderPlugin, Plugin, ResolveResult } from './bundle'
 export { bundle, resolveAndCopyReferences } from './bundle'

--- a/packages/workspace-store/src/plugins/bundler/index.test.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.test.ts
@@ -157,6 +157,35 @@ describe('externalValueResolver', () => {
       },
     })
   })
+
+  it('resolves relative external values against the document origin', async () => {
+    server.get('/examples/pet.json', () => {
+      return { name: 'Kitty' }
+    })
+
+    await server.listen({ port: 0 })
+    url = `http://localhost:${(server.server.address() as AddressInfo).port}`
+
+    const input = {
+      a: {
+        externalValue: '/examples/pet.json',
+      },
+    }
+
+    await bundle(input, {
+      treeShake: false,
+      plugins: [externalValueResolver(), fetchUrls()],
+      // The document was loaded from this URL, so relative paths resolve against it.
+      origin: `${url}/openapi.json`,
+    })
+
+    expect(input).toEqual({
+      a: {
+        externalValue: '/examples/pet.json',
+        value: { name: 'Kitty' },
+      },
+    })
+  })
 })
 
 describe('refsEverywhere', () => {

--- a/packages/workspace-store/src/plugins/bundler/index.ts
+++ b/packages/workspace-store/src/plugins/bundler/index.ts
@@ -6,7 +6,7 @@
 
 import { HTTP_METHODS } from '@scalar/helpers/http/http-methods'
 import { isObject } from '@scalar/helpers/object/is-object'
-import type { LifecyclePlugin } from '@scalar/json-magic/bundle'
+import { type LifecyclePlugin, resolveReferencePath } from '@scalar/json-magic/bundle'
 
 import { isLocalRef } from '@/helpers/general'
 import {
@@ -59,18 +59,22 @@ export const externalValueResolver = (): LifecyclePlugin => {
         return
       }
 
-      const loader = context.loaders.find((it) => it.validate(externalValue))
+      // `externalValue` may be relative (for example `/examples/pet.json`). Resolve it against the
+      // origin of the document it lives in so it becomes an absolute URL a loader can fetch.
+      const resolvedValue = resolveReferencePath(context.origin, externalValue)
+
+      const loader = context.loaders.find((it) => it.validate(resolvedValue))
 
       // We can not process the external value
       if (!loader) {
         return
       }
 
-      if (!cache.has(externalValue)) {
-        cache.set(externalValue, loader.exec(externalValue))
+      if (!cache.has(resolvedValue)) {
+        cache.set(resolvedValue, loader.exec(resolvedValue))
       }
 
-      const result = await cache.get(externalValue)
+      const result = await cache.get(resolvedValue)
 
       // If fetch is successful, assign the data to the node's 'value' property
       if (result?.ok) {


### PR DESCRIPTION
Example objects can use `externalValue` to point at an external payload instead of embedding it. When that URL was relative (e.g. `/examples/pet.json`), Scalar never fetched it, because the resolver handed the raw relative path to the URL loader, which only accepts absolute URLs.

This resolves the `externalValue` against the document origin first, so relative external examples load the same way relative `$ref`s already do.

To make this possible, the bundler now exposes the current `origin` on the node context for lifecycle plugins.

## How to test

- Add an example with a relative `externalValue` and a document served from a URL.
- The example value now loads.

Part of #9784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to example `externalValue` fetching and a new optional context field for lifecycle plugins; behavior for absolute URLs is unchanged.
> 
> **Overview**
> Fixes **OpenAPI examples** that point at external payloads via a relative `externalValue` (e.g. `/examples/pet.json`). Those paths were passed straight to URL loaders, which only accept absolute URLs, so the example body never loaded.
> 
> The json-magic bundler now puts **`origin`** on lifecycle **node context** (document URL/path, updated when a subtree has its own `$id`, same idea as `$ref` resolution). **`externalValueResolver`** resolves `externalValue` with **`resolveReferencePath(context.origin, …)`** before validate/fetch/cache, and **`resolveReferencePath`** is re-exported from `@scalar/json-magic/bundle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72014b5be09a12df5ca62bab9180fac3bc64e3c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->