### PR TITLE
docs: fix typos and grammar across documentation

### DIFF
--- a/documentation/blog/2025-03-05-how-net-9-and-scalar-solve-the-problem.md
+++ b/documentation/blog/2025-03-05-how-net-9-and-scalar-solve-the-problem.md
@@ -43,11 +43,11 @@ Running this then generates an OpenAPI document at `https://localhost:<port>/ope
 
 [![Dotnet 9 OpenAPI](https://substackcdn.com/image/fetch/$s_!CkN3!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7f04e6c4-42a9-48a7-82e8-9fb654dbe118_1480x1190.png "Dotnet 9 OpenAPI")](https://substackcdn.com/image/fetch/$s_!CkN3!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7f04e6c4-42a9-48a7-82e8-9fb654dbe118_1480x1190.png)
 
-Generating this is document is a great first step, but is only part of the solution. It then needs to be turned into documentation people can use. This is where Scalar’s suite of API tools come in.
+Generating this document is a great first step, but is only part of the solution. It then needs to be turned into documentation people can use. This is where Scalar’s suite of API tools come in.
 
 ## Setting up Scalar’s ASP.NET package
 
-Thanks to [@captainsafia](https://github.com/captainsafia) and [@xC0dex](https://github.com/xC0dex) of our community, Scalar has a ASP.NET API package.
+Thanks to [@captainsafia](https://github.com/captainsafia) and [@xC0dex](https://github.com/xC0dex) of our community, Scalar has an ASP.NET API package.
 
 To set it up, simply install the package:
 
@@ -92,7 +92,7 @@ This creates a complete set of API docs in a simple to use UI without all of the
 
 The combination of new ASP.NET OpenAPI generation and Scalar solves the undocumented API problem. No more needing to document, generate, update, and serve your API docs.
 
-We don’t stop there either. Our API seamlessly turn into a fully featured API client. This means you not only get to document your API but test it. This is a core part of our aim of creating a world-class developer experience for your APIs.
+We don’t stop there either. Our API seamlessly turns into a fully featured API client. This means you not only get to document your API but test it. This is a core part of our aim of creating a world-class developer experience for your APIs.
 
 [![Dotnet 9 API client](https://substackcdn.com/image/fetch/$s_!nm9-!,w_1456,c_limit,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7cf53bcc-3c00-48ad-a283-4e5202aa06db_2868x1624.png "Dotnet 9 API client")](https://substackcdn.com/image/fetch/$s_!nm9-!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F7cf53bcc-3c00-48ad-a283-4e5202aa06db_2868x1624.png)
 

--- a/documentation/blog/2025-03-12-how-we-sped-up-our-api-docs-25x.md
+++ b/documentation/blog/2025-03-12-how-we-sped-up-our-api-docs-25x.md
@@ -16,7 +16,7 @@ Next, he experimented by commenting out chunks of the UI until he saw load times
 
 By timing the `onBeforeMount` and `onMounted` hooks, he found that a 7 MB OpenAPI spec took 2.6 seconds to mount (way too long). Narrowing down, it was specifically the [Request Sidebar Item](https://github.com/scalar/scalar/pull/3175/files#diff-3179b1678c7f778417b849d87878807ad518233ca909f20fa108f7fe4e8784ef) that was causing the issue.
 
-The each instance of `RequestSidebarItem` created multiple child modals and menus. These made it easy for editors to rename and delete items, but, when repeated across hundreds of sidebar items, were causing major slowdowns.
+Each instance of `RequestSidebarItem` created multiple child modals and menus. These made it easy for editors to rename and delete items, but, when repeated across hundreds of sidebar items, were causing major slowdowns.
 
 ## Refactoring our sidebar to fix the performance issues
 
@@ -38,7 +38,7 @@ Opening this menu in the right spot required:
 
 Most users probably didn't notice changes to the sidebar functionality. It looks the same and works the same.
 
-What users with large API docs will notice is a dramatic performance improvement. Thanks to these fixes, loading times for a 7 MB OpenAPI doc went improved 25x, going from 2.6s to 0.11s.
+What users with large API docs will notice is a dramatic performance improvement. Thanks to these fixes, loading times for a 7 MB OpenAPI doc improved 25x, going from 2.6s to 0.11s.
 
 Improving performance is a continual process. For example, immediately after this, we upgraded to Vue 3.5, which came with [reactivity system optimizations](https://blog.vuejs.org/posts/vue-3-5#reactivity-system-optimizations). As a company building for developers, we know how important performance is, so expect these improvements to continue.
 

--- a/documentation/blog/2025-03-19-the-hidden-complexity-of-building.md
+++ b/documentation/blog/2025-03-19-the-hidden-complexity-of-building.md
@@ -17,9 +17,9 @@ On top of this, drag and drop can be used to import OpenAPI docs. This can be do
 Creating a slick drag and drop experience required us to solve the following challenges:
 
 * **Where.** You can’t drag everything everywhere. Only certain objects can be dropped into certain spots. This means you need validation and visual feedback like drop zones, UI updates, cancellation, and error handling.
-* **State management**. Both dragging and dropping needs to work with the many levels of state the API client has including collections, folders, and requests as well as their parent-child relationships. The UI aspects like collapsed versus expanded also needs to be handled.
+* **State management**. Both dragging and dropping needs to work with the many levels of state the API client has including collections, folders, and requests as well as their parent-child relationships. The UI aspects like collapsed versus expanded also need to be handled.
 * **Performance.** When you drag an element, your browser fires `dragover` events many times per second. If you don’t throttle these, you run potentially expensive calculations like determining drop zones, calculating positions, updating UI indicators on every single mouse movement. This can create UI jitters or lag your entire app.
-* **Context.** Requests and collections aren’t simple. They include information on authentication settings, examples, test cases, response history, security schemes, and servers. Behind this is an structured OpenAPI document that needs to stay valid.
+* **Context.** Requests and collections aren’t simple. They include information on authentication settings, examples, test cases, response history, security schemes, and servers. Behind this is a structured OpenAPI document that needs to stay valid.
 
 ## How does our API client handle drag and drop challenges?
 

--- a/documentation/blog/2025-03-26-a-guide-to-openapi-security-and-how.md
+++ b/documentation/blog/2025-03-26-a-guide-to-openapi-security-and-how.md
@@ -210,13 +210,13 @@ The whole point of defining a security scheme is that it makes using an API easi
 
 Our [API reference](https://galaxy.scalar.com/) supports API key, HTTP, and OAuth 2.0 security schemes. Based on your OpenAPI document and the security schemes applied to your operations, users can choose one of these and send requests with it.
 
-Behind the scenes, we handle the logic for applying the correct scheme for each operation, include the UI to gather the needed information, set up the correct auth method on users requests, handle state for the auth, and handle errors that come from invalid credentials or other auth failures.
+Behind the scenes, we handle the logic for applying the correct scheme for each operation, include the UI to gather the needed information, set up the correct auth method on users’ requests, handle state for the auth, and handle errors that come from invalid credentials or other auth failures.
 
 ### API client
 
 The [API client](https://client.scalar.com/) looks very similar. The big difference is that because your client state can be private to you, we can store it between sessions and collections. This also means you might have multiple collections as well as multiple active security schemes.
 
-To handle this, we store auth values at the collection-level, support operation-level overrides, and allow you to select the scheme on want on per-request. The selectors for schemes are also more interactive, allowing editing of API key name fields and scheme deletion.
+To handle this, we store auth values at the collection-level, support operation-level overrides, and allow you to select the scheme you want on per-request. The selectors for schemes are also more interactive, allowing editing of API key name fields and scheme deletion.
 
 Our API client also pre-fills as much information as possible. It auto detects security schemes, creates default value structures based on scheme types, pre-configs OAuth flows if provided, and more.
 
@@ -224,6 +224,6 @@ Our API client also pre-fills as much information as possible. It auto detects s
 
 As with many areas of Scalar, we continue to improve the connection between your OpenAPI doc, API reference, and API client. For example, we recently added the ability to sync authentication settings between the API reference and the API client. The API reference can pass auth settings to the client modal and the select security schemes become the default in the client.
 
-Security shouldn’t come at the cost of developer experience. The tools Scalar provides helps developers authenticate quickly and correctly. This helps them test endpoints, debug, and ultimately build better (and more secure) APIs.
+Security shouldn’t come at the cost of developer experience. The tools Scalar provides help developers authenticate quickly and correctly. This helps them test endpoints, debug, and ultimately build better (and more secure) APIs.
 
 **Mar 26, 2025**

--- a/documentation/blog/2025-04-23-an-introduction-to-openapi-variables.md
+++ b/documentation/blog/2025-04-23-an-introduction-to-openapi-variables.md
@@ -5,7 +5,7 @@ There are two types of OpenAPI variables:
 1. **Server variables:** Strings used specifically in the server URL, primarily used for configuration.
 2. **Parameters:** Potentially complex data types used to define data passed through the API.
 
-This guide providers an overview of defining and using both.
+This guide provides an overview of defining and using both.
 
 ## Server variables
 
@@ -34,7 +34,7 @@ Generally, server variables fit into one of the following use cases:
 * Configuring an API to work across dev, staging, and production environments
 * Testing APIs across both `http` and `https` protocols
 * Allowing flexibility in port selection
-* Defining subdomains values for customers, regions, or multi-tenant applications.
+* Defining subdomain values for customers, regions, or multi-tenant applications.
 
 ## Parameters
 

--- a/documentation/blog/2025-04-28-how-cloudinarys-api-docs-create-a.md
+++ b/documentation/blog/2025-04-28-how-cloudinarys-api-docs-create-a.md
@@ -37,7 +37,7 @@ This enables users to discover the full range of Cloudinary’s capability and f
 
 ## The added benefits of OpenAPI and Scalar
 
-Beyond covering many more use cases, the combination of OpenAPI and Scalar provide many benefits for Cloudinary and their users:
+Beyond covering many more use cases, the combination of OpenAPI and Scalar provides many benefits for Cloudinary and their users:
 
 ### Functionality
 

--- a/documentation/blog/2025-05-28-how-we-created-an-animated-responsive.md
+++ b/documentation/blog/2025-05-28-how-we-created-an-animated-responsive.md
@@ -99,7 +99,7 @@ This is done with a combination of HTML (for the links) and SVGs that look like 
 
 ## **Creating animations that will knock your socks off**
 
-Now, all this is cool so far, but you could mistake it for any other GitHub repo. Something that would be totally unique to use is some sweet, sweet animations running in our GitHub repo.
+Now, all this is cool so far, but you could mistake it for any other GitHub repo. Something that would be totally unique to us is some sweet, sweet animations running in our GitHub repo.
 
 We love our contributors. What better way to credit them than an animated shout out in our README? Contribution is a key piece of being open source after all. Again, we use SVGs and `foreignobjects`.
 

--- a/documentation/blog/2026-03-05-agent-scalar.md
+++ b/documentation/blog/2026-03-05-agent-scalar.md
@@ -3,7 +3,7 @@
 
 ![ASCII-style image of a headset](../assets/blog/agent-scalar.jpg)
 
-Make your AI Agents talk to APIs is easy and fun. It's just that bigger APIs are a worst-case workload for agents. Raw API definitions in the prompt overflows context so easily. I mean, we tried that. But all we got is hallucinated endpoints and unreliable responses.
+Making your AI Agents talk to APIs is easy and fun. It's just that bigger APIs are a worst-case workload for agents. Raw API definitions in the prompt overflows context so easily. I mean, we tried that. But all we got is hallucinated endpoints and unreliable responses.
 
 That's something MCP helps with. You just wrap your API as MCP tools, and you're good to go. That's what we thought. Actually, the repeated schemas come with a cost (tokens), too.
 
@@ -27,7 +27,7 @@ Agent keeps the tool surface fixed and super small. It fetches just-in-time deta
 
 ## The problem
 
-If you dump the full OpenAPI document into the prompt, you often blow past the model's context window before the model can do any work. That's exactly what happens with the, for example, the [Zoom Meetings API](https://developers.zoom.us/docs/api/meetings/).
+If you dump the full OpenAPI document into the prompt, you often blow past the model's context window before the model can do any work. That's exactly what happens with, for example, the [Zoom Meetings API](https://developers.zoom.us/docs/api/meetings/).
 
 Even when the API is smaller, like [Notions API](https://developers.notion.com/guides/get-started/getting-started), raw OpenAPI is so expensive: It works, sure, but you pay a steep token tax every run. MCP reduces cost a lot, but native MCP still carries schema tokens for every single endpoint.
 
@@ -49,7 +49,7 @@ We used [Zoom Meetings API](https://developers.zoom.us/docs/api/meetings/) (list
 
 Token counting was done with [tiktoken](https://github.com/openai/tiktoken).
 
-### Zoom Mettings
+### Zoom Meetings
 
 **Summary**
 

--- a/documentation/blog/2026-03-17-agent-mcp.md
+++ b/documentation/blog/2026-03-17-agent-mcp.md
@@ -1,6 +1,6 @@
 # Use your API in Cursor (or your favorite LLM)
 
-We've been hard at work figuring out how to get Agent Scalar as close possible to your favorite tools with as little overhead as possible, and here is what we came up with:
+We've been hard at work figuring out how to get Agent Scalar as close as possible to your favorite tools with as little overhead as possible, and here is what we came up with:
 
 Agent MCP Servers allow you to take your existing OpenAPI document and expose it via an MCP server with all the [performance benefits](./2026-03-05-agent-scalar.md) of Agent:
 

--- a/documentation/blog/index.md
+++ b/documentation/blog/index.md
@@ -17,7 +17,7 @@
   <a class="blog-post-list__link" href="./2026-03-25-scalar-mcp-oauth.md">
     <div class="blog-post-list__meta">Mar 25, 2026</div>
     <h2 class="blog-post-list__title">Too Long; Didn't Read; Used MCP</h2>
-    <p class="blog-post-list__description">Hey, it's 2026, who does even read the documentation for your API anymore. Just boot up a MCP based on your OpenAPI document (using Scalar), and share it with your users or your team.</p>
+    <p class="blog-post-list__description">Hey, it's 2026, who does even read the documentation for your API anymore. Just boot up an MCP based on your OpenAPI document (using Scalar), and share it with your users or your team.</p>
   </a>
 </article>
 <article class="blog-post-list__item" data-file="2026-03-17-agent-mcp.md">

--- a/documentation/guides/agent/mcp.md
+++ b/documentation/guides/agent/mcp.md
@@ -10,7 +10,7 @@ Scalar exposes two separate MCP surfaces, and they're easy to conflate because m
 
 The **Installation MCP** lives at `https://mcp.scalar.com/mcp/YOUR_INSTALL_ID` and lets AI clients call the API endpoints you've selected, using the authentication you've stored for the installation. It is a completely separate endpoint and is private by default: team members connect with a Personal Access Token, while people outside your team sign in through OAuth once you grant them access (see [Authentication](./authentication/index.md)). If you want to verify which one a client is actually pointed at, `curl` the URL directly: the Installation MCP responds with `401` when no valid credentials are present.
 
