### PR TITLE
fix(api-reference): stop rendering discriminator base property twice

### DIFF
--- a/.changeset/fix-9861-discriminator-property-duplicate.md
+++ b/.changeset/fix-9861-discriminator-property-duplicate.md
@@ -2,4 +2,7 @@
 '@scalar/api-reference': patch
 ---
 
-Stop rendering a discriminator base property twice. When a property's schema is a bare `discriminator.mapping` base (an object with `properties` and a `discriminator` but no explicit `oneOf`/`anyOf`), the inferred variant selector already shows those properties inside each variant (the variants `allOf` back to the base). The base object block is no longer rendered alongside the selector, so properties like the discriminator field are shown once instead of twice.
+Fix two rendering issues with discriminator schemas.
+
+- Stop rendering a discriminator base property twice. When a property's schema is a bare `discriminator.mapping` base (an object with `properties` and a `discriminator` but no explicit `oneOf`/`anyOf`), the inferred variant selector already shows those properties inside each variant (the variants `allOf` back to the base). The base object block is no longer rendered alongside the selector, so properties like the discriminator field are shown once instead of twice.
+- Connect the variant selector to its content. A discriminator variant that `allOf`s back to its base rendered its merged object in a nested card, leaving a detached, rounded box below the selector. The variant now renders flush under the selector, matching a plain `oneOf`.

--- a/.changeset/fix-9861-discriminator-property-duplicate.md
+++ b/.changeset/fix-9861-discriminator-property-duplicate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Stop rendering a discriminator base property twice. When a property's schema is a bare `discriminator.mapping` base (an object with `properties` and a `discriminator` but no explicit `oneOf`/`anyOf`), the inferred variant selector already shows those properties inside each variant (the variants `allOf` back to the base). The base object block is no longer rendered alongside the selector, so properties like the discriminator field are shown once instead of twice.

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -590,6 +590,71 @@ describe('Schema', () => {
       // inferred variant dropdown alone.
       expect(wrapper.text()).toContain('sharedAllOfProp')
     })
