### PR TITLE
chore(agent-chat): remove stray console.log from ResponseBody

### DIFF
--- a/.changeset/agent-chat-remove-console-log.md
+++ b/.changeset/agent-chat-remove-console-log.md
@@ -1,0 +1,5 @@
+---
+'@scalar/agent-chat': patch
+---
+
+Remove a stray debug console.log from the response body view.

--- a/packages/agent-chat/src/components/ResponseBody/ResponseBody.vue
+++ b/packages/agent-chat/src/components/ResponseBody/ResponseBody.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import { watch } from 'vue'
-
 import { type MediaConfig } from '@/components/ResponseBody/helpers/media-types'
 import ResponseBodyInfo from '@/components/ResponseBody/ResponseBodyInfo.vue'
 import ResponseBodyPreview from '@/components/ResponseBody/ResponseBodyPreview.vue'
@@ -17,11 +15,6 @@ const { data, responseBody, mediaConfig, display } = defineProps<{
   mediaConfig?: MediaConfig
   display?: 'preview' | 'raw'
 }>()
-
-watch(
-  () => display,
-  (v) => console.log(v),
-)
 </script>
 
 <template>


### PR DESCRIPTION
Removes a leftover debug `console.log` that fired on every response view toggle.