### PR TITLE
fix(nuxt): namespace fetched document state for multiple configurations

### DIFF
--- a/.changeset/nuxt-namespace-document-state.md
+++ b/.changeset/nuxt-namespace-document-state.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nuxt': patch
+---
+
+Fix multiple configurations reusing the first document during client-side navigation

--- a/integrations/nuxt/playground/layouts/default.vue
+++ b/integrations/nuxt/playground/layouts/default.vue
@@ -2,6 +2,10 @@
   <div>
     <header>
       <p>This is an example header</p>
+      <nav>
+        <NuxtLink to="/scalar-a">Config A</NuxtLink>
+        <NuxtLink to="/scalar-b">Config B</NuxtLink>
+      </nav>
     </header>
     <NuxtPage />
   </div>

--- a/integrations/nuxt/playground/nuxt.config.ts
+++ b/integrations/nuxt/playground/nuxt.config.ts
@@ -1,3 +1,5 @@
+import { type NuxtConfig, defineNuxtConfig } from 'nuxt/config'
+
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2025-05-11',
@@ -6,9 +8,39 @@ export default defineNuxtConfig({
 
   modules: ['../src/module'],
 
+  // Two configurations that fetch different documents. This exercises
+  // client-side navigation between multiple Scalar routes, which used to reuse
+  // the first document for every route (see issue #9718).
+  scalar: {
+    layout: 'default',
+    configurations: [
+      {
+        pathRouting: { basePath: '/scalar-a' },
+        url: '/spec-a.json',
+      },
+      {
+        pathRouting: { basePath: '/scalar-b' },
+        url: '/spec-b.json',
+      },
+    ],
+  },
+
+  // The document-reuse bug (#9718) happens during client-side navigation, so
+  // render these routes on the client. This also avoids an unrelated SSR issue
+  // where the reference reaches for a Node worker shim during server render.
+  routeRules: {
+    '/scalar-a': { ssr: false },
+    '/scalar-a/**': { ssr: false },
+    '/scalar-b': { ssr: false },
+    '/scalar-b/**': { ssr: false },
+  },
+
   nitro: {
     experimental: {
       openAPI: true,
     },
   },
-})
+
+  // The `scalar` key is provided by the module, which does not augment the Nuxt
+  // config types, so cast to satisfy the type checker (same as examples/nuxt).
+} as NuxtConfig)