-## Create a MCP Server
+## Create an MCP Server
 
 Create a new MCP Server for your API in under a minute (I promise):
 

--- a/documentation/guides/agent/sdk.md
+++ b/documentation/guides/agent/sdk.md
@@ -1,6 +1,6 @@
 # Agent SDK
 
-Scalar provides SDKs to connect your AI agent to Scalar's OpenAPI MCP servers. We offer a Python and TypeScript SDk to use with your favourite language and frameworks.
+Scalar provides SDKs to connect your AI agent to Scalar's OpenAPI MCP servers. We offer a Python and TypeScript SDK to use with your favourite language and frameworks.
 
 ## TypeScript
 

--- a/documentation/guides/api/getting-started.md
+++ b/documentation/guides/api/getting-started.md
@@ -1,4 +1,4 @@
 # Getting Started
 
-Reading this guide helps you to get started with our API. Everything you can do in our dashboard or apps can be done programatically through our API: Docs, Registry, Linting, Managing etc.
+Reading this guide helps you to get started with our API. Everything you can do in our dashboard or apps can be done programmatically through our API: Docs, Registry, Linting, Managing etc.
 

--- a/documentation/guides/docs/configuration/migration.md
+++ b/documentation/guides/docs/configuration/migration.md
@@ -1,6 +1,6 @@
 # Migrate from Docs 1.0
 
