### PR TITLE
feat(workspace-store): relative proxy URLs

### DIFF
--- a/.changeset/fix-9825-relative-proxy-url-har.md
+++ b/.changeset/fix-9825-relative-proxy-url-har.md
@@ -1,0 +1,7 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix: resolve relative request URLs against the current origin in `fetchRequestToHar`
+
+A relative `proxyUrl` (e.g. `/api/scalar-proxy`) makes `redirectToProxy` return a relative URL, which `new URL()` could not parse, so every request threw `TypeError: Invalid URL` and never made it into history.

--- a/packages/workspace-store/src/mutators/operation/helpers/fetch-request-to-har.test.ts
+++ b/packages/workspace-store/src/mutators/operation/helpers/fetch-request-to-har.test.ts
@@ -535,7 +535,9 @@ describe('fetchRequestToHar', () => {
 
   it('handles relative URLs, e.g. a relative proxy URL', async () => {
     vi.stubGlobal('location', { origin: 'https://portal.example.com' })
-    onTestFinished(() => vi.unstubAllGlobals())
+    onTestFinished(() => {
+      vi.unstubAllGlobals()
+    })
 
     const requestPayload: RequestPayload = [
       '/api/scalar-proxy?scalar_url=https%3A%2F%2Fapi.example.com%2Fusers',
@@ -546,5 +548,26 @@ describe('fetchRequestToHar', () => {
 
     expect(result.url).toBe('/api/scalar-proxy?scalar_url=https%3A%2F%2Fapi.example.com%2Fusers')
     expect(result.queryString).toEqual([{ name: 'scalar_url', value: 'https://api.example.com/users' }])
+  })
+
+  it('handles relative URLs when there is no usable origin (non-browser or opaque origin)', async () => {
+    // Sandboxed iframes and about:blank report an opaque origin as the string "null",
+    // which is not a valid URL base. A missing location behaves the same way.
+    for (const origin of [undefined, 'null']) {
+      vi.stubGlobal('location', origin === undefined ? undefined : { origin })
+      onTestFinished(() => {
+        vi.unstubAllGlobals()
+      })
+
+      const requestPayload: RequestPayload = [
+        '/api/scalar-proxy?scalar_url=https%3A%2F%2Fapi.example.com%2Fusers',
+        { method: 'GET' },
+      ]
+
+      const result = await fetchRequestToHar({ requestPayload })
+
+      expect(result.url).toBe('/api/scalar-proxy?scalar_url=https%3A%2F%2Fapi.example.com%2Fusers')
+      expect(result.queryString).toEqual([{ name: 'scalar_url', value: 'https://api.example.com/users' }])
+    }
   })
 })

--- a/packages/workspace-store/src/mutators/operation/helpers/fetch-request-to-har.test.ts
+++ b/packages/workspace-store/src/mutators/operation/helpers/fetch-request-to-har.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, onTestFinished, vi } from 'vitest'
 
 import type { RequestPayload } from '@/request-example/builder/build-request'
 
@@ -531,5 +531,20 @@ describe('fetchRequestToHar', () => {
     // Should include body since it's under 1MB default limit
     expect(result.postData?.text).toBe(smallBody)
     expect(result.bodySize).toBe(smallBody.length)
+  })
+
+  it('handles relative URLs, e.g. a relative proxy URL', async () => {
+    vi.stubGlobal('location', { origin: 'https://portal.example.com' })
+    onTestFinished(() => vi.unstubAllGlobals())
+
+    const requestPayload: RequestPayload = [
+      '/api/scalar-proxy?scalar_url=https%3A%2F%2Fapi.example.com%2Fusers',
+      { method: 'GET' },
+    ]
+
+    const result = await fetchRequestToHar({ requestPayload })
+
+    expect(result.url).toBe('/api/scalar-proxy?scalar_url=https%3A%2F%2Fapi.example.com%2Fusers')
+    expect(result.queryString).toEqual([{ name: 'scalar_url', value: 'https://api.example.com/users' }])
   })
 })

--- a/packages/workspace-store/src/mutators/operation/helpers/fetch-request-to-har.ts
+++ b/packages/workspace-store/src/mutators/operation/helpers/fetch-request-to-har.ts
@@ -58,8 +58,13 @@ export const fetchRequestToHar = async ({
 }: FetchRequestToHarProps): Promise<HarRequest> => {
   const [originalUrl, requestInit] = requestPayload
 
-  // Extract query string from URL
-  const url = new URL(originalUrl, globalThis.location?.origin)
+  // Resolve relative URLs (e.g. a relative proxy URL) so query params can be read.
+  // Absolute URLs ignore the base. The base only feeds param extraction — the
+  // original URL is preserved on the output — so fall back to a placeholder when
+  // there is no usable origin: non-browser envs (undefined) or opaque origins
+  // like sandboxed iframes / about:blank (the string "null").
+  const origin = globalThis.location?.origin
+  const url = new URL(originalUrl, origin && origin !== 'null' ? origin : 'http://localhost')
 
   // Extract the query strings from the URL
   const queryString = Array.from(url.searchParams.entries()).map(([name, value]) => ({ name, value }))

--- a/packages/workspace-store/src/mutators/operation/helpers/fetch-request-to-har.ts
+++ b/packages/workspace-store/src/mutators/operation/helpers/fetch-request-to-har.ts
@@ -59,7 +59,7 @@ export const fetchRequestToHar = async ({
   const [originalUrl, requestInit] = requestPayload
 
   // Extract query string from URL
-  const url = new URL(originalUrl)
+  const url = new URL(originalUrl, globalThis.location?.origin)
 
   // Extract the query strings from the URL
   const queryString = Array.from(url.searchParams.entries()).map(([name, value]) => ({ name, value }))


### PR DESCRIPTION
A relative proxy URL like `/api/scalar-proxy` throws `TypeError: Invalid URL` in `fetchRequestToHar()`, since `redirectToProxy()` allows relative proxy URLs but `new URL(originalUrl)` is called with no base. The request still goes through, but it never lands in history. Resolving against the current origin (`new URL(originalUrl, globalThis.location?.origin)`) fixes it; absolute URLs are unaffected since they ignore the base.

Closes #9825