### PR TITLE
feat(api-client): order and hide OAuth2 flow tabs

### DIFF
--- a/.changeset/oauth2-flow-order-visibility.md
+++ b/.changeset/oauth2-flow-order-visibility.md
@@ -1,0 +1,7 @@
+---
+'@scalar/workspace-store': minor
+'@scalar/api-client': minor
+'@scalar/types': minor
+---
+
+Control OAuth2 flow tabs from your OpenAPI document. Add `x-order` to a flow to set the order of the tabs in the auth section (the first tab is selected by default, so the lowest `x-order` also becomes the default flow), and add `x-scalar-ignore` to a flow to hide its tab — useful for flows that cannot run in the browser, like Client Credentials, which usually fails on CORS. `x-scalar-ignore` on a whole security scheme now hides it from the auth selector too.

--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -296,6 +296,24 @@ paths:
         - planets
 ```
 
+You can also hide authentication. Add `x-scalar-ignore` to a whole security scheme to drop it from the auth selector, or to a single OAuth2 flow to hide just that flow's tab. This is handy for flows that cannot run in the browser, like Client Credentials, which usually fails on CORS:
+
+```yaml
+components:
+  securitySchemes:
+    oauth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: https://auth.example.com/authorize
+          tokenUrl: https://auth.example.com/token
+          scopes: {}
+        clientCredentials:
+          tokenUrl: https://auth.example.com/token
+          scopes: {}
+          x-scalar-ignore: true
+```
+
 Aliases: `x-internal`
 
 ## x-additionalPropertiesName
@@ -353,6 +371,27 @@ components:
 ```
 
 In this example, properties will be displayed in the order: `name`, `diameter`, `description`.
+
+`x-order` also controls the order of OAuth2 flow tabs in the auth section. Flows with a lower `x-order` appear first, and the first tab is selected by default — so giving a flow the lowest `x-order` both moves it to the front and makes it the default:
+
+```yaml
+components:
+  securitySchemes:
+    oauth2:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://auth.example.com/authorize
+          scopes: {}
+          x-order: 2
+        authorizationCode:
+          authorizationUrl: https://auth.example.com/authorize
+          tokenUrl: https://auth.example.com/token
+          scopes: {}
+          x-order: 1
+```
+
+Here the `authorizationCode` tab appears first and is selected by default.
 
 ## x-scalar-stability
 

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.test.ts
@@ -838,6 +838,63 @@ describe('RequestAuthTab', () => {
       expect(oauth2Component.props('type')).toBe('authorizationCode')
     })
 
