### PR TITLE
Feat/nested sidebar sub tag path

### DIFF
--- a/.changeset/copy-as-markdown-llm-button.md
+++ b/.changeset/copy-as-markdown-llm-button.md
@@ -1,7 +1,15 @@
 ---
 '@scalar/api-reference': minor
+'@scalar/types': minor
+'@scalar/schemas': minor
 ---
 
 feat: add "Copy as Markdown for LLM" button on every operation in both Classic and Modern layouts
 
 Clicking the brain icon copies a structured Markdown snapshot of the operation — method, path, summary, description, parameters table, request body schema, and responses — to the clipboard, ready to paste into any LLM chat.
+
+Follow-up improvements:
+- **Localized label**: button label is now routed through the localization system (`actions.copyAsMarkdownForLlm`) with translations for all 7 built-in locales (en, ar, de, es, fr, ru, zh-CN)
+- **`$ref` resolution**: `operation.parameters`, `requestBody`, and each `responses` entry are now resolved via `getResolvedRef` before serialization, so documents that use shared `$ref` components render correctly instead of producing empty sections
+- **Table escaping**: pipe characters (`|`) in descriptions are escaped to `\|` so they don't break Markdown table rows
+- **Opt-out flag**: a new `hideCopyAsMarkdownButton: boolean` configuration option (default `false`) hides the button when set to `true`, consistent with `hideTestRequestButton`

--- a/.changeset/copy-as-markdown-llm-button.md
+++ b/.changeset/copy-as-markdown-llm-button.md
@@ -1,0 +1,7 @@
+---
+'@scalar/api-reference': minor
+---
+
+feat: add "Copy as Markdown for LLM" button on every operation in both Classic and Modern layouts
+
+Clicking the brain icon copies a structured Markdown snapshot of the operation — method, path, summary, description, parameters table, request body schema, and responses — to the clipboard, ready to paste into any LLM chat.

--- a/.changeset/nested-sidebar-sub-tags.md
+++ b/.changeset/nested-sidebar-sub-tags.md
@@ -1,0 +1,48 @@
+---
+'@scalar/workspace-store': minor
+---
+
+feat: add `x-subTagPath` for unlimited sidebar nesting depth
+
+Operations can now declare `x-subTagPath` — an ordered array of collapsible group names that defines an arbitrarily deep nesting path in the sidebar. Each element adds one collapsible level beneath the parent tag.
+
+The resulting structure is:
+
+```
+x-tagGroups group  (non-collapsible section header)
+  └── Tag           (collapsible)
+        └── Level 1 (collapsible, x-subTagPath[0])
+              └── Level 2 (collapsible, x-subTagPath[1])
+                    └── Level 3 (collapsible, x-subTagPath[2])
+                          └── Endpoint
+```
+
+Any number of levels is supported. Operations without `x-subTagPath` render flat under their tag.
+
+**OpenAPI spec usage:**
+
+```yaml
+x-tagGroups:
+  - name: Automated Prior Authorization (CMS-0057)
+    tags: [Payer Catalog]
+
+paths:
+  /fhir/r4/PayerCatalog:
+    get:
+      tags: [Payer Catalog]
+      summary: List all payers in the catalog
+      x-subTagPath: [Payer Operations]                        # 1 level deep
+    post:
+      tags: [Payer Catalog]
+      summary: Register a payer
+      x-subTagPath: [Payer Operations, Single Payer]          # 2 levels deep
+    put:
+      tags: [Payer Catalog]
+      summary: Update payer details
+      x-subTagPath: [Payer Operations, Single Payer, Write]   # 3 levels deep
+  /health:
+    get:
+      tags: [Payer Catalog]
+      summary: Health check
+      # no x-subTagPath — rendered flat under the tag
+```

