### PR TITLE
fix(workspace-store): schema fallback for unresolved externalValue request bodies

### DIFF
--- a/.changeset/request-example-external-value-fallback.md
+++ b/.changeset/request-example-external-value-fallback.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Fall back to a schema-generated request body when a selected example only has an unresolved `externalValue`, so the Test Request editor no longer shows an empty body

--- a/packages/blocks/src/code-example/helpers/operation-to-har/process-body.test.ts
+++ b/packages/blocks/src/code-example/helpers/operation-to-har/process-body.test.ts
@@ -31,6 +31,53 @@ describe('processBody', () => {
     })
   })
 
+  it('uses a resolved externalValue example for the snippet', () => {
+    // The bundler resolves `externalValue` into `value`, which the snippet then uses.
+    const content = {
+      'application/json': {
+        examples: {
+          external: {
+            externalValue: 'https://example.com/pet.json',
+            value: { name: 'Kitty' },
+          },
+        },
+      },
+    }
+
+    const result = processBody({ requestBody: { content }, contentType: 'application/json', example: 'external' })
+
+    expect(result).toEqual({
+      mimeType: 'application/json',
+      text: JSON.stringify({ name: 'Kitty' }),
+    })
+  })
+
+  it('falls back to a schema example when an externalValue is not resolved', () => {
+    // Only `externalValue` is present, so the snippet generates from the schema instead of being empty.
+    const content = {
+      'application/json': {
+        schema: coerceValue(SchemaObjectSchema, {
+          type: 'object',
+          properties: {
+            name: { type: 'string', example: 'John Doe' },
+          },
+        }),
+        examples: {
+          external: {
+            externalValue: 'https://example.com/pet.json',
+          },
+        },
+      },
+    }
+
+    const result = processBody({ requestBody: { content }, contentType: 'application/json', example: 'external' })
+
+    expect(result).toEqual({
+      mimeType: 'application/json',
+      text: JSON.stringify({ name: 'John Doe' }),
+    })
+  })
+
   it('extracts example from schema with examples array', () => {
     const content = {
       'application/json': {

--- a/packages/workspace-store/src/request-example/builder/body/get-request-body-example.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/get-request-body-example.test.ts
@@ -26,6 +26,54 @@ describe('get-request-body-example', () => {
     expect(result).toEqual({ value: { id: 123, name: 'Test User' } })
   })
 
+  it('uses a resolved externalValue example', () => {
+    // The bundler resolves `externalValue` into `value`, so a resolved external example
+    // is used just like an inline one.
+    const requestBody = {
+      content: {
+        'application/json': {
+          examples: {
+            external: {
+              externalValue: 'https://example.com/pet.json',
+              value: { name: 'Kitty' },
+            },
+          },
+        },
+      },
+    }
+
+    const result = getExampleFromBody(requestBody, 'application/json', 'external')
+
+    expect(result).toEqual({ externalValue: 'https://example.com/pet.json', value: { name: 'Kitty' } })
+  })
+
+  it('falls back to a schema example when an externalValue is not resolved', () => {
+    // Only `externalValue` is present (no resolved `value`), so we generate from the schema
+    // instead of returning an empty body.
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              id: { type: 'integer' },
+              name: { type: 'string' },
+            },
+          },
+          examples: {
+            external: {
+              externalValue: 'https://example.com/pet.json',
+            },
+          },
+        },
+      },
+    })
+
+    const result = getExampleFromBody(requestBody, 'application/json', 'external')
+
+    expect(result).toEqual({ value: { id: 1, name: '' } })
+  })
+
   it('generates example from schema when no example exists', () => {
     const requestBody = coerceValue(RequestBodyObjectSchema, {
       content: {

--- a/packages/workspace-store/src/request-example/builder/body/get-request-body-example.ts
+++ b/packages/workspace-store/src/request-example/builder/body/get-request-body-example.ts
@@ -20,9 +20,11 @@ export const getExampleFromBody = (
 ): ExampleObject | null => {
   const content = requestBody.content?.[contentType]
 
-  // Return existing example value if we have one
+  // Return the existing example when it carries a usable value. An example that only has an
+  // `externalValue` (not yet resolved to a `value`) is treated as missing, so we fall back to a
+  // schema-generated example instead of building an empty request body.
   const example = getExample(requestBody, exampleName, contentType)
-  if (example) {
+  if (example && example.value !== undefined) {
     return example
   }
 


### PR DESCRIPTION
When a request body example only has an `externalValue` that has not been resolved to a `value`, the Test Request editor built an empty body instead of falling back to the schema.

Now an example without a usable `value` is treated as missing, so we generate an example from the schema instead. This matches how code snippets already behave, so both stay consistent.

Adds tests for resolved and unresolved `externalValue` in both the request body builder and the snippet generator.

Part of #9784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to example selection in request-body building; improves UX when external examples are not resolved and aligns with existing snippet logic.
> 
> **Overview**
> Fixes the **Test Request** editor showing an **empty body** when the selected request-body example only has an unresolved `externalValue` (no inlined `value`).
> 
> `getExampleFromBody` now returns the named example only when `example.value` is defined; otherwise it **generates from the request-body schema**, matching code-snippet behavior (`processBody` already skipped examples without a usable `value`). Resolved externals (bundler-populated `value`) are unchanged.
> 
> Adds regression tests for resolved vs unresolved `externalValue` in the workspace-store builder and in `process-body` tests, plus a patch changeset for `@scalar/workspace-store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55cd5d11bd4de562ef8749fdfaa15b5e4cef34ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->