### PR TITLE
fix(api-reference): render model names as plain text when models are hidden

### DIFF
--- a/.changeset/fix-9854-hide-models-plain-text.md
+++ b/.changeset/fix-9854-hide-models-plain-text.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-Render model names as plain text when `hideModels` is enabled. The names next to types and on the request body heading used to be links, but with the models section hidden there was nothing to scroll to, so clicking them did nothing.
+Render model names as plain text when there is no models section to link to. The names next to types and on the request body heading used to be links even when the whole models section was hidden via `hideModels`, or when the referenced model itself was hidden via `x-internal` / `x-scalar-ignore`. There was nothing to scroll to, so clicking them did nothing. They now render as plain text in both cases.

--- a/.changeset/fix-9854-hide-models-plain-text.md
+++ b/.changeset/fix-9854-hide-models-plain-text.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Render model names as plain text when `hideModels` is enabled. The names next to types and on the request body heading used to be links, but with the models section hidden there was nothing to scroll to, so clicking them did nothing.

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -835,5 +835,23 @@ describe('SchemaProperty', () => {
       expect(wrapper.text()).toContain('Planet')
       expect(wrapper.find('.property-heading button').exists()).toBe(false)
     })
+
+    it('renders the model name as plain text when the referenced model is hidden', () => {
+      const wrapper = mount(SchemaProperty, {
+        props: {
+          eventBus: createWorkspaceEventBus(),
+          modelName: 'Planet',
+          schema: coerceValue(SchemaObjectSchema, { type: 'object' }),
+          options: {
+            document: {
+              components: { schemas: { Planet: { type: 'object', 'x-internal': true } } },
+            },
+          } as any,
+        },
+      })
+
+      expect(wrapper.text()).toContain('Planet')
+      expect(wrapper.find('.property-heading button').exists()).toBe(false)
+    })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -1,4 +1,5 @@
 import { ScalarListbox } from '@scalar/components/listbox'
+import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
 import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
@@ -817,6 +818,22 @@ describe('SchemaProperty', () => {
       })
 
       expect(wrapper.find('#body\\.BaseObject\\.nestedField').exists()).toBe(false)
+    })
+  })
+
+  describe('model links', () => {
+    it('renders the model name as plain text when hideModels is enabled', () => {
+      const wrapper = mount(SchemaProperty, {
+        props: {
+          eventBus: createWorkspaceEventBus(),
+          modelName: 'Planet',
+          schema: coerceValue(SchemaObjectSchema, { type: 'object' }),
+          options: { hideModels: true },
+        },
+      })
+
+      expect(wrapper.text()).toContain('Planet')
+      expect(wrapper.find('.property-heading button').exists()).toBe(false)
     })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.test.ts
@@ -1,7 +1,7 @@
 import { ScalarListbox } from '@scalar/components/listbox'
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
-import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { OpenAPIDocumentSchema, SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 
@@ -843,10 +843,12 @@ describe('SchemaProperty', () => {
           modelName: 'Planet',
           schema: coerceValue(SchemaObjectSchema, { type: 'object' }),
           options: {
-            document: {
+            document: coerceValue(OpenAPIDocumentSchema, {
+              openapi: '3.1.0',
+              info: { title: 'Test', version: '1.0.0' },
               components: { schemas: { Planet: { type: 'object', 'x-internal': true } } },
-            },
-          } as any,
+            }),
+          },
         },
       })
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -314,6 +314,7 @@ const isDiscriminatorProperty = computed(() =>
       class="group"
       :enum="hasEnum"
       :eventBus="eventBus"
+      :hideModelLinks="options.hideModels"
       :hideModelNames
       :isDiscriminator="isDiscriminatorProperty"
       :modelName="modelName"

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -314,9 +314,12 @@ const isDiscriminatorProperty = computed(() =>
       class="group"
       :enum="hasEnum"
       :eventBus="eventBus"
-      :hideModelLinks="options.hideModels"
       :hideModelNames
       :isDiscriminator="isDiscriminatorProperty"
+      :modelLinkOptions="{
+        hideModels: options.hideModels,
+        document: options.document,
+      }"
       :modelName="modelName"
       :propertyNames="propertyNamesSchema"
       :required

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -1,3 +1,4 @@
+import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
 import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
@@ -363,6 +364,22 @@ describe('SchemaPropertyHeading', () => {
     const detailsElement = wrapper.find('.property-heading')
     expect(detailsElement.text()).toContain('Type: array string[]')
     expect(detailsElement.text()).toContain('Planet')
+  })
+
+  it('renders the model name as plain text when hideModelLinks is true', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: coerceValue(SchemaObjectSchema, {
+          type: 'object',
+        }),
+        modelName: 'Planet',
+        hideModelLinks: true,
+        eventBus: createWorkspaceEventBus(),
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('Planet')
+    expect(detailsElement.find('button').exists()).toBe(false)
   })
 
   it('renders multipleOf property', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -1,6 +1,6 @@
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
-import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { OpenAPIDocumentSchema, SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 
@@ -390,10 +390,12 @@ describe('SchemaPropertyHeading', () => {
         }),
         modelName: 'Planet',
         modelLinkOptions: {
-          document: {
+          document: coerceValue(OpenAPIDocumentSchema, {
+            openapi: '3.1.0',
+            info: { title: 'Test', version: '1.0.0' },
             components: { schemas: { Planet: { type: 'object', 'x-internal': true } } },
-          },
-        } as any,
+          }),
+        },
         eventBus: createWorkspaceEventBus(),
       },
     })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.test.ts
