### PR TITLE
fix(api-client): header params showing as empty rows in the client

### DIFF
--- a/.changeset/quick-headers-9797.md
+++ b/.changeset/quick-headers-9797.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix header parameters showing as empty rows in the API client when an earlier operation has a request body

--- a/packages/api-client/src/v2/components/code-input/CodeInputLite.test.ts
+++ b/packages/api-client/src/v2/components/code-input/CodeInputLite.test.ts
@@ -1,7 +1,7 @@
 import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
 import { enableAutoUnmount, mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it } from 'vitest'
-import { nextTick } from 'vue'
+import { defineComponent, h, nextTick, useTemplateRef, watch } from 'vue'
 
 import CodeInputLite from './CodeInputLite.vue'
 
@@ -58,6 +58,33 @@ type ExposedApi = {
   cursorPosition: () => number | undefined
 }
 const api = (wrapper: ReturnType<typeof mountInput>) => wrapper.vm as unknown as ExposedApi
+
+/**
+ * A host that focuses the input as soon as its cell switches into editor mode — the focus-management
+ * pattern table cells use, running from a post-flush effect so the DOM is guaranteed to be patched.
+ */
+const FocusOnEditorMode = defineComponent({
+  props: {
+    modelValue: { type: String, required: true },
+    type: { type: String, required: true },
+  },
+  setup(props) {
+    const inputRef = useTemplateRef<ExposedApi>('inputRef')
+    watch(
+      () => props.type,
+      () => inputRef.value?.focus('end'),
+      { flush: 'post' },
+    )
+
+    return () =>
+      h(CodeInputLite, {
+        ref: 'inputRef',
+        modelValue: props.modelValue,
+        environment: env,
+        type: props.type,
+      })
+  },
+})
 
 describe('CodeInputLite', () => {
   it('renders the model value in the input', async () => {
@@ -1074,6 +1101,50 @@ describe('CodeInputLite', () => {
       const wrapper = mountInput({ modelValue: '' })
       const editor = wrapper.get('.code-input-lite__editor').element
       expect(document.activeElement).not.toBe(editor)
+    })
+  })
+
+  describe('editor created after mount', () => {
+    // The editable surface only exists in editor mode, so a table row that starts out in a select
+    // mode (or a reused component instance that switches rows) creates it long after `onMounted`
+    // has run.
+    it('paints the model value when the instance switches from select mode into editor mode', async () => {
+      const wrapper = mountInput({ modelValue: 'true', type: 'boolean' })
+      expect(wrapper.find('.code-input-lite__editor').exists()).toBe(false)
+
+      // The reused instance now serves a plain string row with a different value.
+      await wrapper.setProps({ modelValue: 'Bearer 123', type: 'string' })
+
+      const editor = wrapper.get('.code-input-lite__editor').element as HTMLDivElement
+      expect(editor.textContent).toBe('Bearer 123')
+      expect(api(wrapper).getValue()).toBe('Bearer 123')
+      expect(wrapper.find('.code-input-lite').classes()).not.toContain('code-input-lite--empty')
+    })
+
+    it('renders variable pills when the editor is created after mount', async () => {
+      const wrapper = mountInput({ modelValue: 'true', type: 'boolean' })
+      await wrapper.setProps({ modelValue: '{{baseUrl}}/users', type: 'string' })
+
+      const pill = wrapper.get('.scalar-pill').element as HTMLElement
+      expect(pill.dataset.variable).toBe('baseUrl')
+      expect(api(wrapper).getValue()).toBe('{{baseUrl}}/users')
+    })
+
+    it('paints the value before consumers position the caret in the same update', async () => {
+      // Consumers do focus work in post-flush effects, because that is where Vue guarantees the DOM
+      // is patched. The paint has to land before that: it replaces the editor's children, so a caret
+      // placed into a still-empty editor is dropped and lands back at offset 0.
+      const wrapper = mount(FocusOnEditorMode, {
+        attachTo: document.body,
+        props: { modelValue: 'true', type: 'boolean' },
+      })
+
+      await wrapper.setProps({ modelValue: 'Bearer 123', type: 'string' })
+
+      const input = wrapper.findComponent(CodeInputLite)
+      const editor = wrapper.get('.code-input-lite__editor').element as HTMLDivElement
+      expect(document.activeElement).toBe(editor)
+      expect((input.vm as unknown as ExposedApi).cursorPosition()).toBe('Bearer 123'.length)
     })
   })
 })