-With Docs 2.0 we've completely started from scratch. We tried to stick to the patterns we already had, so they way you set it up is not too different.
+With Docs 2.0 we've completely started from scratch. We tried to stick to the patterns we already had, so the way you set it up is not too different.
 
 **TL;DR**
 

--- a/documentation/guides/docs/content/mdx.mdx
+++ b/documentation/guides/docs/content/mdx.mdx
@@ -57,7 +57,7 @@ import Intro from './intro.mdx'
 This is **Markdown**.
 ```
 
-And this how the other
+And this is how the other
 
 ```markdown
 # Introduction

--- a/documentation/guides/registry/upload.md
+++ b/documentation/guides/registry/upload.md
@@ -16,7 +16,7 @@ You can upload any version of OpenAPI (even Swagger) or a Postman Collection!
 
 ![Scalar Imported OpenAPI Document](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/glhdU91VygnDIlywcnUsL.png "Scalar Imported OpenAPI Document")
 
-Awesome, now your OpenAPI Document is in the Registry under your companies namespace!
+Awesome, now your OpenAPI Document is in the Registry under your company's namespace!
 
 
 ## Update an OpenAPI Document

--- a/documentation/integrations/adonisjs.md
+++ b/documentation/integrations/adonisjs.md
@@ -28,7 +28,7 @@ Do you want us to install dependencies using "npm"?
 ❯ Yes
 ```
 
-Wow, you're half way there already. Jump into the directory and start the devlopment server:
+Wow, you're half way there already. Jump into the directory and start the development server:
 
 ```bash
 cd my-awesome-app

