### PR TITLE
fix(api-reference): only link model names for components.schemas refs

### DIFF
--- a/.changeset/fix-nonschema-model-links.md
+++ b/.changeset/fix-nonschema-model-links.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Only render a clickable model name link when the `$ref` actually targets `#/components/schemas/`. Refs into other component buckets (parameters, responses, ...) or external files now show the name as plain text instead of a dead link that scrolls nowhere.

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-ref-name.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-ref-name.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { getRefName, getSchemaRefName } from './get-ref-name'
+
+describe('get-ref-name', () => {
+  describe('getRefName', () => {
+    it('returns the last segment of a schema ref', () => {
+      expect(getRefName('#/components/schemas/Planet')).toBe('Planet')
+    })
+
+    it('returns the last segment of any ref', () => {
+      expect(getRefName('#/components/parameters/Planet')).toBe('Planet')
+    })
+
+    it('returns the fragment of an external ref', () => {
+      expect(getRefName('./planets.yaml#/Planet')).toBe('Planet')
+    })
+
+    it('returns null for an empty ref', () => {
+      expect(getRefName('')).toBe(null)
+    })
+  })
+
+  describe('getSchemaRefName', () => {
+    it('returns the schema name for a components.schemas ref', () => {
+      expect(getSchemaRefName('#/components/schemas/Planet')).toBe('Planet')
+    })
+
+    it('decodes url-encoded schema names', () => {
+      expect(getSchemaRefName('#/components/schemas/Planet%20Model')).toBe('Planet Model')
+    })
+
+    it('returns null for a parameters ref', () => {
+      expect(getSchemaRefName('#/components/parameters/Planet')).toBe(null)
+    })
+
+    it('returns null for a responses ref', () => {
+      expect(getSchemaRefName('#/components/responses/Planet')).toBe(null)
+    })
+
+    it('returns null for an external file ref', () => {
+      expect(getSchemaRefName('./planets.yaml#/Planet')).toBe(null)
+    })
+
+    it('returns null for a nested schemas ref with extra segments', () => {
+      expect(getSchemaRefName('#/components/schemas/Planet/properties/name')).toBe(null)
+    })
+
+    it('returns null for an empty ref', () => {
+      expect(getSchemaRefName('')).toBe(null)
+    })
+  })
+})

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-ref-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-ref-name.ts
@@ -19,3 +19,38 @@ export const getRefName = (ref: string) => {
 
   return null
 }
+
+/**
+ * Matches a local reference that points at `#/components/schemas/<name>` and
+ * captures the schema name. Intentionally strict: only refs that resolve to a
+ * navigable model in `components.schemas` should be linkable.
+ */
+const COMPONENTS_SCHEMAS_REF = /^#\/components\/schemas\/([^/]+)$/
+
+/**
+ * Gets the models-section key for a `$ref`, but only when the ref actually
+ * targets `#/components/schemas/`.
+ *
+ * The models index used for navigation is built exclusively from
+ * `components.schemas`, so a ref into any other bucket (`parameters`,
+ * `responses`, ...) or an external file (`./other.yaml#/Foo`) has no navigable
+ * target. Returning `null` for those keeps the name visible as plain text while
+ * avoiding a dead link.
+ *
+ * @example
+ * getSchemaRefName('#/components/schemas/Planet') // 'Planet'
+ * getSchemaRefName('#/components/parameters/Planet') // null
+ * getSchemaRefName('./planets.yaml#/Planet') // null
+ */
+export const getSchemaRefName = (ref: string): string | null => {
+  if (!ref) {
+    return null
+  }
+
+  const match = ref.match(COMPONENTS_SCHEMAS_REF)
+  if (match?.[1]) {
+    return decodeURIComponent(match[1])
+  }
+
+  return null
+}

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.test.ts
@@ -36,5 +36,30 @@ describe('schema-name', () => {
       const schema: SchemaObject = { __scalar_: '' }
       expect(getModelNameFromSchema(schema)).toBe(null)
     })
