### PR TITLE
fix(api-client): render NDJSON responses instead of Binary file

### DIFF
--- a/.changeset/ndjson-response-preview.md
+++ b/.changeset/ndjson-response-preview.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+'@scalar/agent-chat': patch
+---
+
+Show NDJSON responses instead of "Binary file". Responses with `application/x-ndjson` or `application/ndjson` are now rendered as text, with each JSON record pretty-printed in the preview.

--- a/packages/agent-chat/src/components/ResponseBody/helpers/media-types.ts
+++ b/packages/agent-chat/src/components/ResponseBody/helpers/media-types.ts
@@ -27,6 +27,11 @@ const mediaTypes: { [type: string]: MediaConfig | undefined } = {
     language: 'json',
   },
   'application/dns-json': { extension: '.json', raw: true, language: 'json' },
+  // Newline-delimited JSON is many JSON objects separated by newlines, not one
+  // JSON document, so we show it as raw text with JSON highlighting rather than
+  // pretty-printing it as a single object.
+  'application/x-ndjson': { extension: '.ndjson', raw: true, language: 'json' },
+  'application/ndjson': { extension: '.ndjson', raw: true, language: 'json' },
   'application/msword': { extension: '.doc' },
   'application/octet-stream': { extension: '.bin' },
   'application/ogg': { extension: '.ogx' },

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyPreview.test.ts
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyPreview.test.ts
@@ -37,6 +37,37 @@ describe('ResponseBodyPreview', () => {
     })
   })
 
