### PR TITLE
docs(sdks): note the skipped release-title-edit workflow on older SDK repos

### DIFF
--- a/documentation/guides/sdks/publishing/overview.md
+++ b/documentation/guides/sdks/publishing/overview.md
@@ -114,6 +114,9 @@ release: 1.0.0
 
 The `Release PR version` check goes red while the title and the committed version disagree, Scalar re-renders the pull request at your version, and the check goes green. Wait for green before merging. The git-native equivalent is an empty commit on `scalar-next` with a `Release-As: 1.0.0` footer.
 
+> [!IMPORTANT]
+> If retitling appears to do nothing and the `Release PR version` check never reports — the workflow run shows as **skipped**, with neither of its jobs executed — your repository has an early copy of `release-title-edit.yml` whose branch guard never matched the release pull request. Both of its jobs skip on every release pull request, and because a skipped job is not a failed one, nothing turns red to tell you: merging ships the version release-please computed from your commits, not the one in the title. Rebuild the SDK to pick up the corrected workflow. Until you do, set the version with the `Release-As` commit above, which never depended on that workflow.
+
 Every release gets a `vX.Y.Z` tag, a GitHub Release, and an entry in the repository's `CHANGELOG.md`, so your release history lives in your repo next to the code. The generated `VERSIONING.md` documents all of this for your maintainers.
 
 ## Permissions


### PR DESCRIPTION
## Problem

The SDK publishing docs tell maintainers that editing a release pull request's title is how you ship an exact version, and that the `Release PR version` check goes red until the title and the committed version agree.

On every SDK repo generated so far, neither happens. The generated `release-title-edit.yml` guarded on `startsWith(head.ref, 'release-please--branches--scalar-next--')` — the trailing separator of release-please's *multi-component* branch form — but the emitted `release-please-config.json` declares a single root package with no `component`, so release-please renders the componentless `release-please--branches--scalar-next`. The guard matched nothing, both jobs skipped, and:

- retitling pushed no `Release-As` commit, so the pull request was never re-rendered and merging shipped the computed version;
- the `Release PR version` check never reported at all, so nothing blocked that merge.

A skipped job is not a failed one, so this surfaced only as a workflow run with no jobs in it — nothing in the UI reads as broken. A maintainer following the docs exactly gets the wrong version with no signal. Seen in the wild on a customer SDK repo, where a retitle from `release: 0.3.0` to `release: 0.5.0` did nothing.

## Solution

One `> [!IMPORTANT]` callout in `documentation/guides/sdks/publishing/overview.md`, in the existing `## Versioning and releases` section directly under the retitling instructions it qualifies. It covers how to recognise the case (run reports *skipped*, check never appears), why nothing goes red, the fix (rebuild the SDK), and the workaround that still works meanwhile (the `Release-As` commit described in the paragraph above it).

Kept to the existing section rather than a new page — the surrounding prose already documents both the retitle flow and the `Release-As` equivalent, and this is a caveat on them, not a new topic.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation.

Docs-only prose change under `documentation/`, so no changeset and no tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LCjgX5B4vibhrt4MPPbihz)_