### PR TITLE
docs(agent): reorganize Agent docs

### DIFF
--- a/documentation/guides/agent/key.md
+++ b/documentation/guides/agent/key.md
@@ -1,4 +1,4 @@
-# Getting an Agent Key
+# Agent Keys
 
 Agent requires a key for production deployments. Keys are tied to specific OpenAPI documents in the Registry.
 

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -698,6 +698,18 @@
           "to": "/products/docs/configuration/redirects"
         },
         {
+          "from": "/products/agent/sdk",
+          "to": "/products/agent/integration/sdk"
+        },
+        {
+          "from": "/products/agent/api-reference",
+          "to": "/products/agent/integration/api-reference"
+        },
+        {
+          "from": "/products/agent/key",
+          "to": "/products/agent/integration/agent-keys"
+        },
+        {
           "from": "/blog/agent-scalar-mcp",
           "to": "/blog/posts/2026-03-17-agent-mcp"
         },
@@ -1688,12 +1700,12 @@
                   "authentication": {
                     "title": "Authentication",
                     "type": "group",
-                    "mode": "nested",
+                    "mode": "flat",
                     "description": "How an MCP server authenticates: who is allowed to connect (public, team, access groups) and how the server calls your API (global or passthrough).",
                     "children": {
                       "/": {
                         "type": "page",
-                        "title": "Authentication",
+                        "title": "Overview",
                         "description": "The two layers of MCP auth—who can connect and how the server calls your API—plus recipes for the common setups.",
                         "filepath": "documentation/guides/agent/authentication/index.md"
                       },
@@ -1717,41 +1729,30 @@
                       }
                     }
                   },
-                  "sdk": {
-                    "title": "Agent SDK",
-                    "type": "page",
-                    "description": "Build AI agents on your API with the Scalar Agent SDK: chat, tool calls, and OpenAPI-backed context.",
-                    "filepath": "documentation/guides/agent/sdk.md"
-                  },
-                  "api-reference": {
-                    "title": "Agent in API Reference",
-                    "type": "page",
-                    "description": "Add the Scalar Agent chat to your API reference so developers can ask questions and try your API with AI.",
-                    "filepath": "documentation/guides/agent/api-reference.md"
-                  },
-                  "pricing": {
-                    "title": "Pricing",
-                    "type": "page",
-                    "description": "Scalar Agent pricing: what is free, what is metered, and how usage is billed.",
-                    "filepath": "documentation/guides/agent/pricing.md"
-                  },
-                  "key": {
-                    "title": "API Keys",
-                    "type": "page",
-                    "description": "Create and manage API keys for Scalar Agent and MCP servers.",
-                    "filepath": "documentation/guides/agent/key.md"
-                  },
-                  "release-notes": {
-                    "title": "Release notes",
-                    "filepath": "packages/agent-chat/RELEASE_NOTES.md",
-                    "type": "page",
-                    "head": {
-                      "links": [
-                        {
-                          "rel": "canonical",
-                          "href": "https://scalar.com/resources/changelog/agent"
-                        }
-                      ]
+                  "integration": {
+                    "title": "Integration",
+                    "type": "group",
+                    "mode": "flat",
+                    "description": "Ways to integrate Scalar Agent: build on the Agent SDK or add the chat to your API reference.",
+                    "children": {
+                      "sdk": {
+                        "title": "Agent SDK",
+                        "type": "page",
+                        "description": "Build AI agents on your API with the Scalar Agent SDK: chat, tool calls, and OpenAPI-backed context.",
+                        "filepath": "documentation/guides/agent/sdk.md"
+                      },
+                      "api-reference": {
+                        "title": "Agent in API Reference",
+                        "type": "page",
+                        "description": "Add the Scalar Agent chat to your API reference so developers can ask questions and try your API with AI.",
+                        "filepath": "documentation/guides/agent/api-reference.md"
+                      },
+                      "agent-keys": {
+                        "title": "Agent Keys",
+                        "type": "page",
+                        "description": "Create an Agent key in the Registry to enable the Agent chat in your API reference in production.",
+                        "filepath": "documentation/guides/agent/key.md"
+                      }
                     }
                   },
                   "examples": {
@@ -1789,6 +1790,25 @@
                         "type": "page",
                         "title": "Stakeholder Digest"
                       }
+                    }
+                  },
+                  "pricing": {
+                    "title": "Pricing",
+                    "type": "page",
+                    "description": "Scalar Agent pricing: what is free, what is metered, and how usage is billed.",
+                    "filepath": "documentation/guides/agent/pricing.md"
+                  },
+                  "release-notes": {
+                    "title": "Release Notes",
+                    "filepath": "packages/agent-chat/RELEASE_NOTES.md",
+                    "type": "page",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/changelog/agent"
+                        }
+                      ]
                     }
                   }
                 }


### PR DESCRIPTION
## What changed

- Grouped Agent docs into authentication, integration, examples, pricing, and release notes.
- Added redirects for old Agent docs URLs.
- Renamed the Agent key page title.

## Checks

- pnpm prettier --check documentation/guides/agent/key.md scalar.config.json
- pnpm changeset status

**Before**

<img width="294" height="524" alt="Screenshot 2026-08-03 at 12 34 46" src="https://github.com/user-attachments/assets/2fd49c57-f02c-4c44-b6d9-27d19996ad6b" />

**After**

<img width="296" height="692" alt="Screenshot 2026-08-03 at 14 39 21" src="https://github.com/user-attachments/assets/14ca5e0d-7a0b-439c-add7-5c50a927d7c6" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and routing config only; redirects preserve old Agent doc URLs with no application or security impact.
> 
> **Overview**
> Reorganizes the **MCP & Agent** docs sidebar in `scalar.config.json`: SDK, API reference, and keys move under a new **Integration** group (`/products/agent/integration/...`); **Authentication** switches from nested to flat layout with the landing page titled **Overview**; **Pricing** and **Release Notes** sit after **Examples** (release notes title capitalized).
> 
> Adds **redirects** from `/products/agent/sdk`, `/api-reference`, and `/key` to the new integration URLs. Renames the key guide heading in `documentation/guides/agent/key.md` from "Getting an Agent Key" to **Agent Keys** and updates the nav entry to **Agent Keys** at `agent-keys`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e5a01b79dc94618c8088c5a09e2b9f8a0ee13d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->