### PR TITLE
docs: fix broken CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/scalar/scalar/actions/workflows/ci.yml/badge.svg)](https://github.com/scalar/scalar/actions/workflows/ci.yml)
+[![CI](https://github.com/scalar/scalar/actions/workflows/main.yml/badge.svg)](https://github.com/scalar/scalar/actions/workflows/main.yml)
 [![Contributors](https://img.shields.io/github/contributors/scalar/scalar)](https://github.com/scalar/scalar/graphs/contributors)
 [![GitHub License](https://img.shields.io/github/license/scalar/scalar)](https://github.com/scalar/scalar/blob/main/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/scalar)](https://x.com/scalar)


### PR DESCRIPTION
The CI badge pointed to `ci.yml`, which was removed when CI was split into separate workflows (#9373). That made the badge a broken image.

This points it to `main.yml`, the workflow that runs on every push to `main`, so the badge shows the real CI status again.