### PR TITLE
fix(api-client): keep multipart form values readable

### DIFF
--- a/.changeset/bright-forms-expand.md
+++ b/.changeset/bright-forms-expand.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Keep multipart form values readable by bounding the upload column and exposing full filenames on hover.

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTable.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTable.test.ts
@@ -189,6 +189,19 @@ describe('RequestTable', () => {
     expect(row.props('showUploadButton')).toBe(true)
   })
 
+  it('reserves more space for multipart values than file controls', () => {
+    const wrapper = mount(RequestTable, {
+      props: {
+        data: [{ name: 'file', value: '', isEnabled: true }],
+        environment,
+        showUploadButton: true,
+      },
+    })
+
+    const table = wrapper.findComponent({ name: 'DataTable' })
+    expect(table.props('columns')).toEqual(['36px', 'minmax(0, 1fr)', 'minmax(0, 2fr)', 'minmax(104px, 0.5fr)'])
+  })
+
   it('renders DataTableHeader with correct label', () => {
     const wrapper = mount(RequestTable, {
       props: {

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
@@ -49,7 +49,7 @@ const emit = defineEmits<{
 
 const columns = computed(() => {
   if (showUploadButton) {
-    return ['36px', '', '', 'auto']
+    return ['36px', 'minmax(0, 1fr)', 'minmax(0, 2fr)', 'minmax(104px, 0.5fr)']
   }
   return ['36px', '', '']
 })
@@ -107,12 +107,5 @@ const displayData = computed(() => {
 }
 :deep(.scalar-pill:not(:first-of-type)) {
   margin-left: 0.5px;
-}
-.filemask {
-  mask-image: linear-gradient(
-    to right,
-    transparent 0,
-    var(--scalar-background-2) 20px
-  );
 }
 </style>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
@@ -502,6 +502,7 @@ describe('RequestTableRow', () => {
     })
 
     expect(wrapper.text()).toContain(longFileName)
+    expect(wrapper.find(`[title="${longFileName}"]`).exists()).toBe(true)
   })
 
   it('emits removeFile when delete button is clicked on a file', async () => {

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -295,8 +295,12 @@ const handleKeyBlur = (newName: string): void => {
       class="group/upload flex items-center justify-center whitespace-nowrap">
       <template v-if="isFile">
         <div
-          class="text-c-2 filemask flex w-full max-w-[100%] items-center justify-center overflow-hidden p-1">
-          <span>{{ displayValue }}</span>
+          class="text-c-2 flex w-full max-w-full items-center justify-center overflow-hidden p-1">
+          <span
+            class="w-full truncate text-center"
+            :title="displayValue">
+            {{ displayValue }}
+          </span>
         </div>
         <button
           class="bg-b-2 mt-1 block rounded p-0.5 text-center text-xs font-medium md:pointer-events-none md:absolute md:inset-x-1 md:top-1/2 md:mt-0 md:-translate-y-1/2 md:opacity-0 md:group-hover/upload:pointer-events-auto md:group-hover/upload:opacity-100"


### PR DESCRIPTION
## Summary

- bound the multipart upload column so long filenames cannot shrink the value field
- give value cells twice the flexible space of key cells
- truncate selected filenames visually while preserving the full name on hover

## Visual

Before ([reported in #9803](https://github.com/scalar/scalar/issues/9803)):

<img width="699" alt="Multipart value obscured before the fix" src="https://github.com/user-attachments/assets/af4e2a98-bb34-4210-9e62-19fae672f4d6" />

After (long value and filename at 1400x900):

<img width="695" alt="Multipart value remains readable and the filename truncates after the fix" src="https://raw.githubusercontent.com/sidsri14/scalar/pr-9823-visual/.github/pr-artifacts/9823-multipart-table.png" />

## Validation

- `pnpm --filter @scalar/api-client types:check`
- focused component tests: 2 files, 61 tests passed
- API client suite across two compatible pools: 94 files / 1,652 tests passed in the thread run; 6 worker-dependent files / 76 tests passed under the default fork pool
- scoped Prettier, Biome, and ESLint checks
- Chromium playground at 1400x900: tracks resolved to `36px 184.5px 369px 104px`; filename ellipsis and title verified

`knip --workspace @scalar/api-client` could not start in the sparse checkout because an unrelated API Reference config imports the omitted `rollup-plugin-webpack-stats` dependency.

Fixes #9803