### PR TITLE
fix(agent-chat): do not send message while composing IME input

### DIFF
--- a/.changeset/agent-chat-ime-enter.md
+++ b/.changeset/agent-chat-ime-enter.md
@@ -1,0 +1,5 @@
+---
+'@scalar/agent-chat': patch
+---
+
+Do not send the chat message while an IME composition is in progress. Pressing Enter to confirm Japanese, Chinese, or Korean input used to send the message too early and drop part of the text (macOS Chrome and Safari). Enter now sends only once composition has finished.

--- a/packages/agent-chat/src/views/PromptForm.vue
+++ b/packages/agent-chat/src/views/PromptForm.vue
@@ -65,6 +65,13 @@ watch(state.prompt, () => {
 })
 
 function handlePromptKeydown(e: KeyboardEvent) {
+  // Ignore the Enter that only commits an IME composition (e.g. Japanese, Chinese,
+  // Korean). On macOS Chrome that keydown still reports key === 'Enter' with
+  // isComposing === true, so without this guard the message sends mid-composition.
+  if (e.isComposing) {
+    return
+  }
+
   if (state.loading.value) {
     return
   }


### PR DESCRIPTION
## What

Pressing Enter to confirm Japanese (IME) input in the chat sent the message too early and dropped part of the text.

## Fix

Ignore Enter while an IME composition is still going. The message now only sends on a normal Enter.

## Notes

- Only happened on macOS Chrome/Safari. Windows was fine.
- Shift+Enter (new line) and normal Enter (send) still work.

Matches the same fix in the private repo (guide-layout / editor Ask AI). Reported by a Scalar Pro trial user.