### PR TITLE
fix(openapi-parser): clearer error for a response missing description

### DIFF
--- a/.changeset/openapi-parser-response-description-error.md
+++ b/.changeset/openapi-parser-response-description-error.md
@@ -1,0 +1,8 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+Show a clearer error when a response is missing its `description`. Before, the
+validator reported the confusing `must have required property '$ref'` (or
+`oneOf must match exactly one schema in oneOf`) instead of pointing at the
+actual problem.

--- a/packages/openapi-parser/src/utils/betterAjvErrors/helpers.ts
+++ b/packages/openapi-parser/src/utils/betterAjvErrors/helpers.ts
@@ -77,8 +77,16 @@ function filterRedundantErrors(root, parent, key) {
       // Clear parent errors, keep children as they're more meaningful
       delete root.errors
     } else {
-      // No other errors, keep oneOf as it's all we have
-      root.errors = errors.filter((error) => isOneOfError(error))
+      // Both `oneOf` branches produced a `required` error: one from the schema
+      // the user most likely intended (e.g. a Response needs `description`) and
+      // one from the `Reference` branch (needs `$ref`). Surface the intended
+      // schema's error and drop the `$ref` noise so the message is actionable.
+      // Only fall back to the generic `oneOf` error when the sole requirement
+      // left is `$ref` (i.e. the value looks like a broken reference).
+      const meaningfulRequiredErrors = errors.filter(
+        (error) => isRequiredError(error) && error.params?.missingProperty !== '$ref',
+      )
+      root.errors = meaningfulRequiredErrors.length > 0 ? meaningfulRequiredErrors : errors.filter(isOneOfError)
     }
   } else if (hasOneOfError && !hasRequiredError && hasChildren) {
     /**

--- a/packages/openapi-parser/src/utils/validate.test.ts
+++ b/packages/openapi-parser/src/utils/validate.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import type { AnyObject } from '@/types/index'
 
 import { validate } from './validate'
@@ -129,6 +130,45 @@ paths: {}
     expect(result.errors).toContainEqual(
       expect.objectContaining({
         message: 'Path parameter "testId" must have the corresponding {testId} segment in the "/pets/{petId}" path',
+      }),
+    )
+  })
+
+  it('reports the missing `description` instead of the misleading `$ref` for a response', async () => {
+    // Regression test for https://github.com/scalar/scalar/issues/4838
+    // A response value validates against `oneOf: [Response, Reference]`. When it
+    // is missing the required `description`, both branches fail. The error should
+    // point at the missing `description`, not the `$ref` of the Reference branch
+    // (nor the opaque "oneOf must match exactly one schema in oneOf").
+    const result = await validate({
+      openapi: '3.0.0',
+      info: { title: 'DAPI', version: '1.0' },
+      paths: {
+        '/user_activity': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/json': {
+                    schema: { type: 'object', properties: { foo: { type: 'string' } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({
+        message: "must have required property 'description'",
+      }),
+    )
+    expect(result.errors).not.toContainEqual(
+      expect.objectContaining({
+        message: "must have required property '$ref'",
       }),
     )
   })


### PR DESCRIPTION
The CLI said `must have required property '$ref'` when a response was really just missing its `description`. That was confusing, because most people never touch `$ref`.

Now it points at the real problem:

```
must have required property 'description'
  at /paths/.../get/responses/200
```

Same for the newer `oneOf must match exactly one schema in oneOf` message.

Reported spec still renders fine in the Sandbox because rendering does not require `description` — only `validate`/`serve` do.

## Ticket

Fixes #4838
