### PR TITLE
feat(api-client): dropdown for same name cookies

### DIFF
--- a/.changeset/cookie-value-presets.md
+++ b/.changeset/cookie-value-presets.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': minor
+---
+
+Add a preset switcher for global cookies that share a name. Instead of rendering one row per value (where toggling one toggled them all), same-named `x-scalar-cookies` now collapse into a single row with a dropdown to switch between the predefined values — for example a `Culture` cookie with `PL` and `EN`. Only the selected value is sent, and the choice persists.

--- a/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/request-block/RequestBlock.vue
@@ -40,6 +40,7 @@ import type { TableRow } from '@/v2/blocks/request-block/components/RequestTable
 import { createParameterHandlers } from '@/v2/blocks/request-block/helpers/create-parameter-handlers'
 import { createParameterRows } from '@/v2/blocks/request-block/helpers/create-parameter-rows'
 import { groupBy } from '@/v2/blocks/request-block/helpers/group-by'
+import { groupGlobalCookies } from '@/v2/blocks/request-block/helpers/group-global-cookies'
 import { AuthSelector } from '@/v2/blocks/scalar-auth-selector-block'
 import type { OAuth2Options } from '@/v2/blocks/scalar-auth-selector-block/components/OAuth2.vue'
 import type { ClientLayout } from '@/v2/types/layout'
@@ -255,55 +256,70 @@ const headers = computed(() => [
   ...(sections.value.header ?? []),
 ])
 