@@ -366,14 +366,34 @@ describe('SchemaPropertyHeading', () => {
     expect(detailsElement.text()).toContain('Planet')
   })
 
-  it('renders the model name as plain text when hideModelLinks is true', () => {
+  it('renders the model name as plain text when the models section is hidden', () => {
     const wrapper = mount(SchemaPropertyHeading, {
       props: {
         value: coerceValue(SchemaObjectSchema, {
           type: 'object',
         }),
         modelName: 'Planet',
-        hideModelLinks: true,
+        modelLinkOptions: { hideModels: true },
+        eventBus: createWorkspaceEventBus(),
+      },
+    })
+    const detailsElement = wrapper.find('.property-heading')
+    expect(detailsElement.text()).toContain('Planet')
+    expect(detailsElement.find('button').exists()).toBe(false)
+  })
+
+  it('renders the model name as plain text when the referenced model is hidden', () => {
+    const wrapper = mount(SchemaPropertyHeading, {
+      props: {
+        value: coerceValue(SchemaObjectSchema, {
+          type: 'object',
+        }),
+        modelName: 'Planet',
+        modelLinkOptions: {
+          document: {
+            components: { schemas: { Planet: { type: 'object', 'x-internal': true } } },
+          },
+        } as any,
         eventBus: createWorkspaceEventBus(),
       },
     })

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -31,6 +31,8 @@ const props = withDefaults(
     additional?: boolean
     withExamples?: boolean
     hideModelNames?: boolean
+    /** Render model names as plain text, for when there is no models section to link to. */
+    hideModelLinks?: boolean
     /** When the schema was resolved from a $ref, pass the ref name so it displays as e.g. "Data" instead of "object". */
     modelName?: string | null
     /** Resolved propertyNames schema, used to surface key constraints like `format` for additional properties. */
@@ -42,6 +44,7 @@ const props = withDefaults(
     required: false,
     withExamples: true,
     hideModelNames: false,
+    hideModelLinks: false,
     eventBus: null,
   },
 )
@@ -337,7 +340,9 @@ const exampleValue = computed(() => {
         <template v-if="modelLink">
           ·
           <LinkButton
-            v-if="props.eventBus && modelLink.schemaKey"
+            v-if="
+              props.eventBus && modelLink.schemaKey && !props.hideModelLinks
+            "
             @click="
               props.eventBus.emit('scroll-to:model-by-name', {
                 name: modelLink.schemaKey,

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -16,6 +16,10 @@ import ScreenReader from '@/components/ScreenReader.vue'
 import { useLocalization } from '@/features/localization'
 
 import { getSchemaType } from './helpers/get-schema-type'
+import {
+  isModelLinkable,
+  type ModelLinkOptions,
+} from './helpers/is-model-linkable'
 import { getModelNameFromSchema } from './helpers/schema-name'
 import RenderString from './RenderString.vue'
 import SchemaPropertyDefault from './SchemaPropertyDefault.vue'
@@ -31,8 +35,11 @@ const props = withDefaults(
     additional?: boolean
     withExamples?: boolean
     hideModelNames?: boolean
-    /** Render model names as plain text, for when there is no models section to link to. */
-    hideModelLinks?: boolean
+    /**
+     * Config for deciding whether a model name links to the models section. When the section or
+     * the referenced model is hidden there is nothing to scroll to, so the name renders as plain text.
+     */
+    modelLinkOptions?: ModelLinkOptions
     /** When the schema was resolved from a $ref, pass the ref name so it displays as e.g. "Data" instead of "object". */
     modelName?: string | null
     /** Resolved propertyNames schema, used to surface key constraints like `format` for additional properties. */
@@ -44,7 +51,6 @@ const props = withDefaults(
     required: false,
     withExamples: true,
     hideModelNames: false,
-    hideModelLinks: false,
     eventBus: null,
   },
 )
@@ -249,6 +255,11 @@ const modelLink = computed(() => {
   return null
 })
 
+/** Whether the model name links to the models section, or renders as plain text. */
+const modelLinkable = computed(() =>
+  isModelLinkable(modelLink.value?.schemaKey, props.modelLinkOptions ?? {}),
+)
+
 /** Check if we should show the type information */
 const shouldShowType = computed(() => {
   if (!props.value || !('type' in props.value)) {
@@ -340,9 +351,7 @@ const exampleValue = computed(() => {
         <template v-if="modelLink">
           ·
           <LinkButton
-            v-if="
-              props.eventBus && modelLink.schemaKey && !props.hideModelLinks
-            "
+            v-if="props.eventBus && modelLink.schemaKey && modelLinkable"
             @click="
               props.eventBus.emit('scroll-to:model-by-name', {
                 name: modelLink.schemaKey,

--- a/packages/api-reference/src/components/Content/Schema/helpers/is-model-linkable.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/is-model-linkable.test.ts
@@ -1,12 +1,17 @@
+import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
+import { OpenAPIDocumentSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { describe, expect, it } from 'vitest'
 
-import type { ModelLinkOptions } from './is-model-linkable'
 import { isModelLinkable } from './is-model-linkable'
 
-describe('isModelLinkable', () => {
-  const documentWith = (schemas: Record<string, unknown>): ModelLinkOptions['document'] =>
-    ({ components: { schemas } }) as ModelLinkOptions['document']
+const documentWith = (schemas: Record<string, unknown>) =>
+  coerceValue(OpenAPIDocumentSchema, {
+    openapi: '3.1.0',
+    info: { title: 'Test', version: '1.0.0' },
+    components: { schemas },
+  })
 
+describe('isModelLinkable', () => {
   it('links a visible model', () => {
     const options = { document: documentWith({ Planet: { type: 'object' } }) }
     expect(isModelLinkable('Planet', options)).toBe(true)
@@ -36,7 +41,8 @@ describe('isModelLinkable', () => {
   it('honors x-internal set alongside a $ref wrapper', () => {
     const options = {
       document: documentWith({
-        Planet: { '$ref': '#/components/schemas/Base', '$ref-value': { type: 'object' }, 'x-internal': true },
+        Base: { type: 'object' },
+        Planet: { '$ref': '#/components/schemas/Base', 'x-internal': true },
       }),
     }
     expect(isModelLinkable('Planet', options)).toBe(false)

--- a/packages/api-reference/src/components/Content/Schema/helpers/is-model-linkable.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/is-model-linkable.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ModelLinkOptions } from './is-model-linkable'
+import { isModelLinkable } from './is-model-linkable'
+
+describe('isModelLinkable', () => {
+  const documentWith = (schemas: Record<string, unknown>): ModelLinkOptions['document'] =>
+    ({ components: { schemas } }) as ModelLinkOptions['document']
+
+  it('links a visible model', () => {
+    const options = { document: documentWith({ Planet: { type: 'object' } }) }
+    expect(isModelLinkable('Planet', options)).toBe(true)
+  })
+
+  it('does not link when there is no schema key', () => {
+    expect(isModelLinkable(null, {})).toBe(false)
+    expect(isModelLinkable(undefined, {})).toBe(false)
+    expect(isModelLinkable('', {})).toBe(false)
+  })
+
+  it('does not link when the whole models section is hidden', () => {
+    const options = { hideModels: true, document: documentWith({ Planet: { type: 'object' } }) }
+    expect(isModelLinkable('Planet', options)).toBe(false)
+  })
+
+  it('does not link a model hidden via x-internal', () => {
+    const options = { document: documentWith({ Planet: { type: 'object', 'x-internal': true } }) }
+    expect(isModelLinkable('Planet', options)).toBe(false)
+  })
+
+  it('does not link a model hidden via x-scalar-ignore', () => {
+    const options = { document: documentWith({ Planet: { type: 'object', 'x-scalar-ignore': true } }) }
+    expect(isModelLinkable('Planet', options)).toBe(false)
+  })
+
+  it('honors x-internal set alongside a $ref wrapper', () => {
+    const options = {
+      document: documentWith({
+        Planet: { '$ref': '#/components/schemas/Base', '$ref-value': { type: 'object' }, 'x-internal': true },
+      }),
+    }
+    expect(isModelLinkable('Planet', options)).toBe(false)
+  })
+
+  it('links when the model is not found in the document', () => {
+    expect(isModelLinkable('Missing', { document: documentWith({}) })).toBe(true)
+    expect(isModelLinkable('Missing', {})).toBe(true)
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/helpers/is-model-linkable.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/is-model-linkable.ts
@@ -1,0 +1,30 @@
+import { getResolvedRef, mergeSiblingReferences } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { isHidden } from '@scalar/workspace-store/helpers/is-hidden'
+
+import type { SchemaOptions } from '../types'
+
+/** The slice of schema options needed to decide whether a model name renders as a link. */
+export type ModelLinkOptions = Pick<SchemaOptions, 'hideModels' | 'document'>
+
+/**
+ * A model name normally links to its entry in the models section. It should render as plain
+ * text when there is nothing to scroll to:
+ *
+ * - the whole models section is hidden via `hideModels`, or
+ * - the referenced schema itself is hidden via `x-internal` / `x-scalar-ignore`.
+ *
+ * The hidden check mirrors how the sidebar decides which schemas to drop (see `traverseSchemas`),
+ * so the link only shows when the model actually exists in the models section.
+ */
+export const isModelLinkable = (
+  schemaKey: string | null | undefined,
+  { hideModels, document }: ModelLinkOptions,
+): boolean => {
+  if (!schemaKey || hideModels) {
+    return false
+  }
+
+  const schema = document?.components?.schemas?.[schemaKey]
+
+  return !isHidden(getResolvedRef(schema, mergeSiblingReferences))
+}

--- a/packages/api-reference/src/components/Content/Schema/types.ts
+++ b/packages/api-reference/src/components/Content/Schema/types.ts
@@ -18,6 +18,13 @@ export type SchemaOptions = {
   /** Expand all nested schema properties by default while keeping the toggle available */
   expandAllSchemaProperties?: ApiReferenceConfiguration['expandAllSchemaProperties']
   /**
+   * Whether the models section is hidden.
+   *
+   * Model names stay visible, but there is no models section to scroll to, so they
+   * render as plain text instead of links.
+   */
+  hideModels?: ApiReferenceConfiguration['hideModels']
+  /**
    * The document the schema belongs to.
    *
    * Used purely for display, e.g. to resolve discriminator `mapping` references into

--- a/packages/api-reference/src/features/Operation/components/Header.vue
+++ b/packages/api-reference/src/features/Operation/components/Header.vue
@@ -16,6 +16,7 @@ const {
   orderSchemaPropertiesBy,
   orderRequiredPropertiesFirst,
   expandAllSchemaProperties,
+  hideModels,
 } = defineProps<{
   header: HeaderObject
   name: string
@@ -26,6 +27,8 @@ const {
   orderSchemaPropertiesBy: 'alpha' | 'preserve' | undefined
   orderRequiredPropertiesFirst: boolean | undefined
   expandAllSchemaProperties: boolean | undefined
+  /** Whether the models section is hidden, so model names render as plain text instead of links */
+  hideModels: boolean | undefined
 }>()
 </script>
 <template>
@@ -39,6 +42,7 @@ const {
       orderRequiredPropertiesFirst: orderRequiredPropertiesFirst,
       orderSchemaPropertiesBy: orderSchemaPropertiesBy,
       expandAllSchemaProperties: expandAllSchemaProperties,
+      hideModels: hideModels,
       document,
     }"
     :schema="getResolvedRef(header.schema)" />

--- a/packages/api-reference/src/features/Operation/components/Headers.vue
+++ b/packages/api-reference/src/features/Operation/components/Headers.vue
@@ -21,6 +21,8 @@ const { headers, breadcrumb } = defineProps<{
   orderRequiredPropertiesFirst: boolean | undefined
   orderSchemaPropertiesBy: 'alpha' | 'preserve' | undefined
   expandAllSchemaProperties: boolean | undefined
+  /** Whether the models section is hidden, so model names render as plain text instead of links */
+  hideModels: boolean | undefined
 }>()
 const { translate } = useLocalization()
 </script>
@@ -59,6 +61,7 @@ const { translate } = useLocalization()
               :eventBus="eventBus"
               :expandAllSchemaProperties="expandAllSchemaProperties"
               :header="getResolvedRef(header)"
+              :hideModels="hideModels"
               :name="key"
               :orderRequiredPropertiesFirst="orderRequiredPropertiesFirst"
               :orderSchemaPropertiesBy="orderSchemaPropertiesBy" />

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -198,6 +198,7 @@ const isOnScrollTargetPath = computed<boolean>(() => {
           :eventBus="eventBus"
           :expandAllSchemaProperties="options.expandAllSchemaProperties"
           :headers="headers"
+          :hideModels="options.hideModels"
           :orderRequiredPropertiesFirst="options.orderRequiredPropertiesFirst"
           :orderSchemaPropertiesBy="options.orderSchemaPropertiesBy" />
 

--- a/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
+++ b/packages/api-reference/src/features/Operation/components/ParameterListItem.vue
@@ -217,6 +217,7 @@ const isOnScrollTargetPath = computed<boolean>(() => {
             orderRequiredPropertiesFirst: options.orderRequiredPropertiesFirst,
             orderSchemaPropertiesBy: options.orderSchemaPropertiesBy,
             expandAllSchemaProperties: options.expandAllSchemaProperties,
+            hideModels: options.hideModels,
             document,
           }"
           :required="'required' in parameter && parameter.required"

--- a/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
@@ -1,6 +1,6 @@
 import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
-import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { OpenAPIDocumentSchema, SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 
@@ -293,11 +293,13 @@ describe('RequestBody', () => {
       props: {
         eventBus: createWorkspaceEventBus(),
         options: defaultRequestOptions,
-        document: {
+        document: coerceValue(OpenAPIDocumentSchema, {
+          openapi: '3.1.0',
+          info: { title: 'Test', version: '1.0.0' },
           components: {
             schemas: { CreateUserRequest: { type: 'object', 'x-internal': true } },
           },
-        } as any,
+        }),
         requestBody: {
           content: {
             'application/json': {

--- a/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
@@ -287,6 +287,40 @@ describe('RequestBody', () => {
     expect(modelName.text()).toContain('CreateUserRequest')
     expect(modelName.find('button').exists()).toBe(false)
   })
+
+  it('renders the model name as plain text when the referenced model is hidden', () => {
+    const wrapper = mount(RequestBody, {
+      props: {
+        eventBus: createWorkspaceEventBus(),
+        options: defaultRequestOptions,
+        document: {
+          components: {
+            schemas: { CreateUserRequest: { type: 'object', 'x-internal': true } },
+          },
+        } as any,
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/CreateUserRequest',
+                type: 'object',
+                properties: {
+                  email: { type: 'string' },
+                },
+              } as any,
+            },
+          },
+        },
+      },
+      slots: {
+        title: 'Body',
+      },
+    })
+
+    const modelName = wrapper.find('[data-testid="request-body-schema-name"]')
+    expect(modelName.text()).toContain('CreateUserRequest')
+    expect(modelName.find('button').exists()).toBe(false)
+  })
   it('updates selectedContentType via v-model when changing the content type', async () => {
     const wrapper = mount(RequestBody, {
       props: {

--- a/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.test.ts
@@ -1,3 +1,4 @@
+import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
 import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
 import { SchemaObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { mount } from '@vue/test-utils'
@@ -253,6 +254,38 @@ describe('RequestBody', () => {
 
     const schema = wrapper.findComponent(Schema)
     expect(schema.props('hideModelNames')).toBe(false)
+  })
+
+  it('renders the model name as plain text when hideModels is enabled', () => {
+    const wrapper = mount(RequestBody, {
+      props: {
+        eventBus: createWorkspaceEventBus(),
+        options: {
+          ...defaultRequestOptions,
+          hideModels: true,
+        },
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/CreateUserRequest',
+                type: 'object',
+                properties: {
+                  email: { type: 'string' },
+                },
+              } as any,
+            },
+          },
+        },
+      },
+      slots: {
+        title: 'Body',
+      },
+    })
+
+    const modelName = wrapper.find('[data-testid="request-body-schema-name"]')
+    expect(modelName.text()).toContain('CreateUserRequest')
+    expect(modelName.find('button').exists()).toBe(false)
   })
   it('updates selectedContentType via v-model when changing the content type', async () => {
     const wrapper = mount(RequestBody, {

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -10,6 +10,7 @@ import { computed } from 'vue'
 
 import { Schema } from '@/components/Content/Schema'
 import { inferDiscriminatorMappingComposition } from '@/components/Content/Schema/helpers/get-compositions-to-render'
+import { isModelLinkable } from '@/components/Content/Schema/helpers/is-model-linkable'
 import { isTypeObject } from '@/components/Content/Schema/helpers/is-type-object'
 import { getModelNameFromSchema } from '@/components/Content/Schema/helpers/schema-name'
 import {
@@ -65,6 +66,14 @@ const schema = computed(() => getResolvedRef(rawSchema.value))
 /** When the schema is a $ref, preserve its name so the UI can show the ref name instead of just the type. */
 const modelLink = computed(
   () => (rawSchema.value && getModelNameFromSchema(rawSchema.value)) ?? null,
+)
+
+/** Whether the model name links to the models section, or renders as plain text. */
+const modelLinkable = computed(() =>
+  isModelLinkable(modelLink.value?.schemaKey, {
+    hideModels: options.hideModels,
+    document,
+  }),
 )
 
 /**
@@ -153,7 +162,7 @@ const shouldRenderRequestBody = computed(
           data-testid="request-body-schema-name">
           <span class="text-c-3 mx-1.5">·</span>
           <LinkButton
-            v-if="eventBus && modelLink.schemaKey && !options.hideModels"
+            v-if="eventBus && modelLink.schemaKey && modelLinkable"
             @click="
               eventBus.emit('scroll-to:model-by-name', {
                 name: modelLink.schemaKey,

--- a/packages/api-reference/src/features/Operation/components/RequestBody.vue
+++ b/packages/api-reference/src/features/Operation/components/RequestBody.vue
@@ -153,7 +153,7 @@ const shouldRenderRequestBody = computed(
           data-testid="request-body-schema-name">
           <span class="text-c-3 mx-1.5">·</span>
           <LinkButton
-            v-if="eventBus && modelLink.schemaKey"
+            v-if="eventBus && modelLink.schemaKey && !options.hideModels"
             @click="
               eventBus.emit('scroll-to:model-by-name', {
                 name: modelLink.schemaKey,
@@ -197,6 +197,7 @@ const shouldRenderRequestBody = computed(
           orderRequiredPropertiesFirst: options.orderRequiredPropertiesFirst,
           orderSchemaPropertiesBy: options.orderSchemaPropertiesBy,
           expandAllSchemaProperties: options.expandAllSchemaProperties,
+          hideModels: options.hideModels,
           document,
         }"
         :schema="partitionedSchema.visibleProperties"
@@ -215,6 +216,7 @@ const shouldRenderRequestBody = computed(
           orderRequiredPropertiesFirst: options.orderRequiredPropertiesFirst,
           orderSchemaPropertiesBy: options.orderSchemaPropertiesBy,
           expandAllSchemaProperties: options.expandAllSchemaProperties,
+          hideModels: options.hideModels,
           document,
         }"
         :schema="partitionedSchema.collapsedProperties"
@@ -238,6 +240,7 @@ const shouldRenderRequestBody = computed(
           orderRequiredPropertiesFirst: options.orderRequiredPropertiesFirst,
           orderSchemaPropertiesBy: options.orderSchemaPropertiesBy,
           expandAllSchemaProperties: options.expandAllSchemaProperties,
+          hideModels: options.hideModels,
           document,
         }"
         :schema="schema"


### PR DESCRIPTION
## Problem

With `hideModels: true` there is no models section, but the model names next to types and on the request body heading still render as links. They are underlined, they change color on hover, and clicking one does nothing, so the reference feels broken.

### Before

<img alt="Before: the Satellite[] model name is underlined and looks clickable" src="https://raw.githubusercontent.com/lazerg/scalar/assets-9854/before-type-9854.png" width="660" />

<img alt="Before: the request body model name Planet is underlined and looks clickable" src="https://raw.githubusercontent.com/lazerg/scalar/assets-9854/before-9854.png" width="660" />

### After

<img alt="After: the Satellite[] model name renders as plain text" src="https://raw.githubusercontent.com/lazerg/scalar/assets-9854/after-type-9854.png" width="660" />

<img alt="After: the request body model name Planet renders as plain text" src="https://raw.githubusercontent.com/lazerg/scalar/assets-9854/after-9854.png" width="660" />

## Solution

The names stay visible, they just lose the link when the models section is hidden. `hideModels` now rides along with the schema options down to the property heading, and the request body heading reads it as well.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

Closes #9854