### PR TITLE
docs(documentation): add user management guide

### DIFF
--- a/documentation/guides/team/user-management.md
+++ b/documentation/guides/team/user-management.md
@@ -1,0 +1,100 @@
+# User Management
+
+Everything in Scalar belongs to a **team**. Your docs, registry APIs, SDKs, themes and billing all live on the team, and the people you invite to that team get access to them based on their **role**.
+
+This guide covers how to set up your team, invite people, and choose the right role for each of them.
+
+## Teams
+
+A team is the top-level container in Scalar. When you sign up, we create one for you automatically.
+
+Every team has:
+
+- A **name** and a **slug** (the unique identifier used in URLs)
+- A **namespace** used by the [Registry](../registry/getting-started.md)
+- A **billing plan** shared by everyone on the team
+- A list of **members**, each with a role
+
+You can belong to more than one team, and switch between them from the team switcher in [Settings](https://dashboard.scalar.com/team/settings). This is useful when you separate work by company, client or environment. Keep in mind that members, billing and projects are never shared between teams: a person who needs access to two teams has to be invited to both.
+
+> Every account must belong to at least one team, so you cannot delete your only team.
+
+## Roles and permissions
+
+Scalar uses three roles. Assign the lowest role that still lets someone do their job.
+
+| Role | Best for | Can do |
+|------|----------|--------|
+| **Owner** | The people responsible for the account | Everything an Admin can do, plus adding and removing other Owners, changing Owner roles, and deleting the team |
+| **Admin** | Team leads and API platform owners | Invite and remove members, change roles of non-Owners, manage billing and the plan, and everything an Editor can do |
+| **Editor** | Everyone writing docs or shipping APIs | Create, edit and delete docs, APIs, SDKs and themes |
+
+Here is the same information as a permission matrix:
+
+| Permission | Owner | Admin | Editor |
+|------------|:-----:|:-----:|:------:|
+| Create, edit and delete docs and projects | ✅ | ✅ | ✅ |
+| Invite and remove members | ✅ | ✅ | ❌ |
+| Change roles below Owner | ✅ | ✅ | ❌ |
+| Manage billing and the plan | ✅ | ✅ | ❌ |
+| Add, remove or promote Owners | ✅ | ❌ | ❌ |
+| Delete the team | ✅ | ❌ | ❌ |
+
+A team must always have at least one Owner. If you are the only Owner, promote somebody else before you remove yourself or leave the team.
+
+## Invite members
+
+You need to be an Owner or an Admin to invite somebody.
+
+1. Go to [Team > Members](https://dashboard.scalar.com/team/members) in the dashboard
+2. Click **Invite Member**
+3. Enter the email address and pick a role
+4. Click **Send Invite**
+
+The invited person receives an email with a link to join your team. Invites are valid for three days. If an invite expires, cancel it and send a new one.
+
+Pending invites appear in the member list marked as **Invite Pending**. To withdraw one, open the menu next to the invite and choose **Cancel Invite**.
+
+> On a paid plan, every member you invite adds a billing seat, and removing a member removes one again. You can see the current seat count above the member list.
+
+## Manage members
+
+All member management happens in [Team > Members](https://dashboard.scalar.com/team/members). Open the menu next to a person to:
+
+- **Change role** — move somebody between Owner, Admin and Editor
+- **Remove from team** — revoke their access to the team and free up their billing seat
+
+Owners are listed separately from the rest of the team, so it is always clear who is ultimately responsible for the account.
+
+Removing a member does not delete anything they created. Their docs, APIs and SDKs stay with the team.
+
+### Leave a team
+
+To leave a team yourself, go to [User Settings](https://dashboard.scalar.com/user/profile) and choose **Leave Team** in the Danger Zone. If you are the only Owner of the team, make somebody else an Owner first.
+
+## Restrict who can join
+
+Two enterprise controls help you keep the team limited to your own organization:
+
+- **Domain restrictions** limit invites to email addresses from domains you approve, so an invite to a personal address is rejected before it is sent.
+- **[SSO/SAML](../sso/getting-started.md)** connects Scalar to your identity provider, so access follows the same rules as the rest of your company. You can also disable password login so SSO is the only way in.
+
+Both are available on the Enterprise plan. See [pricing](../pricing.md) or email [support@scalar.com](mailto:support@scalar.com) to get started.
+
+## Team members vs. access groups
+
+These two things sound similar, so it is worth being precise:
+
+- **Team members** are the people who build with you inside the Scalar dashboard. They are covered by this guide.
+- **[Access groups](../docs/configuration/private-docs.md)** are the people allowed to *read* your private docs. They do not need a seat on your team, and they never see the dashboard.
+
+Use team members for your colleagues, and access groups for customers and partners who should only read your documentation.
+
+## Recommendations
+
+A few things we have seen work well:
+
+- Keep the number of Owners small, but never at one. Two or three is usually right.
+- Make team leads Admins so that they can handle invites without waiting on an Owner.
+- Default new people to Editor. You can always promote later.
+- Review your member list when someone leaves your company, or connect SSO so that offboarding happens automatically.

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -3935,6 +3935,39 @@
                   }
                 }
               },
+              "user-management": {
+                "type": "page",
+                "title": "User Management",
+                "icon": "phosphor/regular/users",
+                "description": "Manage your Scalar team: invite members, assign Owner, Admin and Editor roles, and control who can join.",
+                "filepath": "documentation/guides/team/user-management.md",
+                "head": {
+                  "links": [
+                    {
+                      "rel": "canonical",
+                      "href": "https://scalar.com/resources/user-management"
+                    }
+                  ],
+                  "meta": [
+                    {
+                      "name": "description",
+                      "content": "Manage your Scalar team: invite members, assign Owner, Admin and Editor roles, and control who can join."
+                    },
+                    {
+                      "property": "og:title",
+                      "content": "User Management - Scalar Teams, Roles and Permissions"
+                    },
+                    {
+                      "property": "og:description",
+                      "content": "Manage your Scalar team: invite members, assign Owner, Admin and Editor roles, and control who can join."
+                    },
+                    {
+                      "name": "robots",
+                      "content": "index, follow"
+                    }
+                  ]
+                }
+              },
               "sso": {
                 "title": "SSO/SAML",
                 "icon": "phosphor/regular/keyhole",


### PR DESCRIPTION
> [!NOTE]
> This PR recreates the changes from #9840 (originally authored by @marclave) on a fresh branch.

## Problem

We have no public documentation on how teams and user management work in Scalar. Support and sales get repeat questions about it: what the roles actually allow, who can invite people, whether inviting adds a billing seat, and — most often — the difference between "team members" (people with dashboard access) and "access groups" (people allowed to read private docs). Right now the only place that answers any of this is the SSO guide, and only in passing.

## Solution

Adds a single guide at `documentation/guides/team/user-management.md`, published under **Resources** next to SSO/SAML since it is team-level rather than tied to one product.

It covers:

- What a team is, and that members/billing/projects are never shared across teams
- The Owner / Admin / Editor roles, with a plain-language table and a permission matrix
- Inviting members, the three-day invite expiry, and cancelling pending invites
- Changing roles, removing members, leaving a team, and the "at least one Owner" rule
- Billing seats on paid plans
- Domain restrictions and SSO for controlling who can join
- Team members vs. access groups, with a pointer to the Private Docs guide

Everything is grounded in current behavior rather than assumed — sourced from the team entity schema and permission map, the core team service (invites, role updates, error cases), and the dashboard team views.

### Notes for the reviewer

Three judgment calls worth a second opinion (carried over from the original PR):

1. **The `Viewer` role is intentionally left out.** It exists in `TeamUserRole`, but both the invite modal and the change-role modal filter it out, so nobody can be assigned it today. Documenting an unassignable role seemed more confusing than helpful. Happy to add a footnote if we would rather be exhaustive.
2. **Billing is documented as Owner *and* Admin.** The role descriptor copy in the dashboard implies billing is Owner-only, but the actual gate on the billing plan grid is the `manageTeam` permission, which Admins have. I documented the real behavior — it may be the UI copy that needs fixing rather than the docs.
3. **No screenshots yet.** The Private Docs guide is screenshot-heavy and this one is not. I can add shots of the Members page and the invite modal if we want the styles to match.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Documentation-only change, no package versions affected -->
- [ ] I added tests. <!-- Not applicable -->
- [x] I updated the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