+
+    // https://github.com/scalar/scalar/issues/9861
+    // A property whose schema is a bare `discriminator.mapping` base (rendered
+    // through `SchemaProperty`, e.g. a request body's `data` field) must not
+    // render its base properties both as a plain object block AND inside the
+    // inferred oneOf variants (which `allOf` back to the base).
+    it('does not render base properties twice for a discriminator-mapping property', () => {
+      const configSchema = {
+        type: 'object',
+        required: ['formatVersion'],
+        properties: {
+          formatVersion: { type: 'string' },
+        },
+        discriminator: {
+          propertyName: 'formatVersion',
+          mapping: {
+            '2.2': '#/components/schemas/Config_v2_2',
+            '2.3': '#/components/schemas/Config_v2_3',
+          },
+        },
+      }
+
+      const document = {
+        components: {
+          schemas: {
+            Config: configSchema,
+            Config_v2_2: {
+              allOf: [
+                { $ref: '#/components/schemas/Config', '$ref-value': configSchema },
+                { type: 'object', properties: { fieldA: { type: 'string' } } },
+              ],
+            },
+            Config_v2_3: {
+              allOf: [
+                { $ref: '#/components/schemas/Config', '$ref-value': configSchema },
+                { type: 'object', properties: { fieldB: { type: 'string' } } },
+              ],
+            },
+          },
+        },
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          name: 'Request Body',
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              data: { $ref: '#/components/schemas/Config', '$ref-value': configSchema },
+            },
+          }),
+          options: { expandAllSchemaProperties: true, document: document as never },
+        },
+      })
+
+      // Exactly one variant selector, inferred from the mapping.
+      expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
+
+      // `formatVersion` renders once (inside the selected variant), not a second
+      // time as a base object block outside the selector.
+      const formatVersionCount = (wrapper.text().match(/formatVersion/g) ?? []).length
+      expect(formatVersionCount).toBe(1)
+      expect(wrapper.text()).toContain('fieldA')
+    })
   })
 
   describe('additionalProperties Vue prop', () => {

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -596,7 +596,7 @@ describe('Schema', () => {
     // through `SchemaProperty`, e.g. a request body's `data` field) must not
     // render its base properties both as a plain object block AND inside the
     // inferred oneOf variants (which `allOf` back to the base).
-    it('does not render base properties twice for a discriminator-mapping property', () => {
+    it('does not render base properties twice for a discriminator-mapping property', async () => {
       const configSchema = {
         type: 'object',
         required: ['formatVersion'],
@@ -646,14 +646,32 @@ describe('Schema', () => {
         },
       })
 
+      // The names of every rendered `formatVersion` property row (there should be
+      // exactly one, and it must live inside the variant selector's panel).
+      const formatVersionRows = () =>
+        wrapper.findAll('.property-name').filter((node) => node.text().trim() === 'formatVersion')
+
       // Exactly one variant selector, inferred from the mapping.
       expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
 
-      // `formatVersion` renders once (inside the selected variant), not a second
+      // `formatVersion` renders once, inside the selected variant — not a second
       // time as a base object block outside the selector.
-      const formatVersionCount = (wrapper.text().match(/formatVersion/g) ?? []).length
-      expect(formatVersionCount).toBe(1)
+      expect(formatVersionRows()).toHaveLength(1)
+      expect(formatVersionRows()[0]!.element.closest('.composition-panel')).not.toBeNull()
       expect(wrapper.text()).toContain('fieldA')
+      expect(wrapper.text()).not.toContain('fieldB')
+
+      // Switching variants keeps the single, in-panel `formatVersion` — the base
+      // block never reappears alongside the other variant.
+      const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+      await listbox.vm.$emit('update:modelValue', { id: '1', label: 'Config_v2_3' })
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
+      expect(formatVersionRows()).toHaveLength(1)
+      expect(formatVersionRows()[0]!.element.closest('.composition-panel')).not.toBeNull()
+      expect(wrapper.text()).toContain('fieldB')
+      expect(wrapper.text()).not.toContain('fieldA')
     })
   })
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -350,11 +350,13 @@ if (
  * below the selector. Drop that nested card's border so the variant renders as
  * flush content, like a plain object variant.
  *
- * The `:not(:has(> .property-heading))` restricts this to a *bare* composition —
- * a variant that is the composition itself, with no property heading — so a
- * genuine nested composition *property* (which has a heading) keeps its own
- * frame. Matching on the absent heading rather than position keeps it correct
- * even when the variant renders a description before the composition.
+ * The `:not(:has(> .property-heading > .property-name))` restricts this to a
+ * *bare* composition — a variant that is the composition itself, rendered with no
+ * property name — so a genuine nested composition *property* (which has a name)
+ * keeps its own frame. Keying off the absent name rather than the absent heading
+ * stays correct when the variant still renders a heading for its own annotations
+ * (a top-level `type`, `deprecated`, …), and rather than position it stays
+ * correct when the variant renders a description before the composition.
  *
  * This is a targeted style patch: the underlying cause is that an `allOf`-back
  * variant renders one card deeper than a plain variant. Flattening that nesting
@@ -366,7 +368,7 @@ if (
       > .schema-card
       > .schema-properties.schema-properties-open
       > ul
-      > li.property:not(:has(> .property-heading))
+      > li.property:not(:has(> .property-heading > .property-name))
       > .property-rule
       > .schema-card
       > .schema-properties.schema-properties-open

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -322,3 +322,47 @@ if (
     </template>
   </div>
 </template>
+
+<style scoped>
+/*
+ * Connect the selected variant to the selector above it. These rules live here,
+ * not in `SchemaProperty`, because a discriminator-inferred `oneOf` is rendered
+ * straight from `Schema.vue` (bypassing `SchemaProperty`), so styles scoped to
+ * `SchemaProperty` never reach it. See https://github.com/scalar/scalar/issues/9861
+ *
+ * Square the top of the panel's topmost card so it sits flush under the selector.
+ * A plain variant renders that card at level 1, but a variant that `allOf`s back
+ * to a discriminator base renders it deeper, so we target the panel's direct card
+ * rather than a specific level.
+ */
+.property-rule
+  :deep(
+    .composition-panel
+      > .schema-card
+      > .schema-properties.schema-properties-open
+  ) {
+  border-radius: 0 0 var(--scalar-radius-lg) var(--scalar-radius-lg);
+}
+
+/*
+ * Such an `allOf` variant renders its merged object in a nested card inside the
+ * panel, which keeps its own border/radius and reads as a detached box floating
+ * below the selector. Drop that nested card's border so the variant renders as
+ * flush content, like a plain object variant. `:first-child` restricts this to a
+ * bare composition (the variant is the composition itself, with no property
+ * heading before it), so a genuine nested composition property keeps its frame.
+ */
+.property-rule
+  :deep(
+    .composition-panel
+      > .schema-card
+      > .schema-properties.schema-properties-open
+      > ul
+      > li.property
+      > .property-rule:first-child
+      > .schema-card
+      > .schema-properties.schema-properties-open
+  ) {
+  border: none;
+}
+</style>

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -348,9 +348,17 @@ if (
  * Such an `allOf` variant renders its merged object in a nested card inside the
  * panel, which keeps its own border/radius and reads as a detached box floating
  * below the selector. Drop that nested card's border so the variant renders as
- * flush content, like a plain object variant. `:first-child` restricts this to a
- * bare composition (the variant is the composition itself, with no property
- * heading before it), so a genuine nested composition property keeps its frame.
+ * flush content, like a plain object variant.
+ *
+ * The `:not(:has(> .property-heading))` restricts this to a *bare* composition —
+ * a variant that is the composition itself, with no property heading — so a
+ * genuine nested composition *property* (which has a heading) keeps its own
+ * frame. Matching on the absent heading rather than position keeps it correct
+ * even when the variant renders a description before the composition.
+ *
+ * This is a targeted style patch: the underlying cause is that an `allOf`-back
+ * variant renders one card deeper than a plain variant. Flattening that nesting
+ * upstream would remove the need for this rule, but is a larger change.
  */
 .property-rule
   :deep(
@@ -358,8 +366,8 @@ if (
       > .schema-card
       > .schema-properties.schema-properties-open
       > ul
-      > li.property
-      > .property-rule:first-child
+      > li.property:not(:has(> .property-heading))
+      > .property-rule
       > .schema-card
       > .schema-properties.schema-properties-open
   ) {

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -152,6 +152,21 @@ const hasComplexArrayItemsComputed = computed(() =>
 /** Check if enum should be displayed (from value schema or from propertyNames) */
 const hasEnum = computed(() => enumValues.value.length > 0)
 
+/**
+ * The `oneOf` inferred from a bare `discriminator.mapping`, or `null` when there
+ * is nothing to infer. Computed once and shared: `shouldRenderObjectProperties`
+ * uses it to suppress the duplicate base object block, and `compositionsToRender`
+ * passes it on so the inference does not run twice per render.
+ */
+const inferredDiscriminatorComposition = computed(() =>
+  optimizedValue.value
+    ? inferDiscriminatorMappingComposition(
+        optimizedValue.value,
+        props.options.document,
+      )
+    : null,
+)
+
 /** Determine if object properties should be displayed */
 const shouldRenderObjectProperties = computed(() => {
   const value = optimizedValue.value
@@ -194,10 +209,7 @@ const shouldRenderObjectProperties = computed(() => {
     !!props.schema &&
     typeof props.schema === 'object' &&
     'allOf' in props.schema
-  if (
-    !composesWithAllOf &&
-    inferDiscriminatorMappingComposition(value, props.options.document)
-  ) {
+  if (!composesWithAllOf && inferredDiscriminatorComposition.value) {
     return false
   }
 
@@ -283,7 +295,11 @@ const shouldDisplayHeadingComputed = computed(() =>
 
 /** Computes which compositions should be rendered and with which values */
 const compositionsToRender = computed(() =>
-  getCompositionsToRender(optimizedValue.value, props.options.document),
+  getCompositionsToRender(
+    optimizedValue.value,
+    props.options.document,
+    inferredDiscriminatorComposition.value,
+  ),
 )
 const getCompositionDiscriminator = (
   composition: CompositionKeyword,

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -24,7 +24,10 @@ import { getCycleKey } from '@/components/Content/Schema/helpers/schema-cycle'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
 import { SpecificationExtension } from '@/features/specification-extension'
 
-import { getCompositionsToRender } from './helpers/get-compositions-to-render'
+import {
+  getCompositionsToRender,
+  inferDiscriminatorMappingComposition,
+} from './helpers/get-compositions-to-render'
 import { getEnumValues } from './helpers/get-enum-values'
 import { getPropertyDescription } from './helpers/get-property-description'
 import { hasComplexArrayItems } from './helpers/has-complex-array-items'
@@ -164,6 +167,28 @@ const shouldRenderObjectProperties = computed(() => {
   // rendered result (see `mergeAllOfSchemas`), so rendering a separate object
   // block here would show those properties twice. Let the composition handle it.
   if ('allOf' in value) {
+    return false
+  }
+
+  // A *plain* bare `discriminator.mapping` base (no explicit `oneOf`/`anyOf` and
+  // no `allOf` of its own) is rendered as an inferred `oneOf` composition below,
+  // whose variants `allOf` back to this base type and therefore already include
+  // its properties (including the discriminator property). Rendering the base
+  // object block here as well would show those properties a second time, outside
+  // the selector. `Schema.vue` renders the two mutually exclusively; mirror that
+  // here. See https://github.com/scalar/scalar/issues/9861
+  //
+  // A base that composes itself via `allOf` is excluded: `optimizeValueForDisplay`
+  // flattens its members up into `properties`, and those contribute fields the
+  // inferred variants do not carry, so the block must still render them.
+  const composesWithAllOf =
+    !!props.schema &&
+    typeof props.schema === 'object' &&
+    'allOf' in props.schema
+  if (
+    !composesWithAllOf &&
+    inferDiscriminatorMappingComposition(value, props.options.document)
+  ) {
     return false
   }
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -176,11 +176,20 @@ const shouldRenderObjectProperties = computed(() => {
   // its properties (including the discriminator property). Rendering the base
   // object block here as well would show those properties a second time, outside
   // the selector. `Schema.vue` renders the two mutually exclusively; mirror that
-  // here. See https://github.com/scalar/scalar/issues/9861
+  // here so the property and the model render the base identically.
+  // See https://github.com/scalar/scalar/issues/9861
+  //
+  // This intentionally shows the base only through its variants, matching the
+  // discriminator contract that each mapped variant extends the base. A malformed
+  // mapping whose variants do not include the base (or a base carrying only
+  // `additionalProperties`/`patternProperties`) would surface those fields solely
+  // via the variants — the same behavior `Schema.vue` already has for the model.
   //
   // A base that composes itself via `allOf` is excluded: `optimizeValueForDisplay`
   // flattens its members up into `properties`, and those contribute fields the
-  // inferred variants do not carry, so the block must still render them.
+  // inferred variants do not carry, so the block must still render them. The check
+  // reads the raw `props.schema` because the flattening has already erased `allOf`
+  // from the optimized `value`.
   const composesWithAllOf =
     !!props.schema &&
     typeof props.schema === 'object' &&
@@ -568,15 +577,12 @@ const isDiscriminatorProperty = computed(() =>
   left: -2rem;
 }
 
-.property-rule
-  :deep(
-    .composition-panel
-      .schema-card--level-1
-      > .schema-properties.schema-properties-open
-  ) {
-  border-radius: 0 0 var(--scalar-radius-lg) var(--scalar-radius-lg);
-}
-
+/*
+ * Squaring the top of a composition panel's content used to live here, but it
+ * only reached compositions rendered through `SchemaProperty`. It now lives in
+ * `SchemaComposition` so it also applies to a discriminator-inferred `oneOf`
+ * rendered straight from `Schema.vue`. See https://github.com/scalar/scalar/issues/9861
+ */
 .property-rule
   :deep(.composition-panel > .schema-card > .schema-card-description) {
   padding: 10px;

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-compositions-to-render.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-compositions-to-render.ts
@@ -71,12 +71,19 @@ export const inferDiscriminatorMappingComposition = (
 export const getCompositionsToRender = (
   value: SchemaObject | undefined,
   document?: DocumentSchemaLookup,
+  /**
+   * The `oneOf` inferred from a bare `discriminator.mapping`, when the caller has
+   * already computed it. `SchemaProperty` needs the same value to decide whether
+   * to suppress the duplicate base object block, so it passes it here to avoid
+   * inferring twice. Omit it and it is inferred from `value`.
+   */
+  inferredDiscriminatorComposition: SchemaObject | null = value
+    ? inferDiscriminatorMappingComposition(value, document)
+    : null,
 ): CompositionToRender[] => {
   if (!value) {
     return []
   }
-
-  const inferredDiscriminatorComposition = inferDiscriminatorMappingComposition(value, document)
 
   return compositions
     .map((composition) => {


### PR DESCRIPTION
Fixes both issues in #9861, which both stem from how a discriminator variant that `allOf`s back to its base is rendered.

## 1. Property rendered twice

When a property's schema is a bare `discriminator.mapping` base (an object with `properties` + `discriminator` but no explicit `oneOf`/`anyOf`), `SchemaProperty` rendered the base properties twice: once as a plain object block, and again inside every inferred `oneOf` variant (the variants `allOf` back to the base, so they already carry those fields). The discriminator field (`formatVersion` in the report) showed up outside the selector and inside it.

`Schema.vue` already renders the inferred composition and the object block mutually exclusively; `SchemaProperty` now does the same, so the property and the model render the base identically. A base that composes itself via its own `allOf` is excluded, since those members get flattened into `properties` and are not present in the variants.

## 2. Body-level `oneOf` spacing

A discriminator variant renders its merged object in a nested card inside the composition panel, which kept its own border/radius and read as a **detached box** floating below the selector. The connecting styles lived in `SchemaProperty`, but a discriminator-inferred `oneOf` is rendered straight from `Schema.vue` (bypassing `SchemaProperty`), so they never applied. Moved the connecting rules to `SchemaComposition` (which owns the panel), removed the now-redundant `SchemaProperty` rule, and dropped the nested card's border so the variant renders flush under the selector — like a plain `oneOf`.

## Verified

Plain `oneOf`, a variant with a nested object property, a variant with a nested `oneOf` property (keeps its own frame), and a variant that renders a description before its content all still render correctly. The nested-card rule keys off an absent property heading (not element position) to stay correct in those cases.

One intentional behavior worth noting: the base is now shown only through its variants, matching `Schema.vue`. A malformed mapping whose variants do not extend the base would surface base-only fields solely via the variants — this matches the existing model rendering and is documented in the code.

## Ticket

Closes #9861