+  describe('ndjson mode', () => {
+    it('renders ResponseBodyRaw with each record pretty-printed', () => {
+      const wrapper = mount(ResponseBodyPreview, {
+        props: {
+          src: 'blob:http://localhost/fake',
+          type: 'application/x-ndjson',
+          mode: 'ndjson',
+          content: '{"a":1}\n{"b":2}',
+        },
+      })
+
+      const raw = wrapper.findComponent(ResponseBodyRaw)
+      expect(raw.exists()).toBe(true)
+      expect(raw.props('language')).toBe('json')
+      expect(raw.props('content')).toBe('{\n  "a": 1\n}\n\n{\n  "b": 2\n}')
+    })
+
+    it('does not render an image wrapper for ndjson mode', () => {
+      const wrapper = mount(ResponseBodyPreview, {
+        props: {
+          src: 'blob:http://localhost/fake',
+          type: 'application/x-ndjson',
+          mode: 'ndjson',
+          content: '{"a":1}',
+        },
+      })
+
+      expect(wrapper.find('img').exists()).toBe(false)
+    })
+  })
+
   describe('image mode', () => {
     it('renders image element for image mode', () => {
       const wrapper = mount(ResponseBodyPreview, {

--- a/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyPreview.vue
+++ b/packages/api-client/src/v2/blocks/response-block/components/ResponseBodyPreview.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from 'vue'
 
 import { type MediaPreview } from '@/v2/blocks/response-block/helpers/media-types'
+import { prettifyNdjson } from '@/v2/blocks/response-block/helpers/prettify-ndjson'
 
 import ResponseBodyInfo from './ResponseBodyInfo.vue'
 import ResponseBodyRaw from './ResponseBodyRaw.vue'
@@ -31,6 +32,11 @@ const jsonPreviewContent = computed((): string => {
   }
   return String(value)
 })
+
+/** NDJSON pretty-printed one record per block for the `ndjson` preview. */
+const ndjsonPreviewContent = computed((): string =>
+  prettifyNdjson(jsonPreviewContent.value),
+)
 
 /**
  * Validates the `src` against an allow-list of safe protocols before it is
@@ -111,6 +117,10 @@ watch(
     :content="jsonPreviewContent"
     language="json"
     prettyPrintJson />
+  <ResponseBodyRaw
+    v-else-if="mode === 'ndjson'"
+    :content="ndjsonPreviewContent"
+    language="json" />
   <div
     v-else-if="!error && safeSrc"
     class="flex justify-center overflow-auto rounded-b"

--- a/packages/api-client/src/v2/blocks/response-block/helpers/media-types.test.ts
+++ b/packages/api-client/src/v2/blocks/response-block/helpers/media-types.test.ts
@@ -32,6 +32,24 @@ describe('mediaTypes', () => {
       },
     },
     {
+      type: 'application/x-ndjson',
+      config: {
+        extension: '.ndjson',
+        raw: true,
+        language: 'json',
+        preview: 'ndjson',
+      },
+    },
+    {
+      type: 'application/ndjson',
+      config: {
+        extension: '.ndjson',
+        raw: true,
+        language: 'json',
+        preview: 'ndjson',
+      },
+    },
+    {
       type: 'image/jpeg',
       config: {
         extension: '.jpg',
@@ -55,6 +73,8 @@ describe('mediaTypes', () => {
 
   it('isTextMediaType', () => {
     expect(isTextMediaType('application/json')).toBe(true)
+    expect(isTextMediaType('application/x-ndjson')).toBe(true)
+    expect(isTextMediaType('application/ndjson')).toBe(true)
     expect(isTextMediaType('application/ld+json')).toBe(true)
     expect(isTextMediaType('application/fhir+json')).toBe(true)
     expect(isTextMediaType('text/plain')).toBe(true)

--- a/packages/api-client/src/v2/blocks/response-block/helpers/media-types.ts
+++ b/packages/api-client/src/v2/blocks/response-block/helpers/media-types.ts
@@ -1,6 +1,6 @@
 import type { CodeMirrorLanguage } from '@scalar/use-codemirror'
 
-export type MediaPreview = 'object' | 'image' | 'video' | 'audio' | 'json'
+export type MediaPreview = 'object' | 'image' | 'video' | 'audio' | 'json' | 'ndjson'
 
 type MediaConfig = {
   preview?: MediaPreview
@@ -45,6 +45,21 @@ const mediaTypes: { [type: string]: MediaConfig | undefined } = {
     raw: true,
     language: 'json',
     preview: 'json',
+  },
+  // Newline-delimited JSON is many JSON objects separated by newlines, not one
+  // JSON document. The `ndjson` preview pretty-prints each line on its own, while
+  // Raw keeps the exact wire format of one object per line.
+  'application/x-ndjson': {
+    extension: '.ndjson',
+    raw: true,
+    language: 'json',
+    preview: 'ndjson',
+  },
+  'application/ndjson': {
+    extension: '.ndjson',
+    raw: true,
+    language: 'json',
+    preview: 'ndjson',
   },
   'application/msword': { extension: '.doc' },
   'application/octet-stream': { extension: '.bin' },

--- a/packages/api-client/src/v2/blocks/response-block/helpers/prettify-ndjson.test.ts
+++ b/packages/api-client/src/v2/blocks/response-block/helpers/prettify-ndjson.test.ts
@@ -21,6 +21,14 @@ describe('prettifyNdjson', () => {
     expect(prettifyNdjson(content)).toBe('{\n  "a": 1\n}\n\nnot json\n\n{\n  "b": 2\n}')
   })
 
+  it('pretty-prints a single record without a trailing newline', () => {
+    expect(prettifyNdjson('{"a":1}')).toBe('{\n  "a": 1\n}')
+  })
+
+  it('reformats leniently without validating (a trailing comma is kept)', () => {
+    expect(prettifyNdjson('{"a":1,}')).toBe('{\n  "a": 1,\n}')
+  })
+
   it('returns an empty string for empty input', () => {
     expect(prettifyNdjson('')).toBe('')
   })

--- a/packages/api-client/src/v2/blocks/response-block/helpers/prettify-ndjson.test.ts
+++ b/packages/api-client/src/v2/blocks/response-block/helpers/prettify-ndjson.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { prettifyNdjson } from './prettify-ndjson'
+
+describe('prettifyNdjson', () => {
+  it('pretty-prints each line and separates records with a blank line', () => {
+    const content = '{"a":1}\n{"b":2}'
+
+    expect(prettifyNdjson(content)).toBe('{\n  "a": 1\n}\n\n{\n  "b": 2\n}')
+  })
+
+  it('ignores empty lines and trailing newlines', () => {
+    const content = '{"a":1}\n\n{"b":2}\n'
+
+    expect(prettifyNdjson(content)).toBe('{\n  "a": 1\n}\n\n{\n  "b": 2\n}')
+  })
+
+  it('passes malformed lines through unchanged', () => {
+    const content = '{"a":1}\nnot json\n{"b":2}'
+
+    expect(prettifyNdjson(content)).toBe('{\n  "a": 1\n}\n\nnot json\n\n{\n  "b": 2\n}')
+  })
+
+  it('returns an empty string for empty input', () => {
+    expect(prettifyNdjson('')).toBe('')
+  })
+})

--- a/packages/api-client/src/v2/blocks/response-block/helpers/prettify-ndjson.ts
+++ b/packages/api-client/src/v2/blocks/response-block/helpers/prettify-ndjson.ts
@@ -1,0 +1,18 @@
+import { prettifyJsoncString } from '@/v2/blocks/response-block/helpers/prettify-jsonc-string'
+
+/**
+ * Pretty-print newline-delimited JSON (NDJSON) for preview.
+ *
+ * NDJSON is one JSON value per line, so we format each line on its own and
+ * separate the records with a blank line to keep them visually distinct.
+ * Empty lines are dropped and any line that is not valid JSON is passed through
+ * unchanged, so a malformed or partial record never breaks the whole preview.
+ */
+export function prettifyNdjson(content: string): string {
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => prettifyJsoncString(line))
+    .join('\n\n')
+}

--- a/packages/api-client/src/v2/blocks/response-block/helpers/prettify-ndjson.ts
+++ b/packages/api-client/src/v2/blocks/response-block/helpers/prettify-ndjson.ts
@@ -5,8 +5,10 @@ import { prettifyJsoncString } from '@/v2/blocks/response-block/helpers/prettify
  *
  * NDJSON is one JSON value per line, so we format each line on its own and
  * separate the records with a blank line to keep them visually distinct.
- * Empty lines are dropped and any line that is not valid JSON is passed through
- * unchanged, so a malformed or partial record never breaks the whole preview.
+ * Empty lines are dropped. Formatting is lenient: each line is reformatted as
+ * far as the JSONC formatter can restructure it, and anything it cannot parse
+ * is left as-is rather than rejected, so a malformed or partial record never
+ * breaks the whole preview.
  */
 export function prettifyNdjson(content: string): string {
   return content


### PR DESCRIPTION
NDJSON responses (`application/x-ndjson`, `application/ndjson`) used to show up as "Binary file" in the client. Now they render as text, and the preview pretty-prints each JSON record.

Raw still shows the exact response (one object per line).

<img width="450" height="926" alt="Screenshot 2026-08-10 at 15 09 01" src="https://github.com/user-attachments/assets/e5697651-9f84-412b-b1ae-d24e9872f360" />

## Ticket

Part of #3885