### PR TITLE
docs(sdks): document CLI destinations and fix publishing docs

### DIFF
--- a/documentation/guides/sdks/cli.md
+++ b/documentation/guides/sdks/cli.md
@@ -38,6 +38,30 @@ Add `cli` under `targets` to generate a command-line interface for your API.
 | `destinations`       | `object` | GitHub destinations for generated output.                        |
 | `publish`            | `object` | npm, standalone binary, and Homebrew publishing configuration.   |
 
+## Destinations
+
+Use `destinations.production` to push generated output to a GitHub repository.
+
+```json
+{
+  "targets": {
+    "cli": {
+      "destinations": {
+        "production": {
+          "repo": "acme/acme-cli",
+          "branch": "main"
+        }
+      }
+    }
+  }
+}
+```
+
+| Property | Description                                                                 |
+| -------- | --------------------------------------------------------------------------- |
+| `repo`   | GitHub repository in `owner/name` form.                                     |
+| `branch` | Default branch of the destination repository that releases are promoted to. Defaults to `main`. Generated output itself always goes to the fixed `scalar-generated` branch. |
+
 ## Method Commands
 
 Use method-level `cli` settings in `resources` to enable, disable, or tune command generation for a specific method.

--- a/documentation/guides/sdks/cli.md
+++ b/documentation/guides/sdks/cli.md
@@ -40,7 +40,7 @@ Add `cli` under `targets` to generate a command-line interface for your API.
 
 ## Destinations
 
-Use `destinations.production` to push generated output to a GitHub repository.
+Use `destinations.production` to push generated output to a GitHub repository. This option is available on every target, not just `cli`.
 
 ```json
 {

--- a/documentation/guides/sdks/configuration/go.md
+++ b/documentation/guides/sdks/configuration/go.md
@@ -104,4 +104,4 @@ Set `publish.go` to `true` to tag each release so the Go module proxy can serve 
 | `go`                 | Set to `true` to tag each release and warm the Go module proxy. |
 | `releaseEnvironment` | Release environment the generated publish job runs in.        |
 
-Go publishes through the Git tag, so there is nothing to authenticate against: the release workflow only warms the public module proxy, using the built-in `GITHUB_TOKEN`. The shared `authMethod` option has nothing to act on here and is ignored.
+Go publishes through the Git tag, so there is nothing to authenticate against: the release workflow just warms the public module proxy so it caches the new version. The shared `authMethod` option has nothing to act on here and is ignored.

--- a/documentation/guides/sdks/configuration/go.md
+++ b/documentation/guides/sdks/configuration/go.md
@@ -101,5 +101,7 @@ Set `publish.go` to `true` to tag each release so the Go module proxy can serve 
 
 | Property             | Description                                                   |
 | -------------------- | ------------------------------------------------------------- |
-| `authMethod`         | Registry authentication mechanism, such as `oidc` or `access-token`. |
-| `releaseEnvironment` | Release environment name used by generated publishing workflows. |
+| `go`                 | Set to `true` to tag each release and warm the Go module proxy. |
+| `releaseEnvironment` | Release environment the generated publish job runs in.        |
+
+Go publishes through the Git tag, so there is nothing to authenticate against: the release workflow only warms the public module proxy, using the built-in `GITHUB_TOKEN`. The shared `authMethod` option has nothing to act on here and is ignored.

--- a/documentation/guides/sdks/configuration/php.md
+++ b/documentation/guides/sdks/configuration/php.md
@@ -75,5 +75,6 @@ Set `publish.packagist` to `true` to tag each release for Packagist. Packagist s
 
 | Property             | Description                                                   |
 | -------------------- | ------------------------------------------------------------- |
-| `authMethod`         | Registry authentication mechanism, such as `oidc` or `access-token`. |
-| `releaseEnvironment` | Release environment name used by generated publishing workflows. |
+| `packagist`          | Set to `true` to tag each release for Packagist.              |
+
+Packagist serves the package from the Git tag, so no publish job is generated for this target. The shared `authMethod` and `releaseEnvironment` publish options have nothing to act on here and are ignored.

--- a/documentation/guides/sdks/configuration/swift.md
+++ b/documentation/guides/sdks/configuration/swift.md
@@ -75,5 +75,6 @@ Set `publish.swiftpm` to `true` to tag each release for Swift Package Manager. T
 
 | Property             | Description                                                   |
 | -------------------- | ------------------------------------------------------------- |
-| `authMethod`         | Registry authentication mechanism, such as `oidc` or `access-token`. |
-| `releaseEnvironment` | Release environment name used by generated publishing workflows. |
+| `swiftpm`            | Set to `true` to tag each release for Swift Package Manager.  |
+
+Swift Package Manager resolves packages straight from the Git tag, so no publish job is generated for this target. The shared `authMethod` and `releaseEnvironment` publish options have nothing to act on here and are ignored.

--- a/documentation/guides/sdks/publishing/overview.md
+++ b/documentation/guides/sdks/publishing/overview.md
@@ -41,7 +41,7 @@ Merging runs `release-please.yml` on the default branch, which cuts the `vX.Y.Z`
 
   <scalar-step id="step-publish" title="The publish job publishes">
 
-In the same workflow run, the inline `publish` job checks out the tag that was just cut and publishes the package to its registry, then the release is synced back to `scalar-next`. The publish step is idempotent: if that version is already on the registry, it is skipped, so re-runs never fail or double-publish.
+In the same workflow run, the release is synced back to `scalar-next`, and the inline `publish` job then checks out the tag that was just cut and publishes the package to its registry. The publish step is idempotent: if that version is already on the registry, it is skipped, so re-runs never fail or double-publish.
 
   </scalar-step>
 </scalar-steps>


### PR DESCRIPTION
## Problem

The SDK docs had a few gaps and mistakes:

- The CLI target's `destinations` option was listed but never explained.
- The Go, PHP, and Swift config tables listed `authMethod` and `releaseEnvironment`, but those targets ignore them. They publish straight from the Git tag, so there is no registry to log in to.
- The publishing overview described the publish and sync steps in the wrong order.

## Solution

- Add a Destinations section to the CLI docs showing `destinations.production` (`repo` and `branch`).
- Fix the Go, PHP, and Swift tables to list the real option and explain why `authMethod` (and `releaseEnvironment`) do not apply.
- Fix the step order in the publishing overview: the release is synced back to `scalar-next` first, then the package is published.

Docs only. Checked against the SDK generator source.