--- a/packages/api-client/src/v2/components/code-input/CodeInputLite.vue
+++ b/packages/api-client/src/v2/components/code-input/CodeInputLite.vue
@@ -752,6 +752,26 @@ watch(
   },
 )
 
+// The editable surface only exists in "editor mode" (see template). When a row switches into editor
+// mode after mount — most notably when this component instance is reused for a different table row —
+// `onMounted` has already run and the `modelValue` watch fired while `editorRef` was still null, so
+// the model was never painted into the freshly created element and the cell renders empty.
+//
+// Paint the model when the element appears, but only into a still-empty editor: an editor that
+// already holds text is either up to date or ahead of `modelValue` with an uncommitted edit/paste,
+// and must not be clobbered.
+watch(editorRef, (editor) => {
+  if (!editor || !isBlankValue(serializeEditor())) {
+    return
+  }
+  const serialized = serializeValue(modelValue)
+  if (isBlankValue(serialized)) {
+    return
+  }
+  lastPillSignature = pillSignature(serialized, withVariables)
+  renderModel(serialized)
+})
+
 watch(
   [() => environment, () => withVariables],
   () => {

--- a/packages/api-client/src/v2/components/code-input/CodeInputLite.vue
+++ b/packages/api-client/src/v2/components/code-input/CodeInputLite.vue
@@ -760,17 +760,28 @@ watch(
 // Paint the model when the element appears, but only into a still-empty editor: an editor that
 // already holds text is either up to date or ahead of `modelValue` with an uncommitted edit/paste,
 // and must not be clobbered.
-watch(editorRef, (editor) => {
-  if (!editor || !isBlankValue(serializeEditor())) {
-    return
-  }
-  const serialized = serializeValue(modelValue)
-  if (serialized === '') {
-    return
-  }
-  lastPillSignature = pillSignature(serialized, withVariables)
-  renderModel(serialized)
-})
+//
+// `flush: 'sync'` makes the paint part of the same step that creates the element. Vue assigns a
+// non-null template ref from a post-render effect, so the element is already mounted and patched
+// when this runs — deferring any further (the `pre` default, or `post`) only pushes the paint past
+// the consumer effects that run later in the same flush. A parent that focuses the cell as it
+// switches into editor mode would then place the caret in a still-empty editor, and the paint's
+// `replaceChildren` would drop that selection.
+watch(
+  editorRef,
+  (editor) => {
+    if (!editor || !isBlankValue(serializeEditor())) {
+      return
+    }
+    const serialized = serializeValue(modelValue)
+    if (serialized === '') {
+      return
+    }
+    lastPillSignature = pillSignature(serialized, withVariables)
+    renderModel(serialized)
+  },
+  { flush: 'sync' },
+)
 
 watch(
   [() => environment, () => withVariables],

--- a/packages/api-client/src/v2/components/code-input/CodeInputLite.vue
+++ b/packages/api-client/src/v2/components/code-input/CodeInputLite.vue
@@ -765,7 +765,7 @@ watch(editorRef, (editor) => {
     return
   }
   const serialized = serializeValue(modelValue)
-  if (isBlankValue(serialized)) {
+  if (serialized === '') {
     return
   }
   lastPillSignature = pillSignature(serialized, withVariables)


### PR DESCRIPTION
In the API client, a header parameter could show up as an empty row (and not get sent) when an earlier operation in the document had a request body.

The row data was correct — the input just never painted its text because the editor component gets reused across rows and the paint step ran before its editor element existed. Now it paints when the element shows up, without overwriting anything you have typed.

## Ticket

Fixes #9797