--- a/integrations/nuxt/playground/public/spec-a.json
+++ b/integrations/nuxt/playground/public/spec-a.json
@@ -1,0 +1,12 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Scalar Config A", "version": "1.0.0" },
+  "paths": {
+    "/alpha": {
+      "get": {
+        "summary": "Operation Alpha",
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  }
+}

--- a/integrations/nuxt/playground/public/spec-b.json
+++ b/integrations/nuxt/playground/public/spec-b.json
@@ -1,0 +1,12 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Scalar Config B", "version": "1.0.0" },
+  "paths": {
+    "/beta": {
+      "get": {
+        "summary": "Operation Beta",
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  }
+}

--- a/integrations/nuxt/src/runtime/components/ScalarApiReference.vue
+++ b/integrations/nuxt/src/runtime/components/ScalarApiReference.vue
@@ -34,8 +34,14 @@ const url = props.configuration.spec?.url ?? props.configuration.url
 const currentRoute = useRoute()
 const meta = currentRoute.meta as { isOpenApiEnabled?: boolean }
 
-// Grab spec if we can
-const document = useState<string | null>('document', () => null)
+// Grab spec if we can.
+// The state key is namespaced by the route name so that each configuration keeps
+// its own document. With a shared key, navigating between multiple Scalar routes
+// would reuse the first document instead of fetching each one.
+const document = useState<string | null>(
+  `scalar-document:${String(currentRoute.name)}`,
+  () => null,
+)
 
 // If the document is not set, we need to fetch it
 if (!document.value) {
@@ -61,12 +67,15 @@ if (!document.value) {
   else if (meta.isOpenApiEnabled) {
     try {
       // Use useAsyncData for proper server-to-client data flow
-      const { data } = await useAsyncData('openapi-spec', async () => {
-        const response = await $fetch<string>('/_openapi.json', {
-          responseType: 'text',
-        })
-        return response
-      })
+      const { data } = await useAsyncData(
+        `scalar-openapi-spec:${String(currentRoute.name)}`,
+        async () => {
+          const response = await $fetch<string>('/_openapi.json', {
+            responseType: 'text',
+          })
+          return response
+        },
+      )
       document.value = data.value || null
     } catch (error) {
       console.error('Failed to fetch OpenAPI spec from /_openapi.json:', error)
@@ -75,7 +84,7 @@ if (!document.value) {
 }
 
 // Check for empty spec
-if (!document) {
+if (!document.value) {
   throw new Error(
     'You must provide a document for Scalar API References. Either provide a spec URL/content, or enable experimental openAPI in the Nitro config.',
   )

--- a/integrations/nuxt/test/nuxt.e2e.ts
+++ b/integrations/nuxt/test/nuxt.e2e.ts
@@ -38,3 +38,29 @@ test('Content page at /docs-keys is not hijacked by Scalar', async ({ page }) =>
   await expect(page.getByRole('heading', { name: 'API Keys Management' })).toBeVisible()
   await expect(page.getByText('This is a content page for managing API keys.')).toBeVisible()
 })
+
+/**
+ * With multiple configurations, client-side navigation between two Scalar routes
+ * used to keep showing the first document because the fetched document was
+ * stored under a single shared state key (see issue #9718). Once the first
+ * document was fetched, later routes reused it and never fetched their own.
+ *
+ * Each configuration points at its own spec URL, so watching for that request is
+ * a precise signal that the document was actually fetched for the route.
+ */
+test('Fetches each configuration document during client-side navigation', async ({ page }) => {
+  // The first navigation compiles the reference in dev mode, which can be slow
+  // on CI, so give this test extra headroom.
+  test.setTimeout(120_000)
+
+  // Loading the first configuration fetches its own spec.
+  const specA = page.waitForRequest((request) => request.url().includes('/spec-a.json'), { timeout: 90_000 })
+  await page.goto('/scalar-a')
+  await specA
+
+  // Navigating to the second configuration must fetch its own spec, rather than
+  // reusing the first document.
+  const specB = page.waitForRequest((request) => request.url().includes('/spec-b.json'), { timeout: 30_000 })
+  await page.getByRole('link', { name: 'Config B' }).click()
+  await specB
+})


### PR DESCRIPTION
With multiple Scalar configurations, navigating between docs routes showed the first document on every route until a hard refresh.

The cause: `useState` used a shared `'document'` key, so once the first route filled it, later routes saw a value and skipped their own fetch.

The fix: namespace the state key by route name, so each configuration keeps its own document. Also namespaced the Nitro `useAsyncData` key the same way, and fixed an empty-spec check that tested the ref instead of its value.

Added an e2e test with two configurations that navigates between them and checks each renders its own document. It fails on the old code and passes with the fix.

## Ticket

Closes #9718

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted state-key and validation fixes in the Nuxt integration with playground e2e coverage; no auth or data-layer changes.
> 
> **Overview**
> Fixes **#9718**: with multiple Scalar configurations, client-side navigation between docs routes reused the **first** fetched OpenAPI document because `useState('document')` and a shared `useAsyncData('openapi-spec')` key were global across routes.
> 
> **`ScalarApiReference.vue`** now keys cached spec state per route (`scalar-document:${route.name}` and matching `useAsyncData` key), so each configuration fetches and keeps its own document. The empty-spec guard now checks **`document.value`** instead of the ref object.
> 
> The **playground** adds two configs (`/scalar-a`, `/scalar-b`) with distinct specs and nav links; **CSR route rules** exercise the client-nav path. A new **Playwright e2e** asserts `/spec-b.json` is requested when navigating from A to B.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77593282db972ac2c10dd1dd74644c9a30572910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->