-const defaultCookies = computed(() => {
+/** Resolved request URL, used to filter global cookies by their domain and path. */
+const requestCookieUrl = computed(() => {
   const environmentVariables = getEnvironmentVariables(environment)
-  const resolvedUrl = getResolvedUrl({
-    server,
-    path,
-  })
-  const url = replaceEnvVariables(resolvedUrl, environmentVariables)
+  const resolvedUrl = getResolvedUrl({ server, path })
+  return replaceEnvVariables(resolvedUrl, environmentVariables)
+})
 
+/**
+ * Global cookies grouped by name. Same-named cookies collapse into a single logical cookie so
+ * duplicate names no longer share one disabled state (which made toggling one toggle them all).
+ * A name with multiple values becomes a preset the user can switch between.
+ */
+const globalCookieGroups = computed(() =>
+  groupGlobalCookies({
+    sources: [
+      { location: 'workspace', cookies: workspaceCookies },
+      { location: 'document', cookies: documentCookies },
+    ],
+    // Keep domain/path filtering but ignore the disabled flag, so a disabled preset value stays
+    // selectable in the switcher (it is only hidden from the request, not from the dropdown).
+    shouldInclude: (cookie) =>
+      filterGlobalCookie({
+        cookie: { ...cookie, isDisabled: false },
+        url: requestCookieUrl.value,
+        disabledGlobalCookies: {},
+      }),
+  }),
+)
+
+const defaultCookies = computed<TableRow[]>(() => {
   const disabledGlobalCookies =
     operation['x-scalar-disable-parameters']?.['global-cookies']?.[
       exampleKey
     ] ?? {}
 
-  const transform = (
-    cookie: XScalarCookie,
-    location: 'document' | 'workspace',
-  ) => {
-    return {
-      name: cookie.name,
-      value: cookie.value,
-      globalRoute: { page: location, path: 'cookies' } as const,
-      isReadonly: true,
-      isDisabled: disabledGlobalCookies[cookie.name.toLowerCase()] ?? false,
-    } satisfies TableRow
+  return globalCookieGroups.value.map((group) => ({
+    name: group.name,
+    value: group.selectedValue,
+    globalRoute: { page: group.location, path: 'cookies' } as const,
+    isReadonly: true,
+    isDisabled: disabledGlobalCookies[group.name.toLowerCase()] ?? false,
+    presetOptions: group.isPreset ? group.options : undefined,
+  }))
+})
+
+/**
+ * Switch a grouped global cookie preset to the chosen value by enabling the matching sibling and
+ * disabling the rest. Selection is written back to the source `x-scalar-cookies` list so it
+ * persists, and the send path drops disabled cookies, so only the selected value is sent.
+ */
+const handleSelectCookiePreset = (index: number, value: string): void => {
+  const group = globalCookieGroups.value[index]
+  if (!group) {
+    return
   }
 
-  const globalCookies = [
-    {
-      location: 'workspace',
-      cookies: workspaceCookies,
-    },
-    {
-      location: 'document',
-      cookies: documentCookies,
-    },
-  ] as const
-
-  return globalCookies.flatMap(({ location, cookies }) => {
-    return cookies
-      .filter((cookie) =>
-        filterGlobalCookie({
-          cookie,
-          url,
-          disabledGlobalCookies: {},
-        }),
-      )
-      .map((cookie) => transform(cookie, location))
-  })
-})
+  for (const sibling of group.siblings) {
+    eventBus.emit('cookie:upsert:cookie', {
+      collectionType: sibling.location,
+      index: sibling.index,
+      payload: { isDisabled: sibling.value !== value },
+    })
+  }
+}
 
 const cookies = computed(() => [
   ...(defaultCookies.value ?? []),
@@ -437,10 +453,13 @@ const parameterHandlers = computed(() => ({
   path: createParameterHandlers('path', eventBus, meta.value, {
     context: sections.value.path ?? [],
   }),
-  cookie: createParameterHandlers('cookie', eventBus, meta.value, {
-    context: cookies.value ?? [],
-    globalParameters: defaultCookies.value.length,
-  }),
+  cookie: {
+    ...createParameterHandlers('cookie', eventBus, meta.value, {
+      context: cookies.value ?? [],
+      globalParameters: defaultCookies.value.length,
+    }),
+    selectPreset: handleSelectCookiePreset,
+  },
   header: createParameterHandlers('header', eventBus, meta.value, {
     context: headers.value,
     defaultParameters: defaultHeaders.value.length,

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestParams.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestParams.vue
@@ -43,6 +43,8 @@ const emit = defineEmits<{
   ): void
   (e: 'delete', payload: { index: number }): void
   (e: 'deleteAll'): void
+  /** Select a value for a grouped global cookie preset at the given row index. */
+  (e: 'selectPreset', index: number, value: string): void
 }>()
 
 const showTooltip = computed(() => rows.length > 1)
@@ -94,6 +96,7 @@ const handleUpserRow = (index: number, payload: TableRowUpsertPayload) => {
       :showAddRowPlaceholder="showAddRowPlaceholder"
       @deleteRow="(index) => emit('delete', { index })"
       @navigate="(route) => eventBus.emit('ui:navigate', route)"
+      @selectPreset="(index, value) => emit('selectPreset', index, value)"
       @upsertRow="handleUpserRow" />
   </CollapsibleSection>
 </template>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
@@ -45,6 +45,8 @@ const emit = defineEmits<{
   (e: 'uploadFile', index: number): void
   (e: 'removeFile', index: number): void
   (e: 'navigate', route: NonNullable<TableRow['globalRoute']>): void
+  /** Select a value for a grouped global cookie preset at the given row index. */
+  (e: 'selectPreset', index: number, value: string): void
 }>()
 
 const columns = computed(() => {
@@ -91,6 +93,7 @@ const displayData = computed(() => {
       @deleteRow="emit('deleteRow', index)"
       @navigate="(route) => emit('navigate', route)"
       @removeFile="emit('removeFile', index)"
+      @selectPreset="(value) => emit('selectPreset', index, value)"
       @uploadFile="emit('uploadFile', index)"
       @upsertRow="(payload) => emit('upsertRow', index, payload)" />
   </DataTable>

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -19,6 +19,7 @@ import { CodeInputLite } from '@/v2/components/code-input'
 import {
   DataTableCell,
   DataTableCheckbox,
+  DataTableInputSelect,
   DataTableRow,
 } from '@/v2/components/data-table'
 
@@ -50,6 +51,12 @@ export type TableRow = {
   originalParameter?: ParameterObject
   /** Path to a value inside the original parameter example for expanded object parameters */
   sourceParameterValuePath?: string[]
+  /**
+   * Selectable values for a grouped global cookie preset. When set, the value cell renders a
+   * dropdown to switch between predefined values (for example a `Culture` cookie with `PL`/`EN`)
+   * instead of an editable input.
+   */
+  presetOptions?: string[]
 }
 
 export type TableRowUpsertPayload = {
@@ -80,6 +87,8 @@ const emit = defineEmits<{
   (e: 'uploadFile'): void
   (e: 'removeFile'): void
   (e: 'navigate', route: NonNullable<TableRow['globalRoute']>): void
+  /** Select a value for a grouped global cookie preset. */
+  (e: 'selectPreset', value: string): void
 }>()
 
 /**
@@ -236,7 +245,15 @@ const handleKeyBlur = (newName: string): void => {
 
     <!-- Value -->
     <DataTableCell>
+      <!-- Preset switcher for grouped global cookies that share a name -->
+      <DataTableInputSelect
+        v-if="data.presetOptions?.length"
+        :canAddCustomValue="false"
+        :modelValue="displayValue"
+        :value="data.presetOptions"
+        @update:modelValue="(v) => emit('selectPreset', v)" />
       <CodeInputLite
+        v-else
         :aria-label="`${label} Value`"
         class="pr-6 group-hover:pr-10 group-has-[.code-input-lite__editor:focus]:pr-10"
         :default="defaultValue"

--- a/packages/api-client/src/v2/blocks/request-block/helpers/group-global-cookies.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/group-global-cookies.test.ts
@@ -1,0 +1,150 @@
+import type { XScalarCookie } from '@scalar/workspace-store/schemas/extensions/general/x-scalar-cookies'
+import { describe, expect, it } from 'vitest'
+
+import { groupGlobalCookies } from './group-global-cookies'
+
+/** Include everything — most tests do not care about domain/path filtering. */
+const includeAll = () => true
+
+const cookie = (partial: Partial<XScalarCookie> & { name: string; value: string }): XScalarCookie => ({
+  path: '/',
+  ...partial,
+})
+
+describe('groupGlobalCookies', () => {
+  it('collapses same-named cookies into a single preset with each value as an option', () => {
+    const groups = groupGlobalCookies({
+      sources: [
+        {
+          location: 'document',
+          cookies: [cookie({ name: 'Culture', value: 'PL' }), cookie({ name: 'Culture', value: 'EN' })],
+        },
+      ],
+      shouldInclude: includeAll,
+    })
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.name).toBe('Culture')
+    expect(groups[0]?.isPreset).toBe(true)
+    expect(groups[0]?.options).toEqual(['PL', 'EN'])
+  })
+
+  it('selects the enabled sibling as the active value', () => {
+    const groups = groupGlobalCookies({
+      sources: [
+        {
+          location: 'document',
+          cookies: [
+            cookie({ name: 'Culture', value: 'PL', isDisabled: true }),
+            cookie({ name: 'Culture', value: 'EN' }),
+          ],
+        },
+      ],
+      shouldInclude: includeAll,
+    })
+
+    expect(groups[0]?.selectedValue).toBe('EN')
+    // A disabled value stays selectable so the user can switch back to it.
+    expect(groups[0]?.options).toEqual(['PL', 'EN'])
+  })
+
+  it('keeps distinct cookie names as separate, non-preset groups', () => {
+    const groups = groupGlobalCookies({
+      sources: [
+        {
+          location: 'document',
+          cookies: [cookie({ name: 'session', value: 'abc' }), cookie({ name: 'theme', value: 'dark' })],
+        },
+      ],
+      shouldInclude: includeAll,
+    })
+
+    expect(groups.map((group) => group.name)).toEqual(['session', 'theme'])
+    expect(groups.every((group) => group.isPreset === false)).toBe(true)
+    expect(groups.every((group) => group.options.length === 0)).toBe(true)
+  })
+
+  it('tracks each sibling location and original index for write-back', () => {
+    const groups = groupGlobalCookies({
+      sources: [
+        {
+          location: 'workspace',
+          cookies: [cookie({ name: 'other', value: 'x' }), cookie({ name: 'Culture', value: 'PL' })],
+        },
+        {
+          location: 'document',
+          cookies: [cookie({ name: 'Culture', value: 'EN' })],
+        },
+      ],
+      shouldInclude: includeAll,
+    })
+
+    const culture = groups.find((group) => group.name === 'Culture')
+    expect(culture?.siblings).toEqual([
+      { location: 'workspace', index: 1, value: 'PL' },
+      { location: 'document', index: 0, value: 'EN' },
+    ])
+  })
+
+  it('respects the shouldInclude predicate while preserving original indices', () => {
+    const groups = groupGlobalCookies({
+      sources: [
+        {
+          location: 'document',
+          cookies: [
+            cookie({ name: 'Culture', value: 'PL', domain: 'other.com' }),
+            cookie({ name: 'Culture', value: 'EN' }),
+          ],
+        },
+      ],
+      // Drop the first cookie by domain, as filterGlobalCookie would.
+      shouldInclude: (candidate) => candidate.domain !== 'other.com',
+    })
+
+    // Only one value survives the domain filter, so it is no longer a preset.
+    expect(groups[0]?.isPreset).toBe(false)
+    expect(groups[0]?.options).toEqual([])
+    expect(groups[0]?.selectedValue).toBe('EN')
+    // The surviving sibling keeps its original index (1), not its filtered position (0).
+    expect(groups[0]?.siblings).toEqual([{ location: 'document', index: 1, value: 'EN' }])
+  })
+
+  it('hides a fully disabled single cookie but keeps a partially disabled preset', () => {
+    const groups = groupGlobalCookies({
+      sources: [
+        {
+          location: 'document',
+          cookies: [
+            cookie({ name: 'session', value: 'abc', isDisabled: true }),
+            cookie({ name: 'Culture', value: 'PL', isDisabled: true }),
+            cookie({ name: 'Culture', value: 'EN', isDisabled: true }),
+          ],
+        },
+      ],
+      shouldInclude: includeAll,
+    })
+
+    // The single disabled cookie is hidden, matching the previous behavior.
+    expect(groups.find((group) => group.name === 'session')).toBeUndefined()
+    // The preset still renders even though every value is currently disabled.
+    expect(groups.find((group) => group.name === 'Culture')?.isPreset).toBe(true)
+  })
+
+  it('deduplicates identical values so they are not offered twice', () => {
+    const groups = groupGlobalCookies({
+      sources: [
+        {
+          location: 'document',
+          cookies: [
+            cookie({ name: 'Culture', value: 'PL' }),
+            cookie({ name: 'Culture', value: 'PL' }),
+            cookie({ name: 'Culture', value: 'EN' }),
+          ],
+        },
+      ],
+      shouldInclude: includeAll,
+    })
+
+    expect(groups[0]?.options).toEqual(['PL', 'EN'])
+  })
+})

--- a/packages/api-client/src/v2/blocks/request-block/helpers/group-global-cookies.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/group-global-cookies.ts
@@ -1,0 +1,119 @@
+import type { XScalarCookie } from '@scalar/workspace-store/schemas/extensions/general/x-scalar-cookies'
+
+/**
+ * A global cookie collection paired with where it lives, so a selection can be written back to the
+ * correct source: the workspace or the active document `x-scalar-cookies` list.
+ */
+export type GlobalCookieSource = {
+  location: 'document' | 'workspace'
+  cookies: XScalarCookie[]
+}
+
+/**
+ * A single cookie within a preset group, carrying just enough to mutate its source: which
+ * collection it belongs to and its index within that collection's `x-scalar-cookies` array.
+ */
+export type GlobalCookieSibling = {
+  location: 'document' | 'workspace'
+  index: number
+  value: string
+}
+
+/**
+ * Global cookies that share a name, grouped into a single logical cookie. When more than one value
+ * exists for the same name the group becomes a preset the user can switch between (for example a
+ * `Culture` cookie with `PL` and `EN` values).
+ */
+export type GlobalCookieGroup = {
+  /** The shared cookie name. */
+  name: string
+  /** The value of the currently active (enabled) sibling — the one that is sent. */
+  selectedValue: string
+  /** Distinct selectable values, in first-seen order. Only populated for presets. */
+  options: string[]
+  /** Whether this group offers more than one value to switch between. */
+  isPreset: boolean
+  /** Location of the first sibling, used to navigate to the global cookie settings. */
+  location: 'document' | 'workspace'
+  /** Every sibling sharing this name, so a selection can enable one and disable the rest. */
+  siblings: GlobalCookieSibling[]
+}
+
+/**
+ * Groups global cookies by name so duplicate names collapse into a single row. Same-named cookies
+ * used to render as independent rows that all shared one disabled state, so toggling one toggled
+ * them all. Grouping them lets a name expose its values as a preset switcher instead.
+ *
+ * The `shouldInclude` predicate applies the caller's domain and path filtering while the original
+ * index is still known, so a selection can be written back to the right entry. That predicate
+ * deliberately ignores the disabled flag for preset values: a disabled value is only hidden from
+ * the request, not from the switcher, so the user can select it again.
+ */
+export const groupGlobalCookies = ({
+  sources,
+  shouldInclude,
+}: {
+  sources: GlobalCookieSource[]
+  /** Whether a cookie is applicable to the current request (domain/path), ignoring its disabled state. */
+  shouldInclude: (cookie: XScalarCookie) => boolean
+}): GlobalCookieGroup[] => {
+  /** Names in first-seen order so the rendered rows keep a stable, predictable order. */
+  const order: string[] = []
+  const grouped = new Map<
+    string,
+    { location: 'document' | 'workspace'; value: string; isDisabled: boolean; index: number }[]
+  >()
+
+  for (const { location, cookies } of sources) {
+    cookies.forEach((cookie, index) => {
+      if (!cookie.name || !shouldInclude(cookie)) {
+        return
+      }
+
+      if (!grouped.has(cookie.name)) {
+        grouped.set(cookie.name, [])
+        order.push(cookie.name)
+      }
+
+      grouped.get(cookie.name)?.push({
+        location,
+        value: cookie.value,
+        isDisabled: cookie.isDisabled ?? false,
+        index,
+      })
+    })
+  }
+
+  const groups: GlobalCookieGroup[] = []
+
+  for (const name of order) {
+    const entries = grouped.get(name) ?? []
+    const first = entries[0]
+    if (!first) {
+      continue
+    }
+
+    const enabled = entries.filter((entry) => !entry.isDisabled)
+    const options = [...new Set(entries.map((entry) => entry.value))]
+    const isPreset = options.length > 1
+
+    // Preserve the previous behavior for plain cookies: a fully disabled single cookie stays hidden
+    // from the request view. A preset always renders so its value can be switched back on.
+    if (!isPreset && enabled.length === 0) {
+      continue
+    }
+
+    groups.push({
+      name,
+      // The enabled sibling is the one that is sent; fall back to the first value when the whole
+      // group happens to be disabled so the switcher still has something to show.
+      selectedValue: (enabled[0] ?? first).value,
+      options: isPreset ? options : [],
+      isPreset,
+      location: first.location,
+      siblings: entries.map(({ location, index, value }) => ({ location, index, value })),
+    })
+  }
+
+  return groups
+}

--- a/packages/api-client/src/v2/blocks/request-block/helpers/group-global-cookies.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/group-global-cookies.ts
@@ -4,7 +4,7 @@ import type { XScalarCookie } from '@scalar/workspace-store/schemas/extensions/g
  * A global cookie collection paired with where it lives, so a selection can be written back to the
  * correct source: the workspace or the active document `x-scalar-cookies` list.
  */
-export type GlobalCookieSource = {
+type GlobalCookieSource = {
   location: 'document' | 'workspace'
   cookies: XScalarCookie[]
 }
@@ -13,7 +13,7 @@ export type GlobalCookieSource = {
  * A single cookie within a preset group, carrying just enough to mutate its source: which
  * collection it belongs to and its index within that collection's `x-scalar-cookies` array.
  */
-export type GlobalCookieSibling = {
+type GlobalCookieSibling = {
   location: 'document' | 'workspace'
   index: number
   value: string
@@ -24,7 +24,7 @@ export type GlobalCookieSibling = {
  * exists for the same name the group becomes a preset the user can switch between (for example a
  * `Culture` cookie with `PL` and `EN` values).
  */
-export type GlobalCookieGroup = {
+type GlobalCookieGroup = {
   /** The shared cookie name. */
   name: string
   /** The value of the currently active (enabled) sibling — the one that is sent. */


### PR DESCRIPTION
Global cookies that share a name used to render as separate rows that all shared one enabled/disabled state, so toggling one toggled them all (#9617). 

They now collapse into a single row with a dropdown to switch between the predefined values.

<img width="730" height="226" alt="Screenshot 2026-08-06 at 10 25 36" src="https://github.com/user-attachments/assets/5658832a-8dbb-40d5-8afa-12b2c204be88" />

## Ticket

Closes #9617