### PR TITLE
docs(openapi): document externalValue support for examples

### DIFF
--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -179,6 +179,40 @@ paths:
                   name: Mars
 ```
 
+## externalValue
+
+`externalValue` is a standard OpenAPI field on an [Example Object](https://spec.openapis.org/oas/v3.1.0#example-object). It lets you keep large request or response examples outside of your OpenAPI document and point to them by URL instead. This is useful when a single document would otherwise contain hundreds or thousands of big example payloads.
+
+Scalar fetches the referenced payload while loading the document and uses it for the example selector, the request preview, the generated code snippets, and the Test Request dialog.
+
+```yaml
+paths:
+  '/shipments':
+    post:
+      requestBody:
+        content:
+          application/json:
+            examples:
+              shipper-standard:
+                summary: Shipper Standard
+                externalValue: /examples/post-shipment/shipper-standard.json
+```
+
+The referenced endpoint returns the raw example payload:
+
+```json
+{
+  "shippingType": "Shipper_001",
+  "packages": []
+}
+```
+
+A few things to keep in mind:
+
+- `value` and `externalValue` are mutually exclusive. If both are present, `value` is used.
+- Relative URLs (like the one above) are resolved against the URL your document was loaded from.
+- The referenced URL must be reachable by the browser (CORS applies), and should return JSON or YAML.
+
 ## x-displayName
 
 You can overwrite tag names with `x-displayName`.


### PR DESCRIPTION
Adds a short docs section explaining that Scalar supports `externalValue` on example objects, so you can keep large request and response examples outside of your OpenAPI document and reference them by URL.

Covers the basic usage, that relative URLs resolve against the document URL, and the `value` vs `externalValue` precedence.

Part of #9784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior modifications.
> 
> **Overview**
> Adds an **`externalValue`** section to `documentation/openapi.md`, placed after the Swagger `x-example` / `x-examples` content and before **`x-displayName`**.
> 
> The new section explains that Scalar treats standard OpenAPI Example Object **`externalValue`** URLs as external example payloads: it fetches them when the spec loads and feeds them into the example picker, request preview, code snippets, and Test Request UI. It includes a YAML reference example, a sample JSON response body, and notes on **`value` vs `externalValue`** precedence, relative URL resolution, and browser/CORS plus JSON or YAML response expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cfd5a92e6f4a2efa1b323c32c610ea4ac8e0f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->