### PR TITLE
feat(api-reference): ship source maps with the standalone browser build

### DIFF
--- a/.changeset/tricky-cups-argue.md
+++ b/.changeset/tricky-cups-argue.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Ship source maps with the standalone browser build (`dist/browser`) so config errors are easier to debug

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -149,7 +149,6 @@
     "rollup-plugin-webpack-stats": "^0.2.5",
     "tailwindcss": "catalog:*",
     "vite": "catalog:*",
-    "vite-plugin-banner": "^0.8.1",
     "vite-plugin-css-injected-by-js": "catalog:*",
     "vitest": "catalog:*"
   }

--- a/packages/api-reference/vite.standalone.config.ts
+++ b/packages/api-reference/vite.standalone.config.ts
@@ -4,12 +4,13 @@ import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { webpackStats } from 'rollup-plugin-webpack-stats'
 import { defineConfig } from 'vite'
-import banner from 'vite-plugin-banner'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 
 import { name, version } from './package.json'
 
-const licenseBannerTemplate = String.raw`/**
+// Opens with `/*!` (a legal comment) rather than `/**` so the oxc minifier keeps it
+// when `output.comments.legal` is enabled. See the `banner`/`comments` output options.
+const licenseBannerTemplate = String.raw`/*!
  *    _____ _________    __    ___    ____
  *   / ___// ____/   |  / /   /   |  / __ \
  *   \__ \/ /   / /| | / /   / /| | / /_/ /
@@ -60,18 +61,16 @@ export default defineConfig({
     // Content Security Policy. See the `nonce` option in @scalar/client-side-rendering.
     cssInjectedByJsPlugin({ attributes: { id: 'scalar-style' }, useStrictCSP: true }),
     webpackStats(),
-    banner({
-      outDir: 'dist/browser',
-      content: replaceVariables(licenseBannerTemplate, {
-        packageName: name,
-        version: version,
-      }),
-    }),
   ],
   build: {
     emptyOutDir: false,
     outDir: 'dist/browser',
     cssCodeSplit: false,
+    // Ship linked source maps (external `.map` + a `//# sourceMappingURL=` comment)
+    // so consumers can debug config errors against readable source. Browsers only
+    // fetch the map when devtools is open and downstream bundlers strip the link, so
+    // this does not affect production page weight.
+    sourcemap: true,
     lib: {
       entry: ['src/standalone.ts'],
       name: '@scalar/api-reference',
@@ -89,6 +88,13 @@ export default defineConfig({
       },
       output: {
         entryFileNames: '[name].js',
+        // Prepend the license banner through Rolldown (not vite-plugin-banner) so the
+        // source map stays aligned: Rolldown accounts for the banner in the map,
+        // whereas vite-plugin-banner rewrites the file after the map is emitted.
+        banner: replaceVariables(licenseBannerTemplate, { packageName: name, version }),
+        // Keep the `/*!` license banner through minification. Vite defaults oxc to
+        // `legalComments: 'none'`, which would otherwise strip it.
+        comments: { legal: true },
         globals: {
           'radix-vue': '{}',
           'radix-vue/namespaced': '{}',

--- a/packages/api-reference/vite.standalone.esm.config.ts
+++ b/packages/api-reference/vite.standalone.esm.config.ts
@@ -4,12 +4,13 @@ import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { webpackStats } from 'rollup-plugin-webpack-stats'
 import { defineConfig } from 'vite'
-import banner from 'vite-plugin-banner'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 
 import { name, version } from './package.json'
 
-const licenseBannerTemplate = String.raw`/**
+// Opens with `/*!` (a legal comment) rather than `/**` so the oxc minifier keeps it
+// when `output.comments.legal` is enabled. See the `banner`/`comments` output options.
+const licenseBannerTemplate = String.raw`/*!
  *    _____ _________    __    ___    ____
  *   / ___// ____/   |  / /   /   |  / __ \
  *   \__ \/ /   / /| | / /   / /| | / /_/ /
@@ -55,18 +56,16 @@ export default defineConfig({
     // Content Security Policy. See the `nonce` option in @scalar/client-side-rendering.
     cssInjectedByJsPlugin({ attributes: { id: 'scalar-style' }, useStrictCSP: true }),
     webpackStats({ fileName: 'webpack-stats.esm.json' }),
-    banner({
-      outDir: 'dist/browser',
-      content: replaceVariables(licenseBannerTemplate, {
-        packageName: name,
-        version: version,
-      }),
-    }),
   ],
   build: {
     emptyOutDir: false,
     outDir: 'dist/browser',
     cssCodeSplit: false,
+    // Ship linked source maps (external `.map` + a `//# sourceMappingURL=` comment)
+    // so consumers can debug config errors against readable source. Browsers only
+    // fetch the map when devtools is open and downstream bundlers strip the link, so
+    // this does not affect production page weight.
+    sourcemap: true,
     lib: {
       entry: { 'standalone.esm': 'src/standalone.esm.ts' },
       name: '@scalar/api-reference',
@@ -83,6 +82,13 @@ export default defineConfig({
       },
       output: {
         entryFileNames: '[name].js',
+        // Prepend the license banner through Rolldown (not vite-plugin-banner) so the
+        // source map stays aligned: Rolldown accounts for the banner in the map,
+        // whereas vite-plugin-banner rewrites the file after the map is emitted.
+        banner: replaceVariables(licenseBannerTemplate, { packageName: name, version }),
+        // Keep the `/*!` license banner through minification. Vite defaults oxc to
+        // `legalComments: 'none'`, which would otherwise strip it.
+        comments: { legal: true },
         // Rolldown names a shared chunk after an arbitrary member module. The large
         // eager chunk that holds the rendering core (highlight.js, zod, typebox, yaml,
         // parse5, plus the shared workspace-store/components code) would otherwise be

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1520,9 +1520,6 @@ importers:
       vite:
         specifier: catalog:*
         version: 8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0)
-      vite-plugin-banner:
-        specifier: ^0.8.1
-        version: 0.8.1
       vite-plugin-css-injected-by-js:
         specifier: catalog:*
         version: 5.0.2(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))
@@ -18205,9 +18202,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  vite-plugin-banner@0.8.1:
-    resolution: {integrity: sha512-0+gGguHk3MH0HvzMSOCJC6fGgH4+jtY9KlKVZh+hwwE+PBkGVzY8xe657JL74vEgbeUJD37XjVqTrmve8XvZBQ==}
-
   vite-plugin-checker@0.10.3:
     resolution: {integrity: sha512-f4sekUcDPF+T+GdbbE8idb1i2YplBAoH+SfRS0e/WRBWb2rYb1Jf5Pimll0Rj+3JgIYWwG2K5LtBPCXxoibkLg==}
     engines: {node: '>=14.16'}
@@ -27044,9 +27038,9 @@ snapshots:
   '@vue/language-core@2.2.12(typescript@5.9.3)':
     dependencies:
       '@volar/language-core': 2.4.15
-      '@vue/compiler-dom': 3.5.30
+      '@vue/compiler-dom': 3.5.40
       '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.30
+      '@vue/shared': 3.5.40
       alien-signals: 1.0.13
       minimatch: 9.0.5
       muggle-string: 0.4.1
@@ -38283,8 +38277,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vite-plugin-banner@0.8.1: {}
 
   vite-plugin-checker@0.10.3(@biomejs/biome@2.2.4)(eslint@9.39.2(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
The standalone browser build (`dist/browser`) shipped without source maps, so config errors were hard to debug. Now it ships them.

Browsers only load source maps when devtools is open, so normal users are not affected.

The license banner still shows and no extra build plugin is needed.

See https://github.com/scalar/scalar/discussions/9801