### PR TITLE
feat(api-reference): add short ESM CDN entrypoint at /esm.js

### DIFF
--- a/.changeset/short-esm-cdn-url.md
+++ b/.changeset/short-esm-cdn-url.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Add a short CDN URL for the ESM standalone build: `https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js`

--- a/biome.json
+++ b/biome.json
@@ -37,6 +37,7 @@
       "!**/packages/openapi-parser/tests/openapi3-examples/**/*.{yml,yaml,json}",
       "!integrations/**/scalar.js",
       "!integrations/**/standalone.js",
+      "!**/packages/api-reference/esm.js",
       "!**/target/**",
       "!.claude/**"
     ]

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -125,6 +125,8 @@
         "src/features/index.ts",
         "src/helpers/index.ts",
         "src/esm.ts",
+        // Short CDN entry point that re-exports the ESM standalone build
+        "esm.js",
         // Used by CI deploy-api-reference preview build
         "vite.previews.config.ts",
         // Not sure why test files are marked as unused here

--- a/packages/api-reference/esm.js
+++ b/packages/api-reference/esm.js
@@ -1,0 +1,18 @@
+/**
+ * Short CDN entry point for the ESM standalone build.
+ *
+ * This thin pointer lives at the package root so the API Reference can be loaded
+ * from a friendly URL:
+ *
+ *   import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'
+ *
+ * The real bundle (and its lazy chunks) stays under `dist/browser`. Because the
+ * browser resolves the re-export below against this file's own CDN URL, the
+ * bundle and its `./chunks/*` imports load as normal explicit paths — so there is
+ * no bare-package-URL chunk-resolution issue to work around here.
+ *
+ * The re-export also evaluates the bundle, so its side effects (registering
+ * `window.Scalar` and reading legacy `data-*` attributes) still run, matching the
+ * existing `dist/browser/standalone.esm.js` behavior.
+ */
+export { createApiReference } from './dist/browser/standalone.esm.js'

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -96,6 +96,7 @@
   },
   "files": [
     "dist",
+    "esm.js",
     "!dist/browser/webpack-stats.json",
     "!dist/browser/webpack-stats.esm.json",
     "!dist/examples",

--- a/packages/api-reference/playground/esm/index.html
+++ b/packages/api-reference/playground/esm/index.html
@@ -13,11 +13,8 @@
     <script type="module">
       import { createApiReference } from '../../src'
 
-      // CDN:
-      // import { createApiReference } from 'https://esm.sh/@scalar/api-reference';
-
-      // Doesn't work:
-      // import { createApiReference } from 'https://esm.run/@scalar/api-reference';
+      // On the CDN, the built bundle is served from a short URL:
+      // import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'
 
       createApiReference('#app', {
         sources: [


### PR DESCRIPTION
Adds a short URL for the ESM build:

`https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js`

Today you have to use the long `.../dist/browser/standalone.esm.js` path. This adds a tiny `esm.js` at the package root that re-exports the same bundle, so the URL is nice and short.

The bare `.../npm/@scalar/api-reference` URL still serves the UMD build, unchanged. This is a lighter alternative to #9550 (which added a whole new package) — everything stays in `@scalar/api-reference`.

Verified locally in a browser: `createApiReference` works and the lazy chunks load fine through the shim.
