### PR TITLE
feat(aspnetcore): add .NET 11 (ASP.NET Core 11) support

### DIFF
--- a/.changeset/dotnet-net11-support.md
+++ b/.changeset/dotnet-net11-support.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': minor
+---
+
+Add .NET 11 (ASP.NET Core 11) as a target framework for the ASP.NET Core packages. .NET 11 is still in preview, so the packages reference the latest preview builds for now.

--- a/.github/workflows/integration-builds.yml
+++ b/.github/workflows/integration-builds.yml
@@ -147,8 +147,9 @@ jobs:
       - name: Setup .NET
         uses: fast-actions/setup-dotnet@a71ae3c1c05fa3c6fae4065438844513d41d893e # v1
         with:
-          sdk-version: 10.x.x
+          sdk-version: 11.0.100-preview.6.26359.118
           aspnetcore-version: |
+            10.x.x
             9.x.x
             8.x.x
 

--- a/.github/workflows/publish-integrations.yml
+++ b/.github/workflows/publish-integrations.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Setup .NET
         uses: fast-actions/setup-dotnet@a71ae3c1c05fa3c6fae4065438844513d41d893e # v1
         with:
-          sdk-version: 10.x.x
+          sdk-version: 11.0.100-preview.6.26359.118
 
       - name: Restore dependencies
         working-directory: integrations/dotnet/aspnetcore

--- a/integrations/dotnet/Directory.Packages.props
+++ b/integrations/dotnet/Directory.Packages.props
@@ -56,4 +56,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
   </ItemGroup>
+
+  <!-- .NET 11 is still in preview, so these track the latest preview build. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="11.0.0-preview.6.26359.118" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="11.0.0-preview.6.26359.118" />
+  </ItemGroup>
 </Project>

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Microsoft/Scalar.AspNetCore.Microsoft.csproj
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Microsoft/Scalar.AspNetCore.Microsoft.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -14,6 +14,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.OpenApi" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.OpenApi" />
   </ItemGroup>

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Scalar.AspNetCore.Swashbuckle.csproj
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore.Swashbuckle/Scalar.AspNetCore.Swashbuckle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <IsAotCompatible>false</IsAotCompatible>
   </PropertyGroup>
 

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Scalar.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Microsoft.Tests/Scalar.AspNetCore.Microsoft.Tests.csproj
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Microsoft.Tests/Scalar.AspNetCore.Microsoft.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0;net11.0</TargetFrameworks>
     <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.OpenApi.Generated</InterceptorsNamespaces>
   </PropertyGroup>
 

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Swashbuckle.Tests/Scalar.AspNetCore.Swashbuckle.Tests.csproj
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Swashbuckle.Tests/Scalar.AspNetCore.Swashbuckle.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/Scalar.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/integrations/dotnet/aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj
+++ b/integrations/dotnet/aspnetcore/tests/apis/Scalar.AspNetCore.Tests.Api/Scalar.AspNetCore.Tests.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 

--- a/integrations/dotnet/global.json
+++ b/integrations/dotnet/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.0",
+    "version": "11.0.100-preview.6.26359.118",
     "rollForward": "latestFeature",
-    "allowPrerelease": false
+    "allowPrerelease": true
   }
 }


### PR DESCRIPTION
Adds .NET 11 (ASP.NET Core 11) as a target framework for the ASP.NET Core packages. Requested in https://github.com/scalar/scalar/discussions/9715.

**Parked until .NET 11 RC — not for merge yet.**

Verified the current stable packages already work on .NET 11 preview: a net11.0 app consuming `Scalar.AspNetCore.Microsoft` 2.16.18 (net10 asset) + `Microsoft.AspNetCore.OpenApi 11.0.0-preview.6` builds with no warnings, all transformers run without errors, and the Scalar UI serves. So .NET 11 users are not blocked today.

Merging now would force the whole dotnet build onto the .NET 11 preview SDK and ship a preview dependency inside the stable package — not worth it three months before GA (Nov 10, 2026). Keeping this draft ready to flip on during the RC window, mirroring how .NET 10 was handled.

Note: .NET 11 emits OpenAPI 3.2 by default. That intersects Scalar's in-progress 3.2 rendering and is separate from this TFM change.