### PR TITLE
perf(workspace-store): cap concurrent external fetches during bundling

### DIFF
--- a/.changeset/external-value-concurrency-limit.md
+++ b/.changeset/external-value-concurrency-limit.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Cap concurrent external fetches while bundling a document, so documents that reference many external examples (`externalValue`) or references do not open an unbounded number of connections on load

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.test.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from 'node:net'
 import { type FastifyInstance, fastify } from 'fastify'
 import { assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { fetchUrl } from '.'
+import { fetchUrl, fetchUrls } from '.'
 
 describe('fetchUrl', () => {
   const noLimit = <T>(fn: () => Promise<T>) => fn()
@@ -142,5 +142,29 @@ describe('fetchUrl', () => {
 
     expect(customFetch).toHaveBeenCalledOnce()
     expect(customFetch).toHaveBeenCalledWith('https://example.com', { headers: undefined })
+  })
+})
+
+describe('fetchUrls', () => {
+  it('caps the number of concurrent requests when a limit is given', async () => {
+    let active = 0
+    let maxActive = 0
+
+    // A fetch that stays briefly "in flight" so we can observe how many run at the same time.
+    const fetch = vi.fn(async () => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      active -= 1
+      return new Response('{}', { status: 200 })
+    })
+
+    const loader = fetchUrls({ fetch, limit: 2 })
+
+    // Kick off more requests than the limit allows.
+    await Promise.all(Array.from({ length: 6 }, (_, index) => loader.exec(`https://example.com/${index}`)))
+
+    expect(maxActive).toBeLessThanOrEqual(2)
+    expect(fetch).toHaveBeenCalledTimes(6)
   })
 })

--- a/packages/workspace-store/src/client.ts
+++ b/packages/workspace-store/src/client.ts
@@ -60,6 +60,13 @@ import type {
 import type { WorkspaceSpecification } from '@/schemas/workspace-specification'
 import type { WorkspacePlugin, WorkspaceStateChangeEvent } from '@/workspace-plugin'
 
+/**
+ * Maximum number of external references and example `externalValue`s fetched at once while bundling
+ * a document. Keeps large documents (which can reference thousands of external examples) from opening
+ * an unbounded number of connections on load.
+ */
+const EXTERNAL_FETCH_CONCURRENCY_LIMIT = 10
+
 type ExtraDocumentConfigurations = Record<
   string,
   {
@@ -990,6 +997,9 @@ export const createWorkspaceStore = (workspaceProps?: WorkspaceProps): Workspace
     const loaders = [
       fetchUrls({
         fetch: extraDocumentConfigurations[name]?.fetch ?? workspaceProps?.fetch,
+        // Cap concurrent fetches so a document with many external references or example
+        // `externalValue`s (potentially thousands) does not flood the network on load.
+        limit: EXTERNAL_FETCH_CONCURRENCY_LIMIT,
       }),
     ]
 


### PR DESCRIPTION
Documents can reference a lot of external content. The discussion in #9784 describes an API with 1,200+ request examples using `externalValue`, growing toward ~12,000. Today every external reference is fetched during bundling with no limit, which can open thousands of connections at once on load.

This caps external fetches to 10 at a time while bundling. Everything still resolves; it just no longer floods the network.

Full lazy loading (only fetching the selected example) is the larger follow-up; this makes the current eager behavior safe at scale in the meantime.

Part of #9784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change only throttles network parallelism during bundling; it does not alter fetch URLs, auth headers, or resolution semantics, though very large specs may take slightly longer to finish loading.
> 
> **Overview**
> **Bundling** in `@scalar/workspace-store` now passes **`limit: 10`** into the `fetchUrls` loader so resolving external `$ref`s and example **`externalValue`** URLs no longer runs unbounded parallel HTTP requests on load. All references still resolve; work is queued behind a shared concurrency cap.
> 
> A **Vitest** case exercises `fetchUrls({ limit: 2 })` and asserts peak in-flight requests stay at or below the limit while every URL is still fetched. A **changeset** records a patch release for `@scalar/workspace-store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27c02ae17940244cf2ffbe091bf532f5f3affda1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->