### PR TITLE
fix(api-reference): empty popup when hovering Generate MCP without an MCP config

### DIFF
--- a/.changeset/mcp-button-empty-popup.md
+++ b/.changeset/mcp-button-empty-popup.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix empty popup when hovering the "Generate MCP" button without an MCP config

--- a/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue
+++ b/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue
@@ -223,7 +223,8 @@ function openRegisterLink(documentUrl: string) {
   height: 32px;
 }
 .scalar-mcp-layer:hover {
-  height: 172px;
+  /* Height of the three stacked rows. */
+  height: 97px;
 }
 .scalar-mcp-layer-link:hover {
   cursor: pointer !important;
@@ -271,19 +272,19 @@ function openRegisterLink(documentUrl: string) {
 .scalar-mcp-layer .scalar-mcp-layer-link:nth-last-child(2) {
   transform: translate3d(0, -2px, 0) scale(0.99);
 }
-.scalar-mcp-layer:hover a:nth-last-child(2) {
+.scalar-mcp-layer:hover .scalar-mcp-layer-link:nth-last-child(2) {
   transform: translate3d(0, calc(-100% - 2px), 0) scale(0.99);
 }
 .scalar-mcp-layer .scalar-mcp-layer-link:nth-last-child(3) {
   transform: translate3d(0, -4px, 0) scale(0.98);
 }
-.scalar-mcp-layer:hover a:nth-last-child(3) {
+.scalar-mcp-layer:hover .scalar-mcp-layer-link:nth-last-child(3) {
   transform: translate3d(0, calc(-200% - 4px), 0) scale(1);
 }
 .scalar-mcp-layer .scalar-mcp-layer-link:nth-last-child(4) {
   transform: translate3d(0, -6px, 0) scale(0.97);
 }
-.scalar-mcp-layer:hover a:nth-last-child(4) {
+.scalar-mcp-layer:hover .scalar-mcp-layer-link:nth-last-child(4) {
   transform: translate3d(0, calc(-300% - 6px), 0) scale(1);
 }
 .scalar-mcp-layer .scalar-mcp-layer-link:nth-last-child(5) {

--- a/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue
+++ b/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue
@@ -213,6 +213,11 @@ function openRegisterLink(documentUrl: string) {
 
 <style scoped>
 .scalar-mcp-layer {
+  /* Rows are absolutely positioned, so the container cannot auto-size to them.
+     Derive the hover height from these instead of hardcoding a magic number.
+     Bump --mcp-row-count when a row is added or removed. */
+  --mcp-row-height: 31px;
+  --mcp-row-count: 3;
   gap: 2px;
   display: flex;
   flex-direction: column;
@@ -223,8 +228,11 @@ function openRegisterLink(documentUrl: string) {
   height: 32px;
 }
 .scalar-mcp-layer:hover {
-  /* Height of the three stacked rows. */
-  height: 97px;
+  /* N rows plus the 2px fan-out offset between each */
+  height: calc(
+    var(--mcp-row-count) * var(--mcp-row-height) + (var(--mcp-row-count) - 1) *
+      2px
+  );
 }
 .scalar-mcp-layer-link:hover {
   cursor: pointer !important;
@@ -235,7 +243,7 @@ function openRegisterLink(documentUrl: string) {
   cursor: pointer;
   width: 100%;
   padding: 9px 6px;
-  height: 31px;
+  height: var(--mcp-row-height);
   display: block;
   text-align: center;
   display: flex;

--- a/packages/api-reference/test/configuration/mcp-button.e2e.ts
+++ b/packages/api-reference/test/configuration/mcp-button.e2e.ts
@@ -34,4 +34,22 @@ test.describe('mcpButton', () => {
 
     await expect(page.getByRole('link', { name: 'Open API Client' })).toBeVisible()
   })
+
+  test('fans the entries out on hover with no mcp config', async ({ page }) => {
+    const example = await serveExample()
+
+    await page.goto(example)
+
+    // Without a config the entries render as <button>, so the fan-out has to
+    // move them up on hover instead of leaving an empty popup.
+    const vscode = page.getByRole('button', { name: 'VS Code' })
+    const top = async () => (await vscode.boundingBox())?.y ?? 0
+
+    const collapsed = await top()
+
+    await page.locator('.scalar-mcp-layer').hover()
+
+    // poll waits out the CSS transition rather than reading a mid-animation frame
+    await expect.poll(async () => collapsed - (await top())).toBeGreaterThan(40)
+  })
 })


### PR DESCRIPTION
## Problem

<!--
  What problem does the PR solve?
  WHY did you submit the PR?

  We are interested in the WHY (LLMs won't know).
-->
Hovering the **Generate MCP** button in the sidebar footer opens an empty popup when no MCP config is set. The VS code/cursor/ Generate MCP rows are meant to fan out on hover, but the container just expands and nothing appears inside it.

https://github.com/scalar/scalar/blob/8cbc745b18f6076934d97e4ef12b20d24a203a7c/packages/api-reference/src/components/AgentScalar/OpenMCPButton.vue#L94-L96

### Steps to reproduce:
1. drop custom/test API to `packages/api-reference/public/`
2. edit index.html
`<script type="module">
  Scalar.createApiReference('#app', {
    url: '/your_test_api.yaml',
    persistAuth: true,
    proxyUrl: 'https://proxy.scalar.com',
  })
</script>`
3. build and run


**Clip/Before**
<img width="400" height="405" alt="2026-08-10 at 13 54 10" src="https://github.com/user-attachments/assets/b1e97235-3c90-4b19-ae54-283f78d40440" />

## Solution

Point the three hover fan-out selectors at the shared `.scalar-mcp-layer-link` class. So they apply whether the rows are `<a>` (when the user provides an MCP config) or `<button>` (without one).

Also reduce the hovered container height from `172px` to `97px`. The height of the three rows that render (VS code, cursor, generate/connect). context: at `172px` the hover revealed an empty gap above the top row. e2e test added.

**Clip/After**
<img width="400" height="428" alt="2026-08-10 at 16 08 42" src="https://github.com/user-attachments/assets/c711634d-aea7-4da3-ade4-66cf06ae2965" />

If the extra height is intentional, happy to drop this part. ✌🏻 

<!--
  How did you solve it?
  What alternative solutions did you consider?

  Cursor Bugbot (LLM) will summarize the code changes for you.
-->

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

<!--
  Use semantic PR titles:

    fix(api-client): crashes when API returns null
    ^   ^            ^
    |   |            |
    |   |            |____ subject
    |   |_________________ package
    |_____________________ type of change

  Read more: https://github.com/scalar/scalar/blob/main/CONTRIBUTING.md
-->
