### PR TITLE
fix(api-reference): keep selected server across configuration updates

### DIFF
--- a/.changeset/fix-5071-selected-server-update-config.md
+++ b/.changeset/fix-5071-selected-server-update-config.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Keep the selected server when the configuration is updated. Pushing a config update to a mounted reference (for example a refreshed auth token via `updateConfiguration`) rebases the document in the store, which previously reset the server selector back to the first server. The user's selected server is now preserved across configuration updates.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -823,19 +823,42 @@ const addDocument: typeof workspaceStore.addDocument = async (
   navigationOptions,
 ) => {
   const result = await workspaceStore.addDocument(input, navigationOptions)
+
+  // The selected server lives only on the client store document. The user picks it in the
+  // reference, it is never part of the imported source. Reloading the freshly imported document
+  // below would drop it, so any config update that rebases the document — a new auth token,
+  // reordered servers, an edited spec — would otherwise reset the server back to the first one.
+  // Capture it here and re-apply it after the reload so the user's choice survives. See #5071.
+  const previousDocument = clientStore.workspace.documents[input.name]
+  const selectedServer =
+    previousDocument && typeof previousDocument === 'object'
+      ? (previousDocument as Record<string, unknown>)[
+          'x-scalar-selected-server'
+        ]
+      : undefined
+
   // Now add it to the client store
   const state = workspaceStore.exportWorkspace()
+  const nextDocument = safeDeepClone(state.documents[input.name]) ?? {
+    'openapi': '3.1.0',
+    'info': {
+      title: '',
+      version: '',
+    },
+    'x-scalar-original-document-hash': '',
+  }
+
+  // Carry the user's server selection over to the reloaded document. An empty string is a
+  // deliberate "no server selected" state, so it is preserved too; only `undefined` (a first
+  // load with no prior selection) falls through to the default-server logic elsewhere.
+  if (typeof selectedServer === 'string') {
+    Object.assign(nextDocument, { 'x-scalar-selected-server': selectedServer })
+  }
+
   clientStore.loadWorkspace({
     auth: {},
     documents: {
-      [input.name]: safeDeepClone(state.documents[input.name]) ?? {
-        'openapi': '3.1.0',
-        'info': {
-          title: '',
-          version: '',
-        },
-        'x-scalar-original-document-hash': '',
-      },
+      [input.name]: nextDocument,
     },
     intermediateDocuments: {},
     originalDocuments: {},

--- a/packages/api-reference/test/configuration/html/update-config-servers.html
+++ b/packages/api-reference/test/configuration/html/update-config-servers.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Scalar API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="/scalar.js"></script>
+    <script>
+      // A document with two servers and a bearer scheme, mirroring the setup from #5071
+      // where the embedder keeps pushing a fresh token through updateConfiguration.
+      const baseDocument = {
+        openapi: '3.1.1',
+        info: { title: 'Test API', version: '1.0.0' },
+        servers: [
+          { url: 'https://api.example.com' },
+          { url: 'https://staging.example.com' },
+        ],
+        components: {
+          securitySchemes: {
+            bearerAuth: { type: 'http', scheme: 'bearer' },
+          },
+        },
+        security: [{ bearerAuth: [] }],
+        paths: {
+          '/planets': {
+            get: { summary: 'Get all planets', tags: ['Planets'] },
+          },
+        },
+      }
+
+      const buildConfig = (overrides = {}) => ({
+        content: overrides.content ?? baseDocument,
+        authentication: overrides.authentication,
+      })
+
+      const instance = window.Scalar.createApiReference('#app', buildConfig())
+
+      // Expose the instance so the test can read back the applied configuration.
+      window.__scalar = instance
+
+      // Case A: update only the auth token. The document content is unchanged, so this must
+      // not rebase the document or touch the selected server.
+      window.__updateAuth = (token) =>
+        instance.updateConfiguration(
+          buildConfig({
+            authentication: {
+              preferredSecurityScheme: 'bearerAuth',
+              securitySchemes: { bearerAuth: { token } },
+            },
+          }),
+        )
+
+      // Case B: update the document content (adds a `/moons` operation). This rebases the
+      // document, which previously wiped the selected server back to the first one.
+      window.__updateContent = () =>
+        instance.updateConfiguration(
+          buildConfig({
+            content: {
+              ...baseDocument,
+              paths: {
+                ...baseDocument.paths,
+                '/moons': {
+                  get: { summary: 'Get all moons', tags: ['Moons'] },
+                },
+              },
+            },
+          }),
+        )
+    </script>
+  </body>
+</html>

--- a/packages/api-reference/test/configuration/update-config-server-selection.e2e.ts
+++ b/packages/api-reference/test/configuration/update-config-server-selection.e2e.ts
@@ -1,0 +1,77 @@
+import { join } from 'node:path'
+
+import { expect, test } from '@playwright/test'
+import { serveHTMLExample } from '@test/utils/serve-example'
+
+/**
+ * Regression test for https://github.com/scalar/scalar/issues/5071
+ *
+ * The embedder selects a non-default server and then keeps pushing configuration updates
+ * (for example a refreshed auth token). The user's server selection must survive those updates
+ * instead of snapping back to the first server.
+ *
+ * The server selector renders the currently selected server URL as its trigger button, so we
+ * assert on that button to know which server is active.
+ */
+test.describe('updateConfiguration keeps the selected server', () => {
+  const fixture = join(import.meta.dirname, 'html', 'update-config-servers.html')
+
+  /** Open the server dropdown and pick the staging server (the second, non-default one). */
+  const selectStagingServer = async (page: import('@playwright/test').Page) => {
+    await page.getByRole('button', { name: 'https://api.example.com' }).first().click()
+    await page.getByText('https://staging.example.com').click()
+    await expect(page.getByRole('button', { name: 'https://staging.example.com' }).first()).toBeVisible()
+  }
+
+  // Case A: updating only the auth token does not change the document, so it must never rebase
+  // the document or reset the server. This confirms the originally reported scenario.
+  test('when only the auth token changes', async ({ page }) => {
+    const { url, shutdown } = await serveHTMLExample(fixture)
+    await page.goto(url)
+
+    await selectStagingServer(page)
+
+    // Push a fresh token, exactly like the embedder in the issue does.
+    await page.evaluate(() => (window as unknown as { __updateAuth: (t: string) => void }).__updateAuth('new-token'))
+
+    // The update was actually applied (guards against this becoming a no-op)...
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          type Config = { authentication?: { securitySchemes?: { bearerAuth?: { token?: string } } } }
+          const instance = (window as unknown as { __scalar: { getConfiguration: () => Config } }).__scalar
+          return instance.getConfiguration()?.authentication?.securitySchemes?.bearerAuth?.token
+        }),
+      )
+      .toBe('new-token')
+
+    // ...and the selected server is still staging, not back to production.
+    await expect(page.getByRole('button', { name: 'https://staging.example.com' }).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: 'https://api.example.com' })).toHaveCount(0)
+
+    shutdown()
+  })
+
+  // Case B: updating the document content rebases the document. This used to wipe the selection
+  // back to the first server. We wait for the rebased content to render before asserting so we
+  // check the settled state, not a transient one.
+  test('when the document content changes', async ({ page }) => {
+    const { url, shutdown } = await serveHTMLExample(fixture)
+    await page.goto(url)
+
+    await selectStagingServer(page)
+
+    // Change the document (adds a `/moons` operation), which rebases it in the store.
+    await page.evaluate(() => (window as unknown as { __updateContent: () => void }).__updateContent())
+
+    // Wait for the rebased document to render (the new `/moons` tag section appears) so we assert
+    // on the settled state rather than a transient one.
+    await expect(page.getByRole('heading', { name: 'Moons' })).toBeVisible()
+
+    // The selected server is still staging, not back to production.
+    await expect(page.getByRole('button', { name: 'https://staging.example.com' }).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: 'https://api.example.com' })).toHaveCount(0)
+
+    shutdown()
+  })
+})


### PR DESCRIPTION
Picking a non-default server, then updating the config (like refreshing an auth token) could snap the server back to the first one.

A token-only update was already fine. But any update that changes the document reloaded it and lost the selected server, so it fell back to the first server. This keeps the selected server across config updates.

## Ticket

Fixes #5071