--- a/packages/api-reference/src/features/Operation/Operation.vue
+++ b/packages/api-reference/src/features/Operation/Operation.vue
@@ -13,6 +13,7 @@ export type OperationProps = {
     | 'expandAllResponses'
     | 'hideModels'
     | 'hideTestRequestButton'
+    | 'hideCopyAsMarkdownButton'
     | 'layout'
     | 'orderRequiredPropertiesFirst'
     | 'orderSchemaPropertiesBy'

--- a/packages/api-reference/src/features/Operation/components/CopyAsMarkdownButton.vue
+++ b/packages/api-reference/src/features/Operation/components/CopyAsMarkdownButton.vue
@@ -4,6 +4,7 @@ import { ScalarIconBrain } from '@scalar/icons'
 import { useClipboard } from '@scalar/use-hooks/useClipboard'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/operation'
 
+import { useLocalization } from '@/features/localization'
 import { operationToMarkdown } from '@/features/Operation/helpers/operation-to-markdown'
 
 const { method, path, operation } = defineProps<{
@@ -13,6 +14,7 @@ const { method, path, operation } = defineProps<{
 }>()
 
 const { copyToClipboard } = useClipboard()
+const { translate } = useLocalization()
 
 const handleCopy = () =>
   copyToClipboard(operationToMarkdown({ method, path, operation }))
@@ -21,7 +23,7 @@ const handleCopy = () =>
   <ScalarIconButton
     class="endpoint-copy-markdown p-0.5"
     :icon="ScalarIconBrain"
-    label="Copy as Markdown for LLM"
+    :label="translate('actions.copyAsMarkdownForLlm')"
     size="xs"
     variant="ghost"
     @click.stop="handleCopy" />

--- a/packages/api-reference/src/features/Operation/components/CopyAsMarkdownButton.vue
+++ b/packages/api-reference/src/features/Operation/components/CopyAsMarkdownButton.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { ScalarIconButton } from '@scalar/components/icon-button'
+import { ScalarIconBrain } from '@scalar/icons'
+import { useClipboard } from '@scalar/use-hooks/useClipboard'
+import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/operation'
+
+import { operationToMarkdown } from '@/features/Operation/helpers/operation-to-markdown'
+
+const { method, path, operation } = defineProps<{
+  method: string
+  path: string
+  operation: OperationObject
+}>()
+
+const { copyToClipboard } = useClipboard()
+
+const handleCopy = () =>
+  copyToClipboard(operationToMarkdown({ method, path, operation }))
+</script>
+<template>
+  <ScalarIconButton
+    class="endpoint-copy-markdown p-0.5"
+    :icon="ScalarIconBrain"
+    label="Copy as Markdown for LLM"
+    size="xs"
+    variant="ghost"
+    @click.stop="handleCopy" />
+</template>

--- a/packages/api-reference/src/features/Operation/helpers/operation-to-markdown.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/operation-to-markdown.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest'
+
+import { operationToMarkdown } from './operation-to-markdown'
+
+const baseOperation = {
+  summary: 'List pets',
+  description: 'Returns a list of all pets.',
+  parameters: [],
+}
+
+describe('operationToMarkdown', () => {
+  it('renders method, path, summary and description', () => {
+    const result = operationToMarkdown({
+      method: 'get',
+      path: '/pets',
+      operation: baseOperation,
+    })
+
+    expect(result).toContain('## GET /pets')
+    expect(result).toContain('**List pets**')
+    expect(result).toContain('Returns a list of all pets.')
+  })
+
+  it('uppercases the HTTP method', () => {
+    const result = operationToMarkdown({
+      method: 'post',
+      path: '/pets',
+      operation: { summary: 'Create pet' },
+    })
+
+    expect(result).toContain('## POST /pets')
+  })
+
+  it('renders a deprecated notice when operation.deprecated is true', () => {
+    const result = operationToMarkdown({
+      method: 'delete',
+      path: '/pets/{id}',
+      operation: { deprecated: true },
+    })
+
+    expect(result).toContain('deprecated')
+  })
+
+  it('renders a parameters table with name, in, type, required and description', () => {
+    const result = operationToMarkdown({
+      method: 'get',
+      path: '/pets',
+      operation: {
+        parameters: [
+          {
+            name: 'limit',
+            in: 'query',
+            required: false,
+            description: 'Max results',
+            schema: { type: 'integer' },
+          },
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+      },
+    })
+
+    expect(result).toContain('### Parameters')
+    expect(result).toContain('`limit`')
+    expect(result).toContain('query')
+    expect(result).toContain('integer')
+    expect(result).toContain('Max results')
+    expect(result).toContain('`id`')
+    expect(result).toContain('path')
+    // required param shows Yes
+    expect(result).toMatch(/`id`.*Yes/)
+    // optional param shows No
+    expect(result).toMatch(/`limit`.*No/)
+  })
+
+  it('renders request body with content type and schema properties', () => {
+    const result = operationToMarkdown({
+      method: 'post',
+      path: '/pets',
+      operation: {
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['name'],
+                properties: {
+                  name: { type: 'string', description: 'Pet name' },
+                  age: { type: 'integer' },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result).toContain('### Request Body')
+    expect(result).toContain('`application/json`')
+    expect(result).toContain('`name`')
+    expect(result).toContain('`age`')
+    expect(result).toContain('Pet name')
+    // name is required
+    expect(result).toMatch(/`name`.*Yes/)
+    // age is not required
+    expect(result).toMatch(/`age`.*No/)
+  })
+
+  it('renders responses section with status codes and descriptions', () => {
+    const result = operationToMarkdown({
+      method: 'get',
+      path: '/pets',
+      operation: {
+        responses: {
+          '200': { description: 'A list of pets' },
+          '404': { description: 'Not found' },
+        },
+      },
+    })
+
+    expect(result).toContain('### Responses')
+    expect(result).toContain('`200`')
+    expect(result).toContain('A list of pets')
+    expect(result).toContain('`404`')
+    expect(result).toContain('Not found')
+  })
+
+  it('renders array type as type[]', () => {
+    const result = operationToMarkdown({
+      method: 'post',
+      path: '/pets',
+      operation: {
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  tags: { type: 'array', items: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result).toContain('string[]')
+  })
+
+  it('renders enum types as union literals', () => {
+    const result = operationToMarkdown({
+      method: 'post',
+      path: '/pets',
+      operation: {
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  status: { enum: ['active', 'inactive'] },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result).toContain('"active" | "inactive"')
+  })
+
+  it('omits sections that have no data', () => {
+    const result = operationToMarkdown({
+      method: 'get',
+      path: '/health',
+      operation: {},
+    })
+
+    expect(result).not.toContain('### Parameters')
+    expect(result).not.toContain('### Request Body')
+    expect(result).not.toContain('### Responses')
+  })
+})

--- a/packages/api-reference/src/features/Operation/helpers/operation-to-markdown.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/operation-to-markdown.test.ts
@@ -186,4 +186,105 @@ describe('operationToMarkdown', () => {
     expect(result).not.toContain('### Request Body')
     expect(result).not.toContain('### Responses')
   })
+
+  it('escapes pipe characters in descriptions to avoid breaking table rows', () => {
+    const result = operationToMarkdown({
+      method: 'get',
+      path: '/pets',
+      operation: {
+        parameters: [
+          {
+            name: 'filter',
+            in: 'query',
+            required: false,
+            description: 'One value | another value',
+            schema: { type: 'string' },
+          },
+        ],
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  mode: { type: 'string', description: 'read | write' },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result).toContain('One value \\| another value')
+    expect(result).toContain('read \\| write')
+  })
+
+  it('resolves $ref parameters', () => {
+    const result = operationToMarkdown({
+      method: 'get',
+      path: '/pets',
+      operation: {
+        parameters: [
+          {
+            $ref: '#/components/parameters/LimitParam',
+            '$ref-value': {
+              name: 'limit',
+              in: 'query',
+              required: false,
+              description: 'Max results',
+              schema: { type: 'integer' },
+            },
+          } as any,
+        ],
+      },
+    })
+
+    expect(result).toContain('`limit`')
+    expect(result).toContain('integer')
+    expect(result).toContain('Max results')
+  })
+
+  it('resolves a $ref requestBody', () => {
+    const result = operationToMarkdown({
+      method: 'post',
+      path: '/pets',
+      operation: {
+        requestBody: {
+          $ref: '#/components/requestBodies/PetBody',
+          '$ref-value': {
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { name: { type: 'string' } },
+                },
+              },
+            },
+          },
+        } as any,
+      },
+    })
+
+    expect(result).toContain('### Request Body')
+    expect(result).toContain('`name`')
+  })
+
+  it('resolves $ref responses', () => {
+    const result = operationToMarkdown({
+      method: 'get',
+      path: '/pets',
+      operation: {
+        responses: {
+          '200': {
+            $ref: '#/components/responses/PetList',
+            '$ref-value': { description: 'A list of pets' },
+          } as any,
+        },
+      },
+    })
+
+    expect(result).toContain('`200`')
+    expect(result).toContain('A list of pets')
+  })
 })

--- a/packages/api-reference/src/features/Operation/helpers/operation-to-markdown.ts
+++ b/packages/api-reference/src/features/Operation/helpers/operation-to-markdown.ts
@@ -1,0 +1,124 @@
+import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/operation'
+import type { ParameterObject } from '@scalar/workspace-store/schemas/v3.1/strict/parameter'
+import type { ResponsesObject } from '@scalar/workspace-store/schemas/v3.1/strict/responses'
+import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/schema'
+
+/** Render a schema object as a compact inline type string for Markdown tables */
+function schemaToType(schema: SchemaObject | undefined): string {
+  if (!schema) return ''
+  if (schema.type === 'array') {
+    const items = schema.items as SchemaObject | undefined
+    return items?.type ? `${items.type}[]` : 'array'
+  }
+  if (schema.enum) {
+    return schema.enum.map((v) => JSON.stringify(v)).join(' | ')
+  }
+  return String(schema.type ?? '')
+}
+
+/** Render a schema's properties as a Markdown table (one level deep) */
+function schemaPropertiesToMarkdown(schema: SchemaObject | undefined): string {
+  if (!schema?.properties) return ''
+
+  const required = new Set<string>(Array.isArray(schema.required) ? (schema.required as string[]) : [])
+
+  const rows = Object.entries(schema.properties as Record<string, SchemaObject>)
+    .map(([name, prop]) => {
+      const type = schemaToType(prop)
+      const req = required.has(name) ? 'Yes' : 'No'
+      const desc = prop.description?.replace(/\n/g, ' ') ?? ''
+      return `| \`${name}\` | ${type} | ${req} | ${desc} |`
+    })
+    .join('\n')
+
+  return `| Name | Type | Required | Description |\n|------|------|----------|-------------|\n${rows}`
+}
+
+/** Serialize a single operation to a Markdown string suitable for LLM consumption */
+export function operationToMarkdown({
+  method,
+  path,
+  operation,
+}: {
+  method: string
+  path: string
+  operation: OperationObject
+}): string {
+  const lines: string[] = []
+
+  // Heading
+  lines.push(`## ${method.toUpperCase()} ${path}`)
+  lines.push('')
+
+  if (operation.summary) {
+    lines.push(`**${operation.summary}**`)
+    lines.push('')
+  }
+
+  if (operation.description) {
+    lines.push(operation.description.trim())
+    lines.push('')
+  }
+
+  if (operation.deprecated) {
+    lines.push('> ⚠️ This operation is deprecated.')
+    lines.push('')
+  }
+
+  // Parameters
+  const params = (operation.parameters ?? []) as ParameterObject[]
+  if (params.length > 0) {
+    lines.push('### Parameters')
+    lines.push('')
+    lines.push('| Name | In | Type | Required | Description |')
+    lines.push('|------|----|------|----------|-------------|')
+    for (const param of params) {
+      const schema = 'schema' in param ? (param.schema as SchemaObject | undefined) : undefined
+      const type = schemaToType(schema)
+      const req = param.required ? 'Yes' : 'No'
+      const desc = param.description?.replace(/\n/g, ' ') ?? ''
+      lines.push(`| \`${param.name}\` | ${param.in} | ${type} | ${req} | ${desc} |`)
+    }
+    lines.push('')
+  }
+
+  // Request body
+  const requestBody = operation.requestBody as RequestBodyObject | undefined
+  if (requestBody?.content) {
+    lines.push('### Request Body')
+    lines.push('')
+    if (requestBody.description) {
+      lines.push(requestBody.description.trim())
+      lines.push('')
+    }
+    for (const [contentType, mediaType] of Object.entries(requestBody.content)) {
+      lines.push(`**Content-Type:** \`${contentType}\``)
+      lines.push('')
+      const schema = mediaType.schema as SchemaObject | undefined
+      const propTable = schemaPropertiesToMarkdown(schema)
+      if (propTable) {
+        lines.push(propTable)
+        lines.push('')
+      } else if (schema?.type) {
+        lines.push(`Type: \`${schemaToType(schema)}\``)
+        lines.push('')
+      }
+    }
+  }
+
+  // Responses
+  const responses = operation.responses as ResponsesObject | undefined
+  if (responses) {
+    lines.push('### Responses')
+    lines.push('')
+    for (const [statusCode, response] of Object.entries(responses)) {
+      if (!response || typeof response !== 'object') continue
+      const desc = ('description' in response ? response.description : '') ?? ''
+      lines.push(`- \`${statusCode}\` — ${desc}`)
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n').trimEnd()
+}

--- a/packages/api-reference/src/features/Operation/helpers/operation-to-markdown.ts
+++ b/packages/api-reference/src/features/Operation/helpers/operation-to-markdown.ts
@@ -1,14 +1,19 @@
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/operation'
 import type { ParameterObject } from '@scalar/workspace-store/schemas/v3.1/strict/parameter'
+import type { ResponseObject } from '@scalar/workspace-store/schemas/v3.1/strict/response'
 import type { ResponsesObject } from '@scalar/workspace-store/schemas/v3.1/strict/responses'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/schema'
+
+/** Escape pipe characters so they don't break Markdown table rows */
+const escapeTableCell = (value: string): string => value.replace(/\|/g, '\\|').replace(/\n/g, ' ')
 
 /** Render a schema object as a compact inline type string for Markdown tables */
 function schemaToType(schema: SchemaObject | undefined): string {
   if (!schema) return ''
   if (schema.type === 'array') {
-    const items = schema.items as SchemaObject | undefined
+    const items = getResolvedRef(schema.items as SchemaObject | undefined)
     return items?.type ? `${items.type}[]` : 'array'
   }
   if (schema.enum) {
@@ -24,10 +29,11 @@ function schemaPropertiesToMarkdown(schema: SchemaObject | undefined): string {
   const required = new Set<string>(Array.isArray(schema.required) ? (schema.required as string[]) : [])
 
   const rows = Object.entries(schema.properties as Record<string, SchemaObject>)
-    .map(([name, prop]) => {
+    .map(([name, propRef]) => {
+      const prop = getResolvedRef(propRef)
       const type = schemaToType(prop)
       const req = required.has(name) ? 'Yes' : 'No'
-      const desc = prop.description?.replace(/\n/g, ' ') ?? ''
+      const desc = prop?.description ? escapeTableCell(prop.description) : ''
       return `| \`${name}\` | ${type} | ${req} | ${desc} |`
     })
     .join('\n')
@@ -67,24 +73,25 @@ export function operationToMarkdown({
   }
 
   // Parameters
-  const params = (operation.parameters ?? []) as ParameterObject[]
+  const rawParams = operation.parameters ?? []
+  const params = rawParams.map((p) => getResolvedRef(p as ParameterObject)).filter(Boolean) as ParameterObject[]
   if (params.length > 0) {
     lines.push('### Parameters')
     lines.push('')
     lines.push('| Name | In | Type | Required | Description |')
     lines.push('|------|----|------|----------|-------------|')
     for (const param of params) {
-      const schema = 'schema' in param ? (param.schema as SchemaObject | undefined) : undefined
+      const schema = 'schema' in param ? getResolvedRef(param.schema as SchemaObject | undefined) : undefined
       const type = schemaToType(schema)
       const req = param.required ? 'Yes' : 'No'
-      const desc = param.description?.replace(/\n/g, ' ') ?? ''
+      const desc = param.description ? escapeTableCell(param.description) : ''
       lines.push(`| \`${param.name}\` | ${param.in} | ${type} | ${req} | ${desc} |`)
     }
     lines.push('')
   }
 
   // Request body
-  const requestBody = operation.requestBody as RequestBodyObject | undefined
+  const requestBody = getResolvedRef(operation.requestBody as RequestBodyObject | undefined)
   if (requestBody?.content) {
     lines.push('### Request Body')
     lines.push('')
@@ -95,7 +102,7 @@ export function operationToMarkdown({
     for (const [contentType, mediaType] of Object.entries(requestBody.content)) {
       lines.push(`**Content-Type:** \`${contentType}\``)
       lines.push('')
-      const schema = mediaType.schema as SchemaObject | undefined
+      const schema = getResolvedRef(mediaType.schema as SchemaObject | undefined)
       const propTable = schemaPropertiesToMarkdown(schema)
       if (propTable) {
         lines.push(propTable)
@@ -112,7 +119,8 @@ export function operationToMarkdown({
   if (responses) {
     lines.push('### Responses')
     lines.push('')
-    for (const [statusCode, response] of Object.entries(responses)) {
+    for (const [statusCode, responseRef] of Object.entries(responses)) {
+      const response = getResolvedRef(responseRef as ResponseObject | undefined)
       if (!response || typeof response !== 'object') continue
       const desc = ('description' in response ? response.description : '') ?? ''
       lines.push(`- \`${statusCode}\` — ${desc}`)

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -214,6 +214,7 @@ const { copyToClipboard } = useClipboard()
         variant="ghost"
         @click.stop="copyToClipboard(path)" />
       <CopyAsMarkdownButton
+        v-if="!options.hideCopyAsMarkdownButton"
         :method
         :operation
         :path />

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -28,6 +28,7 @@ import { ExampleResponses } from '@/features/example-responses'
 import { ExternalDocs } from '@/features/external-docs'
 import { useLocalization } from '@/features/localization'
 import Callbacks from '@/features/Operation/components/callbacks/Callbacks.vue'
+import CopyAsMarkdownButton from '@/features/Operation/components/CopyAsMarkdownButton.vue'
 import OperationParameters from '@/features/Operation/components/OperationParameters.vue'
 import OperationResponses from '@/features/Operation/components/OperationResponses.vue'
 import OperationScopes from '@/features/Operation/components/OperationScopes.vue'
@@ -212,6 +213,10 @@ const { copyToClipboard } = useClipboard()
         size="xs"
         variant="ghost"
         @click.stop="copyToClipboard(path)" />
+      <CopyAsMarkdownButton
+        :method
+        :operation
+        :path />
     </template>
     <template
       v-if="operation.description"

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -22,6 +22,7 @@ import { ExampleResponses } from '@/features/example-responses'
 import { ExternalDocs } from '@/features/external-docs'
 import { useLocalization } from '@/features/localization'
 import Callbacks from '@/features/Operation/components/callbacks/Callbacks.vue'
+import CopyAsMarkdownButton from '@/features/Operation/components/CopyAsMarkdownButton.vue'
 import OperationParameters from '@/features/Operation/components/OperationParameters.vue'
 import OperationResponses from '@/features/Operation/components/OperationResponses.vue'
 import OperationScopes from '@/features/Operation/components/OperationScopes.vue'
@@ -146,6 +147,10 @@ provide(REQUEST_BODY_COMPOSITION_INDEX_SYMBOL, requestBodyCompositionSelection)
           <XBadges
             :badges="operation['x-badges']"
             position="after" />
+          <CopyAsMarkdownButton
+            :method
+            :operation
+            :path />
         </div>
       </div>
       <div class="operation-layout">

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -148,6 +148,7 @@ provide(REQUEST_BODY_COMPOSITION_INDEX_SYMBOL, requestBodyCompositionSelection)
             :badges="operation['x-badges']"
             position="after" />
           <CopyAsMarkdownButton
+            v-if="!options.hideCopyAsMarkdownButton"
             :method
             :operation
             :path />

--- a/packages/api-reference/src/features/localization/locales/ar.ts
+++ b/packages/api-reference/src/features/localization/locales/ar.ts
@@ -132,6 +132,7 @@ export const ar = {
     copyLinkTo: 'نسخ الرابط إلى {name}',
     copyToClipboard: 'نسخ الرابط إلى الحافظة',
     copyEndpointUrl: 'نسخ رابط endpoint',
+    copyAsMarkdownForLlm: 'نسخ كـ Markdown لـ LLM',
     showMore: 'عرض المزيد',
   },
   agent: {

--- a/packages/api-reference/src/features/localization/locales/de.ts
+++ b/packages/api-reference/src/features/localization/locales/de.ts
@@ -133,6 +133,7 @@ export const de = {
     copyLinkTo: 'Link zu {name} kopieren',
     copyToClipboard: 'Link in die Zwischenablage kopieren',
     copyEndpointUrl: 'Endpoint-URL kopieren',
+    copyAsMarkdownForLlm: 'Als Markdown für LLM kopieren',
     showMore: 'Mehr anzeigen',
   },
   agent: {

--- a/packages/api-reference/src/features/localization/locales/en.ts
+++ b/packages/api-reference/src/features/localization/locales/en.ts
@@ -132,6 +132,7 @@ export const en = {
     copyLinkTo: 'Copy link to {name}',
     copyToClipboard: 'Copy link to clipboard',
     copyEndpointUrl: 'Copy endpoint URL',
+    copyAsMarkdownForLlm: 'Copy as Markdown for LLM',
     showMore: 'Show More',
   },
   agent: {

--- a/packages/api-reference/src/features/localization/locales/es.ts
+++ b/packages/api-reference/src/features/localization/locales/es.ts
@@ -132,6 +132,7 @@ export const es = {
     copyLinkTo: 'Copiar enlace a {name}',
     copyToClipboard: 'Copiar enlace al portapapeles',
     copyEndpointUrl: 'Copiar URL del endpoint',
+    copyAsMarkdownForLlm: 'Copiar como Markdown para LLM',
     showMore: 'Mostrar más',
   },
   agent: {

--- a/packages/api-reference/src/features/localization/locales/fr.ts
+++ b/packages/api-reference/src/features/localization/locales/fr.ts
@@ -133,6 +133,7 @@ export const fr = {
     copyLinkTo: 'Copier le lien vers {name}',
     copyToClipboard: 'Copier le lien dans le presse-papiers',
     copyEndpointUrl: 'Copier l’URL de l’endpoint',
+    copyAsMarkdownForLlm: 'Copier en Markdown pour LLM',
     showMore: 'Afficher plus',
   },
   agent: {

--- a/packages/api-reference/src/features/localization/locales/ru.ts
+++ b/packages/api-reference/src/features/localization/locales/ru.ts
@@ -133,6 +133,7 @@ export const ru = {
     copyLinkTo: 'Скопировать ссылку на {name}',
     copyToClipboard: 'Скопировать ссылку в буфер обмена',
     copyEndpointUrl: 'Скопировать URL endpoint-а',
+    copyAsMarkdownForLlm: 'Скопировать как Markdown для LLM',
     showMore: 'Показать ещё',
   },
   agent: {

--- a/packages/api-reference/src/features/localization/locales/zh-cn.ts
+++ b/packages/api-reference/src/features/localization/locales/zh-cn.ts
@@ -132,6 +132,7 @@ export const zhCn = {
     copyLinkTo: '复制指向 {name} 的链接',
     copyToClipboard: '复制链接到剪贴板',
     copyEndpointUrl: '复制端点 URL',
+    copyAsMarkdownForLlm: '复制为 LLM Markdown 格式',
     showMore: '显示更多',
   },
   agent: {

--- a/packages/schemas/src/api-reference/api-reference-configuration.ts
+++ b/packages/schemas/src/api-reference/api-reference-configuration.ts
@@ -83,6 +83,10 @@ export const apiReferenceConfigurationSchema = intersection([
       default: false,
       typeComment: 'Whether to show the "Test Request" button',
     }),
+    hideCopyAsMarkdownButton: boolean({
+      default: false,
+      typeComment: 'Whether to hide the "Copy as Markdown for LLM" button on operations',
+    }),
     hideSearch: boolean({
       default: false,
       typeComment: 'Whether to show the sidebar search bar',

--- a/packages/types/src/api-reference/types.ts
+++ b/packages/types/src/api-reference/types.ts
@@ -489,6 +489,7 @@ export type ApiReferenceTranslations = {
     copyLinkTo: string
     copyToClipboard: string
     copyEndpointUrl: string
+    copyAsMarkdownForLlm: string
     showMore: string
   }
   agent: {
@@ -660,6 +661,8 @@ type ExtendedConfiguration = {
   hideDownloadButton?: boolean
   /** Whether to show the "Test Request" button */
   hideTestRequestButton: boolean
+  /** Whether to hide the "Copy as Markdown for LLM" button on operations */
+  hideCopyAsMarkdownButton: boolean
   /** Whether to show the sidebar search bar */
   hideSearch: boolean
   /** Whether to show the operationId */

--- a/packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-paths.test.ts
@@ -624,4 +624,90 @@ describe('traversePaths', () => {
 
     expect(tagsMap.get('Widget')?.entries[0]?.title).toBe('List widgets')
   })
+
+  it('should carry x-subTagPath from operation into the traversed entry as xSubTagPath', () => {
+    const document = createDocument()
+    document.paths = {
+      '/fhir/r4/PayerCatalog': {
+        get: {
+          tags: ['Payer Catalog'],
+          summary: 'List all payers in the catalog',
+          'x-subTagPath': ['Payer Operations'],
+        },
+        post: {
+          tags: ['Payer Catalog'],
+          summary: 'Register a payer',
+          'x-subTagPath': ['Payer Operations', 'Single Payer'],
+        },
+      },
+      '/fhir/r4/PayerCatalog/$bulk': {
+        get: {
+          tags: ['Payer Catalog'],
+          summary: 'Bulk export payers',
+          'x-subTagPath': ['Bulk Operations'],
+        },
+      },
+      '/health': {
+        get: {
+          tags: ['Payer Catalog'],
+          summary: 'Health check',
+          // no x-subTagPath
+        },
+      },
+    }
+
+    const tagsMap: TagsMap = new Map([
+      ['Payer Catalog', { id: 'tag/payer-catalog', parentId: 'doc-1', tag: { name: 'Payer Catalog' }, entries: [] }],
+    ])
+
+    traversePaths({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      generateId: (props) => {
+        if (props.type === 'operation') return `${props.method?.toUpperCase()}-${props.path}`
+        return 'unknown-id'
+      },
+    })
+
+    const entries = tagsMap.get('Payer Catalog')?.entries ?? []
+    expect(entries).toHaveLength(4)
+
+    expect(entries[0]).toMatchObject({ title: 'List all payers in the catalog', xSubTagPath: ['Payer Operations'] })
+    expect(entries[1]).toMatchObject({ title: 'Register a payer', xSubTagPath: ['Payer Operations', 'Single Payer'] })
+    expect(entries[2]).toMatchObject({ title: 'Bulk export payers', xSubTagPath: ['Bulk Operations'] })
+    expect(entries[3]).toMatchObject({ title: 'Health check' })
+    expect(entries[3]).not.toHaveProperty('xSubTagPath')
+  })
+
+  it('should not set xSubTagPath when x-subTagPath is an empty array', () => {
+    const document = createDocument()
+    document.paths = {
+      '/payers': {
+        get: {
+          tags: ['Payer Catalog'],
+          summary: 'List payers',
+          'x-subTagPath': [],
+        },
+      },
+    }
+
+    const tagsMap: TagsMap = new Map([
+      ['Payer Catalog', { id: 'tag/payer-catalog', parentId: 'doc-1', tag: { name: 'Payer Catalog' }, entries: [] }],
+    ])
+
+    traversePaths({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      generateId: (props) => {
+        if (props.type === 'operation') return `${props.method?.toUpperCase()}-${props.path}`
+        return 'unknown-id'
+      },
+    })
+
+    const entries = tagsMap.get('Payer Catalog')?.entries ?? []
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).not.toHaveProperty('xSubTagPath')
+  })
 })

--- a/packages/workspace-store/src/navigation/helpers/traverse-paths.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-paths.ts
@@ -79,6 +79,7 @@ const createOperationEntry = ({
     type: 'operation',
     isDeprecated,
     children: examples.length ? examples : undefined,
+    ...(operation['x-subTagPath']?.length ? { xSubTagPath: operation['x-subTagPath'] as string[] } : {}),
   } satisfies TraversedOperation
 
   return entry

--- a/packages/workspace-store/src/navigation/helpers/traverse-tags.test.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-tags.test.ts
@@ -509,6 +509,296 @@ describe('traverseTags', () => {
     expect(result[0]?.title).toBe('public')
   })
 
+  it('should group operations under sub-tags using xSubTagPath (1 level deep)', () => {
+    const document = createMockDocument()
+    const tagsMap: TagsMap = new Map([
+      [
+        'Payer Catalog',
+        {
+          id: 'tag/payer-catalog',
+          parentId: 'doc-1',
+          tag: createMockTag('Payer Catalog'),
+          entries: [
+            {
+              id: 'op-list-payers',
+              title: 'List all payers',
+              method: 'get',
+              type: 'operation',
+              path: '/fhir/r4/PayerCatalog',
+              ref: '#/paths/~1fhir~1r4~1PayerCatalog/get',
+              xSubTagPath: ['Payer Operations'],
+            },
+            {
+              id: 'op-register-payer',
+              title: 'Register a payer',
+              method: 'post',
+              type: 'operation',
+              path: '/fhir/r4/PayerCatalog',
+              ref: '#/paths/~1fhir~1r4~1PayerCatalog/post',
+              xSubTagPath: ['Payer Operations'],
+            },
+            {
+              id: 'op-bulk-export',
+              title: 'Bulk export payers',
+              method: 'get',
+              type: 'operation',
+              path: '/fhir/r4/PayerCatalog/$bulk',
+              ref: '#/paths/~1fhir~1r4~1PayerCatalog~1$bulk/get',
+              xSubTagPath: ['Bulk Operations'],
+            },
+          ],
+        },
+      ],
+    ])
+
+    const result = traverseTags({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      options: {
+        generateId: (props) => (props.type === 'tag' ? `tag/${props.tag.name}` : 'unknown-id'),
+        tagsSorter: undefined,
+        operationsSorter: undefined,
+      },
+    })
+
+    assert(result[0]?.type === 'tag')
+    const children = result[0].children ?? []
+    expect(children).toHaveLength(2)
+
+    assert(children[0]?.type === 'tag')
+    expect(children[0].name).toBe('Payer Operations')
+    expect(children[0].children).toHaveLength(2)
+    expect(children[0].children?.[0]?.title).toBe('List all payers')
+    expect(children[0].children?.[1]?.title).toBe('Register a payer')
+
+    assert(children[1]?.type === 'tag')
+    expect(children[1].name).toBe('Bulk Operations')
+    expect(children[1].children).toHaveLength(1)
+    expect(children[1].children?.[0]?.title).toBe('Bulk export payers')
+  })
+
+  it('should support arbitrary nesting depth via xSubTagPath (n levels deep)', () => {
+    const document = createMockDocument()
+    const tagsMap: TagsMap = new Map([
+      [
+        'Payer Catalog',
+        {
+          id: 'tag/payer-catalog',
+          parentId: 'doc-1',
+          tag: createMockTag('Payer Catalog'),
+          entries: [
+            {
+              id: 'op-single',
+              title: 'Get single payer',
+              method: 'get',
+              type: 'operation',
+              path: '/fhir/r4/PayerCatalog/single',
+              ref: '#/paths/single/get',
+              xSubTagPath: ['Payer Operations', 'Single Payer', 'Details'],
+            },
+            {
+              id: 'op-list',
+              title: 'List all payers',
+              method: 'get',
+              type: 'operation',
+              path: '/fhir/r4/PayerCatalog',
+              ref: '#/paths/list/get',
+              xSubTagPath: ['Payer Operations', 'Single Payer'],
+            },
+            {
+              id: 'op-bulk',
+              title: 'Bulk export',
+              method: 'get',
+              type: 'operation',
+              path: '/fhir/r4/PayerCatalog/$bulk',
+              ref: '#/paths/bulk/get',
+              xSubTagPath: ['Bulk Operations'],
+            },
+          ],
+        },
+      ],
+    ])
+
+    const result = traverseTags({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      options: {
+        generateId: (props) => (props.type === 'tag' ? `tag/${props.tag.name}` : 'unknown-id'),
+        tagsSorter: undefined,
+        operationsSorter: undefined,
+      },
+    })
+
+    assert(result[0]?.type === 'tag')
+    const l1 = result[0].children ?? []
+    // Payer Operations + Bulk Operations
+    expect(l1).toHaveLength(2)
+
+    assert(l1[0]?.type === 'tag')
+    expect(l1[0].name).toBe('Payer Operations')
+    const l2 = l1[0].children ?? []
+    // Single Payer sub-group
+    expect(l2).toHaveLength(1)
+    assert(l2[0]?.type === 'tag')
+    expect(l2[0].name).toBe('Single Payer')
+    const l3 = l2[0].children ?? []
+    // Details sub-group + List all payers (path length 2, stops here)
+    expect(l3).toHaveLength(2)
+    assert(l3[0]?.type === 'tag')
+    expect(l3[0].name).toBe('Details')
+    expect(l3[0].children?.[0]?.title).toBe('Get single payer')
+    assert(l3[1]?.type === 'operation')
+    expect(l3[1].title).toBe('List all payers')
+
+    assert(l1[1]?.type === 'tag')
+    expect(l1[1].name).toBe('Bulk Operations')
+    expect(l1[1].children?.[0]?.title).toBe('Bulk export')
+  })
+
+  it('should place operations without xSubTagPath flat under the tag', () => {
+    const document = createMockDocument()
+    const tagsMap: TagsMap = new Map([
+      [
+        'Payer Catalog',
+        {
+          id: 'tag/payer-catalog',
+          parentId: 'doc-1',
+          tag: createMockTag('Payer Catalog'),
+          entries: [
+            {
+              id: 'op-grouped',
+              title: 'List all payers',
+              method: 'get',
+              type: 'operation',
+              path: '/fhir/r4/PayerCatalog',
+              ref: '#/paths/~1fhir~1r4~1PayerCatalog/get',
+              xSubTagPath: ['Payer Operations'],
+            },
+            {
+              id: 'op-ungrouped',
+              title: 'Health check',
+              method: 'get',
+              type: 'operation',
+              path: '/health',
+              ref: '#/paths/~1health/get',
+            },
+          ],
+        },
+      ],
+    ])
+
+    const result = traverseTags({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      options: {
+        generateId: (props) => (props.type === 'tag' ? `tag/${props.tag.name}` : 'unknown-id'),
+        tagsSorter: undefined,
+        operationsSorter: undefined,
+      },
+    })
+
+    assert(result[0]?.type === 'tag')
+    const children = result[0].children ?? []
+    expect(children).toHaveLength(2)
+    assert(children[0]?.type === 'tag')
+    expect(children[0].name).toBe('Payer Operations')
+    assert(children[1]?.type === 'operation')
+    expect(children[1].title).toBe('Health check')
+  })
+
+  it('should work with x-tagGroups and xSubTagPath together (n-level nesting)', () => {
+    const tagGroups = [{ name: 'Automated Prior Authorization', tags: ['Payer Catalog'] }]
+    const document = createMockDocument(tagGroups)
+    const tagsMap: TagsMap = new Map([
+      [
+        'Payer Catalog',
+        {
+          id: 'tag/payer-catalog',
+          parentId: 'doc-1',
+          tag: createMockTag('Payer Catalog'),
+          entries: [
+            {
+              id: 'op-list-payers',
+              title: 'List all payers',
+              method: 'get',
+              type: 'operation',
+              path: '/fhir/r4/PayerCatalog',
+              ref: '#/paths/~1fhir~1r4~1PayerCatalog/get',
+              xSubTagPath: ['Payer Operations'],
+            },
+          ],
+        },
+      ],
+    ])
+
+    const result = traverseTags({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      options: {
+        generateId: (props) => (props.type === 'tag' ? `tag/${props.tag.name}` : 'unknown-id'),
+        tagsSorter: undefined,
+        operationsSorter: undefined,
+      },
+    })
+
+    // Level 1: x-tagGroups group
+    expect(result).toHaveLength(1)
+    assert(result[0]?.type === 'tag')
+    expect(result[0].isGroup).toBe(true)
+    expect(result[0].name).toBe('Automated Prior Authorization')
+
+    // Level 2: tag
+    const level2 = result[0].children ?? []
+    assert(level2[0]?.type === 'tag')
+    expect(level2[0].name).toBe('Payer Catalog')
+
+    // Level 3: sub-tag from xSubTagPath[0]
+    const level3 = level2[0].children ?? []
+    assert(level3[0]?.type === 'tag')
+    expect(level3[0].name).toBe('Payer Operations')
+
+    // Level 4: operation
+    const level4 = level3[0].children ?? []
+    assert(level4[0]?.type === 'operation')
+    expect(level4[0].title).toBe('List all payers')
+  })
+
+  it('should not affect tags without xSubTagPath on any operation', () => {
+    const document = createMockDocument()
+    const tagsMap: TagsMap = new Map([
+      [
+        'Authentication',
+        {
+          id: 'tag/authentication',
+          parentId: 'doc-1',
+          tag: createMockTag('Authentication'),
+          entries: [createMockEntry('Get a token', 'post'), createMockEntry('Get authenticated user', 'get')],
+        },
+      ],
+    ])
+
+    const result = traverseTags({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      options: {
+        generateId: (props) => (props.type === 'tag' ? `tag/${props.tag.name}` : 'unknown-id'),
+        tagsSorter: undefined,
+        operationsSorter: undefined,
+      },
+    })
+
+    assert(result[0]?.type === 'tag')
+    // Children are flat operations, no sub-tag wrapping
+    expect(result[0].children).toHaveLength(2)
+    expect(result[0].children?.[0]?.type).toBe('operation')
+    expect(result[0].children?.[1]?.type).toBe('operation')
+  })
+
   it('should handle scalar-ignore tags', () => {
     const document = createMockDocument()
     const tagsMap: TagsMap = new Map([
@@ -550,5 +840,255 @@ describe('traverseTags', () => {
     })
     expect(result).toHaveLength(1)
     expect(result[0]?.title).toBe('visible')
+  })
+
+  it('should produce the exact structure: x-tagGroups > tag > level1 > level2 > level3 > endpoint', () => {
+    // This is the primary use-case: full 6-level sidebar nesting
+    // x-tagGroups group (non-collapsible section header)
+    //   └── Tag (collapsible)
+    //         └── Level 1 (collapsible, xSubTagPath[0])
+    //               └── Level 2 (collapsible, xSubTagPath[1])
+    //                     └── Level 3 (collapsible, xSubTagPath[2])
+    //                           └── Endpoint (operation)
+    const tagGroups = [{ name: 'Automated Prior Authorization (CMS-0057)', tags: ['Payer Catalog'] }]
+    const document = createMockDocument(tagGroups)
+    const tagsMap: TagsMap = new Map([
+      [
+        'Payer Catalog',
+        {
+          id: 'tag/payer-catalog',
+          parentId: 'doc-1',
+          tag: createMockTag('Payer Catalog'),
+          entries: [
+            {
+              id: 'op-1',
+              title: 'List all payers in the catalog',
+              method: 'get' as const,
+              type: 'operation' as const,
+              path: '/fhir/r4/PayerCatalog',
+              ref: '#/paths/~1fhir~1r4~1PayerCatalog/get',
+              xSubTagPath: ['Payer Operations', 'Single Payer', 'Read'],
+            },
+          ],
+        },
+      ],
+    ])
+
+    const result = traverseTags({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      options: {
+        generateId: (props) => (props.type === 'tag' ? `tag/${props.tag.name}` : 'unknown-id'),
+        tagsSorter: undefined,
+        operationsSorter: undefined,
+      },
+    })
+
+    // x-tagGroups group
+    expect(result).toHaveLength(1)
+    assert(result[0]?.type === 'tag')
+    expect(result[0].isGroup).toBe(true)
+    expect(result[0].title).toBe('Automated Prior Authorization (CMS-0057)')
+
+    // Tag
+    const tagChildren = result[0].children ?? []
+    expect(tagChildren).toHaveLength(1)
+    assert(tagChildren[0]?.type === 'tag')
+    expect(tagChildren[0].name).toBe('Payer Catalog')
+    expect(tagChildren[0].isGroup).toBe(false)
+
+    // Level 1
+    const level1Children = tagChildren[0].children ?? []
+    expect(level1Children).toHaveLength(1)
+    assert(level1Children[0]?.type === 'tag')
+    expect(level1Children[0].name).toBe('Payer Operations')
+
+    // Level 2
+    const level2Children = level1Children[0].children ?? []
+    expect(level2Children).toHaveLength(1)
+    assert(level2Children[0]?.type === 'tag')
+    expect(level2Children[0].name).toBe('Single Payer')
+
+    // Level 3
+    const level3Children = level2Children[0].children ?? []
+    expect(level3Children).toHaveLength(1)
+    assert(level3Children[0]?.type === 'tag')
+    expect(level3Children[0].name).toBe('Read')
+
+    // Endpoint
+    const endpoints = level3Children[0].children ?? []
+    expect(endpoints).toHaveLength(1)
+    assert(endpoints[0]?.type === 'operation')
+    expect(endpoints[0].title).toBe('List all payers in the catalog')
+    expect(endpoints[0].method).toBe('get')
+  })
+
+  it('should handle operations at mixed nesting depths within the same tag', () => {
+    // Some operations are nested 1 level, some 2, some 3, some flat
+    const document = createMockDocument()
+    const tagsMap: TagsMap = new Map([
+      [
+        'Payer Catalog',
+        {
+          id: 'tag/payer-catalog',
+          parentId: 'doc-1',
+          tag: createMockTag('Payer Catalog'),
+          entries: [
+            {
+              id: 'op-flat',
+              title: 'Health check',
+              method: 'get' as const,
+              type: 'operation' as const,
+              path: '/health',
+              ref: '#/paths/~1health/get',
+              // no xSubTagPath — flat
+            },
+            {
+              id: 'op-l1',
+              title: 'List payers',
+              method: 'get' as const,
+              type: 'operation' as const,
+              path: '/payers',
+              ref: '#/paths/~1payers/get',
+              xSubTagPath: ['Payer Operations'],
+            },
+            {
+              id: 'op-l2',
+              title: 'Get single payer',
+              method: 'get' as const,
+              type: 'operation' as const,
+              path: '/payers/single',
+              ref: '#/paths/~1payers~1single/get',
+              xSubTagPath: ['Payer Operations', 'Single'],
+            },
+            {
+              id: 'op-l3',
+              title: 'Get payer details',
+              method: 'get' as const,
+              type: 'operation' as const,
+              path: '/payers/single/details',
+              ref: '#/paths/~1payers~1single~1details/get',
+              xSubTagPath: ['Payer Operations', 'Single', 'Details'],
+            },
+          ],
+        },
+      ],
+    ])
+
+    const result = traverseTags({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      options: {
+        generateId: (props) => (props.type === 'tag' ? `tag/${props.tag.name}` : 'unknown-id'),
+        tagsSorter: undefined,
+        operationsSorter: undefined,
+      },
+    })
+
+    assert(result[0]?.type === 'tag')
+    const tagChildren = result[0].children ?? []
+    // 'Payer Operations' group + flat 'Health check'
+    expect(tagChildren).toHaveLength(2)
+
+    // Level 1 group
+    assert(tagChildren[0]?.type === 'tag')
+    expect(tagChildren[0].name).toBe('Payer Operations')
+    const l1Children = tagChildren[0].children ?? []
+    // 'Single' group + 'List payers' (path length 1, stops at l1)
+    expect(l1Children).toHaveLength(2)
+
+    assert(l1Children[0]?.type === 'tag')
+    expect(l1Children[0].name).toBe('Single')
+    const l2Children = l1Children[0].children ?? []
+    // 'Details' group + 'Get single payer' (path length 2, stops at l2)
+    expect(l2Children).toHaveLength(2)
+
+    assert(l2Children[0]?.type === 'tag')
+    expect(l2Children[0].name).toBe('Details')
+    expect(l2Children[0].children?.[0]?.title).toBe('Get payer details')
+
+    assert(l2Children[1]?.type === 'operation')
+    expect(l2Children[1].title).toBe('Get single payer')
+
+    assert(l1Children[1]?.type === 'operation')
+    expect(l1Children[1].title).toBe('List payers')
+
+    // Flat operation
+    assert(tagChildren[1]?.type === 'operation')
+    expect(tagChildren[1].title).toBe('Health check')
+  })
+
+  it('should handle multiple operations at the same nesting path', () => {
+    const document = createMockDocument()
+    const tagsMap: TagsMap = new Map([
+      [
+        'Payer Catalog',
+        {
+          id: 'tag/payer-catalog',
+          parentId: 'doc-1',
+          tag: createMockTag('Payer Catalog'),
+          entries: [
+            {
+              id: 'op-get',
+              title: 'Get payer',
+              method: 'get' as const,
+              type: 'operation' as const,
+              path: '/payers/{id}',
+              ref: '#/paths/~1payers~1{id}/get',
+              xSubTagPath: ['Payer Operations', 'Single'],
+            },
+            {
+              id: 'op-put',
+              title: 'Update payer',
+              method: 'put' as const,
+              type: 'operation' as const,
+              path: '/payers/{id}',
+              ref: '#/paths/~1payers~1{id}/put',
+              xSubTagPath: ['Payer Operations', 'Single'],
+            },
+            {
+              id: 'op-delete',
+              title: 'Delete payer',
+              method: 'delete' as const,
+              type: 'operation' as const,
+              path: '/payers/{id}',
+              ref: '#/paths/~1payers~1{id}/delete',
+              xSubTagPath: ['Payer Operations', 'Single'],
+            },
+          ],
+        },
+      ],
+    ])
+
+    const result = traverseTags({
+      document,
+      tagsMap,
+      documentId: 'doc-1',
+      options: {
+        generateId: (props) => (props.type === 'tag' ? `tag/${props.tag.name}` : 'unknown-id'),
+        tagsSorter: undefined,
+        operationsSorter: undefined,
+      },
+    })
+
+    assert(result[0]?.type === 'tag')
+    const l1 = result[0].children ?? []
+    expect(l1).toHaveLength(1)
+    assert(l1[0]?.type === 'tag')
+    expect(l1[0].name).toBe('Payer Operations')
+
+    const l2 = l1[0].children ?? []
+    expect(l2).toHaveLength(1)
+    assert(l2[0]?.type === 'tag')
+    expect(l2[0].name).toBe('Single')
+
+    // All 3 operations land under the same sub-tag
+    const ops = l2[0].children ?? []
+    expect(ops).toHaveLength(3)
+    expect(ops[0]?.title).toBe('Get payer')
+    expect(ops[1]?.title).toBe('Update payer')
+    expect(ops[2]?.title).toBe('Delete payer')
   })
 })

--- a/packages/workspace-store/src/navigation/helpers/traverse-tags.ts
+++ b/packages/workspace-store/src/navigation/helpers/traverse-tags.ts
@@ -75,6 +75,57 @@ const createTagEntry = ({
  * @param options - Sorting and ID generation options
  * @returns Array of processed and sorted tag entries
  */
+/**
+ * Recursively groups a flat list of entries into a nested tag tree based on each
+ * operation's xSubTagPath (e.g. ['Payer Operations', 'Single Payer']).
+ *
+ * At each depth level it:
+ * 1. Collects all operations whose path segment at `depth` matches a group name
+ * 2. Recurses into that group for the next depth level
+ * 3. Leaves operations with no path segment at `depth` ungrouped (rendered flat)
+ *
+ * This means any number of nesting levels is supported without code changes —
+ * just add more segments to x-subTagPath in the OpenAPI spec.
+ */
+const groupBySubTagPath = (
+  entries: TraversedEntry[],
+  parentPathSegments: string[],
+  generateId: TraverseSpecOptions['generateId'],
+): TraversedEntry[] => {
+  const grouped = new Map<string, TraversedEntry[]>()
+  const ungrouped: TraversedEntry[] = []
+  const depth = parentPathSegments.length
+
+  for (const entry of entries) {
+    const segment =
+      entry.type === 'operation' && entry.xSubTagPath && entry.xSubTagPath.length > depth
+        ? entry.xSubTagPath[depth]
+        : undefined
+    if (segment) {
+      if (!grouped.has(segment)) grouped.set(segment, [])
+      grouped.get(segment)!.push(entry)
+    } else {
+      ungrouped.push(entry)
+    }
+  }
+
+  if (grouped.size === 0) return ungrouped
+
+  const subTagEntries: TraversedEntry[] = Array.from(grouped.entries()).map(([name, children]) => {
+    const nestedChildren = groupBySubTagPath(children, [...parentPathSegments, name], generateId)
+    const subTag: TagObject = { name }
+    return createTagEntry({
+      tag: subTag,
+      generateId,
+      children: nestedChildren,
+      parentId: parentPathSegments.join('/') || name,
+      isGroup: false,
+    })
+  })
+
+  return [...subTagEntries, ...ungrouped]
+}
+
 /** Sorts tags and returns entries */
 const getSortedTagEntries = ({
   _keys,
@@ -137,10 +188,12 @@ const getSortedTagEntries = ({
       }
     }
 
+    const sortedEntries = sortOrder ? sortByOrder(entries, sortOrder, (item) => item.id) : entries
+
     return createTagEntry({
       tag,
       generateId,
-      children: sortOrder ? sortByOrder(entries, sortOrder, (item) => item.id) : entries,
+      children: groupBySubTagPath(sortedEntries, [], generateId),
       parentId: documentId,
       isGroup: false,
     })

--- a/packages/workspace-store/src/schemas/navigation.ts
+++ b/packages/workspace-store/src/schemas/navigation.ts
@@ -102,6 +102,12 @@ export type TraversedOperation = BaseSchema & {
   path: string
   isDeprecated?: boolean
   children?: TraversedEntry[]
+  /**
+   * xSubTagPath: ordered list of sub-tag names that form the nesting path for this operation.
+   * e.g. ['Payer Operations', 'Single Payer'] places the operation 2 levels deep.
+   * Derived from the operation's x-subTagPath extension.
+   */
+  xSubTagPath?: string[]
 }
 
 export const TraversedAsyncApiOperationSchemaDefinition = compose(

--- a/packages/workspace-store/src/schemas/v3.1/strict/operation.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/operation.ts
@@ -109,4 +109,15 @@ export type OperationObject = {
   XPostResponse &
   XPreRequest &
   XDraftExamples &
-  XScalarSelectedServer
+  XScalarSelectedServer & {
+    /**
+     * x-subTagPath
+     *
+     * An ordered array of sub-tag names that defines the nesting path for this operation
+     * in the sidebar. Each element adds one collapsible level.
+     *
+     * @example ['Payer Operations', 'Single Payer'] — places the operation under
+     *   Tag > Payer Operations > Single Payer > operation
+     */
+    'x-subTagPath'?: string[]
+  }


### PR DESCRIPTION
# feat(workspace-store): add `x-subTagPath` for unlimited sidebar nesting depth

## Problem

The sidebar currently supports only one level of nesting beneath a tag (via `x-tagGroups`), giving a maximum structure of:

```
Group (section header)
  └── Tag
        └── Endpoint
```

There was no way to add intermediate collapsible groupings between a tag and its endpoints. For API references with many operations under a single tag (e.g. a healthcare payer API with dozens of endpoints across logical sub-categories), this made the sidebar flat and hard to navigate.

## Solution

Added a new OpenAPI extension `x-subTagPath` on operations — an ordered array of strings where each element becomes one collapsible nesting level in the sidebar beneath the parent tag.

The resulting structure supports any number of levels:

```
x-tagGroups group          ← non-collapsible section header
  └── Tag                  ← collapsible
        └── Level 1        ← collapsible  (x-subTagPath[0])
              └── Level 2  ← collapsible  (x-subTagPath[1])
                    └── Level 3  ← collapsible  (x-subTagPath[2])
                          └── Endpoint
```

**How it works:**

- A new `groupBySubTagPath` recursive helper in `traverse-tags.ts` walks the flat list of operations under a tag and builds a nested tag tree based on each operation's `xSubTagPath` array
- At each depth level it buckets operations by their path segment at that depth, recurses into each bucket, and leaves operations with no segment at that depth flat
- Operations without `x-subTagPath` (or with an empty array) render flat directly under their parent tag — fully backward compatible

Alternative considered: hardcoding `x-subTag1`, `x-subTag2`, `x-subTag3` fields — rejected because it requires code changes to add more levels and is harder to use.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.