--- a/documentation/integrations/aspire.md
+++ b/documentation/integrations/aspire.md
@@ -55,7 +55,7 @@ scalar
 builder.Build().Run();
 ```
 
-That's it! 🎉 The Aspire dashboard will display a API Reference resource with unified documentation for all your services.
+That's it! 🎉 The Aspire dashboard will display an API Reference resource with unified documentation for all your services.
 
 ## Configuration
 

--- a/documentation/integrations/django-ninja.md
+++ b/documentation/integrations/django-ninja.md
@@ -78,7 +78,7 @@ api = NinjaAPI(
 )
 ```
 
-It's recommend to use `ScalarConfig` to have a fully typed configuration.
+It's recommended to use `ScalarConfig` to have a fully typed configuration.
 
 ## Configuration
 

--- a/documentation/integrations/docusaurus.md
+++ b/documentation/integrations/docusaurus.md
@@ -1,6 +1,6 @@
 # API Reference for Docusaurus
 
-Docusaurus helps you to ship a beautiful documentation site in no time. For everyone who wants to make their API reference part of a Docusaurus website, we've built a API Reference plugin.
+Docusaurus helps you to ship a beautiful documentation site in no time. For everyone who wants to make their API reference part of a Docusaurus website, we've built an API Reference plugin.
 
 ![Screenshot of the Docusaurus integration](../assets/screenshots/docusaurus.png)
 

