### PR TITLE
fix(api-reference): stop listing enum values twice for $ref array items

### DIFF
--- a/.changeset/fix-api-reference-array-ref-enum-duplicate.md
+++ b/.changeset/fix-api-reference-array-ref-enum-duplicate.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': patch
+---
+
+Stop listing enum values twice for an array parameter whose `items` is a `$ref`
+to an enum schema. The values are now listed only in the array items card, which
+also shows the item schema's title and description.

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -397,6 +397,33 @@ describe('SchemaProperty', () => {
         expect(html).toContain('A planet made mostly of iron')
       })
 
+      it('lists enum values once for an array whose items are a $ref to an enum', () => {
+        // `noncollapsible` is how ParameterListItem mounts this. Without it the
+        // items card starts collapsed and this passes even with the bug present.
+        const wrapper = mount(SchemaProperty, {
+          props: {
+            eventBus: null,
+            compact: true,
+            noncollapsible: true,
+            schema: coerceValue(SchemaObjectSchema, {
+              type: 'array',
+              items: {
+                '$ref': '#/components/schemas/OrderBy',
+                '$ref-value': {
+                  type: 'string',
+                  title: 'OrderBy',
+                  enum: ['created_at', 'name'],
+                },
+              },
+            }),
+            options: {},
+          },
+        })
+
+        expect(wrapper.findAll('.property-enum-values')).toHaveLength(1)
+        expect(wrapper.findAll('.property-enum-value')).toHaveLength(2)
+      })
+
       it('displays enum values within composition schemas', () => {
         const wrapper = mount(SchemaProperty, {
           props: {

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -369,8 +369,9 @@ const isDiscriminatorProperty = computed(() =>
       :value="{ enum: propertyNamesEnum } as SchemaObject" />
 
     <!-- Enum values -->
+    <!-- The array items card rendered below already lists these same values. -->
     <SchemaEnums
-      v-if="enumValues.length > 0"
+      v-if="enumValues.length > 0 && !shouldRenderArrayOfObjects"
       :value="optimizedValue" />
 
     <!-- Object -->


### PR DESCRIPTION
## Problem

An array parameter whose `items` is a `$ref` to an enum schema lists its enum values twice: once directly under the parameter, then again inside the nested items card.

```yaml
- name: order_by
  in: query
  schema:
    type: array
    items:
      $ref: '#/components/schemas/ItemOrderBy'
```

Two independent paths both render the values, neither aware of the other:

- `getEnumValues` resolves `items` and lifts the item enum onto the property, so a plain `array` of inline enum values needs no card.
- `hasComplexArrayItems` returns `true` for any `$ref` items, without looking at what the ref resolves to, so an enum is classified as complex and `shouldRenderArrayOfObjects` renders the items as their own schema. That card lists the same values a second time.

This is the default shape for generated specs. protoc-gen-openapi emits every repeated enum field this way, so every `order_by` parameter in such a document is affected.

## Solution

Skip the lifted list when the items card renders.

The card is the one worth keeping, because it also shows the item schema's `title` and `description`, and the lifted list shows neither. Verified both ways: with the values inlined on `items` instead of `$ref`-ed, the description is lost, so suppressing the card instead would trade a duplicate for missing documentation.

Deliberately not fixed in `hasComplexArrayItems` by resolving the ref before classifying it. That reads like the root cause, but the `$ref` short-circuit is load-bearing for refs that cannot be resolved (as its own comment says), and the function also feeds `shouldRenderArrayItemComposition`, so changing it moves composition rendering too. The template condition is the narrower fix.

`hasEnum` is untouched, so the `enum` chip in the property heading still shows.

## Visual

Before / After

<img width="49%" alt="enum values listed twice" src="https://github.com/user-attachments/assets/7363b1a6-a09e-4088-9df4-0bc027438794" /><img width="49%" alt="enum values listed once" src="https://github.com/user-attachments/assets/5e952064-1bb1-4537-982c-5b6961e3e692" />

## Tests

A regression test in `SchemaProperty.test.ts` asserts one values list for an array whose items are a resolved `$ref` to an enum. It mounts with `noncollapsible`, matching how `ParameterListItem` mounts the component; without that the items card starts collapsed, the duplicate never renders, and the test passes with the bug present. Confirmed it fails before the change and passes after.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.
