### PR TITLE
fix(openapi-upgrader): convert nullable $ref patterns when upgrading to 3.1

### DIFF
--- a/.changeset/nullable-ref-upgrade.md
+++ b/.changeset/nullable-ref-upgrade.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-upgrader': patch
+---
+
+Convert nullable `$ref` patterns to the 3.1 null-union form when upgrading from OpenAPI 3.0 to 3.1

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.test.ts
@@ -139,6 +139,116 @@ describe('upgradeFromThreeToThreeOne', () => {
         },
       })
     })
+
+    it('migrates a nullable `allOf` wrapping a `$ref`', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.3',
+        info: { title: 'Hello World', version: '1.0.0' },
+        paths: {},
+        components: {
+          schemas: {
+            Pet: { type: 'object', properties: { id: { type: 'integer' } } },
+            Wrapper: {
+              type: 'object',
+              properties: {
+                pet: {
+                  nullable: true,
+                  allOf: [{ $ref: '#/components/schemas/Pet' }],
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(result.components?.schemas?.Wrapper?.properties?.pet).toEqual({
+        anyOf: [{ $ref: '#/components/schemas/Pet' }, { type: 'null' }],
+      })
+    })
+
+    it('migrates a nullable `$ref` sibling', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.3',
+        info: { title: 'Hello World', version: '1.0.0' },
+        paths: {},
+        components: {
+          schemas: {
+            Pet: { type: 'object', properties: { id: { type: 'integer' } } },
+            Wrapper: {
+              type: 'object',
+              properties: {
+                pet: {
+                  $ref: '#/components/schemas/Pet',
+                  nullable: true,
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(result.components?.schemas?.Wrapper?.properties?.pet).toEqual({
+        anyOf: [{ $ref: '#/components/schemas/Pet' }, { type: 'null' }],
+      })
+    })
+
+    it('keeps other keywords when unwrapping a nullable `$ref`', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.3',
+        info: { title: 'Hello World', version: '1.0.0' },
+        paths: {},
+        components: {
+          schemas: {
+            Pet: { type: 'object', properties: { id: { type: 'integer' } } },
+            Wrapper: {
+              type: 'object',
+              properties: {
+                pet: {
+                  description: 'The pet, or null',
+                  nullable: true,
+                  allOf: [{ $ref: '#/components/schemas/Pet' }],
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(result.components?.schemas?.Wrapper?.properties?.pet).toEqual({
+        description: 'The pet, or null',
+        anyOf: [{ $ref: '#/components/schemas/Pet' }, { type: 'null' }],
+      })
+    })
+
+    it('wraps a nullable multi-member `allOf` without dropping members', () => {
+      const result: OpenAPIV3_1.Document = upgradeFromThreeToThreeOne({
+        openapi: '3.0.3',
+        info: { title: 'Hello World', version: '1.0.0' },
+        paths: {},
+        components: {
+          schemas: {
+            Pet: { type: 'object', properties: { id: { type: 'integer' } } },
+            Extra: { type: 'object', properties: { tag: { type: 'string' } } },
+            Wrapper: {
+              type: 'object',
+              properties: {
+                pet: {
+                  nullable: true,
+                  allOf: [{ $ref: '#/components/schemas/Pet' }, { $ref: '#/components/schemas/Extra' }],
+                },
+              },
+            },
+          },
+        },
+      })
+
+      expect(result.components?.schemas?.Wrapper?.properties?.pet).toEqual({
+        anyOf: [
+          { allOf: [{ $ref: '#/components/schemas/Pet' }, { $ref: '#/components/schemas/Extra' }] },
+          { type: 'null' },
+        ],
+      })
+    })
   })
 
   describe('exclusiveMinimum and exclusiveMaximum', () => {

--- a/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
+++ b/packages/openapi-upgrader/src/3.0-to-3.1/upgrade-from-three-to-three-one.ts
@@ -133,6 +133,26 @@ const applyChangesToDocument = (schema: UnknownObject, path?: string[]) => {
     schema.type = [schema.type, 'null']
     delete schema.nullable
   }
+  // 1b. Handle nullable `$ref` patterns.
+  // OpenAPI 3.0 had no way to mark a `$ref` as nullable, so people wrote `nullable: true` next to
+  // a `$ref`, or next to an `allOf` wrapping one. `nullable` does not exist in 3.1, so leaving these
+  // untouched would silently drop the null option. Rewrite them to the 3.1 null-union form. This only
+  // runs when there is no sibling `type` (that case is handled above).
+  else if (schema.nullable === true && schema.type === undefined) {
+    if (typeof schema.$ref === 'string') {
+      const { nullable: _nullable, $ref, ...rest } = schema
+      return { ...rest, anyOf: [{ $ref }, { type: 'null' }] }
+    }
+
+    if (Array.isArray(schema.allOf)) {
+      const { nullable: _nullable, allOf, ...rest } = schema
+      // A single-member `allOf` unwraps so the union reads `anyOf: [<member>, { type: 'null' }]`.
+      const base = allOf.length === 1 ? allOf[0] : { allOf }
+      return { ...rest, anyOf: [base, { type: 'null' }] }
+    }
+
+    // Otherwise there is nothing for `nullable` to attach to, so leave the schema untouched.
+  }
 
   // 2. Handle exclusiveMinimum and exclusiveMaximum
   if (schema.exclusiveMinimum === true) {


### PR DESCRIPTION
When upgrading from OpenAPI 3.0 to 3.1, nullable `$ref` shapes were left unchanged. That kept the `nullable` keyword in the output, which does not exist in 3.1, so the `$ref` was no longer nullable.

Now these get rewritten to the 3.1 null-union form:

```yaml
# before
pet:
  nullable: true
  allOf:
    - $ref: '#/components/schemas/Pet'

# after
pet:
  anyOf:
    - $ref: '#/components/schemas/Pet'
    - type: 'null'
```

This covers both `nullable` next to an `allOf` and `nullable` next to a `$ref`. A multi-member `allOf` is kept whole inside the union so no members are lost. Schemas with `type` are untouched.

## Ticket

Fixes #9694