### PR TITLE
feat(api-reference): use webhook icon in search results

### DIFF
--- a/.changeset/webhook-search-icon.md
+++ b/.changeset/webhook-search-icon.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Use the webhook icon for webhooks in search results so they are easy to tell apart from operations

--- a/packages/api-reference/src/features/Search/components/SearchResult.vue
+++ b/packages/api-reference/src/features/Search/components/SearchResult.vue
@@ -5,6 +5,7 @@ import {
   ScalarIconTag,
   ScalarIconTerminalWindow,
   ScalarIconTextAlignLeft,
+  ScalarIconWebhooksLogo,
 } from '@scalar/icons'
 import type { ScalarIconComponent } from '@scalar/icons/types'
 import { HttpMethod } from '@scalar/sidebar'
@@ -31,7 +32,7 @@ const ENTRY_ICONS: { [x in EntryType]: ScalarIconComponent } = {
   model: ScalarIconBracketsCurly,
   operation: ScalarIconTerminalWindow,
   tag: ScalarIconTag,
-  webhook: ScalarIconTerminalWindow,
+  webhook: ScalarIconWebhooksLogo,
 }
 
 const entryLabels = computed((): { [x in EntryType]: string } => ({


### PR DESCRIPTION
Webhooks now use the webhook icon in the search results box, so they are easy to tell apart from operations.

See #9855