### PR TITLE
chore: auto-generate the monthly top contributors image

### DIFF
--- a/.github/assets/contributors/top-contributors-dark.svg
+++ b/.github/assets/contributors/top-contributors-dark.svg
@@ -1,0 +1,147 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <foreignObject width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml" class="fixme">
+            <div class="markdown-body">
+              <div class="banner-bunny-bounce">
+                <div class="banner">
+                  <div class="banner-text banner-text-oner"></div>
+                  <div class="banner-bunny">
+                    <pre class="markdown-code visible">              ____
+|~~~ \       |     \         |
+| |   \______\ (..) /|_______:_ 
+|_|___        \_~~_/   ``````|/
+\_|__/--,   ,=========(_____/:  
+        '___\       /        |
+             \     |
+              \____|</pre>
+                    <pre class="markdown-code hidden">              ____
+|~~~ \       |     \         :
+| |   \______\ (..) /|_______|_ 
+|_|___        \_~~_/   ``````|/
+\_|__/--,   ,=========(_____/|  
+        '___\       /        :
+             \     |
+              \____|</pre>
+                  </div>
+                </div>
+              </div>
+              <div class="banner-bunny-bounce banner-bunny-bounce2">
+                <div class="banner">
+                  <div class="banner-text banner-text-twoer"></div>
+                  <div class="banner-bunny">
+                    <pre class="markdown-code visible">              ____
+|~~~ \       |     \         |
+| |   \______\ (..) /|_______:_ 
+|_|___        \_~~_/   ``````|/
+\_|__/--,   ,=========(_____/:  
+        '___\       /        |
+             \     |
+              \____|</pre>
+                    <pre class="markdown-code hidden">              ____
+|~~~ \       |     \         :
+| |   \______\ (..) /|_______|_ 
+|_|___        \_~~_/   ``````|/
+\_|__/--,   ,=========(_____/|  
+        '___\       /        :
+             \     |
+              \____|</pre>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <style>
+              * { margin: 0; padding: 0; box-sizing: border-box; }
+              .markdown-code {
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+                white-space: pre;
+                font-size: 10px;
+              }
+              .markdown-body {
+                gap: 18px;
+                display: flex;
+                color: #e7e7e7;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+              }
+              .fixme { position: relative; }
+              .banner {
+                width: 700px;
+                height: 70px;
+                display: flex;
+                align-items: center;
+                transform: rotate(3deg);
+                top: 50px;
+                position: absolute;
+                animation: bannermove 10s infinite linear;
+              }
+              .banner-bunny-bounce2 { top: 100px; left: -100px; position: absolute; }
+              .banner-bunny-bounce2 .banner { animation: bannermove 9s infinite linear; }
+              .banner-text {
+                width: 100%;
+                background: #069061;
+                height: 38px;
+                line-height: 38px;
+                position: relative;
+                text-align: center;
+                color: white;
+                font-weight: bold;
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+                margin-top: 12px;
+                margin-right: -3px;
+              }
+              .banner-text-oner { animation: bannerbgchange 50s steps(5) infinite; }
+              @keyframes bannerbgchange {
+                0%, 20% { background: #069061; }
+                20.1%, 40% { background: #dc1b19; }
+                40.1%, 60% { background: #edbe20; }
+                60.1%, 80% { background: #069061; }
+                80.1%, 100% { background: #5203d1; }
+              }
+              .banner-text-twoer { animation: bannerbgchangetwoer 45s steps(5) infinite; }
+              @keyframes bannerbgchangetwoer {
+                0%, 20% { background: #0082d0; }
+                20.1%, 40% { background: #fb892c; }
+                40.1%, 60% { background: black; }
+                60.1%, 80% { background: #0082d0; }
+                80.1%, 100% { background: #fb2c90; }
+              }
+              .banner-text-oner:before {
+                content: "#1 hanspagel - 45 commits 14,224 ++ 1,382 --";
+                animation: bannertextchange 50s infinite linear;
+              }
+              @keyframes bannertextchange {
+                0%, 20% { content: "#1 hanspagel - 45 commits 14,224 ++ 1,382 --"; }
+                20.1%, 40% { content: "#3 bielu - 9 commits 7,907 ++ 739 --"; }
+                40.1%, 60% { content: "#5 amritk - 5 commits 1,161 ++ 742 --"; }
+                60.1%, 80% { content: "#7 lazerg - 2 commits 368 ++ 18 --"; }
+                80.1%, 100% { content: "#9 bgrcs - 1 commits 1,480 ++ 148 --"; }
+              }
+              .banner-text-twoer:before {
+                content: "#2 marclave - 33 commits 4,853 ++ 1,349 --";
+                animation: bannertexttwochange 45s infinite linear;
+              }
+              @keyframes bannertexttwochange {
+                0%, 20% { content: "#2 marclave - 33 commits 4,853 ++ 1,349 --"; }
+                20.1%, 40% { content: "#4 hwkr - 8 commits 1,118 ++ 237 --"; }
+                40.1%, 60% { content: "#6 cameronrohani - 4 commits 935 ++ 850 --"; }
+                60.1%, 80% { content: "#8 guillaume-flambard - 2 commits 223 ++ 6 --"; }
+                80.1%, 100% { content: "#10 aqeelat - 1 commits 683 ++ 4 --"; }
+              }
+              .banner-bunny-bounce2 .banner-text { background: #0082d0; }
+              .banner-bunny { background: transparent; width: 190px; height: 80px; z-index: 10; position: relative; }
+              .visible { opacity: 0; animation: rabbitanimation2 .5s steps(1) infinite; }
+              .hidden { position: absolute; top: 0; opacity: 1; animation: rabbitanimation .5s steps(1) infinite; }
+              .banner-bunny-bounce { animation: bannerbunnybounce .5s steps(2) infinite; }
+              @keyframes bannerbunnybounce {
+                0% { transform: translate3d(0,3px,0); }
+                100% { transform: translate3d(0,0,0); }
+              }
+              @keyframes bannermove {
+                0% { transform: translate3d(-100%,0,0) rotate(3deg); }
+                100% { transform: translate3d(140%,0,0) rotate(3deg); }
+              }
+              @keyframes rabbitanimation2 { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+              @keyframes rabbitanimation { 0%, 100% { opacity: 0; } 50% { opacity: 1; } }
+            </style>
+        </div>
+    </foreignObject>
+</svg>

--- a/.github/assets/contributors/top-contributors-light.svg
+++ b/.github/assets/contributors/top-contributors-light.svg
@@ -1,0 +1,147 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <foreignObject width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml" class="fixme">
+            <div class="markdown-body">
+              <div class="banner-bunny-bounce">
+                <div class="banner">
+                  <div class="banner-text banner-text-oner"></div>
+                  <div class="banner-bunny">
+                    <pre class="markdown-code visible">              ____
+|~~~ \       |     \         |
+| |   \______\ (..) /|_______:_ 
+|_|___        \_~~_/   ``````|/
+\_|__/--,   ,=========(_____/:  
+        '___\       /        |
+             \     |
+              \____|</pre>
+                    <pre class="markdown-code hidden">              ____
+|~~~ \       |     \         :
+| |   \______\ (..) /|_______|_ 
+|_|___        \_~~_/   ``````|/
+\_|__/--,   ,=========(_____/|  
+        '___\       /        :
+             \     |
+              \____|</pre>
+                  </div>
+                </div>
+              </div>
+              <div class="banner-bunny-bounce banner-bunny-bounce2">
+                <div class="banner">
+                  <div class="banner-text banner-text-twoer"></div>
+                  <div class="banner-bunny">
+                    <pre class="markdown-code visible">              ____
+|~~~ \       |     \         |
+| |   \______\ (..) /|_______:_ 
+|_|___        \_~~_/   ``````|/
+\_|__/--,   ,=========(_____/:  
+        '___\       /        |
+             \     |
+              \____|</pre>
+                    <pre class="markdown-code hidden">              ____
+|~~~ \       |     \         :
+| |   \______\ (..) /|_______|_ 
+|_|___        \_~~_/   ``````|/
+\_|__/--,   ,=========(_____/|  
+        '___\       /        :
+             \     |
+              \____|</pre>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <style>
+              * { margin: 0; padding: 0; box-sizing: border-box; }
+              .markdown-code {
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+                white-space: pre;
+                font-size: 10px;
+              }
+              .markdown-body {
+                gap: 18px;
+                display: flex;
+                color: #1b1b1b;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+              }
+              .fixme { position: relative; }
+              .banner {
+                width: 700px;
+                height: 70px;
+                display: flex;
+                align-items: center;
+                transform: rotate(3deg);
+                top: 50px;
+                position: absolute;
+                animation: bannermove 10s infinite linear;
+              }
+              .banner-bunny-bounce2 { top: 100px; left: -100px; position: absolute; }
+              .banner-bunny-bounce2 .banner { animation: bannermove 9s infinite linear; }
+              .banner-text {
+                width: 100%;
+                background: #069061;
+                height: 38px;
+                line-height: 38px;
+                position: relative;
+                text-align: center;
+                color: white;
+                font-weight: bold;
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+                margin-top: 12px;
+                margin-right: -3px;
+              }
+              .banner-text-oner { animation: bannerbgchange 50s steps(5) infinite; }
+              @keyframes bannerbgchange {
+                0%, 20% { background: #069061; }
+                20.1%, 40% { background: #dc1b19; }
+                40.1%, 60% { background: #edbe20; }
+                60.1%, 80% { background: #069061; }
+                80.1%, 100% { background: #5203d1; }
+              }
+              .banner-text-twoer { animation: bannerbgchangetwoer 45s steps(5) infinite; }
+              @keyframes bannerbgchangetwoer {
+                0%, 20% { background: #0082d0; }
+                20.1%, 40% { background: #fb892c; }
+                40.1%, 60% { background: black; }
+                60.1%, 80% { background: #0082d0; }
+                80.1%, 100% { background: #fb2c90; }
+              }
+              .banner-text-oner:before {
+                content: "#1 hanspagel - 45 commits 14,224 ++ 1,382 --";
+                animation: bannertextchange 50s infinite linear;
+              }
+              @keyframes bannertextchange {
+                0%, 20% { content: "#1 hanspagel - 45 commits 14,224 ++ 1,382 --"; }
+                20.1%, 40% { content: "#3 bielu - 9 commits 7,907 ++ 739 --"; }
+                40.1%, 60% { content: "#5 amritk - 5 commits 1,161 ++ 742 --"; }
+                60.1%, 80% { content: "#7 lazerg - 2 commits 368 ++ 18 --"; }
+                80.1%, 100% { content: "#9 bgrcs - 1 commits 1,480 ++ 148 --"; }
+              }
+              .banner-text-twoer:before {
+                content: "#2 marclave - 33 commits 4,853 ++ 1,349 --";
+                animation: bannertexttwochange 45s infinite linear;
+              }
+              @keyframes bannertexttwochange {
+                0%, 20% { content: "#2 marclave - 33 commits 4,853 ++ 1,349 --"; }
+                20.1%, 40% { content: "#4 hwkr - 8 commits 1,118 ++ 237 --"; }
+                40.1%, 60% { content: "#6 cameronrohani - 4 commits 935 ++ 850 --"; }
+                60.1%, 80% { content: "#8 guillaume-flambard - 2 commits 223 ++ 6 --"; }
+                80.1%, 100% { content: "#10 aqeelat - 1 commits 683 ++ 4 --"; }
+              }
+              .banner-bunny-bounce2 .banner-text { background: #0082d0; }
+              .banner-bunny { background: transparent; width: 190px; height: 80px; z-index: 10; position: relative; }
+              .visible { opacity: 0; animation: rabbitanimation2 .5s steps(1) infinite; }
+              .hidden { position: absolute; top: 0; opacity: 1; animation: rabbitanimation .5s steps(1) infinite; }
+              .banner-bunny-bounce { animation: bannerbunnybounce .5s steps(2) infinite; }
+              @keyframes bannerbunnybounce {
+                0% { transform: translate3d(0,3px,0); }
+                100% { transform: translate3d(0,0,0); }
+              }
+              @keyframes bannermove {
+                0% { transform: translate3d(-100%,0,0) rotate(3deg); }
+                100% { transform: translate3d(140%,0,0) rotate(3deg); }
+              }
+              @keyframes rabbitanimation2 { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+              @keyframes rabbitanimation { 0%, 100% { opacity: 0; } 50% { opacity: 1; } }
+            </style>
+        </div>
+    </foreignObject>
+</svg>

--- a/.github/workflows/update-monthly-contributors.yml
+++ b/.github/workflows/update-monthly-contributors.yml
@@ -1,0 +1,71 @@
+name: Update Monthly Contributors in README
+
+on:
+  schedule:
+    # Run on the first day of every month at 06:00 UTC (for the previous month)
+    - cron: '0 6 1 * *'
+  # Allow running it by hand from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-readme:
+    name: Update the monthly contributors image
+    if: ${{ github.repository_owner == 'scalar' }}
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    # Holds the release bot app credentials so the README PR is opened by the
+    # app rather than by GITHUB_TOKEN. Pull requests created with GITHUB_TOKEN
+    # do not trigger workflow events, so their CI checks stay pending forever.
+    environment: release-bot
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate the monthly contributors image
+        run: pnpm --filter @scalar-internal/build-scripts start generate-monthly-contributors
+        env:
+          # A token lifts the GitHub API rate limit while listing commits.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: chore/update-monthly-contributors
+          commit-message: 'docs: update monthly contributors'
+          title: 'docs: update monthly contributors'
+          body: Auto-generated image of last month's top contributors.
+          draft: true
+          add-paths: |
+            README.md
+            .github/assets/contributors/*.svg

--- a/README.md
+++ b/README.md
@@ -230,12 +230,14 @@ We are API nerds. You too? Let's chat on Discord: <https://discord.gg/scalar>
 
 Contributions are welcome! Read the [`CONTRIBUTING`](CONTRIBUTING.md) guide.
 
-**Top 10 Contributors (April 2025)**
+**Top Contributors (Last Month)**
 
+<!-- monthly-contributors:start -->
 <p>
-	<img width="830" height="280" src="https://github.com/user-attachments/assets/8c10d2aa-9eb4-4818-9ca2-625cfed5ca08#gh-light-mode-only">
-	<img width="830" height="280" src="https://github.com/user-attachments/assets/50b9b042-107e-4167-9c7f-94497f85d2e0#gh-dark-mode-only">
+	<img width="830" height="280" src="./.github/assets/contributors/top-contributors-light.svg?v=2026-07#gh-light-mode-only" alt="Top contributors in July 2026">
+	<img width="830" height="280" src="./.github/assets/contributors/top-contributors-dark.svg?v=2026-07#gh-dark-mode-only" alt="Top contributors in July 2026">
 </p>
+<!-- monthly-contributors:end -->
 
 <br>
 <br>

--- a/tooling/scripts/src/cli.ts
+++ b/tooling/scripts/src/cli.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 
 import { cat } from '@/commands/cat'
 import { generateBlog } from '@/commands/generate-blog'
+import { generateMonthlyContributors } from '@/commands/generate-monthly-contributors'
 import { generateReadme } from '@/commands/generate-readme'
 import { packages } from '@/commands/packages'
 import { updatePlaywrightDocker } from '@/commands/playwright-docker/push-container'
@@ -26,4 +27,5 @@ program.addCommand(run)
 program.addCommand(updatePlaywrightDocker)
 program.addCommand(generateReadme)
 program.addCommand(generateBlog)
+program.addCommand(generateMonthlyContributors)
 program.parse()

--- a/tooling/scripts/src/commands/generate-monthly-contributors.test.ts
+++ b/tooling/scripts/src/commands/generate-monthly-contributors.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  aggregateMonthly,
+  formatEntry,
+  isBot,
+  renderSvg,
+  resolveRange,
+  selectTop,
+  updateReadme,
+} from './generate-monthly-contributors'
+
+const range = resolveRange('2026-07')
+
+describe('resolveRange', () => {
+  it('defaults to the previous full month', () => {
+    const result = resolveRange(undefined, new Date('2026-08-11T00:00:00Z'))
+
+    expect(result.slug).toBe('2026-07')
+    expect(result.label).toBe('July 2026')
+    expect(result.since).toBe('2026-07-01T00:00:00.000Z')
+    expect(result.until).toBe('2026-08-01T00:00:00.000Z')
+  })
+
+  it('handles the January rollover into the previous year', () => {
+    const result = resolveRange(undefined, new Date('2026-01-05T00:00:00Z'))
+
+    expect(result.slug).toBe('2025-12')
+    expect(result.label).toBe('December 2025')
+  })
+
+  it('exposes unix bounds for week bucketing', () => {
+    expect(range.sinceUnix).toBe(Date.UTC(2026, 6, 1) / 1000)
+    expect(range.untilUnix).toBe(Date.UTC(2026, 7, 1) / 1000)
+  })
+})
+
+describe('isBot', () => {
+  it('keeps regular users, including staff', () => {
+    expect(isBot('hanspagel', 'User')).toBe(false)
+  })
+
+  it('drops accounts of type Bot', () => {
+    expect(isBot('some-app', 'Bot')).toBe(true)
+  })
+
+  it('drops logins ending in [bot]', () => {
+    expect(isBot('renovate[bot]', 'User')).toBe(true)
+  })
+
+  it('drops AI agents and bot-like accounts on the denylist', () => {
+    expect(isBot('scalar-release-bot', 'User')).toBe(true)
+    expect(isBot('claude', 'User')).toBe(true)
+    expect(isBot('junie-agent', 'User')).toBe(true)
+  })
+})
+
+describe('aggregateMonthly', () => {
+  const inMonth = range.sinceUnix + 60
+  const beforeMonth = range.sinceUnix - 60
+
+  it('sums only the weeks inside the month and skips bots', () => {
+    const contributors = aggregateMonthly(
+      [
+        {
+          author: { login: 'human', type: 'User' },
+          weeks: [
+            { w: inMonth, a: 100, d: 10, c: 3 },
+            { w: beforeMonth, a: 999, d: 99, c: 9 },
+          ],
+        },
+        { author: { login: 'ci[bot]', type: 'Bot' }, weeks: [{ w: inMonth, a: 1, d: 1, c: 5 }] },
+        { author: null, weeks: [{ w: inMonth, a: 1, d: 1, c: 5 }] },
+      ],
+      range,
+    )
+
+    expect(contributors).toEqual([{ login: 'human', commits: 3, additions: 100, deletions: 10 }])
+  })
+})
+
+describe('selectTop', () => {
+  it('ranks by commits, then additions, then login', () => {
+    const top = selectTop(
+      [
+        { login: 'b', commits: 5, additions: 10, deletions: 0 },
+        { login: 'a', commits: 5, additions: 99, deletions: 0 },
+        { login: 'c', commits: 9, additions: 1, deletions: 0 },
+      ],
+      2,
+    )
+
+    expect(top.map((contributor) => contributor.login)).toEqual(['c', 'a'])
+  })
+})
+
+describe('formatEntry', () => {
+  it('formats a banner line with rank, commits and thousands separators', () => {
+    expect(formatEntry({ login: 'hanspagel', commits: 45, additions: 14224, deletions: 1382 }, 1)).toBe(
+      '#1 hanspagel - 45 commits 14,224 ++ 1,382 --',
+    )
+  })
+})
+
+describe('renderSvg', () => {
+  const entries = ['#1 a - 1 commits 1 ++ 1 --', '#2 b - 1 commits 1 ++ 1 --', '#3 c - 1 commits 1 ++ 1 --']
+
+  it('renders the animated planes with fresh data', () => {
+    const svg = renderSvg(entries, 'dark')
+
+    expect(svg).toContain('<foreignObject')
+    expect(svg).toContain('@keyframes bannermove')
+    // Odd ranks go on banner one, even ranks on banner two.
+    expect(svg).toContain('content: "#1 a - 1 commits 1 ++ 1 --"')
+    expect(svg).toContain('content: "#3 c - 1 commits 1 ++ 1 --"')
+    expect(svg).toContain('content: "#2 b - 1 commits 1 ++ 1 --"')
+    // Dark theme text color.
+    expect(svg).toContain('#e7e7e7')
+  })
+
+  it('keeps the ASCII plane intact with its backslashes', () => {
+    const svg = renderSvg(entries, 'light')
+
+    expect(svg).toContain('(..)')
+    expect(svg).toContain('\\_|__/--,')
+    expect(svg).toContain('#1b1b1b')
+  })
+})
+
+describe('updateReadme', () => {
+  it('replaces the block between the markers and bumps the cache-busting query', () => {
+    const readme = [
+      'before',
+      '<!-- monthly-contributors:start -->',
+      'old',
+      '<!-- monthly-contributors:end -->',
+      'after',
+    ].join('\n')
+
+    const result = updateReadme(readme, range)
+
+    expect(result).toContain('top-contributors-light.svg?v=2026-07#gh-light-mode-only')
+    expect(result).toContain('top-contributors-dark.svg?v=2026-07#gh-dark-mode-only')
+    expect(result).toContain('before')
+    expect(result).toContain('after')
+    expect(result).not.toContain('old')
+  })
+
+  it('throws when the markers are missing', () => {
+    expect(() => updateReadme('no markers here', range)).toThrow()
+  })
+})

--- a/tooling/scripts/src/commands/generate-monthly-contributors.ts
+++ b/tooling/scripts/src/commands/generate-monthly-contributors.ts
@@ -1,0 +1,407 @@
+// Checkout /tooling/scripts/README.md for more information on how to use this command.
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import as from 'ansis'
+import { Command } from 'commander'
+
+import { getWorkspaceRoot } from '@/helpers'
+
+// The repository we count contributions for.
+const OWNER = 'scalar'
+const REPO = 'scalar'
+
+// Where the generated images live, relative to the repository root.
+const ASSETS_DIR = '.github/assets/contributors'
+
+// How many contributors we show, split across the two flying banners.
+const TOP_N = 10
+
+// Bot accounts never show up in the list, even though staff members do. Logins
+// ending in `[bot]` and accounts of type `Bot` are filtered automatically. This
+// denylist catches bot-like and AI agent accounts that GitHub reports as `User`.
+const BOT_DENYLIST = new Set([
+  'scalar-release-bot',
+  'renovate',
+  'dependabot',
+  'cobyfrombrooklyn-bot',
+  'claude',
+  'junie-agent',
+  'cursor',
+  'cursoragent',
+  'devin-ai-integration',
+  'copilot',
+])
+
+// --- Types -----------------------------------------------------------------
+
+type WeekStat = { w: number; a: number; d: number; c: number }
+
+type StatsContributor = {
+  author: { login: string; type: string } | null
+  weeks: WeekStat[]
+}
+
+type Contributor = {
+  login: string
+  commits: number
+  additions: number
+  deletions: number
+}
+
+type MonthRange = {
+  /** ISO start of the month, inclusive. */
+  since: string
+  /** ISO start of the next month, exclusive. */
+  until: string
+  /** Unix seconds for the start of the month. */
+  sinceUnix: number
+  /** Unix seconds for the start of the next month. */
+  untilUnix: number
+  /** Machine friendly month, for example `2026-07`. */
+  slug: string
+  /** Human friendly month, for example `July 2026`. */
+  label: string
+}
+
+// --- Command ---------------------------------------------------------------
+
+export const generateMonthlyContributors = new Command('generate-monthly-contributors')
+  .description('Refresh the animated top contributors image and the README')
+  .option('-m, --month <YYYY-MM>', 'The month to generate, defaults to the previous full month')
+  .action(async ({ month }: { month?: string }) => {
+    const range = resolveRange(month)
+    console.log(as.cyan(`Refreshing top contributors for ${as.bold(range.label)}...`))
+
+    const token = process.env.GITHUB_TOKEN
+    const stats = await fetchContributorStats(token)
+    const ranked = selectTop(aggregateMonthly(stats, range), TOP_N)
+
+    if (ranked.length === 0) {
+      console.log(as.yellow('No human contributors found for this month. Nothing to generate.'))
+      return
+    }
+
+    console.log(as.cyan(`Top ${ranked.length}: ${ranked.map((contributor) => contributor.login).join(', ')}`))
+    const entries = ranked.map((contributor, index) => formatEntry(contributor, index + 1))
+
+    const root = getWorkspaceRoot()
+    const assetsDir = path.join(root, ASSETS_DIR)
+    await fs.mkdir(assetsDir, { recursive: true })
+    await fs.writeFile(path.join(assetsDir, 'top-contributors-light.svg'), renderSvg(entries, 'light'))
+    await fs.writeFile(path.join(assetsDir, 'top-contributors-dark.svg'), renderSvg(entries, 'dark'))
+
+    const readmePath = path.join(root, 'README.md')
+    const readme = await fs.readFile(readmePath, 'utf-8')
+    await fs.writeFile(readmePath, updateReadme(readme, range))
+
+    console.log(as.green(`✔ Updated the README and images for ${range.label}`))
+  })
+
+// --- Data ------------------------------------------------------------------
+
+/**
+ * Resolves the month to generate. Without an explicit month we use the previous
+ * full month, which is what the scheduled workflow wants on the first of a month.
+ */
+export function resolveRange(month?: string, now = new Date()): MonthRange {
+  const target =
+    month !== undefined
+      ? new Date(Date.UTC(Number(month.slice(0, 4)), Number(month.slice(5, 7)) - 1, 1))
+      : new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))
+
+  const start = new Date(Date.UTC(target.getUTCFullYear(), target.getUTCMonth(), 1))
+  const end = new Date(Date.UTC(target.getUTCFullYear(), target.getUTCMonth() + 1, 1))
+
+  return {
+    since: start.toISOString(),
+    until: end.toISOString(),
+    sinceUnix: Math.floor(start.getTime() / 1000),
+    untilUnix: Math.floor(end.getTime() / 1000),
+    slug: `${start.getUTCFullYear()}-${String(start.getUTCMonth() + 1).padStart(2, '0')}`,
+    label: start.toLocaleString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' }),
+  }
+}
+
+/**
+ * Fetches per-contributor weekly stats. GitHub computes these asynchronously and
+ * answers with `202` while the cache is warming up, so we retry a few times.
+ */
+async function fetchContributorStats(token?: string): Promise<StatsContributor[]> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'scalar-monthly-contributors',
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const response = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/stats/contributors`, { headers })
+
+    if (response.status === 202) {
+      // Stats are being generated, wait and try again.
+      await sleep(3000)
+      continue
+    }
+    if (!response.ok) {
+      throw new Error(`GitHub API request failed (${response.status}): ${await response.text()}`)
+    }
+
+    return (await response.json()) as StatsContributor[]
+  }
+
+  throw new Error('GitHub did not finish computing contributor stats in time')
+}
+
+/** Sums the weekly stats that fall within the month, dropping bots. */
+export function aggregateMonthly(stats: StatsContributor[], range: MonthRange): Contributor[] {
+  const contributors: Contributor[] = []
+
+  for (const { author, weeks } of stats) {
+    if (!author || isBot(author.login, author.type)) {
+      continue
+    }
+
+    let commits = 0
+    let additions = 0
+    let deletions = 0
+    for (const week of weeks) {
+      // A week is bucketed into the month that contains its (Sunday) start.
+      if (week.w >= range.sinceUnix && week.w < range.untilUnix) {
+        commits += week.c
+        additions += week.a
+        deletions += week.d
+      }
+    }
+
+    if (commits > 0) {
+      contributors.push({ login: author.login, commits, additions, deletions })
+    }
+  }
+
+  return contributors
+}
+
+/** Bots and AI agents are filtered out, human staff members are kept. */
+export function isBot(login: string, type: string): boolean {
+  return type === 'Bot' || login.endsWith('[bot]') || BOT_DENYLIST.has(login.toLowerCase())
+}
+
+/** Returns the top contributors, ranked by commits then additions then login. */
+export function selectTop(contributors: Contributor[], limit: number): Contributor[] {
+  return [...contributors]
+    .sort((a, b) => b.commits - a.commits || b.additions - a.additions || a.login.localeCompare(b.login))
+    .slice(0, limit)
+}
+
+/** Builds the banner text, for example `#1 hanspagel - 45 commits 14,224 ++ 1,382 --`. */
+export function formatEntry(contributor: Contributor, rank: number): string {
+  const additions = contributor.additions.toLocaleString('en-US')
+  const deletions = contributor.deletions.toLocaleString('en-US')
+  return `#${rank} ${contributor.login} - ${contributor.commits} commits ${additions} ++ ${deletions} --`
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+// --- Rendering -------------------------------------------------------------
+
+// The two flap frames of the ASCII plane. Kept as line arrays so the many
+// backslashes do not have to be escaped inside a template literal.
+const PLANE_FRAME_A = [
+  '              ____',
+  '|~~~ \\       |     \\         |',
+  '| |   \\______\\ (..) /|_______:_ ',
+  '|_|___        \\_~~_/   ``````|/',
+  '\\_|__/--,   ,=========(_____/:  ',
+  "        '___\\       /        |",
+  '             \\     |',
+  '              \\____|',
+].join('\n')
+
+const PLANE_FRAME_B = [
+  '              ____',
+  '|~~~ \\       |     \\         :',
+  '| |   \\______\\ (..) /|_______|_ ',
+  '|_|___        \\_~~_/   ``````|/',
+  '\\_|__/--,   ,=========(_____/|  ',
+  "        '___\\       /        :",
+  '             \\     |',
+  '              \\____|',
+].join('\n')
+
+/**
+ * Renders the animated contributors image: two ASCII planes that fly across the
+ * README, each cycling through five contributors. This mirrors the original
+ * hand-made SVG and only swaps in fresh data.
+ */
+export function renderSvg(entries: string[], theme: 'light' | 'dark'): string {
+  // Banner one carries the odd ranks (#1, #3, ...), banner two the even ranks.
+  const bannerOne = entries.filter((_, index) => index % 2 === 0)
+  const bannerTwo = entries.filter((_, index) => index % 2 === 1)
+
+  const textColor = theme === 'dark' ? '#e7e7e7' : '#1b1b1b'
+
+  return `<svg xmlns="http://www.w3.org/2000/svg">
+    <foreignObject width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml" class="fixme">
+            <div class="markdown-body">
+              <div class="banner-bunny-bounce">
+                <div class="banner">
+                  <div class="banner-text banner-text-oner"></div>
+                  ${renderPlane()}
+                </div>
+              </div>
+              <div class="banner-bunny-bounce banner-bunny-bounce2">
+                <div class="banner">
+                  <div class="banner-text banner-text-twoer"></div>
+                  ${renderPlane()}
+                </div>
+              </div>
+            </div>
+            <style>
+              * { margin: 0; padding: 0; box-sizing: border-box; }
+              .markdown-code {
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+                white-space: pre;
+                font-size: 10px;
+              }
+              .markdown-body {
+                gap: 18px;
+                display: flex;
+                color: ${textColor};
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+              }
+              .fixme { position: relative; }
+              .banner {
+                width: 700px;
+                height: 70px;
+                display: flex;
+                align-items: center;
+                transform: rotate(3deg);
+                top: 50px;
+                position: absolute;
+                animation: bannermove 10s infinite linear;
+              }
+              .banner-bunny-bounce2 { top: 100px; left: -100px; position: absolute; }
+              .banner-bunny-bounce2 .banner { animation: bannermove 9s infinite linear; }
+              .banner-text {
+                width: 100%;
+                background: #069061;
+                height: 38px;
+                line-height: 38px;
+                position: relative;
+                text-align: center;
+                color: white;
+                font-weight: bold;
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+                margin-top: 12px;
+                margin-right: -3px;
+              }
+              .banner-text-oner { animation: bannerbgchange 50s steps(5) infinite; }
+              @keyframes bannerbgchange {
+                0%, 20% { background: #069061; }
+                20.1%, 40% { background: #dc1b19; }
+                40.1%, 60% { background: #edbe20; }
+                60.1%, 80% { background: #069061; }
+                80.1%, 100% { background: #5203d1; }
+              }
+              .banner-text-twoer { animation: bannerbgchangetwoer 45s steps(5) infinite; }
+              @keyframes bannerbgchangetwoer {
+                0%, 20% { background: #0082d0; }
+                20.1%, 40% { background: #fb892c; }
+                40.1%, 60% { background: black; }
+                60.1%, 80% { background: #0082d0; }
+                80.1%, 100% { background: #fb2c90; }
+              }
+              .banner-text-oner:before {
+                content: "${bannerOne[0] ?? ''}";
+                animation: bannertextchange 50s infinite linear;
+              }
+              ${renderContentKeyframes('bannertextchange', bannerOne)}
+              .banner-text-twoer:before {
+                content: "${bannerTwo[0] ?? ''}";
+                animation: bannertexttwochange 45s infinite linear;
+              }
+              ${renderContentKeyframes('bannertexttwochange', bannerTwo)}
+              .banner-bunny-bounce2 .banner-text { background: #0082d0; }
+              .banner-bunny { background: transparent; width: 190px; height: 80px; z-index: 10; position: relative; }
+              .visible { opacity: 0; animation: rabbitanimation2 .5s steps(1) infinite; }
+              .hidden { position: absolute; top: 0; opacity: 1; animation: rabbitanimation .5s steps(1) infinite; }
+              .banner-bunny-bounce { animation: bannerbunnybounce .5s steps(2) infinite; }
+              @keyframes bannerbunnybounce {
+                0% { transform: translate3d(0,3px,0); }
+                100% { transform: translate3d(0,0,0); }
+              }
+              @keyframes bannermove {
+                0% { transform: translate3d(-100%,0,0) rotate(3deg); }
+                100% { transform: translate3d(140%,0,0) rotate(3deg); }
+              }
+              @keyframes rabbitanimation2 { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+              @keyframes rabbitanimation { 0%, 100% { opacity: 0; } 50% { opacity: 1; } }
+            </style>
+        </div>
+    </foreignObject>
+</svg>
+`
+}
+
+/** Renders the two flap frames of a single ASCII plane. */
+function renderPlane(): string {
+  return `<div class="banner-bunny">
+                    <pre class="markdown-code visible">${PLANE_FRAME_A}</pre>
+                    <pre class="markdown-code hidden">${PLANE_FRAME_B}</pre>
+                  </div>`
+}
+
+/**
+ * Builds a `@keyframes` rule that swaps the banner text between the given
+ * entries at equal intervals. CSS `content` cannot interpolate, so each entry
+ * simply holds for its slice of the timeline.
+ */
+function renderContentKeyframes(name: string, entries: string[]): string {
+  const count = Math.max(entries.length, 1)
+  const step = 100 / count
+
+  const frames = entries
+    .map((entry, index) => {
+      const start = index === 0 ? '0%' : `${trimNumber(index * step)}.1%`
+      const end = `${trimNumber((index + 1) * step)}%`
+      return `                ${start}, ${end} { content: "${entry}"; }`
+    })
+    .join('\n')
+
+  return `@keyframes ${name} {\n${frames}\n              }`
+}
+
+/** Formats a percentage without noisy trailing zeros (20 -> "20", 33.33 -> "33.3"). */
+function trimNumber(value: number): string {
+  return Number(value.toFixed(1)).toString()
+}
+
+// --- README ----------------------------------------------------------------
+
+const START_MARKER = '<!-- monthly-contributors:start -->'
+const END_MARKER = '<!-- monthly-contributors:end -->'
+
+/** Replaces the content between the markers, bumping the cache-busting query. */
+export function updateReadme(readme: string, range: MonthRange): string {
+  // The `?v=` query busts GitHub's image proxy cache when the file is replaced.
+  // The `#gh-*-mode-only` fragments let GitHub pick the light or dark variant.
+  const block = `${START_MARKER}
+<p>
+	<img width="830" height="280" src="./${ASSETS_DIR}/top-contributors-light.svg?v=${range.slug}#gh-light-mode-only" alt="Top contributors in ${range.label}">
+	<img width="830" height="280" src="./${ASSETS_DIR}/top-contributors-dark.svg?v=${range.slug}#gh-dark-mode-only" alt="Top contributors in ${range.label}">
+</p>
+${END_MARKER}`
+
+  const pattern = new RegExp(`${START_MARKER}[\\s\\S]*?${END_MARKER}`)
+  if (!pattern.test(readme)) {
+    throw new Error(`Could not find the ${START_MARKER} ... ${END_MARKER} block in the README`)
+  }
+
+  return readme.replace(pattern, block)
+}


### PR DESCRIPTION
The README top-contributors image was stuck on April 2025.

This adds a small script and a monthly GitHub Action that rebuild the same animated "planes" image for the previous month and open a PR on their own. Same design as before, just fresh names, commits and +/- lines.

Bots and AI agents (release bot, renovate, `claude`, `junie-agent`, ...) are left out.

The committed SVGs already hold Julys data. To watch it animate, open the README on this branch. You can also run it by hand:

```
pnpm --filter @scalar-internal/build-scripts start generate-monthly-contributors --month 2026-07
```

https://github.com/user-attachments/assets/94ff23ee-3a24-4816-b813-cdd4609dfb5c
