### PR TITLE
docs(docs): document the changelog RSS feed site config

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -322,6 +322,26 @@ For `scripts` and `styles`: path relative to config root. For `links` (favicon):
 }
 ```
 
+### rss
+
+Publishes an RSS feed for your changelog so readers can subscribe. Written to `<path>/rss.xml` — a changelog at `/changelog` publishes its feed at `/changelog/rss.xml`.
+
+```json
+"rss": {
+  "path": "/changelog",
+  "title": "Scalar Changelog",
+  "description": "Every Scalar release, as a feed"
+}
+```
+
+| Property      | Type     | Required | Description                                              |
+| ------------- | -------- | -------- | -------------------------------------------------------- |
+| `path`        | `string` | Yes      | Changelog route, e.g. `/changelog`. No `..` segments     |
+| `title`       | `string` | No       | Feed title. Defaults to your site title plus `Changelog` |
+| `description` | `string` | No       | Feed description                                         |
+
+Entries come from dated headings (`## 1.2.0 (2026-07-24)`) on the page at `path` or any page beneath it, merged newest-first. Only the top-most dated heading level starts entries; deeper headings (dated or not) fold into the release above them. Hidden pages are skipped. Every page advertises the feed with a `<link rel="alternate" type="application/rss+xml">` tag, and pages under `path` show a subscribe button in the page header.
+
 ### routing
 
 **Redirects:**

--- a/documentation/guides/docs/configuration/site-config.md
+++ b/documentation/guides/docs/configuration/site-config.md
@@ -418,6 +418,77 @@ The `footer` property allows you to add a custom footer to your documentation si
 | ---------- | -------- | ------------------------------------------ |
 | `filepath` | `string` | Relative path to a custom HTML footer file |
 
+## RSS
+
+The `rss` property publishes an RSS feed for your changelog, so readers can subscribe to your releases in a feed reader.
+
+Point `path` at the route your changelog lives on. The feed is written to `rss.xml` under that route — a changelog at `/changelog` publishes its feed at `/changelog/rss.xml`.
+
+```json
+// scalar.config.json
+{
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
+  "scalar": "2.0.0",
+  "siteConfig": {
+    "rss": {
+      "path": "/changelog",
+      "title": "Scalar Changelog",
+      "description": "Every Scalar release, as a feed"
+    }
+  }
+}
+```
+
+### Properties
+
+| Property      | Type     | Required | Description                                                                         |
+| ------------- | -------- | -------- | ----------------------------------------------------------------------------------- |
+| `path`        | `string` | Yes      | Route of your changelog, for example `/changelog`                                   |
+| `title`       | `string` | No       | Title of the feed, shown in feed readers. Defaults to your site title plus `Changelog` |
+| `description` | `string` | No       | Description of the feed, shown in feed readers                                      |
+
+### Writing Entries
+
+Each entry in the feed comes from a heading that carries a date in `YYYY-MM-DD` form:
+
+```markdown
+## 1.2.0 (2026-07-24)
+
+Added a dark mode toggle to the header.
+
+## 1.1.0 (2026-07-10)
+
+Introduced page actions: copy as Markdown, open in editor, and report an issue.
+```
+
+The heading becomes the item title, and the content below it becomes the item description. Headings without a date are not entries of their own — they belong to the entry above them, so you can use subheadings inside a release without splitting it apart.
+
+If a heading looks dated but the date is not real (`## 2.0.0 (2026-13-01)`), that release is left out of the feed and the build warns you, since a typo is the only way to get there.
+
+### Multiple Products
+
+A changelog split across several pages works too. Every page at `path` or beneath it contributes its entries, and the feed merges them newest-first:
+
+```
+/changelog                 <- index page, lists the products
+/changelog/api-client      <- entries
+/changelog/api-reference   <- entries
+```
+
+An index page with no dated headings contributes nothing of its own, which is what you want when it only links to the products.
+
+Hidden pages are skipped. A page kept out of the sidebar and the sitemap stays out of the feed as well.
+
+### Discovery
+
+Every page on your site advertises the feed in its `<head>`, so feed readers and browser extensions can find it from any URL:
+
+```html
+<link rel="alternate" type="application/rss+xml" href="https://example.com/changelog/rss.xml">
+```
+
+Pages at `path` and beneath it also show a subscribe button in the page header, next to Copy Page.
+
 ## Routing
 
 The `routing` property configures URL redirects and path patterns for your documentation.

--- a/documentation/guides/docs/configuration/site-config.md
+++ b/documentation/guides/docs/configuration/site-config.md
@@ -443,7 +443,7 @@ Point `path` at the route your changelog lives on. The feed is written to `rss.x
 
 | Property      | Type     | Required | Description                                                                         |
 | ------------- | -------- | -------- | ----------------------------------------------------------------------------------- |
-| `path`        | `string` | Yes      | Route of your changelog, for example `/changelog`                                   |
+| `path`        | `string` | Yes      | Route of your changelog, for example `/changelog`. Must be a plain site route with no `..` segments |
 | `title`       | `string` | No       | Title of the feed, shown in feed readers. Defaults to your site title plus `Changelog` |
 | `description` | `string` | No       | Description of the feed, shown in feed readers                                      |
 
@@ -461,7 +461,7 @@ Added a dark mode toggle to the header.
 Introduced page actions: copy as Markdown, open in editor, and report an issue.
 ```
 
-The heading becomes the item title, and the content below it becomes the item description. Headings without a date are not entries of their own — they belong to the entry above them, so you can use subheadings inside a release without splitting it apart.
+The heading becomes the item title, and the content below it becomes the item description. Only the top-most heading level that carries dates starts entries; any deeper heading folds into the release above it — even one that happens to contain a date — so you can nest subheadings like `### Fixes` inside a release without splitting it apart.
 
 If a heading looks dated but the date is not real (`## 2.0.0 (2026-13-01)`), that release is left out of the feed and the build warns you, since a typo is the only way to get there.
 


### PR DESCRIPTION
Documents `siteConfig.rss`, the changelog RSS feed being added in scalar-org#5395.

## What's covered

- Where the feed is written — `path` plus `rss.xml`, so `/changelog` publishes at `/changelog/rss.xml`
- The properties table, including that `title` defaults to your site title plus "Changelog"
- **Writing entries** — the `## 1.2.0 (2026-07-24)` dated-heading format, that undated subheadings belong to the entry above them, and what happens on an unparseable date
- **Multiple products** — a changelog split across several pages merges newest-first; an index page with no dated headings contributes nothing; hidden pages are skipped
- **Discovery** — the `<link rel="alternate">` tag on every page, and the subscribe button in the page header

## Scope

Documentation only. This adds one section to `site-config.md` and touches nothing else — no changelog or release-notes files, and no change to `scalar.config.json`. Enabling the feed on scalar.com is a separate change.

## Sequencing

**Do not merge before the feature ships.** The `rss` key is not in the published config schema yet, so this documents an option users cannot use until scalar-org#5395 lands and deploys.