### PR TITLE
fix(api-reference): make x-tagged model-name links reachable

### DIFF
--- a/.changeset/fix-xtags-model-links.md
+++ b/.changeset/fix-xtags-model-links.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix dead model-name links for schemas grouped under a tag via `x-tags`. The models index now collects model entries from the whole navigation tree, so clicking a model name that lives under a tag group scrolls to the model instead of doing nothing.

--- a/packages/api-reference/src/components/ApiReference.vue
+++ b/packages/api-reference/src/components/ApiReference.vue
@@ -92,6 +92,7 @@ import {
 } from '@/features/localization'
 import DocumentSelector from '@/features/multiple-documents/DocumentSelector.vue'
 import SearchButton from '@/features/Search/components/SearchButton.vue'
+import { buildModelsIndex } from '@/helpers/build-models-index'
 import { getSystemModePreference } from '@/helpers/color-mode'
 import { downloadDocument } from '@/helpers/download'
 import {
@@ -801,21 +802,13 @@ defineExpose({
 
 /**
  * Computes a mapping from model names to their sidebar entry IDs.
- * This is used for quick lookups and navigation within the sidebar.
+ *
+ * We collect model entries from the whole navigation tree, not just the top-level `models` group,
+ * so that schemas grouped under a tag via `x-tags` are still reachable by name.
+ *
+ * @see https://github.com/scalar/scalar/issues/9854
  */
-const modelsIndex = computed(() => {
-  return sidebarItems.value
-    .filter((item) => item.type === 'models')
-    .flatMap((item) => item.children ?? [])
-    .filter((item) => item.type === 'model')
-    .reduce(
-      (acc, item) => {
-        acc[item.name] = item.id
-        return acc
-      },
-      {} as Record<string, string>,
-    )
-})
+const modelsIndex = computed(() => buildModelsIndex(sidebarItems.value))
 
 eventBus.on('scroll-to:model-by-name', ({ name }) => {
   /** Find the model in the models index */

--- a/packages/api-reference/src/helpers/build-models-index.test.ts
+++ b/packages/api-reference/src/helpers/build-models-index.test.ts
@@ -1,0 +1,91 @@
+import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+import { describe, expect, it } from 'vitest'
+
+import { buildModelsIndex } from './build-models-index'
+
+/** Builds a model navigation entry with sensible defaults. */
+const model = (name: string, id = `model-${name}`): TraversedEntry => ({
+  type: 'model',
+  id,
+  title: name,
+  name,
+  ref: `#/components/schemas/${name}`,
+})
+
+/** Builds a tag navigation entry wrapping the given children. */
+const tag = (name: string, children: TraversedEntry[]): TraversedEntry => ({
+  type: 'tag',
+  id: `tag-${name}`,
+  title: name,
+  name,
+  isGroup: false,
+  children,
+})
+
+describe('buildModelsIndex', () => {
+  it('collects models from the top-level models group', () => {
+    const items: TraversedEntry[] = [
+      {
+        type: 'models',
+        id: 'models',
+        title: 'Models',
+        name: 'Models',
+        children: [model('Planet'), model('Satellite')],
+      },
+    ]
+
+    expect(buildModelsIndex(items)).toEqual({
+      Planet: 'model-Planet',
+      Satellite: 'model-Satellite',
+    })
+  })
+
+  it('collects models grouped under a tag via x-tags', () => {
+    const items: TraversedEntry[] = [
+      tag('Celestial', [model('Satellite')]),
+      {
+        type: 'models',
+        id: 'models',
+        title: 'Models',
+        name: 'Models',
+        children: [model('Planet')],
+      },
+    ]
+
+    // The x-tagged `Satellite` model lives under the tag group but must still be reachable by name.
+    expect(buildModelsIndex(items)).toEqual({
+      Satellite: 'model-Satellite',
+      Planet: 'model-Planet',
+    })
+  })
+
+  it('collects models nested inside tag groups', () => {
+    const items: TraversedEntry[] = [
+      {
+        type: 'tag',
+        id: 'group',
+        title: 'Group',
+        name: 'Group',
+        isGroup: true,
+        children: [tag('Celestial', [model('Satellite')])],
+      },
+    ]
+
+    expect(buildModelsIndex(items)).toEqual({ Satellite: 'model-Satellite' })
+  })
+
+  it('keeps the first entry when a model appears under multiple tags', () => {
+    const items: TraversedEntry[] = [
+      tag('First', [model('Satellite', 'model-Satellite-first')]),
+      tag('Second', [model('Satellite', 'model-Satellite-second')]),
+    ]
+
+    expect(buildModelsIndex(items)).toEqual({ Satellite: 'model-Satellite-first' })
+  })
+
+  it('returns an empty map when there are no models', () => {
+    const items: TraversedEntry[] = [tag('Empty', [])]
+
+    expect(buildModelsIndex(items)).toEqual({})
+  })
+})

--- a/packages/api-reference/src/helpers/build-models-index.ts
+++ b/packages/api-reference/src/helpers/build-models-index.ts
@@ -1,0 +1,36 @@
+import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
+
+/**
+ * Builds a mapping from model names to their sidebar entry IDs.
+ *
+ * The map powers the `scroll-to:model-by-name` navigation used by model-name links
+ * (for example the `Satellite[]` link next to a property type, or a request-body model name).
+ *
+ * Model entries do not always live under the top-level `models` group: a component schema with an
+ * `x-tags` extension is placed under its tag group instead. To keep those links working we walk the
+ * whole navigation tree and collect every `type === 'model'` entry, wherever it lives.
+ *
+ * @see https://github.com/scalar/scalar/issues/9854
+ */
+export const buildModelsIndex = (entries: TraversedEntry[]): Record<string, string> => {
+  const index: Record<string, string> = {}
+
+  const collect = (items: TraversedEntry[]): void => {
+    for (const item of items) {
+      if (item.type === 'model') {
+        // Keep the first entry for a given name. A name can appear more than once when a schema is
+        // listed under multiple tags, and the exact target does not matter as long as it scrolls
+        // to that model.
+        index[item.name] ??= item.id
+      }
+
+      if ('children' in item && item.children?.length) {
+        collect(item.children)
+      }
+    }
+  }
+
+  collect(entries)
+
+  return index
+}


### PR DESCRIPTION
Clicking a model name (like `Satellite[]` next to a property type, or a request-body model name) emits `scroll-to:model-by-name`, which looks the name up in a `modelsIndex`. That index only scanned the top-level `models` group, but a component schema with an `x-tags` extension lives under its **tag** group instead. So those model-name links rendered as clickable but did nothing.

The fix walks the whole navigation tree to build the index, so models under tag groups are collected too. Behavior for untagged models is unchanged. Extracted the logic into a small `buildModelsIndex` helper with unit tests.

Composes with #9856.

## Ticket

Part of #9854