--- a/documentation/integrations/express.md
+++ b/documentation/integrations/express.md
@@ -12,7 +12,7 @@ npm install @scalar/express-api-reference
 
 ## Usage
 
-[Set up Express](https://expressjs.com/en/starter/hello-world.html) and pass an URL to an OpenAPI/Swagger document to the `apiReference` middleware:
+[Set up Express](https://expressjs.com/en/starter/hello-world.html) and pass a URL to an OpenAPI/Swagger document to the `apiReference` middleware:
 
 > Wait, but how do we get the OpenAPI document? 🤔 There are multiple ways to generate an OpenAPI file for Express. The most popular way is to use [`swagger-jsdoc`](https://github.com/Surnet/swagger-jsdoc).
 

--- a/documentation/integrations/fastify.md
+++ b/documentation/integrations/fastify.md
@@ -20,7 +20,7 @@ await fastify.register(import('@scalar/fastify-api-reference'), {
 
 ## Usage
 
-If you have a OpenAPI/Swagger document already, you can pass an URL to the plugin:
+If you have an OpenAPI/Swagger document already, you can pass a URL to the plugin:
 
 ```typescript
 // Render an API reference for a given OpenAPI/Swagger spec URL
@@ -146,7 +146,7 @@ In order to use it, we need to install the official package first:
 npm install @fastify/swagger
 ```
 
-Okay, you've got this. To actually set up the package, there's a some boilerplate code required. **Replace the content** of our previous `index.js` with the following:
+Okay, you've got this. To actually set up the package, there's some boilerplate code required. **Replace the content** of our previous `index.js` with the following:
 
 ```javascript
 import FastifySwagger from '@fastify/swagger'

--- a/documentation/integrations/java.md
+++ b/documentation/integrations/java.md
@@ -6,7 +6,7 @@ The Scalar Java integration provides an easy way to render beautiful API Referen
 
 The Scalar Java integration consists of **3 separate modules**:
 
-- **`scalar-core`** - Framework-agnostic core module with no dependencies (except Jackson for JSON serialization). Can be used anywhere to display a API Reference.
+- **`scalar-core`** - Framework-agnostic core module with no dependencies (except Jackson for JSON serialization). Can be used anywhere to display an API Reference.
 - **`scalar-webmvc`** - Spring Boot WebMVC integration module
 - **`scalar-webflux`** - Spring Boot WebFlux integration module
 

--- a/documentation/integrations/laravel-scribe.md
+++ b/documentation/integrations/laravel-scribe.md
@@ -55,7 +55,7 @@ In our example, we selected SQLite, so we need to create an empty database:
 touch database/database.sqlite
 ```
 
-If you've choosen another database driver, add the required credentials to your `.env` file. Once you're done, you can use [Laravel Herd](https://herd.laravel.com/) or just spin up a tiny PHP server from the command-line:
+If you've chosen another database driver, add the required credentials to your `.env` file. Once you're done, you can use [Laravel Herd](https://herd.laravel.com/) or just spin up a tiny PHP server from the command-line:
 
 ```bash
 php artisan serve

--- a/documentation/integrations/nestjs.md
+++ b/documentation/integrations/nestjs.md
@@ -40,7 +40,7 @@ const OpenApiSpecification =
   )
 ```
 
-Recommended: If you're serving an OpenAPI/Swagger file already, you can pass an URL, too:
+Recommended: If you're serving an OpenAPI/Swagger file already, you can pass a URL, too:
 
 ```typescript
 import { apiReference } from '@scalar/nestjs-api-reference'
@@ -89,7 +89,7 @@ app.use(
 
 ### Custom CDN
 
-You can use a custom CDN ，default is `https://cdn.jsdelivr.net/npm/@scalar/api-reference`.
+You can use a custom CDN, default is `https://cdn.jsdelivr.net/npm/@scalar/api-reference`.
 
 You can also pin the CDN to a specific version by specifying it in the CDN string like `https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.25.28`
 

--- a/documentation/integrations/nextjs.md
+++ b/documentation/integrations/nextjs.md
@@ -23,7 +23,7 @@ please use version `0.4.106` of this package.
 
 ## Usage
 
-If you have a OpenAPI/Swagger file already, you can pass a URL to the plugin in an API [Route](https://nextjs.org/docs/app/building-your-application/routing/route-handlers):
+If you have an OpenAPI/Swagger file already, you can pass a URL to the plugin in an API [Route](https://nextjs.org/docs/app/building-your-application/routing/route-handlers):
 
 ```typescript
 // app/reference/route.ts

--- a/documentation/legal/privacy-policy.md
+++ b/documentation/legal/privacy-policy.md
@@ -251,7 +251,7 @@ In some cases, We may anonymize Your personal information (so that it can no lon
 Transfer of Your Personal Data
 -------------------------------
 
-Your information, including Personal Data, is processed by Scalar and primarily stored in the United States of America. It means that this information may be transferred to — and maintained on — computers located outside of Your state, province, country or other governmental jurisdiction where the data protection laws may differ from those from Your jurisdiction.
+Your information, including Personal Data, is processed by Scalar and primarily stored in the United States of America. It means that this information may be transferred to — and maintained on — computers located outside of Your state, province, country or other governmental jurisdiction where the data protection laws may differ than those from Your jurisdiction.
 
 Your consent to this Privacy Policy followed by Your submission of such information represents Your agreement to that transfer.
 

--- a/documentation/legal/privacy-policy.md
+++ b/documentation/legal/privacy-policy.md
@@ -251,7 +251,7 @@ In some cases, We may anonymize Your personal information (so that it can no lon
 Transfer of Your Personal Data
 -------------------------------
 
-Your information, including Personal Data, is processed by Scalar and primarily stored in the United States of America. It means that this information may be transferred to — and maintained on — computers located outside of Your state, province, country or other governmental jurisdiction where the data protection laws may differ than those from Your jurisdiction.
+Your information, including Personal Data, is processed by Scalar and primarily stored in the United States of America. It means that this information may be transferred to — and maintained on — computers located outside of Your state, province, country or other governmental jurisdiction where the data protection laws may differ from those from Your jurisdiction.
 
 Your consent to this Privacy Policy followed by Your submission of such information represents Your agreement to that transfer.
 

--- a/documentation/legal/terms-and-conditions.md
+++ b/documentation/legal/terms-and-conditions.md
@@ -354,7 +354,7 @@ If any provision of these Terms is held to be unenforceable or invalid, such pro
 
 **Waiver**
 
-Except as provided herein, the failure to exercise a right or to require performance of an obligation under these Terms shall not effect a party's ability to exercise such right or require such performance at any time thereafter nor shall the waiver of a breach constitute a waiver of any subsequent breach.
+Except as provided herein, the failure to exercise a right or to require performance of an obligation under these Terms shall not affect a party's ability to exercise such right or require such performance at any time thereafter nor shall the waiver of a breach constitute a waiver of any subsequent breach.
 
 ## 25. Third-Party Beneficiaries
 

--- a/documentation/markdown.md
+++ b/documentation/markdown.md
@@ -5,7 +5,7 @@ descriptions, in your parameter descriptions and in a lot of other places. We're
 What's working here, is probably also working in the API reference:
 
 - bullet lists, numbered lists
-- _italic_, **bold**, ~~striked~~ text
+- _italic_, **bold**, ~~struck~~ text
 - accordions
 - links
 - tables

--- a/documentation/migration/stoplight.md
+++ b/documentation/migration/stoplight.md
@@ -49,7 +49,7 @@ Scalar has a free tier, and you can get quite a lot done with it. No credit card
 
 ## Step 2: Introduce your OpenAPI to Scalar
 
-Stoplight had various flavors of project: Web Projects, Git Projects, Local Projects. We're going to make life easy and show you all how to convert to Git projects, and you can play around with others approaches once you've got the hang of the basics.
+Stoplight had various flavors of project: Web Projects, Git Projects, Local Projects. We're going to make life easy and show you all how to convert to Git projects, and you can play around with other approaches once you've got the hang of the basics.
 
 ### Git Projects
 
@@ -59,7 +59,7 @@ To use GitHub Sync go to the dashboard, click **Create Documentation**, then sel
 
 ![](../assets/migration/create-docs-from-git.png)
 
-Click the **Link Repository** link next to the repository of interest, and a page will appear with some GitHub Repository Settings will appear. The defaults are probably all fine, but perhaps you're using a special branch called `docs` or a particular version branch like `v3` instead of `main`.
+Click the **Link Repository** link next to the repository of interest, and a page with some GitHub Repository Settings will appear. The defaults are probably all fine, but perhaps you're using a special branch called `docs` or a particular version branch like `v3` instead of `main`.
 
 All of this can be changed later so pick whatever and click publish, it'll be private by default so no worries about anyone seeing anything that's not ready.
 
@@ -198,7 +198,7 @@ Commit this file and push. If automatic deployment is enabled in the [Scalar Das
 
 ## Step 4: Review The New Documentation
 
-Click the deployment to see find the projects docs URL, something like `https://name-of-your-api.apidocumentation.com`.
+Click the deployment to find the project's docs URL, something like `https://name-of-your-api.apidocumentation.com`.
 
 This will show two distinct sections.
 
@@ -225,7 +225,7 @@ Maybe this is just turning some rules on and off.
 
 Maybe it is defining custom rules.
 
-Be aware rules with custom functions wont work, so just comment those out.
+Be aware rules with custom functions won't work, so just comment those out.
 
 ## Step 6: (Optional) Update Custom Domains
 
@@ -275,4 +275,4 @@ The biggest advantage in this migration is that both tools are fundamentally Ope
 
 Most teams can complete this migration in somewhere between a few hours and a few days, depending on how many projects and APIs need moving over. Larger enterprises will take slightly longer depending on the complexity of their API ecosystem.
 
-Scalar's team is happy to offer migration assistance and consultation to help streamline this process, particularly for teams with complex Stoplight implementations. The team consist of experts that helped build Stoplight in the first place, so they're well placed to help migrate anyone regardless of the size or complexity of the projects.
+Scalar's team is happy to offer migration assistance and consultation to help streamline this process, particularly for teams with complex Stoplight implementations. The team consists of experts that helped build Stoplight in the first place, so they're well placed to help migrate anyone regardless of the size or complexity of the projects.

--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -356,7 +356,7 @@ In this example, properties will be displayed in the order: `name`, `diameter`, 
 
 ## x-scalar-stability
 
-You can show the stability of an endpoint by settings the `x-scalar-stability` to either `stable`, `experimental` or `deprecated`. The native `deprecated` property will take precedence.
+You can show the stability of an endpoint by setting the `x-scalar-stability` to either `stable`, `experimental` or `deprecated`. The native `deprecated` property will take precedence.
 
 ```diff
 openapi: 3.1.0
@@ -402,7 +402,7 @@ paths:
 
 ## x-enum-descriptions
 
-You can add a descriptions to `enum` values with `x-enum-descriptions`:
+You can add descriptions to `enum` values with `x-enum-descriptions`:
 
 ```diff
 openapi: 3.1.0

--- a/documentation/plugins.md
+++ b/documentation/plugins.md
@@ -57,7 +57,7 @@ and pass it via `plugins` instead.
 
 ### Specification Extensions
 
-The OpenAPI specification allows to [**extend the format**](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#specification-extensions).
+The OpenAPI specification allows you to [**extend the format**](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.1.md#specification-extensions).
 You can add custom properties. They are always prefixed with a `x-`, here is an example:
 
 ```diff
@@ -326,7 +326,7 @@ export const FeedbackPlugin = (): ApiReferencePlugin => {
 
 # API Client Plugins
 
-The API Reference uses the API Client to test requests. The API Client has its own plugin API and you can't pass a API Client plugin directly, to the API Reference, but you can wrap it in a API Reference plugin.
+The API Reference uses the API Client to test requests. The API Client has its own plugin API and you can't pass an API Client plugin directly, to the API Reference, but you can wrap it in an API Reference plugin.
 
 API Client Plugins can add lifecycle hooks, custom UI components, and custom response body handlers for content types the client does not natively support.
 

--- a/documentation/themes.md
+++ b/documentation/themes.md
@@ -54,7 +54,7 @@ To get started, overwrite our CSS variables. We won't judge.
 > [!NOTE]
 > By default, we're using Inter and JetBrains Mono, served by our in-house CDN.
 
-If you want use a different font or want to use Google Fonts, pass `withDefaultFonts: false` to the configuration and overwrite the `--scalar-font` and `--scalar-font-code` CSS variables. You will also need to provide the source of your new font which can be local or served over the network.
+If you want to use a different font or want to use Google Fonts, pass `withDefaultFonts: false` to the configuration and overwrite the `--scalar-font` and `--scalar-font-code` CSS variables. You will also need to provide the source of your new font which can be local or served over the network.
 
 Here is an example of how to use the `Roboto` font from Google Fonts with the CDN API reference.
 


### PR DESCRIPTION
Fixes typos and small grammatical mistakes throughout the `documentation/` folder — a/an corrections, doubled words, subject–verb agreement, and a few misspellings ("programatically", "devlopment", "choosen", etc.). Text-only; no code, config, or URLs touched.