### PR TITLE
docs: use relative file links instead of absolute site routes

### DIFF
--- a/documentation/compare/mintlify.md
+++ b/documentation/compare/mintlify.md
@@ -68,7 +68,7 @@ That integration model works well right up until a dependency disappears. Stainl
 
 We raise this because it is the structural difference, not to score a point. When docs and SDKs come from separate vendors, your documentation's code samples depend on a company you did not choose and cannot control. Scalar generates both from the same OpenAPI document, in the same run.
 
-If you are on Stainless today, we have a [migration guide](/resources/migration/stainless).
+If you are on Stainless today, we have a [migration guide](../migration/stainless.md).
 
 ## The wider landscape
 
@@ -84,7 +84,7 @@ Mintlify is not your only alternative, and the category has moved considerably i
 | Standalone API client | Yes | No | No | No |
 | Entry paid tier | $72/mo | $450/mo | $150/mo | Not available |
 
-**Fern** was [acquired by Postman](https://buildwithfern.com/post/postman-acquires-fern) in January 2026. They say the product and roadmap are unchanged. Their SDK generators are genuinely Apache-2.0 and their protocol support is broader than ours — AsyncAPI, gRPC, and OpenRPC alongside OpenAPI. Their docs renderer is not public. We compare in more detail on our [Fern page](/resources/compare/fern).
+**Fern** was [acquired by Postman](https://buildwithfern.com/post/postman-acquires-fern) in January 2026. They say the product and roadmap are unchanged. Their SDK generators are genuinely Apache-2.0 and their protocol support is broader than ours — AsyncAPI, gRPC, and OpenRPC alongside OpenAPI. Their docs renderer is not public. We compare in more detail on our [Fern page](./fern.md).
 
 **Stainless** is winding down following the Anthropic acquisition. Their docs platform never left public beta. Existing customers keep the SDKs they generated; what stops is regeneration.
 

--- a/documentation/compare/postman.md
+++ b/documentation/compare/postman.md
@@ -4,9 +4,9 @@ Postman is the default API client for millions of developers, and it earned that
 
 This page is written by Scalar, so read it with that in mind. Every claim we make about Postman links to Postman's own documentation, pricing page, or public repositories. If we have something wrong, tell us and we will fix it.
 
-The short version: Postman is a large collaboration platform built around its own collection format, with your work synced to Postman's cloud. Scalar is built around OpenAPI — an open standard you already maintain — with an [API client](/products/api-client) that is MIT licensed, offline-first, and works without an account, on the same platform that renders your documentation and generates your SDKs.
+The short version: Postman is a large collaboration platform built around its own collection format, with your work synced to Postman's cloud. Scalar is built around OpenAPI — an open standard you already maintain — with an [API client](../guides/app/index.md) that is MIT licensed, offline-first, and works without an account, on the same platform that renders your documentation and generates your SDKs.
 
-**One thing to know up front:** Postman [acquired Fern in January 2026](https://blog.postman.com/postman-acquires-fern/). We compare against Fern [on its own page](/resources/compare/fern); the acquisition matters here because it signals where Postman is heading — deeper into documentation and SDKs, the territory this page compares.
+**One thing to know up front:** Postman [acquired Fern in January 2026](https://blog.postman.com/postman-acquires-fern/). We compare against Fern [on its own page](./fern.md); the acquisition matters here because it signals where Postman is heading — deeper into documentation and SDKs, the territory this page compares.
 
 ## At a glance
 
@@ -28,9 +28,9 @@ We would rather you hear this from us than find out after switching.
 
 **Ecosystem and reach.** Postman says it serves [more than 500,000 companies worldwide, including 98% of the Fortune 500](https://blog.postman.com/postman-acquires-fern/). The [Public API Network](https://www.postman.com/explore) is a genuine discovery channel where companies publish workspaces and collections for their public APIs. Nothing else in the category has this gravity, and if your users expect to find your API on Postman, that expectation is itself a reason to be there.
 
-**Protocol breadth today.** Postman's client handles [HTTP, gRPC, GraphQL, and WebSocket requests](https://learning.postman.com/docs/getting-started/basics/using-api-client/). Scalar's client is HTTP-first; gRPC, GraphQL, WebSocket, and SOAP clients are [on our roadmap](/pricing) but not shipped. If you need to test non-HTTP protocols this week, Postman does it and we do not yet.
+**Protocol breadth today.** Postman's client handles [HTTP, gRPC, GraphQL, and WebSocket requests](https://learning.postman.com/docs/getting-started/basics/using-api-client/). Scalar's client is HTTP-first; gRPC, GraphQL, WebSocket, and SOAP clients are [on our roadmap](../guides/pricing.md) but not shipped. If you need to test non-HTTP protocols this week, Postman does it and we do not yet.
 
-**Team collaboration in the cloud.** Shared workspaces, commenting, role-based access control, and cloud sync across devices are mature and central to Postman. Scalar's client stores your work locally, and cloud sync is [coming soon](/pricing) — which means teams that want a synced, shared workspace get one from Postman today and not from us.
+**Team collaboration in the cloud.** Shared workspaces, commenting, role-based access control, and cloud sync across devices are mature and central to Postman. Scalar's client stores your work locally, and cloud sync is [coming soon](../guides/pricing.md) — which means teams that want a synced, shared workspace get one from Postman today and not from us.
 
 **Platform breadth.** [Scheduled monitors](https://learning.postman.com/docs/monitoring-your-api/intro-monitors/), [mock servers](https://learning.postman.com/docs/design-apis/mock-apis/set-up-mock-servers/), and a [large integration directory](https://learning.postman.com/docs/integrations/intro-integrations/) covering CI, APM, and messaging tools. Scalar has a [mock server](https://github.com/scalar/scalar/tree/main/packages/mock-server) and CI workflows, but Postman's breadth here is real.
 
@@ -44,7 +44,7 @@ Postman's working artifact is the [Postman Collection Format](https://schema.pos
 
 But the direction of travel matters. Everything you author inside Postman — tests, scripts, examples, organization — accumulates in the collection, not in your OpenAPI document. Over time the collection becomes the thing your team actually maintains, and it is a format only Postman tooling fully understands.
 
-Scalar does not have a native format, because OpenAPI is the native format. The [API client generates collections directly from your OpenAPI document](/products/api-client/import), can watch it for changes, and keeps requests, authentication, and servers aligned with it. The same document drives your documentation, your SDKs, and your client. There is no second artifact to drift.
+Scalar does not have a native format, because OpenAPI is the native format. The [API client generates collections directly from your OpenAPI document](../guides/app/import.md), can watch it for changes, and keeps requests, authentication, and servers aligned with it. The same document drives your documentation, your SDKs, and your client. There is no second artifact to drift.
 
 ## Offline, accounts, and where your work lives
 
@@ -68,21 +68,21 @@ And because the reference embeds the client, every operation in your docs has a 
 
 ## SDKs
 
-Postman's client generates [code snippets](https://github.com/postmanlabs/postman-code-generators) for a request in a wide range of languages — open source, and genuinely useful for copy-paste. But a snippet is not a client library. For SDK generation proper, Postman's answer is now Fern: since the [acquisition](https://blog.postman.com/postman-acquires-fern/), publishing client libraries from Postman means adopting Fern's stack, where the free tier [caps at 50 endpoints](https://buildwithfern.com/pricing) and most SDK capability is Enterprise, priced per SDK and billed annually with no published rate. We compare Fern's generated output in detail [on its own page](/resources/compare/fern).
+Postman's client generates [code snippets](https://github.com/postmanlabs/postman-code-generators) for a request in a wide range of languages — open source, and genuinely useful for copy-paste. But a snippet is not a client library. For SDK generation proper, Postman's answer is now Fern: since the [acquisition](https://blog.postman.com/postman-acquires-fern/), publishing client libraries from Postman means adopting Fern's stack, where the free tier [caps at 50 endpoints](https://buildwithfern.com/pricing) and most SDK capability is Enterprise, priced per SDK and billed annually with no published rate. We compare Fern's generated output in detail [on its own page](./fern.md).
 
-Scalar generates SDKs natively — TypeScript, Python, C#, Java, PHP, and Go — from the same OpenAPI document that renders your reference and drives the client, in the same generation run, so your docs, your client, and your libraries cannot describe different APIs. Custom code survives regeneration through a three-way merge, and each language target is a published [$100/month add-on](/pricing). You can work out what it costs without talking to sales.
+Scalar generates SDKs natively — TypeScript, Python, C#, Java, PHP, and Go — from the same OpenAPI document that renders your reference and drives the client, in the same generation run, so your docs, your client, and your libraries cannot describe different APIs. Custom code survives regeneration through a three-way merge, and each language target is a published [$100/month add-on](../guides/pricing.md). You can work out what it costs without talking to sales.
 
 ## Scripting, tests, and moving over
 
-Scalar's client supports [pre-request scripts and post-response tests using a Postman-compatible syntax](/products/api-client/testing) — `pm.test()`, `pm.expect()`, `pm.response` — so existing test scripts largely carry over, and so does your muscle memory.
+Scalar's client supports [pre-request scripts and post-response tests using a Postman-compatible syntax](../guides/app/testing.md) — `pm.test()`, `pm.expect()`, `pm.response` — so existing test scripts largely carry over, and so does your muscle memory.
 
-The client [imports Postman Collections](/products/api-client/import) (v2.0 and v2.1), converting requests, folders, and basic authentication settings into an OpenAPI-based collection. It also imports OpenAPI 3.x, upgrades Swagger 2.0 documents automatically, and parses pasted cURL commands. To repeat the honest caveat from above: monitors, mock servers, and workspace history do not come across.
+The client [imports Postman Collections](../guides/app/import.md) (v2.0 and v2.1), converting requests, folders, and basic authentication settings into an OpenAPI-based collection. It also imports OpenAPI 3.x, upgrades Swagger 2.0 documents automatically, and parses pasted cURL commands. To repeat the honest caveat from above: monitors, mock servers, and workspace history do not come across.
 
 ## Pricing
 
 Postman's [pricing](https://www.postman.com/pricing/) at the time of writing: a free tier for one user, then Solo at $9/month, Team at $19 per user per month, and Enterprise at $49 per user per month, billed annually. The free tier is genuinely usable, and the paid tiers are reasonable for what the platform does — but the cost scales with every seat, and the features that make Postman sticky (shared workspaces, RBAC, higher API call limits) are the ones that add seats.
 
-Scalar's API client is free and open source for everyone, on every plan, with no per-seat fee, because it is not where we make money. The [docs platform](/pricing) starts free and is $72/month on Pro — a flat price, not per user.
+Scalar's API client is free and open source for everyone, on every plan, with no per-seat fee, because it is not where we make money. The [docs platform](../guides/pricing.md) starts free and is $72/month on Pro — a flat price, not per user.
 
 ## Which should you choose?
 
@@ -90,7 +90,7 @@ Scalar's API client is free and open source for everyone, on every plan, with no
 
 **Choose Scalar if** OpenAPI is your source of truth and you want it to stay that way, you want an API client you can read and fork under MIT, you want your requests and credentials to stay on your machine, you do not want per-seat pricing for an API client, or you want documentation, SDKs, and the client generated from the same document on one platform.
 
-[Try the API client](/products/api-client), [start free](https://dashboard.scalar.com/register), or [talk to us](https://scalar.cal.com/).
+[Try the API client](../guides/app/index.md), [start free](https://dashboard.scalar.com/register), or [talk to us](https://scalar.cal.com/).
 
 ---
 

--- a/documentation/compare/readme.md
+++ b/documentation/compare/readme.md
@@ -38,11 +38,11 @@ Both products render an OpenAPI document into a documentation site with an inter
 
 **Scalar's docs can live inside your application.** Thirty-five framework integrations — Express, Fastify, Hono, NestJS, Next.js, Nuxt, Laravel, Django, Rails, Go, Rust, ASP.NET Core, Spring Boot, and more. You mount the reference inside the app you already run, at whatever route you choose. ReadMe has no framework middleware; your hub lives on a ReadMe-hosted domain (custom domains included, on every plan).
 
-**The site you are reading is the product.** scalar.com — this page, the pricing page, the guides, the API reference, and the blog — is built and hosted entirely on [Scalar Docs](/products/docs) from a single `scalar.config.json`. We do not maintain a separate marketing stack.
+**The site you are reading is the product.** scalar.com — this page, the pricing page, the guides, the API reference, and the blog — is built and hosted entirely on [Scalar Docs](../guides/docs/index.md) from a single `scalar.config.json`. We do not maintain a separate marketing stack.
 
 ## SDKs
 
-Scalar generates SDKs natively in TypeScript, Python, C#, Java, PHP, and Go from the same OpenAPI document that renders your reference, in the same run, so your docs and your client libraries cannot describe different APIs. Each language target is a published [$100/month add-on](/pricing).
+Scalar generates SDKs natively in TypeScript, Python, C#, Java, PHP, and Go from the same OpenAPI document that renders your reference, in the same run, so your docs and your client libraries cannot describe different APIs. Each language target is a published [$100/month add-on](../guides/pricing.md).
 
 ReadMe's SDK story is narrower. Their open-source [`api` package](https://api.readme.dev/docs/getting-started) generates a TypeScript or JavaScript client from an OpenAPI definition — but it is a CLI your API consumers run themselves, in one language family, not a managed pipeline that generates, versions, and publishes packages to registries on your behalf. Teams on ReadMe who want multi-language SDKs typically add a third-party generator such as [APIMatic](https://www.apimatic.io/integrations/readme), which brings back the separate-vendor problem: your documentation's code samples then depend on a company you did not choose.
 
@@ -52,11 +52,11 @@ Scalar ships a standalone, open-source API client — desktop and web, offline-f
 
 ## MCP servers and AI
 
-Both products ship this. ReadMe generates [an MCP server from your documentation](https://docs.readme.com/main/docs/readmes-mcp-server) with a toggle, on every plan, so AI coding assistants can list endpoints, inspect schemas, and call your API. Their Ask AI chat is a [$150/month add-on](https://readme.com/pricing). Scalar hosts MCP servers on the [Pro plan](/pricing), alongside `llms.txt` generation and docs chat, metered through Agent Scalar credits. If MCP hosting is on your checklist, neither product decides it for you.
+Both products ship this. ReadMe generates [an MCP server from your documentation](https://docs.readme.com/main/docs/readmes-mcp-server) with a toggle, on every plan, so AI coding assistants can list endpoints, inspect schemas, and call your API. Their Ask AI chat is a [$150/month add-on](https://readme.com/pricing). Scalar hosts MCP servers on the [Pro plan](../guides/pricing.md), alongside `llms.txt` generation and docs chat, metered through Agent Scalar credits. If MCP hosting is on your checklist, neither product decides it for you.
 
 ## Pricing
 
-Scalar: Free at $0, [Pro at $72/month](/pricing), SDK language targets at $100/month each, Enterprise custom.
+Scalar: Free at $0, [Pro at $72/month](../guides/pricing.md), SDK language targets at $100/month each, Enterprise custom.
 
 ReadMe: [Starter at $0, Pro at $250/month billed annually, Enterprise from $3,000/month](https://readme.com/pricing), with Ask AI as a $150/month add-on. Team collaboration, private docs, custom MDX, and CSS/HTML all start at Pro, so the realistic entry point for a team is $250/month. You may find older ReadMe pricing quoted around the web at $99/month; that reflects a previous pricing model, so check their current page.
 

--- a/documentation/guides/docs/components/buttons.mdx
+++ b/documentation/guides/docs/components/buttons.mdx
@@ -10,7 +10,7 @@ Buttons are interactive elements that link to external resources or other pages.
 | ---- | ---- | ------- | ----------- |
 | `title` | `string` | _required_ | The label shown on the button. |
 | `href` | `string` | _required_ | The URL the button links to. |
-| `icon` | `string` | — | Icon shown before the label. Accepts a built-in [icon key](/products/docs/components/icons#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](/products/docs/components/icons#custom-icons). |
+| `icon` | `string` | — | Icon shown before the label. Accepts a built-in [icon key](./icons.mdx#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](./icons.mdx#custom-icons). |
 | `variant` | `'primary'` `'secondary'` | `primary` | Visual style of the button. |
 | `target` | `'_blank'` `'_self'` | `_blank` | Where the link opens. `_blank` adds `rel="noopener noreferrer"` automatically. |
 

--- a/documentation/guides/docs/components/callouts.mdx
+++ b/documentation/guides/docs/components/callouts.mdx
@@ -9,7 +9,7 @@ Callouts are highlighted boxes that draw attention to important information. Eac
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `type` | `'neutral'` `'success'` `'danger'` `'warning'` `'info'` | `neutral` | Visual style and default icon. Accepts the aliases `warn` and `information`. |
-| `icon` | `string` | — | Overrides the default icon for the type. Accepts a built-in [icon key](/products/docs/components/icons#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](/products/docs/components/icons#custom-icons). |
+| `icon` | `string` | — | Overrides the default icon for the type. Accepts a built-in [icon key](./icons.mdx#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](./icons.mdx#custom-icons). |
 
 ## Examples
 

--- a/documentation/guides/docs/components/cards.mdx
+++ b/documentation/guides/docs/components/cards.mdx
@@ -10,7 +10,7 @@ Cards display content in a bordered box, optionally with a title, description, i
 | ---- | ---- | ------- | ----------- |
 | `title` | `string` | — | Title shown at the top of the card. |
 | `description` | `string` | — | Short description shown below the title. |
-| `icon` | `string` | — | Icon shown alongside the title. Accepts a built-in [icon key](/products/docs/components/icons#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](/products/docs/components/icons#custom-icons). |
+| `icon` | `string` | — | Icon shown alongside the title. Accepts a built-in [icon key](./icons.mdx#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](./icons.mdx#custom-icons). |
 | `iconPosition` | `'title'` `'left'` `'above'` | `title` | Where the icon is placed relative to the card content. |
 | `href` | `string` | — | When set, the entire card becomes a link. |
 | `target` | `'_blank'` `'_self'` | — | Where the link opens. `_blank` adds `rel="noopener noreferrer"` automatically. |

--- a/documentation/guides/docs/components/details.mdx
+++ b/documentation/guides/docs/components/details.mdx
@@ -9,7 +9,7 @@ Details create collapsible content sections, useful for progressive disclosure o
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
 | `title` | `string` | — | Text shown in the summary header. |
-| `icon` | `string` | `phosphor/regular/caret-right` | Marker icon shown on the left of the summary. Accepts a built-in [icon key](/products/docs/components/icons#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](/products/docs/components/icons#custom-icons). |
+| `icon` | `string` | `phosphor/regular/caret-right` | Marker icon shown on the left of the summary. Accepts a built-in [icon key](./icons.mdx#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](./icons.mdx#custom-icons). |
 | `title-icon` | `string` | — | Icon shown inline next to the title text. In MDX this is written as `title-icon` on `<Detail>`. |
 | `open` | `boolean` | `false` | When `true`, the section starts expanded. |
 | `interactivity` | `'none'` | — | Set to `"none"` to render a static, non-collapsible container. |

--- a/documentation/guides/docs/components/images.mdx
+++ b/documentation/guides/docs/components/images.mdx
@@ -4,7 +4,7 @@ import Preview from './Preview.mdx'
 
 Images render responsive figures with optional captions, links, and dark-mode variants.
 
-The examples below reference images from your [assets directory](/products/docs/content/assets) using root-relative paths (e.g. `/marc-cam-scalar.jpg`). You can also pass a full URL to any external image.
+The examples below reference images from your [assets directory](../content/assets.md) using root-relative paths (e.g. `/marc-cam-scalar.jpg`). You can also pass a full URL to any external image.
 
 ## Properties
 

--- a/documentation/guides/docs/components/markdown-support.mdx
+++ b/documentation/guides/docs/components/markdown-support.mdx
@@ -89,7 +89,7 @@ Link to absolute URLs, other Markdown files, and embed images.
 
 [Absolute URLs](https://example.com)
 
-[Relative link](/products/docs/components/tables)
+[Relative link](./tables.mdx)
 
 ![Image](https://docs.scalar.com/scalar-docs.png)
 
@@ -161,7 +161,7 @@ We support standard GitHub-flavored Markdown tables.
 | Cell 4   | Cell 5   | Cell 6   |
 ```
 
-For alignment, escaping pipe characters, and best practices, see [Tables](/products/docs/components/tables).
+For alignment, escaping pipe characters, and best practices, see [Tables](./tables.mdx).
 
 ## Task Lists
 

--- a/documentation/guides/docs/components/row.mdx
+++ b/documentation/guides/docs/components/row.mdx
@@ -3,7 +3,7 @@ import Preview from './Preview.mdx'
 # Row
 
 <Callout type="warning">
-  **Deprecated.** Use the [Grid](/products/docs/components/grid) component instead — it's simpler and the recommended way to lay content out in columns. Row still works for backwards compatibility.
+  **Deprecated.** Use the [Grid](./grid.mdx) component instead — it's simpler and the recommended way to lay content out in columns. Row still works for backwards compatibility.
 </Callout>
 
 Row arranges its children in a horizontal layout with consistent spacing. It's useful for placing cards, callouts, or any other components side-by-side.

--- a/documentation/guides/docs/components/steps.mdx
+++ b/documentation/guides/docs/components/steps.mdx
@@ -12,7 +12,7 @@ Steps render numbered, optionally collapsible sections — ideal for tutorials, 
 | ---- | ---- | ------- | ----------- |
 | `title` | `string` | — | Label shown next to the step marker. |
 | `id` | `string` | — | Optional unique identifier for the step. Used for deep links and accessibility. |
-| `icon` | `string` | — | Custom icon for the step marker. Accepts a built-in [icon key](/products/docs/components/icons#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](/products/docs/components/icons#custom-icons). |
+| `icon` | `string` | — | Custom icon for the step marker. Accepts a built-in [icon key](./icons.mdx#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](./icons.mdx#custom-icons). |
 | `interactivity` | `'none'` | — | Set to `"none"` to render a static, non-collapsible step. |
 
 ### Steps

--- a/documentation/guides/security.md
+++ b/documentation/guides/security.md
@@ -10,14 +10,14 @@ Scalar helps teams create API interfaces built for developers and agents, includ
 ## Trust and compliance
 
 - **SOC 2 report:** Scalar has received a SOC 2 Type 1 report for controls relevant to security.
-- **GDPR privacy:** Scalar publishes European privacy rights and data processing details in our [Privacy Policy](/legal/privacy-policy).
+- **GDPR privacy:** Scalar publishes European privacy rights and data processing details in our [Privacy Policy](../legal/privacy-policy.md).
 - **Trust Center:** Security documentation and compliance materials are available at [trust.scalar.com](https://trust.scalar.com).
 
 ## Access controls
 
 Use Scalar as a controlled surface for API descriptions, SDK generation, MCP installations, registry workflows, and developer tooling.
 
-- **Single sign-on:** SAML-based SSO keeps authentication tied to your organization's identity provider. Read the [SSO guide](/resources/sso/getting-started).
+- **Single sign-on:** SAML-based SSO keeps authentication tied to your organization's identity provider. Read the [SSO guide](./sso/getting-started.md).
 - **Role-based access:** Manage access boundaries across workspaces, teams, and API projects as your organization grows.
 - **Private API interfaces:** Publish internal references, portals, and API workflows behind access controls while keeping public interfaces simple to share.
 - **Git-native review:** Keep API description changes visible in the same review flow your engineers already use.
@@ -31,7 +31,7 @@ Scalar's hosted API interfaces are privacy-friendly by default, with only techni
 - **No request IP logging:** Request traffic is not logged; internal proxy error logs do not include IP addresses.
 - **GDPR privacy rights:** European users can request access, correction, deletion, transfer, or withdraw consent through Scalar's privacy contact.
 
-Read more in the [privacy notes](/products/docs/privacy).
+Read more in the [privacy notes](./docs/privacy.md).
 
 ## API lifecycle security
 
@@ -39,8 +39,8 @@ Scalar treats OpenAPI as a source of truth for developer docs, API clients, gene
 
 - **Auth-aware API descriptions:** Model API keys, bearer tokens, OAuth flows, and other security schemes directly in your OpenAPI document.
 - **Rules and validation:** Add review gates and linting so API changes are caught before they reach consumers.
-- **SDK generation:** Generate production-ready SDKs and CLIs from reviewed API descriptions. See the [SDK Generator](/products/sdk-generator).
-- **MCP guardrails:** Choose which endpoints become tools, decide search versus execute modes, and apply API auth per installation. See [MCP & Agent](/products/agent).
+- **SDK generation:** Generate production-ready SDKs and CLIs from reviewed API descriptions. See the [SDK Generator](./sdks/index.md).
+- **MCP guardrails:** Choose which endpoints become tools, decide search versus execute modes, and apply API auth per installation. See [MCP & Agent](./agent/index.md).
 - **Self-hostable foundation:** Run Scalar's open-source tooling in your own environment when your architecture requires it.
 
 ## Responsible disclosure

--- a/documentation/openapi.md
+++ b/documentation/openapi.md
@@ -490,7 +490,7 @@ info:
 
 ## x-pre-request
 
-Add pre-request scripts to operations or at the document level. Scripts run before the request is sent and can modify headers, set variables, or prepare authentication. See [Scripts in the API Client](/products/api-client/scripts) for the full guide.
+Add pre-request scripts to operations or at the document level. Scripts run before the request is sent and can modify headers, set variables, or prepare authentication. See [Scripts in the API Client](./guides/app/scripts.md) for the full guide.
 
 On an operation:
 
@@ -525,7 +525,7 @@ When both document-level and operation-level scripts are present, the document-l
 
 ## x-post-response
 
-Add post-response scripts to operations to automatically validate API responses. Scripts use a Postman-compatible syntax and run after each request in the [API Client](/products/api-client/testing).
+Add post-response scripts to operations to automatically validate API responses. Scripts use a Postman-compatible syntax and run after each request in the [API Client](./guides/app/testing.md).
 
 ```diff
 openapi: 3.1.0
@@ -563,4 +563,4 @@ paths:
 +        })
 ```
 
-See [Testing in the API Client](/products/api-client/testing) for all available assertions and the full `pm` API reference.
+See [Testing in the API Client](./guides/app/testing.md) for all available assertions and the full `pm` API reference.

--- a/documentation/solutions/api-documentation-for-developer-tools-companies.md
+++ b/documentation/solutions/api-documentation-for-developer-tools-companies.md
@@ -9,14 +9,14 @@ This page is written by Scalar. Every product claim on it is backed by our own d
 | | Scalar |
 | --- | --- |
 | Source of truth | One OpenAPI document (3.0 or 3.1; Swagger 2.0 upgraded on load) |
-| Docs update via | [Git sync](/products/docs/integrations/github): commit, merge, published |
-| Preview before merge | [Preview deployment per pull request](/products/docs/deployment/preview-deployments), with a PR comment link |
+| Docs update via | [Git sync](../guides/docs/integrations/github.md): commit, merge, published |
+| Preview before merge | [Preview deployment per pull request](../guides/docs/deployment/preview-deployments.md), with a PR comment link |
 | SDK targets | TypeScript, Python, Go, CLI generally available; more experimental |
 | Code samples in docs | Generated per SDK, injected as `x-codeSamples` into your reference |
 | Try-it-out | Open-source API client built into the reference |
 | Docs renderer license | MIT, self-hostable on any plan |
 | Framework integrations | 35 (Express, Fastify, Hono, NestJS, Next.js, FastAPI, and more) |
-| Pricing | Free tier; Pro $72/month; $100/month per SDK target — [published](/pricing) |
+| Pricing | Free tier; Pro $72/month; $100/month per SDK target — [published](../guides/pricing.md) |
 
 ## The problem, specifically
 
@@ -33,11 +33,11 @@ The fix is structural, not editorial: everything downstream of the API has to re
 
 ## How Scalar handles it
 
-**The API reference renders from your OpenAPI document, and updates through Git.** Scalar Docs [connects to GitHub](/products/docs/integrations/github) through a GitHub App scoped to the repositories you select. It reads your files, opens pull requests, and publishes when you merge. Your OpenAPI document and your Markdown guides live in your repository, reviewed like any other code. There is no separate CMS to keep in sync.
+**The API reference renders from your OpenAPI document, and updates through Git.** Scalar Docs [connects to GitHub](../guides/docs/integrations/github.md) through a GitHub App scoped to the repositories you select. It reads your files, opens pull requests, and publishes when you merge. Your OpenAPI document and your Markdown guides live in your repository, reviewed like any other code. There is no separate CMS to keep in sync.
 
-**Every pull request gets a preview.** When you open a PR, Scalar [creates a preview deployment](/products/docs/deployment/preview-deployments) and can post a comment with a direct link, so reviewers see the rendered docs — not a diff of Markdown — before anything ships. If your project is not connected to GitHub, the CLI publishes previews too: `npx @scalar/cli project publish --slug your-docs --preview`.
+**Every pull request gets a preview.** When you open a PR, Scalar [creates a preview deployment](../guides/docs/deployment/preview-deployments.md) and can post a comment with a direct link, so reviewers see the rendered docs — not a diff of Markdown — before anything ships. If your project is not connected to GitHub, the CLI publishes previews too: `npx @scalar/cli project publish --slug your-docs --preview`.
 
-**SDKs follow the same document.** The [SDK generator](/products/sdk-generator) points each SDK at an exact version of your API document or at a semver range such as `^1.2.0`. When a matching document changes, Scalar mints a new SDK version, rebuilds every target, and opens pull requests against your repositories. One commit to your API updates all of your clients.
+**SDKs follow the same document.** The [SDK generator](../guides/sdks/index.md) points each SDK at an exact version of your API document or at a semver range such as `^1.2.0`. When a matching document changes, Scalar mints a new SDK version, rebuilds every target, and opens pull requests against your repositories. One commit to your API updates all of your clients.
 
 **The code samples in your docs come from the generated SDKs.** Generation injects samples into your OpenAPI document as `x-codeSamples`, and the reference renders them. The snippet a developer copies out of your docs is derived from the same document the SDK was built from, so it does not rot independently. Examples you curated by hand are preserved.
 
@@ -50,7 +50,7 @@ What Scalar does not do: it will not keep your OpenAPI document itself accurate.
 Scalar's customer profile is companies whose API *is* the product, or is close to it: public APIs, developer-facing surfaces, teams that treat API developer experience as a competitive input rather than a compliance task. Some public examples:
 
 - **[Clerk](https://clerk.com/docs/reference/frontend-api)** — authentication and user management for the modern web. Their Frontend API reference runs on Scalar.
-- **[PAR Technology](https://developers.partech.com)** — restaurant and retail software. PAR [migrated its developer portal to Scalar](/customers/partech) to modernize a docs-as-code workflow tied to GitHub, with pull-request-based reviews and automatic publishing on merge. The full story is worth reading if your setup looks similar.
+- **[PAR Technology](https://developers.partech.com)** — restaurant and retail software. PAR [migrated its developer portal to Scalar](../guides/customers/partech.md) to modernize a docs-as-code workflow tied to GitHub, with pull-request-based reviews and automatic publishing on merge. The full story is worth reading if your setup looks similar.
 - **[Bobcat](https://developer.bobcat.com/)** — equipment manufacturer with a public developer portal on Scalar.
 - **[Thomson Reuters](https://developers.thomsonreuters.com/pages/api-reference/19232a0d-5cf9-53a9-a215-efe481550832)** — API references inside their developer portal.
 
@@ -62,19 +62,19 @@ And scalar.com itself — this page included — is built and hosted on Scalar D
 
 Everything below is documented; each link goes to the guide.
 
-- **[Git sync](/products/docs/integrations/github)** — the Scalar GitHub App reads your files, opens pull requests, and publishes on merge. Access is limited to repositories you select. Scalar describes this as two-way: content flows from your repository into the docs, and edits made through Scalar land back as commits and pull requests attributed to you.
-- **[Preview deployments](/products/docs/deployment/preview-deployments)** — a rendered preview for every pull request, with optional PR comments linking to it.
-- **[Versioning](/products/docs/configuration/versions)** — multiple documentation versions under one domain with a version selector, each with its own navigation. Useful when v1 and v2 of your API coexist for years, which for developer tools companies they usually do.
-- **[Custom domains](/products/docs/configuration/domains)** — `docs.yourcompany.com` via a CNAME to `dns.scalar.com`, with HTTPS provisioned automatically. Requires the Pro plan.
-- **OpenAPI 3.0 and 3.1** — both supported, and Swagger 2.0 documents are [upgraded on load](/products/api-references/openapi). You do not need to modernize your descriptions before adopting the platform; PAR ran this exact incremental path.
+- **[Git sync](../guides/docs/integrations/github.md)** — the Scalar GitHub App reads your files, opens pull requests, and publishes on merge. Access is limited to repositories you select. Scalar describes this as two-way: content flows from your repository into the docs, and edits made through Scalar land back as commits and pull requests attributed to you.
+- **[Preview deployments](../guides/docs/deployment/preview-deployments.md)** — a rendered preview for every pull request, with optional PR comments linking to it.
+- **[Versioning](../guides/docs/configuration/versions.md)** — multiple documentation versions under one domain with a version selector, each with its own navigation. Useful when v1 and v2 of your API coexist for years, which for developer tools companies they usually do.
+- **[Custom domains](../guides/docs/configuration/domains.md)** — `docs.yourcompany.com` via a CNAME to `dns.scalar.com`, with HTTPS provisioned automatically. Requires the Pro plan.
+- **OpenAPI 3.0 and 3.1** — both supported, and Swagger 2.0 documents are [upgraded on load](../openapi.md). You do not need to modernize your descriptions before adopting the platform; PAR ran this exact incremental path.
 - **35 framework integrations** — if you want the reference mounted inside your own application rather than hosted, there are [integrations](/products/api-references/integrations) for Express, Fastify, Hono, NestJS, Next.js, Nuxt, FastAPI, Django, Laravel, Rails, Go, Rust, ASP.NET Core, Spring Boot, and more. The renderer is MIT licensed, so this path has no plan requirement at all.
-- **Markdown and MDX guides** alongside the reference, with [custom HTML, CSS, and JavaScript](/products/docs/content/html-css-js) when the built-in components are not enough.
+- **Markdown and MDX guides** alongside the reference, with [custom HTML, CSS, and JavaScript](../guides/docs/content/html-css-js.md) when the built-in components are not enough.
 
 ## What a devtools setup looks like end to end
 
 A concrete walkthrough, using real generated output. The TypeScript below is from the public [Warp SDK](https://github.com/TeamWarp/warp-sdk-typescript/tree/candidate), generated by Scalar.
 
-**1. Your OpenAPI document lives in your repository.** It is the input to everything: the reference, the SDKs, the code samples. Put it in the [Registry](/products/registry) or import it directly.
+**1. Your OpenAPI document lives in your repository.** It is the input to everything: the reference, the SDKs, the code samples. Put it in the [Registry](../guides/registry/index.md) or import it directly.
 
 **2. Docs connect to the repository.** Install the GitHub App, add a `scalar.config.json` describing navigation, theme, and domain, and publish. From then on, merged changes to the document or the guides deploy automatically, and every PR gets a preview link.
 
@@ -115,12 +115,12 @@ The Warp package ships `"dependencies": {}` — zero runtime dependencies unless
 
 We think it is the strongest default for this segment, for three checkable reasons: the docs renderer is MIT licensed and self-hostable, so you are not betting your primary acquisition surface on a vendor's continuity; docs and SDKs are literally generated from the same document in the same workflow, which is the failure mode this industry actually suffers from; and the pricing is published, so you can cost the whole setup without a sales call.
 
-It is not the right choice for everyone. If your API is gRPC or JSON-RPC rather than REST, or you want to run the SDK generator source yourself, read our honest comparison with [Fern](/resources/compare/fern) — we say plainly where they are stronger. If you only need a rendered reference and nothing hosted, the open-source [API Reference](https://github.com/scalar/scalar) is free and does not require an account.
+It is not the right choice for everyone. If your API is gRPC or JSON-RPC rather than REST, or you want to run the SDK generator source yourself, read our honest comparison with [Fern](../compare/fern.md) — we say plainly where they are stronger. If you only need a rendered reference and nothing hosted, the open-source [API Reference](https://github.com/scalar/scalar) is free and does not require an account.
 
 ## Getting started
 
-- [Scalar Docs](/products/docs) — the documentation platform
-- [SDK Generator](/products/sdk-generator) — client libraries from the same document
+- [Scalar Docs](../guides/docs/index.md) — the documentation platform
+- [SDK Generator](../guides/sdks/index.md) — client libraries from the same document
 - [Start free](https://dashboard.scalar.com/register), or [talk to us](https://scalar.cal.com/) if you are migrating an existing portal
 
 ---

--- a/documentation/solutions/developer-portal.md
+++ b/documentation/solutions/developer-portal.md
@@ -20,15 +20,15 @@ This page describes what a developer portal on Scalar includes, how it compares 
 
 ## What a Scalar developer portal includes
 
-**An API reference generated from OpenAPI.** [Scalar Docs](/products/docs) renders your OpenAPI document into interactive documentation with request testing built in. The renderer is MIT licensed, so you can theme it with CSS variables, add custom HTML, CSS, and JavaScript, or fork it outright if you need behaviour we did not anticipate.
+**An API reference generated from OpenAPI.** [Scalar Docs](../guides/docs/index.md) renders your OpenAPI document into interactive documentation with request testing built in. The renderer is MIT licensed, so you can theme it with CSS variables, add custom HTML, CSS, and JavaScript, or fork it outright if you need behaviour we did not anticipate.
 
 **Guides written in Markdown or MDX.** Product guides, tutorials, and landing pages live beside the reference in one navigation. Content is pulled from GitHub, every pull request gets a preview deployment, and merges deploy automatically — or you publish from the CLI. All of scalar.com, including this page, is built with Scalar Docs from a single `scalar.config.json`.
 
-**A built-in API client.** Developers test endpoints directly in the reference — no separate tool to install, no context switch. Scalar also ships a standalone, open-source [API client](/products/api-client) for desktop and web, with environments, collections, and Postman-compatible scripting, so the testing workflow developers start in your docs continues after they leave them.
+**A built-in API client.** Developers test endpoints directly in the reference — no separate tool to install, no context switch. Scalar also ships a standalone, open-source [API client](../guides/app/index.md) for desktop and web, with environments, collections, and Postman-compatible scripting, so the testing workflow developers start in your docs continues after they leave them.
 
-**SDKs in the languages your users ask for.** The [SDK Generator](/products/sdk-generator) produces idiomatic, type-safe client libraries — TypeScript, Python, C#, Java, PHP, Go, Ruby, Rust, Swift, and Dart — from the same OpenAPI document that renders the reference, and publishes them from your own repositories through pull requests you control.
+**SDKs in the languages your users ask for.** The [SDK Generator](../guides/sdks/index.md) produces idiomatic, type-safe client libraries — TypeScript, Python, C#, Java, PHP, Go, Ruby, Rust, Swift, and Dart — from the same OpenAPI document that renders the reference, and publishes them from your own repositories through pull requests you control.
 
-**MCP servers for AI clients.** Scalar exposes [two MCP surfaces](/products/agent): a Docs MCP at `your-docs-domain/mcp` that lets tools like Cursor and Claude Code search and read your published documentation, and hosted MCP servers that let AI clients call the API endpoints you select, with delegated authentication so agents never receive your upstream credentials.
+**MCP servers for AI clients.** Scalar exposes [two MCP surfaces](../guides/agent/index.md): a Docs MCP at `your-docs-domain/mcp` that lets tools like Cursor and Claude Code search and read your published documentation, and hosted MCP servers that let AI clients call the API endpoints you select, with delegated authentication so agents never receive your upstream credentials.
 
 **Ask AI.** An AI assistant is enabled by default on every Scalar Docs project. It searches your published documentation and combines information from multiple pages into a short, sourced answer — no setup required.
 
@@ -42,7 +42,7 @@ On Scalar, the single source of truth is literal. In the SDK generator, `docs` i
 
 - **API-first companies** whose product is the API, and whose portal is the product page, the manual, and the toolbox at once.
 - **Developer tools companies** where documentation quality is judged by developers who read a lot of documentation.
-- **Teams shipping public APIs** that need the surrounding infrastructure: multiple documentation [versions](/products/docs/configuration/versions) with a version selector, [custom domains](/products/docs/configuration/domains), and access control — from email domain access groups on Pro to SSO/SAML and RBAC on Enterprise.
+- **Teams shipping public APIs** that need the surrounding infrastructure: multiple documentation [versions](../guides/docs/configuration/versions.md) with a version selector, [custom domains](../guides/docs/configuration/domains.md), and access control — from email domain access groups on Pro to SSO/SAML and RBAC on Enterprise.
 
 ## How it compares to ReadMe and Mintlify
 
@@ -50,13 +50,13 @@ Both are credible choices for a developer portal, and the honest comparison is a
 
 **ReadMe** specializes in developer hubs with real API usage data inside them. Their [Developer Dashboard](https://docs.readme.com/main/docs/developer-dashboard) shows who is calling your API, personalized docs surface each developer's own API keys and logs, and their [API metrics](https://readme.com/metrics) report call volume, endpoint usage, and errors. Scalar does not have an equivalent of those API analytics dashboards today. ReadMe offers a per-project [MCP server](https://docs.readme.com/main/docs/readmes-mcp-server) for searching and reading docs content, and their [`api`](https://api.readme.dev/docs/getting-started) tool generates TypeScript SDKs; Scalar's SDK generator covers ten languages with publishing to package registries, and its hosted MCP servers can call your API with delegated authentication.
 
-**Mintlify** focuses on documentation polish: strong theming, localization across 30+ locales, and unlimited editor seats on a flat price. Mintlify does not generate SDKs — it renders code samples from third-party generators such as [Speakeasy](https://www.mintlify.com/docs/integrations/sdks/speakeasy) and [Stainless](https://www.mintlify.com/docs/integrations/sdks/stainless). We publish a detailed [Scalar vs Mintlify](/resources/compare/mintlify) comparison.
+**Mintlify** focuses on documentation polish: strong theming, localization across 30+ locales, and unlimited editor seats on a flat price. Mintlify does not generate SDKs — it renders code samples from third-party generators such as [Speakeasy](https://www.mintlify.com/docs/integrations/sdks/speakeasy) and [Stainless](https://www.mintlify.com/docs/integrations/sdks/stainless). We publish a detailed [Scalar vs Mintlify](../compare/mintlify.md) comparison.
 
 **Scalar** is the option in this group that also generates SDKs and hosts MCP servers from the same OpenAPI document that renders the reference, ships a standalone open-source API client alongside the docs, and licenses the documentation renderer under MIT so the portal layer is yours to keep.
 
 ## Pricing
 
-Scalar publishes its prices, so you can work out what a portal costs without talking to sales. Full details are on the [pricing page](/pricing).
+Scalar publishes its prices, so you can work out what a portal costs without talking to sales. Full details are on the [pricing page](../guides/pricing.md).
 
 - **Free ($0)** — hosted OpenAPI docs, the built-in API client, and one editor seat. Enough to put a real reference online.
 - **Pro ($72/month)** — the full developer portal: custom domains and subdomains, Git Sync, Markdown and MDX, guides, versions, landing pages, email domain access control, and hosted MCP servers. Each SDK language is a $100/month add-on.
@@ -69,11 +69,11 @@ The clearest way to evaluate a portal platform is to use a portal built on it:
 - **[Bobcat developer portal](https://developer.bobcat.com/)** — the American manufacturer of farm and construction equipment runs its public developer portal on Scalar.
 - **[Thomson Reuters developer platform](https://developers.thomsonreuters.com/pages/api-reference/19232a0d-5cf9-53a9-a215-efe481550832)** — API references for the provider of software and decision tools for legal and accounting companies.
 - **[Clerk](https://clerk.com/docs/reference/frontend-api)** — the authentication and user management platform renders its API reference with Scalar.
-- **[PAR developer portal](https://developers.partech.com)** — PAR Technology's portal for the Punchh Loyalty platform, migrated from a legacy platform to Scalar with a docs-as-code workflow in GitHub. The full story is in the [PAR case study](/customers/partech).
+- **[PAR developer portal](https://developers.partech.com)** — PAR Technology's portal for the Punchh Loyalty platform, migrated from a legacy platform to Scalar with a docs-as-code workflow in GitHub. The full story is in the [PAR case study](../guides/customers/partech.md).
 
 ## Get started
 
-[Start free](https://dashboard.scalar.com/register), review [pricing](/pricing), or [book a demo](https://scalar.cal.com/) and we will walk through your portal with you.
+[Start free](https://dashboard.scalar.com/register), review [pricing](../guides/pricing.md), or [book a demo](https://scalar.cal.com/) and we will walk through your portal with you.
 
 ---
 

--- a/documentation/solutions/openapi-documentation.md
+++ b/documentation/solutions/openapi-documentation.md
@@ -22,8 +22,8 @@ Your OpenAPI document is the input for every interface Scalar produces:
 
 - **An interactive API reference.** Every operation, schema, and example in the document is rendered as browsable documentation with code samples for popular HTTP clients and languages, and a "Test Request" button on every operation.
 - **An API client.** A standalone, open-source client — desktop and web, offline-first, with environments, Postman-compatible scripting, and code generation for 40+ HTTP clients. It imports the same document your docs are built from.
-- **SDKs.** The [SDK generator](/products/sdk-generator/getting-started) compiles the document into client libraries. `docs` is a build target alongside the language targets: one generation run emits the SDKs, a static API reference, and the exact augmented document both were produced from. The reference and the client libraries cannot describe different APIs, because they come from the same compiled document in the same run.
-- **An MCP server.** Scalar spins up [MCP servers](/products/agent/mcp) from your OpenAPI document, so AI agents can call the endpoints you choose to expose, with the authentication you configure.
+- **SDKs.** The [SDK generator](../guides/sdks/getting-started.md) compiles the document into client libraries. `docs` is a build target alongside the language targets: one generation run emits the SDKs, a static API reference, and the exact augmented document both were produced from. The reference and the client libraries cannot describe different APIs, because they come from the same compiled document in the same run.
+- **An MCP server.** Scalar spins up [MCP servers](../guides/agent/mcp.md) from your OpenAPI document, so AI agents can call the endpoints you choose to expose, with the authentication you configure.
 
 The phrase "single source of truth" gets used loosely in this category. Here it is literal: the OpenAPI document is the artifact everything else is generated from, and there is no second copy to drift.
 
@@ -31,20 +31,20 @@ The phrase "single source of truth" gets used loosely in this category. Here it 
 
 Scalar renders documents that follow the Swagger 2.0, OpenAPI 3.0, or OpenAPI 3.1 specification. Swagger 2.0 documents are upgraded on load, so a legacy document works without a manual conversion step first.
 
-The upgrade logic is itself an open tool: [`@scalar/openapi-upgrader`](/tools/openapi-upgrader/getting-started) converts Swagger 2.0 to OpenAPI 3.0 or 3.1 (with experimental support for OpenAPI 3.2), as an npm package or a one-line CLI command:
+The upgrade logic is itself an open tool: [`@scalar/openapi-upgrader`](../guides/openapi-upgrader/getting-started.md) converts Swagger 2.0 to OpenAPI 3.0 or 3.1 (with experimental support for OpenAPI 3.2), as an npm package or a one-line CLI command:
 
 ```bash
 npx @scalar/cli document upgrade swagger.json --output openapi.json
 ```
 
-Scalar also reads a set of [OpenAPI extensions](/products/api-references/openapi) — `x-codeSamples` for custom SDK snippets, `x-tagGroups` for sidebar grouping, `x-scalar-ignore` for hiding operations, and others — including extensions written by other tools such as Stainless and ReadMe, so a document generated elsewhere renders correctly without edits.
+Scalar also reads a set of [OpenAPI extensions](../openapi.md) — `x-codeSamples` for custom SDK snippets, `x-tagGroups` for sidebar grouping, `x-scalar-ignore` for hiding operations, and others — including extensions written by other tools such as Stainless and ReadMe, so a document generated elsewhere renders correctly without edits.
 
 ## How the documentation stays in sync
 
-The reference updates whenever the OpenAPI document changes. There are a few ways to wire that up, documented in the [deployment guides](/products/docs/deployment/automatic-deployment):
+The reference updates whenever the OpenAPI document changes. There are a few ways to wire that up, documented in the [deployment guides](../guides/docs/deployment/automatic-deployment.md):
 
-- **Git.** Keep the document in your repository and enable automatic deployment: every merge into your default branch republishes the docs. Preview deployments and a [GitHub Actions workflow](/products/docs/deployment/github-actions) are available when you want more control.
-- **The Registry.** If your docs reference an OpenAPI document from the [Scalar Registry](/products/registry/getting-started), updating that Registry document also triggers the docs to publish again.
+- **Git.** Keep the document in your repository and enable automatic deployment: every merge into your default branch republishes the docs. Preview deployments and a [GitHub Actions workflow](../guides/docs/deployment/github-actions.md) are available when you want more control.
+- **The Registry.** If your docs reference an OpenAPI document from the [Scalar Registry](../guides/registry/getting-started.md), updating that Registry document also triggers the docs to publish again.
 - **The CLI.** `npx @scalar/cli project publish` deploys from your terminal or any CI/CD environment, without granting repository access.
 
 There is no step where documentation is written separately from the API description and then reconciled. The document changes; the reference follows.
@@ -61,7 +61,7 @@ Scalar ships more than 35 framework integrations, so the reference can be mounte
 - **Java**: Spring Boot, Micronaut
 - **Go**, **Rust** (Actix Web, Axum, warp), and **Elixir**
 
-If your framework is not on the list, the plain [HTML integration](/products/api-references/integrations/html-js) is a single script tag:
+If your framework is not on the list, the plain [HTML integration](../integrations/html-js.md) is a single script tag:
 
 ```html
 <div id="app"></div>
@@ -92,8 +92,8 @@ The MIT-licensed renderer is free regardless of plan, on your own infrastructure
 
 ## Where to go next
 
-- [Scalar Docs](/products/docs/getting-started) — hosted documentation sites with guides, versions, and Git Sync
-- [API Reference quickstart](/products/api-references/getting-started) — render an OpenAPI document in a few lines of code
+- [Scalar Docs](../guides/docs/getting-started.md) — hosted documentation sites with guides, versions, and Git Sync
+- [API Reference quickstart](../guides/api-references/getting-started.md) — render an OpenAPI document in a few lines of code
 - [Create a free account](https://dashboard.scalar.com/register) — hosted docs from your OpenAPI document, at $0
 
 ---


### PR DESCRIPTION
Many docs pages linked to each other with absolute site routes like `/pricing` or `/products/docs`. This switches those to relative file links (`../guides/pricing.md`), so they work in more places (editors, GitHub, previews) and are easier to keep correct.

Scope: only Markdown-syntax `](/..)` links that the docs config maps to a real page. Left untouched: external URLs, in-page examples inside code blocks, asset paths, and a few section landing routes with no page file.