+    it('resets to the first visible flow when the active flow becomes hidden via x-scalar-ignore', async () => {
+      const wrapper = mountWithProps({
+        securitySchemes: {
+          'OAuth2': {
+            type: 'oauth2',
+            flows: {
+              implicit: {
+                authorizationUrl: 'https://example.com/auth',
+                scopes: { openid: 'OpenID' },
+              },
+              authorizationCode: {
+                authorizationUrl: 'https://example.com/auth',
+                tokenUrl: 'https://example.com/token',
+                scopes: { profile: 'Profile' },
+              },
+            },
+          },
+        },
+        selectedSecuritySchemas: {
+          'OAuth2': [],
+        },
+      })
+
+      // Select the authorizationCode tab.
+      const acTab = wrapper.findAll('button').find((tab) => tab.text() === 'authorizationCode')
+      expect(acTab, 'authorizationCode tab should exist').toBeTruthy()
+      await acTab!.trigger('click')
+      await nextTick()
+      expect(wrapper.findComponent(OAuth2).props('type')).toBe('authorizationCode')
+
+      // Hide the currently active flow via x-scalar-ignore. Cast because this test only cares about
+      // flow visibility, not the full secret shape the strict prop type otherwise requires.
+      await wrapper.setProps({
+        securitySchemes: {
+          'OAuth2': {
+            type: 'oauth2',
+            flows: {
+              implicit: {
+                authorizationUrl: 'https://example.com/auth',
+                scopes: { openid: 'OpenID' },
+              },
+              authorizationCode: {
+                authorizationUrl: 'https://example.com/auth',
+                tokenUrl: 'https://example.com/token',
+                'x-scalar-ignore': true,
+                scopes: { profile: 'Profile' },
+              },
+            },
+          },
+        } as any,
+      })
+      await nextTick()
+
+      // The active flow is now hidden, so the selection resets to the first visible flow.
+      expect(wrapper.findComponent(OAuth2).props('type')).toBe('implicit')
+    })
+
     it('hides ignored flows and orders tabs by x-order, defaulting to the first', () => {
       const wrapper = mountWithProps({
         securitySchemes: {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.test.ts
@@ -837,6 +837,50 @@ describe('RequestAuthTab', () => {
       expect(oauth2Component.exists()).toBe(true)
       expect(oauth2Component.props('type')).toBe('authorizationCode')
     })
+
+    it('hides ignored flows and orders tabs by x-order, defaulting to the first', () => {
+      const wrapper = mountWithProps({
+        securitySchemes: {
+          'OAuth2': {
+            type: 'oauth2',
+            flows: {
+              clientCredentials: {
+                tokenUrl: 'https://example.com/token',
+                scopes: {},
+                'x-scalar-ignore': true,
+              },
+              implicit: {
+                authorizationUrl: 'https://example.com/auth',
+                scopes: {},
+                'x-order': 2,
+              },
+              authorizationCode: {
+                authorizationUrl: 'https://example.com/auth',
+                tokenUrl: 'https://example.com/token',
+                scopes: {},
+                'x-order': 1,
+              },
+            },
+          },
+        },
+        selectedSecuritySchemas: {
+          'OAuth2': [],
+        },
+      })
+
+      const flowKeys = ['implicit', 'authorizationCode', 'clientCredentials', 'password']
+      const flowTabs = wrapper
+        .findAll('button')
+        .map((tab) => tab.text())
+        .filter((text) => flowKeys.includes(text))
+
+      // clientCredentials is hidden; the remaining tabs follow x-order.
+      expect(flowTabs).toEqual(['authorizationCode', 'implicit'])
+
+      // The first (lowest x-order) flow is the default.
+      const oauth2Component = wrapper.findComponent(OAuth2)
+      expect(oauth2Component.props('type')).toBe('authorizationCode')
+    })
   })
 
   describe('shows correct description', () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue
@@ -22,6 +22,7 @@ import {
   type EncryptionObjectSecret,
   type GssapiObjectSecret,
   type MergedSecuritySchemes,
+  type OAuthFlowsObjectSecret,
   type SaslObjectSecret,
   type SecuritySchemeObjectSecret,
   type X509ObjectSecret,
@@ -56,6 +57,8 @@ type SecurityItem = {
   scheme: SecuritySchemeObjectSecret | undefined
   name: string
   scopes: string[]
+  /** Ordered, non-hidden oauth2/openIdConnect flow keys for this scheme (empty for other types). */
+  visibleFlowKeys: (keyof OAuthFlowsObjectSecret)[]
 }
 
 const {
@@ -112,27 +115,37 @@ const emits = defineEmits<{
  * Each item includes the scheme definition, name, and associated scopes.
  */
 const security = computed<SecurityItem[]>(() =>
-  Object.entries(selectedSecuritySchemas).map(([name, scopes = []]) => ({
-    scheme: getResolvedRef(securitySchemes[name]),
-    name,
-    scopes,
-  })),
+  Object.entries(selectedSecuritySchemas).map(([name, scopes = []]) => {
+    const scheme = getResolvedRef(securitySchemes[name])
+    return {
+      scheme,
+      name,
+      scopes,
+      // Compute the visible, ordered flow keys once per scheme so the tabs, the label, and the
+      // active-flow tracking all agree on the same set (and we do not filter + sort on every access).
+      visibleFlowKeys:
+        scheme?.type === 'oauth2' || scheme?.type === 'openIdConnect'
+          ? getVisibleOrderedFlowKeys(scheme.flows)
+          : [],
+    }
+  }),
 )
 
 /** Tracks which OAuth2 flow is currently active when multiple flows are available. */
 const activeFlow = ref<string>('')
 
-/** Keeps the selected flow in sync with currently available flow keys. */
+/**
+ * Keeps the selected flow in sync with the currently visible flow keys. Validating against the
+ * visible set (not every declared flow) means a selection that becomes hidden — e.g. the document
+ * is updated to mark the active flow with `x-scalar-ignore` — resets, so the default (first visible)
+ * flow activates instead of leaving no tab selected.
+ */
 const selectedFlow = computed<string>(() => {
-  const authFlowKeys = security.value.flatMap(({ scheme }) => {
-    if (scheme?.type !== 'oauth2' && scheme?.type !== 'openIdConnect') {
-      return []
-    }
+  const visibleFlowKeys = security.value.flatMap((item) => item.visibleFlowKeys)
 
-    return Object.keys(scheme.flows ?? {})
-  })
-
-  return authFlowKeys.includes(activeFlow.value) ? activeFlow.value : ''
+  return visibleFlowKeys.some((key) => key === activeFlow.value)
+    ? activeFlow.value
+    : ''
 })
 
 const setActiveFlow = (flow: string): void => {
@@ -411,7 +424,7 @@ const handleConfigAuthorize = (): void => {
 </script>
 <template>
   <template
-    v-for="{ scheme, name, scopes } in security"
+    v-for="{ scheme, name, scopes, visibleFlowKeys } in security"
     :key="name">
     <!--
       Header row for AND'ed schemes: label (bold) and description (rich text) are
@@ -564,10 +577,7 @@ const handleConfigAuthorize = (): void => {
       v-else-if="scheme?.type === 'oauth2' || scheme?.type === 'openIdConnect'">
       <!-- OpenID Connect -->
       <OpenIDConnect
-        v-if="
-          scheme?.type === 'openIdConnect' &&
-          !getVisibleOrderedFlowKeys(scheme.flows).length
-        "
+        v-if="scheme?.type === 'openIdConnect' && !visibleFlowKeys.length"
         :customFetch="options?.customFetch"
         :environment
         :eventBus
@@ -577,11 +587,11 @@ const handleConfigAuthorize = (): void => {
         :scheme />
 
       <!-- Flow selector tabs: shown when multiple visible flows are available -->
-      <DataTableRow v-if="getVisibleOrderedFlowKeys(scheme.flows).length > 1">
+      <DataTableRow v-if="visibleFlowKeys.length > 1">
         <div class="flex min-h-8 border-t text-base">
           <div class="flex h-8 max-w-full gap-2.5 overflow-x-auto px-3">
             <button
-              v-for="(key, ind) in getVisibleOrderedFlowKeys(scheme.flows)"
+              v-for="(key, ind) in visibleFlowKeys"
               :key="key"
               :class="getFlowTabClasses(key, ind)"
               type="button"
@@ -594,7 +604,7 @@ const handleConfigAuthorize = (): void => {
 
       <!-- OAuth2 flow configuration -->
       <template
-        v-for="(key, ind) in getVisibleOrderedFlowKeys(scheme.flows)"
+        v-for="(key, ind) in visibleFlowKeys"
         :key="key">
         <OAuth2
           v-if="scheme.flows && isFlowActive(key, ind)"

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/RequestAuthTab.vue
@@ -36,6 +36,7 @@ import type {
 import { capitalize, computed, ref } from 'vue'
 
 import { refreshOauth2Token } from '@/v2/blocks/scalar-auth-selector-block/helpers/oauth'
+import { getVisibleOrderedFlowKeys } from '@/v2/blocks/scalar-auth-selector-block/helpers/oauth-flows'
 import {
   runOAuth2Authorize,
   storeOAuth2Tokens,
@@ -158,7 +159,7 @@ const generateLabel = (
 
     case 'openIdConnect':
     case 'oauth2': {
-      const firstFlow = Object.keys(scheme.flows ?? {})[0]
+      const firstFlow = getVisibleOrderedFlowKeys(scheme.flows)[0]
       const currentFlow = selectedFlow.value || firstFlow
       if (!currentFlow) {
         return capitalizedName
@@ -565,7 +566,7 @@ const handleConfigAuthorize = (): void => {
       <OpenIDConnect
         v-if="
           scheme?.type === 'openIdConnect' &&
-          !Object.keys(scheme.flows ?? {}).length
+          !getVisibleOrderedFlowKeys(scheme.flows).length
         "
         :customFetch="options?.customFetch"
         :environment
@@ -575,12 +576,12 @@ const handleConfigAuthorize = (): void => {
         :proxyUrl
         :scheme />
 
-      <!-- Flow selector tabs: shown when multiple flows are available -->
-      <DataTableRow v-if="Object.keys(scheme.flows ?? {}).length > 1">
+      <!-- Flow selector tabs: shown when multiple visible flows are available -->
+      <DataTableRow v-if="getVisibleOrderedFlowKeys(scheme.flows).length > 1">
         <div class="flex min-h-8 border-t text-base">
           <div class="flex h-8 max-w-full gap-2.5 overflow-x-auto px-3">
             <button
-              v-for="(_, key, ind) in scheme.flows"
+              v-for="(key, ind) in getVisibleOrderedFlowKeys(scheme.flows)"
               :key="key"
               :class="getFlowTabClasses(key, ind)"
               type="button"
@@ -593,7 +594,7 @@ const handleConfigAuthorize = (): void => {
 
       <!-- OAuth2 flow configuration -->
       <template
-        v-for="(_flow, key, ind) in scheme.flows"
+        v-for="(key, ind) in getVisibleOrderedFlowKeys(scheme.flows)"
         :key="key">
         <OAuth2
           v-if="scheme.flows && isFlowActive(key, ind)"

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-flows.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-flows.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { getVisibleOrderedFlowKeys } from './oauth-flows'
+
+describe('getVisibleOrderedFlowKeys', () => {
+  it('returns an empty array when flows is undefined', () => {
+    expect(getVisibleOrderedFlowKeys(undefined)).toEqual([])
+  })
+
+  it('keeps document order when no x-order is set', () => {
+    const flows = {
+      authorizationCode: {},
+      implicit: {},
+      clientCredentials: {},
+    }
+
+    expect(getVisibleOrderedFlowKeys(flows)).toEqual(['authorizationCode', 'implicit', 'clientCredentials'])
+  })
+
+  it('drops flows marked with x-scalar-ignore', () => {
+    const flows = {
+      authorizationCode: {},
+      clientCredentials: { 'x-scalar-ignore': true },
+    }
+
+    expect(getVisibleOrderedFlowKeys(flows)).toEqual(['authorizationCode'])
+  })
+
+  it('drops flows marked with x-internal', () => {
+    const flows = {
+      authorizationCode: {},
+      clientCredentials: { 'x-internal': true },
+    }
+
+    expect(getVisibleOrderedFlowKeys(flows)).toEqual(['authorizationCode'])
+  })
+
+  it('sorts flows by x-order ascending', () => {
+    const flows = {
+      implicit: { 'x-order': 2 },
+      authorizationCode: { 'x-order': 1 },
+      clientCredentials: { 'x-order': 3 },
+    }
+
+    expect(getVisibleOrderedFlowKeys(flows)).toEqual(['authorizationCode', 'implicit', 'clientCredentials'])
+  })
+
+  it('places ordered flows before unordered ones, which keep document order', () => {
+    const flows = {
+      password: {},
+      implicit: { 'x-order': 2 },
+      clientCredentials: {},
+      authorizationCode: { 'x-order': 1 },
+    }
+
+    expect(getVisibleOrderedFlowKeys(flows)).toEqual(['authorizationCode', 'implicit', 'password', 'clientCredentials'])
+  })
+
+  it('makes the lowest x-order flow the default (first) even when declared last', () => {
+    const flows = {
+      clientCredentials: { 'x-scalar-ignore': true },
+      implicit: {},
+      authorizationCode: { 'x-order': 1 },
+    }
+
+    expect(getVisibleOrderedFlowKeys(flows)[0]).toBe('authorizationCode')
+  })
+})

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-flows.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/oauth-flows.ts
@@ -1,0 +1,47 @@
+import { isHidden } from '@scalar/workspace-store/helpers/is-hidden'
+
+/**
+ * A single OAuth2 flow entry as far as the auth UI is concerned. Flows may carry the shared
+ * display-order (`x-order`) and ignore (`x-scalar-ignore` / `x-internal`) extensions.
+ */
+type OrderableFlow = {
+  'x-order'?: number
+  'x-internal'?: boolean
+  'x-scalar-ignore'?: boolean
+}
+
+/**
+ * Returns the OAuth2 flow keys to show in the auth UI, in display order.
+ *
+ * Flows marked with `x-scalar-ignore` (or `x-internal`) are dropped. The rest are sorted by
+ * `x-order` ascending, with ordered flows first and unordered flows keeping their document order.
+ * The first key in the result is the default (pre-selected) flow tab, so giving a flow the lowest
+ * `x-order` both moves it to the front and makes it the default.
+ */
+export const getVisibleOrderedFlowKeys = <T extends Record<string, OrderableFlow | undefined>>(
+  flows: T | undefined,
+): (keyof T)[] => {
+  if (!flows) {
+    return []
+  }
+
+  return (Object.entries(flows) as [keyof T & string, OrderableFlow | undefined][])
+    .filter((entry): entry is [keyof T & string, OrderableFlow] => entry[1] !== undefined && !isHidden(entry[1]))
+    .map(([key, flow], index) => ({ key, order: flow['x-order'], index }))
+    .sort((a, b) => {
+      // Both ordered: ascending by x-order.
+      if (a.order !== undefined && b.order !== undefined) {
+        return a.order - b.order
+      }
+      // Only one ordered: the ordered flow comes first.
+      if (a.order !== undefined) {
+        return -1
+      }
+      if (b.order !== undefined) {
+        return 1
+      }
+      // Neither ordered: keep the original document order.
+      return a.index - b.index
+    })
+    .map((entry) => entry.key)
+}

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
@@ -734,6 +734,33 @@ describe('security-scheme', () => {
       expect(groups[0]?.options[0]?.value).toEqual({ OAuth2: ['read'] })
       expect(groups[1]?.options.some((option) => option.label === 'OAuth2')).toBe(false)
     })
+
+    it('excludes schemes hidden with x-scalar-ignore from the available options', () => {
+      const schemes: NonNullable<ComponentsObject['securitySchemes']> = {
+        visible: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+        hidden: { type: 'apiKey', in: 'header', name: 'X-Hidden', 'x-scalar-ignore': true },
+      }
+
+      // No required schemes, so a flat list of available options is returned.
+      const result = getSecuritySchemeOptions([], schemes, [])
+      const options = result as SecuritySchemeOption[]
+
+      expect(options.map((option) => option.label)).toEqual(['visible'])
+    })
+
+    it('drops a required scheme hidden with x-scalar-ignore', () => {
+      const security: NonNullable<OpenApiDocument['security']> = [{ hidden: [] }, { visible: [] }]
+      const schemes: NonNullable<ComponentsObject['securitySchemes']> = {
+        visible: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+        hidden: { type: 'apiKey', in: 'header', name: 'X-Hidden', 'x-scalar-ignore': true },
+      }
+
+      // With a required scheme present, grouped options are returned.
+      const groups = getSecuritySchemeOptions(security, schemes, []) as SecuritySchemeGroup[]
+      const required = groups.find((group) => group.label === 'Required authentication')
+
+      expect(required?.options.map((option) => option.label)).toEqual(['visible'])
+    })
   })
 
   describe('getOauth2AcquisitionTarget', () => {
@@ -784,6 +811,49 @@ describe('security-scheme', () => {
 
       const target = getOauth2AcquisitionTarget(schemes)
       expect(target?.name).toBe('ImplicitOnly')
+      expect(target?.flowType).toBe('implicit')
+    })
+
+    it('skips oauth2 schemes hidden with x-scalar-ignore', () => {
+      const schemes: NonNullable<ComponentsObject['securitySchemes']> = {
+        Hidden: {
+          type: 'oauth2',
+          'x-scalar-ignore': true,
+          flows: {
+            authorizationCode: {
+              authorizationUrl: 'https://auth.example.com/authorize',
+              tokenUrl: 'https://auth.example.com/token',
+              refreshUrl: '',
+              'x-usePkce': 'no',
+              scopes: {},
+            },
+          },
+        },
+      }
+
+      expect(getOauth2AcquisitionTarget(schemes)).toBeNull()
+    })
+
+    it('skips a hidden authorization-code flow and falls back to a visible implicit flow', () => {
+      const schemes: NonNullable<ComponentsObject['securitySchemes']> = {
+        Mixed: {
+          type: 'oauth2',
+          flows: {
+            authorizationCode: {
+              authorizationUrl: 'https://auth.example.com/authorize',
+              tokenUrl: 'https://auth.example.com/token',
+              refreshUrl: '',
+              'x-usePkce': 'no',
+              scopes: {},
+              'x-scalar-ignore': true,
+            },
+            implicit: { authorizationUrl: 'https://auth.example.com/authorize', refreshUrl: '', scopes: {} },
+          },
+        },
+      }
+
+      const target = getOauth2AcquisitionTarget(schemes)
+      expect(target?.name).toBe('Mixed')
       expect(target?.flowType).toBe('implicit')
     })
   })

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.test.ts
@@ -761,6 +761,20 @@ describe('security-scheme', () => {
 
       expect(required?.options.map((option) => option.label)).toEqual(['visible'])
     })
+
+    it('drops a complex AND requirement that includes a hidden scheme', () => {
+      const security: NonNullable<OpenApiDocument['security']> = [{ visible: [] }, { visible: [], hidden: [] }]
+      const schemes: NonNullable<ComponentsObject['securitySchemes']> = {
+        visible: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+        hidden: { type: 'apiKey', in: 'header', name: 'X-Hidden', 'x-scalar-ignore': true },
+      }
+
+      const groups = getSecuritySchemeOptions(security, schemes, []) as SecuritySchemeGroup[]
+      const required = groups.find((group) => group.label === 'Required authentication')
+
+      // The "visible & hidden" combination is dropped; only the standalone visible scheme remains.
+      expect(required?.options.map((option) => option.label)).toEqual(['visible'])
+    })
   })
 
   describe('getOauth2AcquisitionTarget', () => {

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
@@ -1,5 +1,6 @@
 import { generateHash } from '@scalar/helpers/string/generate-hash'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { isHidden } from '@scalar/workspace-store/helpers/is-hidden'
 import type { MergedSecuritySchemes, OAuthFlowsObjectSecret } from '@scalar/workspace-store/request-example'
 import type {
   ComponentsObject,
@@ -9,6 +10,13 @@ import type {
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 import { authOptions } from '@/v2/blocks/scalar-auth-selector-block/helpers/auth-options'
+
+/**
+ * Minimal shape read by `isHidden`. Some scheme union members (AsyncAPI broker schemes) do not
+ * structurally carry the ignore extensions, so we cast to this before the check to satisfy the
+ * weak-type check without widening `isHidden` itself.
+ */
+type Hideable = { 'x-internal'?: boolean; 'x-scalar-ignore'?: boolean }
 
 /** A single security scheme option used in the auth dropdown */
 export type SecuritySchemeOption = {
@@ -66,7 +74,8 @@ const formatSecurityRequirement = (
   // Simple auth (single key)
   if (keys[0]) {
     const scheme = getResolvedRef(securitySchemes[keys[0]])
-    if (!scheme) {
+    // Drop schemes that do not exist or are hidden from the auth UI via x-scalar-ignore.
+    if (!scheme || isHidden(scheme as Hideable)) {
       return undefined
     }
     return formatScheme({ name: keys[0], value: requirement })
@@ -101,7 +110,9 @@ export const getOauth2AcquisitionTarget = (
 
   for (const [name, schemeRef] of Object.entries(securitySchemes)) {
     const scheme = getResolvedRef(schemeRef)
-    if (scheme?.type !== 'oauth2') {
+    // Skip schemes hidden from the auth UI via x-scalar-ignore, so the shortcut never
+    // targets a flow the user cannot see or configure.
+    if (scheme?.type !== 'oauth2' || isHidden(scheme)) {
       continue
     }
     const flows = scheme.flows as OAuthFlowsObjectSecret | undefined
@@ -111,11 +122,11 @@ export const getOauth2AcquisitionTarget = (
     const scopes = (scheme as { 'x-default-scopes'?: string[] })['x-default-scopes'] ?? []
 
     // Authorization code can refresh, so it wins outright the moment we find one.
-    if (flows.authorizationCode) {
+    if (flows.authorizationCode && !isHidden(flows.authorizationCode)) {
       return { name, flows, flowType: 'authorizationCode', scopes }
     }
     // Otherwise remember the first implicit-only scheme in case no auth-code flow turns up.
-    if (flows.implicit && !implicitFallback) {
+    if (flows.implicit && !isHidden(flows.implicit) && !implicitFallback) {
       implicitFallback = { name, flows, flowType: 'implicit', scopes }
     }
   }
@@ -175,7 +186,8 @@ export const getSecuritySchemeOptions = (
     }
 
     const scheme = getResolvedRef(schemeRef)
-    if (scheme) {
+    // Skip schemes hidden from the auth UI via x-scalar-ignore.
+    if (scheme && !isHidden(scheme as Hideable)) {
       const formatted = formatScheme({ name, value: { [name]: [] } })
       availableFormatted.push(formatted)
       existingIds.add(formatted.id)

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/helpers/security-scheme.ts
@@ -68,6 +68,15 @@ const formatSecurityRequirement = (
 
   // Complex auth (multiple keys)
   if (keys.length > 1) {
+    // Drop the whole AND combination if any of its schemes is hidden via x-scalar-ignore — a
+    // partly hidden requirement cannot be configured, so it should not appear as an option.
+    const anyHidden = keys.some((key) => {
+      const scheme = getResolvedRef(securitySchemes[key])
+      return scheme ? isHidden(scheme as Hideable) : false
+    })
+    if (anyHidden) {
+      return undefined
+    }
     return formatComplexScheme(requirement)
   }
 

--- a/packages/api-reference/src/features/Operation/components/OperationParameters.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationParameters.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+import { isHidden } from '@scalar/workspace-store/helpers/is-hidden'
 import type {
   OpenApiDocument,
   ParameterObject,
@@ -11,7 +12,6 @@ import { computed } from 'vue'
 
 import { useLocalization } from '@/features/localization'
 import { flattenDeepObjectQueryParameter } from '@/features/Operation/helpers/flatten-deep-object-query-parameter'
-import { shouldIgnoreEntity } from '@/features/Operation/helpers/should-ignore-entity'
 import type { OperationProps } from '@/features/Operation/Operation.vue'
 
 import ParameterList from './ParameterList.vue'
@@ -45,7 +45,7 @@ const splitParameters = computed(() =>
     (acc, p) => {
       const parameter = getResolvedRef(p)
       // Filter out ignored parameters
-      if (!shouldIgnoreEntity(parameter)) {
+      if (!isHidden(parameter)) {
         const flattenedParameters = flattenDeepObjectQueryParameter(parameter)
         flattenedParameters.forEach((flattenedParameter) => {
           acc[flattenedParameter.in as ParameterLocation].push(

--- a/packages/api-reference/src/features/Operation/helpers/should-ignore-entity.ts
+++ b/packages/api-reference/src/features/Operation/helpers/should-ignore-entity.ts
@@ -1,5 +1,0 @@
-/**
- * Check if an entity should be ignored
- */
-export const shouldIgnoreEntity = (data: { 'x-internal'?: boolean; 'x-scalar-ignore'?: boolean }) =>
-  Boolean(data?.['x-internal'] || data?.['x-scalar-ignore'])

--- a/packages/types/src/entities/security-scheme.ts
+++ b/packages/types/src/entities/security-scheme.ts
@@ -9,6 +9,8 @@ import { type ENTITY_BRANDS, nanoidSchema } from '../utils/nanoid'
 const commonProps = z.object({
   /* A description for security scheme. CommonMark syntax MAY be used for rich text representation. */
   description: z.string().optional(),
+  /** When true, the whole scheme is hidden from the auth UI. See documentation/openapi.md. */
+  'x-scalar-ignore': z.boolean().optional(),
 })
 
 const extendedSecuritySchema = z.object({
@@ -123,6 +125,10 @@ const flowsCommon = z.object({
   'x-scalar-security-body': z.record(z.string(), z.string()).optional(),
   /** Extension to specify custom token name in the response (defaults to 'access_token') */
   'x-tokenName': z.string().optional(),
+  /** Display order of this flow's tab in the auth UI (ascending). See documentation/openapi.md. */
+  'x-order': z.number().optional(),
+  /** When true, this flow's tab is hidden from the auth UI. See documentation/openapi.md. */
+  'x-scalar-ignore': z.boolean().optional(),
 })
 
 /** Setup a default redirect uri if we can */

--- a/packages/workspace-store/src/schemas/v3.1/strict/oauth-flow.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/oauth-flow.ts
@@ -1,6 +1,8 @@
 import { Type } from '@scalar/typebox'
 
 import { compose } from '@/schemas/compose'
+import { type XScalarIgnore, XScalarIgnoreSchema } from '@/schemas/extensions/document/x-scalar-ignore'
+import { type XOrder, XOrderSchema } from '@/schemas/extensions/schema/x-order'
 import {
   type XScalarCredentialsLocation,
   XScalarCredentialsLocationSchema,
@@ -35,6 +37,10 @@ const OAuthFlowCommonSchema = compose(
   XTokenNameSchema,
   XScalarAuthUrlSchema,
   XScalarTokenUrlSchema,
+  // Reuse the shared display-order and ignore extensions so authors can reorder and hide
+  // individual OAuth2 flow tabs in the auth UI. See documentation/openapi.md.
+  XOrderSchema,
+  XScalarIgnoreSchema,
 )
 
 /** Common properties used across all OAuth flows */
@@ -47,7 +53,9 @@ type OAuthFlowCommon = {
   XScalarSecurityBody &
   XTokenName &
   XScalarTokenUrl &
-  XScalarAuthUrl
+  XScalarAuthUrl &
+  XOrder &
+  XScalarIgnore
 
 /** Configuration for the OAuth Implicit flow */
 export const OAuthFlowImplicitSchema = compose(

--- a/packages/workspace-store/src/schemas/v3.1/strict/security-scheme.ts
+++ b/packages/workspace-store/src/schemas/v3.1/strict/security-scheme.ts
@@ -1,19 +1,25 @@
 import { Type } from '@scalar/typebox'
 
 import { compose } from '@/schemas/compose'
+import { type XScalarIgnore, XScalarIgnoreSchema } from '@/schemas/extensions/document/x-scalar-ignore'
 import { type XDefaultScopes, XDefaultScopesSchema } from '@/schemas/extensions/security/x-default-scopes'
 import type { OAuthFlowsObject } from '@/schemas/v3.1/strict/oauthflows'
 import { OAuthFlowsObjectRef } from '@/schemas/v3.1/strict/ref-definitions'
 
-const DescriptionSchema = Type.Object({
-  /** A description for security scheme. CommonMark syntax MAY be used for rich text representation. */
-  description: Type.Optional(Type.String()),
-})
+// Shared base for every security scheme: a description plus the ignore extension, so any
+// scheme can be hidden from the auth UI with `x-scalar-ignore`. See documentation/openapi.md.
+const DescriptionSchema = compose(
+  Type.Object({
+    /** A description for security scheme. CommonMark syntax MAY be used for rich text representation. */
+    description: Type.Optional(Type.String()),
+  }),
+  XScalarIgnoreSchema,
+)
 
 type Description = {
   /** A description for security scheme. CommonMark syntax MAY be used for rich text representation. */
   description?: string
-}
+} & XScalarIgnore
 
 const ApiKeySchema = compose(
   DescriptionSchema,


### PR DESCRIPTION
Control the OAuth2 flow tabs in the auth section from your OpenAPI document:

- `x-order` on a flow sets the tab order. The first tab is selected by default.
- `x-scalar-ignore` on a flow hides its tab, or on a whole scheme hides it from the auth selector. Handy for Client Credentials, which usually fails on CORS in the browser.

Part of https://github.com/scalar/scalar/discussions/9792