### PR TITLE
feat(docs): publish an RSS feed for the changelog

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -75,6 +75,11 @@
       "darkMode": "https://cdn.scalar.com/marketing/landing/logo-dark.svg",
       "lightMode": "https://cdn.scalar.com/marketing/landing/logo-light.svg"
     },
+    "rss": {
+      "path": "/resources/changelog",
+      "title": "Scalar Changelog",
+      "description": "Releases across Scalar products — API Client, API Reference, Agent, and Mock Server"
+    },
     "routing": {
       "redirects": [
         {


### PR DESCRIPTION
Enables the changelog RSS feed on scalar.com. One config block, five lines.

```json
"rss": {
  "path": "/resources/changelog",
  "title": "Scalar Changelog",
  "description": "Releases across Scalar products — API Client, API Reference, Agent, and Mock Server"
}
```

The feed publishes at `https://scalar.com/resources/changelog/rss.xml`.

## No content changes needed

The release notes each product generates already use the dated-heading format entries come from. I ran the feed's actual heading parser over the four `RELEASE_NOTES.md` files:

| Page | Entries | Unparseable |
| --- | --- | --- |
| `/resources/changelog` | 0 (index page, as expected) | 0 |
| `/resources/changelog/api-client` | 12 | 0 |
| `/resources/changelog/api-reference` | 12 | 0 |
| `/resources/changelog/agent` | 5 | 0 |
| `/resources/changelog/mock-server` | 6 | 0 |

**35 entries, none unparseable**, merging newest-first across products. The index page contributes nothing of its own, which is correct — it only links to the products.

Note the same release notes are also routed under `/products/...`, but those sit outside `path` so entries appear exactly once.

## Sequencing

**Do not merge before the feature ships.** The `rss` key is not in the published config schema yet, so this is inert until scalar-org#5395 lands and deploys.

Docs for the option are in #9831.