+
+    it('links a $ref that targets components.schemas', () => {
+      const schema = { $ref: '#/components/schemas/Planet' } as any
+      expect(getModelNameFromSchema(schema)).toEqual({ schemaKey: 'Planet', label: 'Planet' })
+    })
+
+    it('does not link a $ref into a non-schema component bucket', () => {
+      const schema = { $ref: '#/components/parameters/Planet' } as any
+      expect(getModelNameFromSchema(schema)).toEqual({ schemaKey: null, label: 'Planet' })
+    })
+
+    it('does not link a $ref into components.responses', () => {
+      const schema = { $ref: '#/components/responses/Planet' } as any
+      expect(getModelNameFromSchema(schema)).toEqual({ schemaKey: null, label: 'Planet' })
+    })
+
+    it('does not link a $ref into an external file', () => {
+      const schema = { $ref: './planets.yaml#/Planet' } as any
+      expect(getModelNameFromSchema(schema)).toEqual({ schemaKey: null, label: 'Planet' })
+    })
+
+    it('keeps the title but drops the link for a non-schema $ref', () => {
+      const schema = { $ref: '#/components/parameters/Planet', title: 'Consumer', type: 'object' } as any
+      expect(getModelNameFromSchema(schema)).toEqual({ schemaKey: null, label: 'Consumer' })
+    })
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
@@ -1,7 +1,7 @@
 import { resolve } from '@scalar/workspace-store/resolve'
 import type { SchemaObject, SchemaReferenceType } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
-import { getRefName } from './get-ref-name'
+import { getRefName, getSchemaRefName } from './get-ref-name'
 
 /**
  * Extract schema name from various schema formats
@@ -11,7 +11,12 @@ import { getRefName } from './get-ref-name'
 export const getModelNameFromSchema = (
   schemaOrRef: SchemaObject | SchemaReferenceType<SchemaObject>,
 ): {
-  /** The key in components.schemas (extracted from $ref), used for sidebar navigation. */
+  /**
+   * The key in `components.schemas` (extracted from `$ref`), used for sidebar
+   * navigation. Only set when the `$ref` actually targets
+   * `#/components/schemas/`; `null` for refs into other component buckets or
+   * external files, so those never render a dead link.
+   */
   schemaKey: string | null
   /** The human-readable name to display (schema.title, schema.name, or ref key). */
   label: string
@@ -22,7 +27,8 @@ export const getModelNameFromSchema = (
 
   const schema = resolve.schema(schemaOrRef)
 
-  const schemaKey = '$ref' in schemaOrRef ? (getRefName(schemaOrRef.$ref) ?? null) : null
+  // Only refs into `#/components/schemas/` are navigable in the models section.
+  const schemaKey = '$ref' in schemaOrRef ? getSchemaRefName(schemaOrRef.$ref) : null
 
   if (schema.title) {
     return { schemaKey, label: schema.title }
@@ -33,8 +39,11 @@ export const getModelNameFromSchema = (
   }
 
   if ('$ref' in schemaOrRef) {
-    if (schemaKey) {
-      return { schemaKey, label: schemaKey }
+    // Fall back to the last ref segment as a display label, even for
+    // non-schema refs. The name still shows, it just is not a link.
+    const label = getRefName(schemaOrRef.$ref)
+    if (label) {
+      return { schemaKey, label }
     }
   }
 


### PR DESCRIPTION
## Problem

A model name next to a type renders as a clickable link whenever the property has a `$ref`. The link key comes from `getRefName($ref)`, which just returns the last path segment of *any* ref. But the models index we scroll to is built only from `components.schemas`.

So a `$ref` into another bucket (`#/components/parameters/Foo`, `#/components/responses/Foo`) or an external file (`./other.yaml#/Foo`) still renders a link, and clicking it scrolls nowhere. In the worst case it jumps to an unrelated schema that happens to share the last segment.

## Fix

`getModelNameFromSchema` now derives the navigable `schemaKey` with a new `getSchemaRefName`, which only returns a name for refs that actually target `#/components/schemas/`. The display `label` still falls back to the last ref segment, so the name is always visible — it just is not a link when there is nothing to navigate to.

This is a follow-up to / composes with #9856: that PR drops the link when the models section is hidden or the target schema is hidden; this one drops it when the ref does not point at a real model in the first place.

## Ticket

Part of #9854