### PR TITLE
fix(documentation): show API references and Scalar subdomain as free

### DIFF
--- a/documentation/guides/pricing.md
+++ b/documentation/guides/pricing.md
@@ -212,14 +212,14 @@
           <tbody class="st_wrap_table pricing-table-group text-sm" data-table_id="0" role="rowgroup">
 <tr class="pricing-table-group-heading-row"><th class="pricing-table-group-heading flex gap-1.5 items-center" colspan="4" scope="rowgroup"><scalar-icon src="phosphor/bold/book" aria-hidden="true"></scalar-icon>Docs</th></tr>
             <tr class="pricing-table-row">
-<th class="pricing-table-column" scope="row">Subdomains</th>
-<td class="pricing-table-column free-price"><span class="pricing-table-visually-hidden">Not included</span></td>
+<th class="pricing-table-column" scope="row">Free Scalar Subdomain</th>
+<td class="pricing-table-column free-price"><span class="pricing-table-visually-hidden">Included</span><scalar-icon src="phosphor/bold/check" aria-hidden="true"></scalar-icon></td>
 <td class="pricing-table-column pro-price"><span class="pricing-table-visually-hidden">Included</span><scalar-icon src="phosphor/bold/check" aria-hidden="true"></scalar-icon></td>
 <td class="pricing-table-column enterprise-price"><span class="pricing-table-visually-hidden">Included</span><scalar-icon src="phosphor/bold/check" aria-hidden="true"></scalar-icon></td>
 </tr>
             <tr class="pricing-table-row">
 <th class="pricing-table-column" scope="row">API References (OpenAPI)</th>
-<td class="pricing-table-column free-price"><span class="pricing-table-visually-hidden">Not included</span></td>
+<td class="pricing-table-column free-price"><span class="pricing-table-visually-hidden">Included</span><scalar-icon src="phosphor/bold/check" aria-hidden="true"></scalar-icon></td>
 <td class="pricing-table-column pro-price"><span class="pricing-table-visually-hidden">Included</span><scalar-icon src="phosphor/bold/check" aria-hidden="true"></scalar-icon></td>
 <td class="pricing-table-column enterprise-price"><span class="pricing-table-visually-hidden">Included</span><scalar-icon src="phosphor/bold/check" aria-hidden="true"></scalar-icon></td>
 </tr>


### PR DESCRIPTION
## Problem

The pricing table showed **API References (OpenAPI)** as *not included* on the Free plan. That is wrong, and it is actively costing us: a user reached out asking "wdym api references aren't in the free plan? aren't they free generally?" after reading the table.

It also contradicts our own Free plan card right above the table, which already advertises "Hosted OpenAPI docs".

Separately, the **Subdomains** row read ambiguously next to the **Custom Domains** row — it was not clear that every plan gets a Scalar subdomain and that only paid plans get a custom domain.

## Solution

- Check **API References (OpenAPI)** on the Free plan column.
- Rename **Subdomains** to **Free Scalar Subdomain** and check it on Free, Pro, and Enterprise.
- **Custom Domains** is unchanged — it was already correct (Pro and Enterprise only), and it now contrasts clearly with the free subdomain row.

The visually hidden `Not included` / `Included` text was updated alongside each icon, so screen readers stay in sync with the check marks.

## Notes for reviewers

- Docs-content only (`documentation/guides/pricing.md`), no package code touched, so no changeset is needed (`pnpm changeset status` is clean).
- Worth a sanity check from whoever owns pricing that "Free Scalar Subdomain" is the wording we want on that row.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- not applicable: documentation content only -->
- [ ] I added tests. <!-- not applicable -->
- [x] I updated the documentation.