### PR TITLE
feat(api-client): add WebSocket channel operations for AsyncAPI

### DIFF
--- a/.changeset/asyncapi-websocket-channel-operation.md
+++ b/.changeset/asyncapi-websocket-channel-operation.md
@@ -1,0 +1,20 @@
+---
+'@scalar/api-client': minor
+'@scalar/workspace-store': patch
+---
+
+feat: add WebSocket channel operation UI for AsyncAPI documents
+
+Introduce WebSocket testing experience for AsyncAPI channels in the API client.
+
+**@scalar/api-client**
+
+- Add `ChannelOperationBlock` and `ChannelOperation` feature: connect to a channel, edit path and query parameters, configure authentication, compose outgoing messages, and inspect a live message and connection log.
+- Add `channel-operation` playground (`pnpm dev:channel-operation`) with an echo WebSocket fixture for local development.
+- Apply selected security schemes to the connection URL on Connect (query `apiKey`, basic auth userinfo, bearer/OAuth `access_token`). Header-based API keys are reported as unsupported because browser `WebSocket` cannot set custom handshake headers.
+- Export `applyAuthToWebSocketUrl` and related helpers from the channel-operation block.
+
+**@scalar/workspace-store**
+
+- Enable document-level auth mutators for AsyncAPI documents so authentication selections and secrets persist in the workspace store.
+- Add `isWorkspaceDocument` type guard for shared document handling across OpenAPI and AsyncAPI shapes.

--- a/.changeset/asyncapi-websocket-channel-operation.md
+++ b/.changeset/asyncapi-websocket-channel-operation.md
@@ -3,18 +3,18 @@
 '@scalar/workspace-store': patch
 ---
 
-feat: add WebSocket channel operation UI for AsyncAPI documents
+feat: add WebSocket channel operations for AsyncAPI documents
 
-Introduce WebSocket testing experience for AsyncAPI channels in the API client.
+Introduce a WebSocket testing experience for AsyncAPI channels in the API client.
 
 **@scalar/api-client**
 
-- Add `ChannelOperationBlock` and `ChannelOperation` feature: connect to a channel, edit path and query parameters, configure authentication, compose outgoing messages, and inspect a live message and connection log.
-- Add `channel-operation` playground (`pnpm dev:channel-operation`) with an echo WebSocket fixture for local development.
+- Add `ChannelOperationBlock` and the `ChannelOperation` feature: connect to a channel, edit path and query parameters, configure authentication, compose outgoing messages, and inspect a live message and connection log.
+- Render AsyncAPI channels in the API client modal. When the active document is AsyncAPI, its channels appear in the sidebar and selecting one opens the channel connection view alongside the existing OpenAPI operation flow.
+- Build the connection URL from the current path and query parameters so edits in the parameter table change where the client connects.
 - Apply selected security schemes to the connection URL on Connect (query `apiKey`, basic auth userinfo, bearer/OAuth `access_token`). Header-based API keys are reported as unsupported because browser `WebSocket` cannot set custom handshake headers.
-- Export `applyAuthToWebSocketUrl` and related helpers from the channel-operation block.
+- Add a `channel-operation` playground (`pnpm dev:channel-operation`) for local development.
 
 **@scalar/workspace-store**
 
-- Enable document-level auth mutators for AsyncAPI documents so authentication selections and secrets persist in the workspace store.
-- Add `isWorkspaceDocument` type guard for shared document handling across OpenAPI and AsyncAPI shapes.
+- Resolve the messages a client can send from the operations the server receives. AsyncAPI describes operations from the application's point of view, so a client-sent message belongs to a `receive` operation.

--- a/.changeset/asyncapi-websocket-channel-operation.md
+++ b/.changeset/asyncapi-websocket-channel-operation.md
@@ -1,6 +1,7 @@
 ---
 '@scalar/api-client': minor
 '@scalar/workspace-store': patch
+'@scalar/sidebar': patch
 ---
 
 feat: add WebSocket channel operations for AsyncAPI documents
@@ -18,3 +19,7 @@ Introduce a WebSocket testing experience for AsyncAPI channels in the API client
 **@scalar/workspace-store**
 
 - Resolve the messages a client can send from the operations the server receives. AsyncAPI describes operations from the application's point of view, so a client-sent message belongs to a `receive` operation.
+
+**@scalar/sidebar**
+
+- Show AsyncAPI channels, operations, and messages in the client layout so channel entries are reachable in the API client sidebar.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -90,8 +90,10 @@
         "src/v2/features/environments/index.ts",
         "src/v2/features/modal/index.ts",
         "src/v2/features/operation/index.ts",
+        "src/v2/features/channel-operation/index.ts",
         "src/v2/features/search/index.ts",
         "src/plugins/posthog/index.ts",
+        "playground/channel-operation/main.ts",
         "playground/modal/main.ts",
         "playground/test/index.ts"
       ]

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -26,6 +26,7 @@
     "build": "vite build && pnpm build:styles && vue-tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "build:styles": "shx cp -r src/styles dist && tailwindcss --optimize -i src/style.css -o dist/style.css && cat dist/vue-styles.css >> dist/style.css",
     "dev": "vite ./playground/modal -c ./vite.config.ts",
+    "dev:channel-operation": "vite ./playground/channel-operation -c ./vite.config.ts",
     "preview": "vite preview",
     "test": "vitest --run",
     "test:benchmark": "vitest bench",
@@ -184,6 +185,16 @@
       "types": "./dist/v2/features/operation/index.d.ts",
       "default": "./dist/v2/features/operation/index.js"
     },
+    "./v2/features/channel-operation": {
+      "import": "./dist/v2/features/channel-operation/index.js",
+      "types": "./dist/v2/features/channel-operation/index.d.ts",
+      "default": "./dist/v2/features/channel-operation/index.js"
+    },
+    "./v2/blocks/channel-operation-block": {
+      "import": "./dist/v2/blocks/channel-operation-block/index.js",
+      "types": "./dist/v2/blocks/channel-operation-block/index.d.ts",
+      "default": "./dist/v2/blocks/channel-operation-block/index.js"
+    },
     "./v2/workspace-events": {
       "import": "./dist/v2/workspace-events.js",
       "types": "./dist/v2/workspace-events.d.ts",
@@ -288,6 +299,11 @@
       "import": "./dist/v2/features/operation/index.js",
       "types": "./dist/v2/features/operation/index.d.ts",
       "default": "./dist/v2/features/operation/index.js"
+    },
+    "./features/channel-operation": {
+      "import": "./dist/v2/features/channel-operation/index.js",
+      "types": "./dist/v2/features/channel-operation/index.d.ts",
+      "default": "./dist/v2/features/channel-operation/index.js"
     },
     "./features/search": {
       "import": "./dist/v2/features/search/index.js",

--- a/packages/api-client/playground/channel-operation/App.vue
+++ b/packages/api-client/playground/channel-operation/App.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { addScalarClassesToHeadless } from '@scalar/components/helpers'
+import { ScalarTeleportRoot } from '@scalar/components/teleport'
+import { ScalarToasts } from '@scalar/use-toasts'
+import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
+import { getActiveEnvironment } from '@scalar/workspace-store/request-example'
+import { isAsyncApiDocument } from '@scalar/workspace-store/schemas/type-guards'
+import { computed, onBeforeMount, onMounted, ref } from 'vue'
+
+import ChannelOperation from '@/v2/features/channel-operation/ChannelOperation.vue'
+import { initializeWorkspaceEventHandlers } from '@/v2/workspace-events'
+
+import {
+  ECHO_WEBSOCKET_CONNECTION_URL,
+  ECHO_WEBSOCKET_DEFAULT_CHANNEL,
+  ECHO_WEBSOCKET_DOCUMENT_SLUG,
+  echoWebsocketAsyncApiDocument,
+} from './fixtures/echo-websocket.asyncapi'
+
+const DOCUMENT_SLUG = ECHO_WEBSOCKET_DOCUMENT_SLUG
+
+const channelOptions = [
+  { id: 'echo', label: 'echo — WebSocket.org echo' },
+] as const
+
+const channelName = ref<string>(ECHO_WEBSOCKET_DEFAULT_CHANNEL)
+
+const workspaceStore = createWorkspaceStore({
+  meta: {
+    'x-scalar-active-document': DOCUMENT_SLUG,
+  },
+})
+
+// @ts-expect-error - For debugging purposes expose the store
+window.dataDumpWorkspace = () => workspaceStore
+
+const eventBus = createWorkspaceEventBus({
+  debug: import.meta.env.DEV,
+})
+
+initializeWorkspaceEventHandlers({
+  eventBus,
+  store: computed(() => workspaceStore),
+  hooks: {},
+})
+
+const loadError = ref<string | null>(null)
+const isLoading = ref(true)
+
+onBeforeMount(() => {
+  addScalarClassesToHeadless()
+})
+
+onMounted(async () => {
+  try {
+    await workspaceStore.addDocument({
+      name: DOCUMENT_SLUG,
+      document: echoWebsocketAsyncApiDocument,
+    })
+  } catch (error) {
+    loadError.value =
+      error instanceof Error
+        ? error.message
+        : 'Failed to load AsyncAPI document'
+  } finally {
+    isLoading.value = false
+  }
+})
+
+const document = computed(() => {
+  const entry = workspaceStore.workspace.documents[DOCUMENT_SLUG]
+  return entry && isAsyncApiDocument(entry) ? entry : null
+})
+
+const environment = computed(
+  () => getActiveEnvironment(workspaceStore, document.value).environment,
+)
+</script>
+
+<template>
+  <ScalarToasts />
+  <div class="bg-b-1 text-c-1 flex min-h-0 flex-1 flex-col">
+    <header class="border-b px-4 py-2">
+      <h1 class="text-c-1 text-sm font-medium">
+        Channel connection playground
+      </h1>
+      <p class="text-c-3 text-xs">
+        {{ DOCUMENT_SLUG }} · channel
+        <code class="font-code">{{ channelName }}</code>
+        ·
+        <code class="font-code">{{ ECHO_WEBSOCKET_CONNECTION_URL }}</code>
+      </p>
+      <p class="text-c-3 mt-1 text-xs">
+        One connection per channel — connect once, send and receive on the same
+        session (like Postman).
+      </p>
+      <div class="mt-2 flex flex-wrap gap-2">
+        <button
+          v-for="option in channelOptions"
+          :key="option.id"
+          class="text-xxs rounded border px-2 py-1"
+          :class="
+            channelName === option.id
+              ? 'border-c-1 bg-b-2 text-c-1'
+              : 'text-c-3 hover:bg-b-2 border-transparent'
+          "
+          type="button"
+          @click="channelName = option.id">
+          {{ option.label }}
+        </button>
+      </div>
+    </header>
+
+    <ScalarTeleportRoot class="flex min-h-0 flex-1 flex-col">
+      <div
+        v-if="isLoading"
+        class="text-c-3 flex flex-1 items-center justify-center text-sm">
+        Loading AsyncAPI document…
+      </div>
+
+      <div
+        v-else-if="loadError"
+        class="text-c-danger flex flex-1 items-center justify-center p-4 text-sm">
+        {{ loadError }}
+      </div>
+
+      <ChannelOperation
+        v-else-if="document"
+        :channelName="channelName"
+        class="min-h-0 flex-1"
+        :document="document"
+        :documentSlug="DOCUMENT_SLUG"
+        :environment="environment"
+        :eventBus="eventBus"
+        layout="web"
+        :plugins="[]"
+        :workspaceStore="workspaceStore" />
+
+      <div
+        v-else
+        class="text-c-3 flex flex-1 items-center justify-center text-sm">
+        Document loaded but is not an AsyncAPI description.
+      </div>
+    </ScalarTeleportRoot>
+  </div>
+</template>

--- a/packages/api-client/playground/channel-operation/fixtures/echo-websocket.asyncapi.ts
+++ b/packages/api-client/playground/channel-operation/fixtures/echo-websocket.asyncapi.ts
@@ -1,0 +1,143 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+
+/**
+ * Minimal AsyncAPI description for the public WebSocket.org echo service.
+ * Used by the channel-operation playground to test connect, send, and message log UI.
+ */
+export const echoWebsocketAsyncApiDocument = {
+  asyncapi: '3.1.0',
+
+  info: {
+    title: 'WebSocket Echo Test',
+    version: '1.0.0',
+    description:
+      'Connects to wss://echo.websocket.org — a public echo server that returns every message you send.',
+  },
+
+  defaultContentType: 'application/json',
+
+  servers: {
+    echo: {
+      host: 'echo.websocket.org',
+      protocol: 'wss',
+      description: 'WebSocket.org echo service',
+
+      security: [
+        {
+          basicAuth: [],
+        },
+      ],
+    },
+
+    local: {
+      host: 'localhost:8080',
+      protocol: 'ws',
+      description: 'Local WebSocket server (for server switching)',
+
+      security: [
+        {
+          basicAuth: [],
+        },
+      ],
+    },
+  },
+
+  components: {
+    securitySchemes: {
+      basicAuth: {
+        type: 'http',
+        scheme: 'basic',
+      },
+    },
+  },
+
+  'x-scalar-selected-server': 'echo',
+
+  channels: {
+    echo: {
+      address: '/',
+      description: 'Bidirectional echo endpoint',
+
+      messages: {
+        echoPayload: {
+          name: 'echoPayload',
+          title: 'Echo payload',
+
+          payload: {
+            type: 'object',
+
+            properties: {
+              message: {
+                type: 'string',
+                examples: ['Hello from Scalar'],
+              },
+            },
+
+            required: ['message'],
+          },
+        },
+      },
+    },
+  },
+
+  operations: {
+    sendEchoMessage: {
+      action: 'send',
+
+      channel: {
+        $ref: '#/channels/echo',
+      },
+
+      title: 'Send echo message',
+
+      description:
+        'Connect and send JSON; the server echoes it back in the message log.',
+
+      messages: [
+        {
+          $ref: '#/channels/echo/messages/echoPayload',
+        },
+      ],
+
+      bindings: {
+        ws: {
+          bindingVersion: '0.1.0',
+          method: 'GET',
+        },
+      },
+    },
+
+    listenOnEcho: {
+      action: 'receive',
+
+      channel: {
+        $ref: '#/channels/echo',
+      },
+
+      title: 'Listen on echo',
+
+      description:
+        'Connect and listen; use the Message tab to send while connected.',
+
+      messages: [
+        {
+          $ref: '#/channels/echo/messages/echoPayload',
+        },
+      ],
+
+      bindings: {
+        ws: {
+          bindingVersion: '0.1.0',
+          method: 'GET',
+        },
+      },
+    },
+  },
+} as unknown as AsyncApiDocument
+
+export const ECHO_WEBSOCKET_DOCUMENT_SLUG = 'echo-websocket'
+
+/** Default channel for the playground (single echo endpoint). */
+export const ECHO_WEBSOCKET_DEFAULT_CHANNEL = 'echo'
+
+export const ECHO_WEBSOCKET_CONNECTION_URL = 'wss://echo.websocket.org'

--- a/packages/api-client/playground/channel-operation/index.html
+++ b/packages/api-client/playground/channel-operation/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0" />
+    <title>Scalar API Client — Channel Connection Playground</title>
+    <style>
+      html,
+      body,
+      #app {
+        height: 100%;
+        width: 100%;
+        margin: 0;
+      }
+
+      #app {
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+      }
+    </style>
+  </head>
+  <body class="dark-mode">
+    <!-- Tailwind utilities in @/style.css are scoped to .scalar-app -->
+    <div
+      id="app"
+      class="scalar scalar-app scalar-client"></div>
+    <script
+      type="module"
+      src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/api-client/playground/channel-operation/main.ts
+++ b/packages/api-client/playground/channel-operation/main.ts
@@ -1,0 +1,7 @@
+import { createApp } from 'vue'
+
+import '@/style.css'
+
+import App from './App.vue'
+
+createApp(App).mount('#app')

--- a/packages/api-client/src/v2/blocks/channel-operation-block/ChannelOperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/ChannelOperationBlock.vue
@@ -1,0 +1,453 @@
+<script lang="ts">
+/**
+ * Channel connection block: Postman-style WebSocket testing for one AsyncAPI channel at a time.
+ */
+export default {
+  name: 'ChannelOperationBlock',
+}
+
+type ChannelOperationBlockProps = {
+  eventBus: WorkspaceEventBus
+  documentSlug: string
+  layout: ClientLayout
+  workspaceStore: WorkspaceStore
+  channelName: string
+  channel: AsyncApiChannelObject
+  channelAddress: string
+  operations: ChannelOperationSummary[]
+  connectionUrl: string
+  parameters: ChannelParametersContext
+  messages: ChannelMessageEntry[]
+  selectedMessage: ChannelMessageEntry | null
+  servers: AsyncApiServerEntry[]
+  selectedServer: AsyncApiServerEntry | null
+  environment: XScalarEnvironment
+  securitySchemes: MergedSecuritySchemes
+  securityRequirements: OpenApiDocument['security']
+  selectedSecurity: SelectedSecurity
+  selectedSecuritySchemes: SecuritySchemeObjectSecret[]
+  authMeta: AuthMeta
+  plugins: ClientPlugin[]
+  options?: ApiClientOptions
+}
+</script>
+
+<script setup lang="ts">
+import type { ClientPlugin } from '@scalar/oas-utils/helpers'
+import type { AsyncApiChannelObject } from '@scalar/types/asyncapi/3.1'
+import { useClipboard } from '@scalar/use-hooks/useClipboard'
+import { useToasts } from '@scalar/use-toasts'
+import {
+  buildConnectionUrl,
+  type AsyncApiServerEntry,
+  type ChannelMessageEntry,
+  type ChannelOperationSummary,
+  type ChannelParametersContext,
+} from '@scalar/workspace-store/channel-example'
+import type { WorkspaceStore } from '@scalar/workspace-store/client'
+import type { SelectedSecurity } from '@scalar/workspace-store/entities/auth'
+import type {
+  AuthMeta,
+  WorkspaceEventBus,
+} from '@scalar/workspace-store/events'
+import {
+  getEnvironmentVariables,
+  type MergedSecuritySchemes,
+  type SecuritySchemeObjectSecret,
+} from '@scalar/workspace-store/request-example'
+import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
+import type {
+  OpenApiDocument,
+  ServerObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import {
+  computed,
+  onBeforeUnmount,
+  ref,
+  shallowRef,
+  useTemplateRef,
+  watch,
+} from 'vue'
+
+import ViewLayout from '@/components/ViewLayout/ViewLayout.vue'
+import ViewLayoutContent from '@/components/ViewLayout/ViewLayoutContent.vue'
+import {
+  connectWebSocket,
+  createWebSocketSession,
+  WEBSOCKET_CONNECTION_FAILED_MESSAGE,
+} from '@/v2/blocks/channel-operation-block'
+import { applyAuthToWebSocketUrl } from '@/v2/blocks/channel-operation-block/helpers/apply-auth-to-websocket-url'
+import { getMessagePayloadExample } from '@/v2/blocks/channel-operation-block/helpers/get-message-payload-example'
+import type {
+  WebSocketConnectionLogEntry,
+  WebSocketFrame,
+} from '@/v2/blocks/channel-operation-block/helpers/websocket-session'
+import type { ClientLayout } from '@/v2/types/layout'
+import type { ApiClientOptions } from '@/v2/types/options'
+
+import ChannelRequestBlock from './components/ChannelRequestBlock.vue'
+import ConnectionBar from './components/ConnectionBar.vue'
+import ConnectionPanel from './components/ConnectionPanel.vue'
+
+const props = defineProps<ChannelOperationBlockProps>()
+
+const { toast } = useToasts()
+const { copyToClipboard } = useClipboard()
+
+const connectionBarRef = useTemplateRef('connectionBarRef')
+const wsSession = shallowRef(createWebSocketSession())
+const sessionState = ref(wsSession.value.state)
+const messageFrames = ref<WebSocketFrame[]>([])
+const connectionLogEntries = ref<WebSocketConnectionLogEntry[]>([])
+
+const pathParameters = ref({ ...props.parameters.path })
+const queryParameters = ref({ ...props.parameters.query })
+const connectionUrlOverride = ref<string | null>(null)
+const selectedMessageName = ref(
+  props.selectedMessage?.name ?? props.messages[0]?.name ?? null,
+)
+const outgoingPayload = ref(
+  props.selectedMessage
+    ? getMessagePayloadExample(props.selectedMessage.message)
+    : '{}',
+)
+
+const canComposeMessage = true
+const isConnected = computed(() => sessionState.value === 'open')
+
+const environmentVariables = computed(() =>
+  getEnvironmentVariables(props.environment),
+)
+
+const channelParameters = computed<ChannelParametersContext>(() => ({
+  definitions: props.parameters.definitions,
+  path: pathParameters.value,
+  query: queryParameters.value,
+}))
+
+const resolvedConnectionUrl = computed(() => {
+  if (connectionUrlOverride.value != null) {
+    return connectionUrlOverride.value
+  }
+
+  const server = props.selectedServer?.server ?? props.servers[0]?.server
+  if (!server) {
+    return props.connectionUrl
+  }
+
+  return (
+    props.selectedServer?.connectionUrl ??
+    buildConnectionUrl({
+      server,
+      channel: props.channel,
+      operation: null,
+      pathParameters: pathParameters.value,
+      queryParameters: queryParameters.value,
+      environmentVariables: environmentVariables.value,
+    })
+  )
+})
+
+const authServer = computed((): ServerObject | null =>
+  props.selectedServer
+    ? {
+        url: resolvedConnectionUrl.value,
+        description: props.selectedServer.description,
+      }
+    : null,
+)
+
+const syncSessionState = (): void => {
+  sessionState.value = wsSession.value.state
+}
+
+const addConnectionLogEntry = (
+  status: WebSocketConnectionLogEntry['status'],
+  message: string,
+  detail?: string,
+  details?: WebSocketConnectionLogEntry['details'],
+): void => {
+  connectionLogEntries.value.push({
+    id: `${Date.now()}-${connectionLogEntries.value.length}`,
+    type: 'connection',
+    status,
+    timestamp: Date.now(),
+    message,
+    detail,
+    details,
+  })
+}
+
+const handleConnect = async (): Promise<void> => {
+  props.eventBus.flushDebouncedEmits?.()
+
+  const missingPathParam = Object.entries(pathParameters.value).find(
+    ([, value]) => !value?.trim(),
+  )
+  if (missingPathParam) {
+    toast(`Path parameter "${missingPathParam[0]}" must have a value.`, 'error')
+    connectionBarRef.value?.stopLoading()
+    return
+  }
+
+  wsSession.value.destroy()
+  wsSession.value = createWebSocketSession()
+  syncSessionState()
+
+  // Apply selected security to the URL before opening the socket. Browser
+  // WebSocket cannot send custom headers, so credentials must travel in the
+  // URL itself (api-key query params, basic auth userinfo, bearer/access_token).
+  const { url: authedConnectionUrl, unsupported: unsupportedAuth } =
+    applyAuthToWebSocketUrl(
+      resolvedConnectionUrl.value,
+      props.selectedSecuritySchemes,
+    )
+
+  if (unsupportedAuth.length > 0) {
+    const summary = unsupportedAuth.map(({ name }) => `"${name}"`).join(', ')
+    addConnectionLogEntry(
+      'error',
+      `Authentication ${summary} could not be applied`,
+      'Browser WebSocket clients cannot send custom request headers.',
+      unsupportedAuth.map(({ name, reason }) => ({
+        label: name,
+        value: reason,
+      })),
+    )
+    for (const { name, reason } of unsupportedAuth) {
+      toast(`Authentication "${name}" was skipped: ${reason}`, 'warn')
+    }
+  }
+
+  const result = await connectWebSocket({
+    connectionUrl: authedConnectionUrl,
+    session: wsSession.value,
+    plugins: props.plugins,
+    callbacks: {
+      onFrame: (frame) => {
+        messageFrames.value = [...messageFrames.value, frame]
+        syncSessionState()
+      },
+      onStateChange: () => syncSessionState(),
+      onOpen: () => {
+        const connectionUrl = resolvedConnectionUrl.value
+        addConnectionLogEntry(
+          'connected',
+          `Connected to ${connectionUrl}`,
+          undefined,
+          [
+            { label: 'Request URL', value: connectionUrl },
+            { label: 'Request Method', value: 'GET' },
+            { label: 'Status Code', value: '101 Switching Protocols' },
+            {
+              label: 'Headers',
+              value:
+                'Browser WebSocket handshake headers are managed by the browser and are not exposed.',
+            },
+          ],
+        )
+        syncSessionState()
+        connectionBarRef.value?.stopLoading()
+      },
+      onClose: (info) => {
+        addConnectionLogEntry(
+          'disconnected',
+          'Disconnected',
+          info.reason || `Code ${info.code}`,
+          [
+            { label: 'Close Code', value: String(info.code) },
+            { label: 'Reason', value: info.reason || 'No reason provided' },
+            { label: 'Clean Close', value: info.wasClean ? 'Yes' : 'No' },
+          ],
+        )
+        syncSessionState()
+      },
+      onError: () => syncSessionState(),
+    },
+  })
+
+  connectionBarRef.value?.stopLoading()
+
+  if (!result.ok) {
+    if (connectionLogEntries.value.length === 0) {
+      addConnectionLogEntry(
+        'error',
+        'Connection failed',
+        result.message ?? WEBSOCKET_CONNECTION_FAILED_MESSAGE,
+        [
+          {
+            label: 'Error',
+            value: result.message ?? WEBSOCKET_CONNECTION_FAILED_MESSAGE,
+          },
+        ],
+      )
+    }
+    toast(result.message ?? WEBSOCKET_CONNECTION_FAILED_MESSAGE, 'error')
+    syncSessionState()
+  }
+}
+
+const handleDisconnect = (): void => {
+  connectionBarRef.value?.stopLoading()
+  wsSession.value.close()
+  syncSessionState()
+}
+
+const handleSendMessage = (): void => {
+  if (sessionState.value !== 'open') {
+    toast('Connect before sending a message.', 'error')
+    return
+  }
+
+  try {
+    JSON.parse(outgoingPayload.value)
+  } catch {
+    toast('Message payload must be valid JSON.', 'error')
+    return
+  }
+
+  wsSession.value.send(outgoingPayload.value)
+  syncSessionState()
+}
+
+const handleClearMessages = (): void => {
+  wsSession.value.clearFrames()
+  messageFrames.value = []
+  connectionLogEntries.value = []
+  syncSessionState()
+}
+
+const handleCopyUrl = async (): Promise<void> => {
+  await copyToClipboard(resolvedConnectionUrl.value)
+}
+
+const handleSelectServer = (serverName: string): void => {
+  connectionUrlOverride.value = null
+  props.workspaceStore.updateDocument(
+    props.documentSlug,
+    'x-scalar-selected-server',
+    serverName,
+  )
+}
+
+const handleConnectionUrlUpdate = (value: string): void => {
+  connectionUrlOverride.value = value
+}
+
+const handlePathParameterUpdate = ({
+  name,
+  value,
+}: {
+  name: string
+  value: string
+}): void => {
+  pathParameters.value[name] = value
+}
+
+const handleQueryParameterUpdate = ({
+  name,
+  value,
+}: {
+  name: string
+  value: string
+}): void => {
+  queryParameters.value[name] = value
+}
+
+const handleSelectedMessageNameUpdate = (value: string): void => {
+  selectedMessageName.value = value
+}
+
+const handleOutgoingPayloadUpdate = (value: string): void => {
+  outgoingPayload.value = value
+}
+
+const resetChannelDraft = (): void => {
+  pathParameters.value = { ...props.parameters.path }
+  queryParameters.value = { ...props.parameters.query }
+  connectionUrlOverride.value = null
+  selectedMessageName.value =
+    props.selectedMessage?.name ?? props.messages[0]?.name ?? null
+  outgoingPayload.value = props.selectedMessage
+    ? getMessagePayloadExample(props.selectedMessage.message)
+    : '{}'
+}
+
+watch(
+  () => props.selectedServer?.name,
+  () => {
+    connectionUrlOverride.value = null
+  },
+)
+
+watch([() => props.channelName, () => props.parameters], () => {
+  resetChannelDraft()
+  handleDisconnect()
+})
+
+onBeforeUnmount(() => {
+  wsSession.value.destroy()
+})
+</script>
+
+<template>
+  <div class="bg-b-1 flex h-full flex-col">
+    <div
+      class="lg:min-h-header t-app__top-container @container flex w-full flex-wrap items-center justify-center p-2">
+      <div class="hidden flex-1 @3xl:flex"></div>
+      <ConnectionBar
+        ref="connectionBarRef"
+        :connectionUrl="resolvedConnectionUrl"
+        :environment="environment"
+        :layout="layout"
+        :selectedServer="selectedServer"
+        :servers="servers"
+        :sessionState="sessionState"
+        @connect="handleConnect"
+        @copy:url="handleCopyUrl"
+        @disconnect="handleDisconnect"
+        @select:server="handleSelectServer"
+        @update:connectionUrl="handleConnectionUrlUpdate" />
+      <div class="mb-2 hidden flex-1 @3xl:mb-0 @3xl:flex"></div>
+    </div>
+
+    <ViewLayout class="border-t">
+      <ViewLayoutContent class="flex-1">
+        <ChannelRequestBlock
+          :authMeta="authMeta"
+          :canSend="canComposeMessage"
+          :channel="channel"
+          :channelAddress="channelAddress"
+          :channelName="channelName"
+          :environment="environment"
+          :eventBus="eventBus"
+          :isConnected="isConnected"
+          :layout="layout"
+          :messages="messages"
+          :operations="operations"
+          :options="options"
+          :outgoingPayload="outgoingPayload"
+          :parameters="channelParameters"
+          :plugins="plugins"
+          proxyUrl=""
+          :securityRequirements="securityRequirements"
+          :securitySchemes="securitySchemes"
+          :selectedMessageName="selectedMessageName"
+          :selectedSecurity="selectedSecurity"
+          :selectedSecuritySchemes="selectedSecuritySchemes"
+          :server="authServer"
+          @send:message="handleSendMessage"
+          @update:outgoingPayload="handleOutgoingPayloadUpdate"
+          @update:pathParameter="handlePathParameterUpdate"
+          @update:queryParameter="handleQueryParameterUpdate"
+          @update:selectedMessageName="handleSelectedMessageNameUpdate" />
+
+        <ConnectionPanel
+          :connectionLogEntries="connectionLogEntries"
+          :frames="messageFrames"
+          :sessionState="sessionState"
+          @clear:messages="handleClearMessages" />
+      </ViewLayoutContent>
+    </ViewLayout>
+  </div>
+</template>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/ChannelOperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/ChannelOperationBlock.vue
@@ -135,17 +135,17 @@ const resolvedConnectionUrl = computed(() => {
     return props.connectionUrl
   }
 
-  return (
-    props.selectedServer?.connectionUrl ??
-    buildConnectionUrl({
-      server,
-      channel: props.channel,
-      operation: null,
-      pathParameters: pathParameters.value,
-      queryParameters: queryParameters.value,
-      environmentVariables: environmentVariables.value,
-    })
-  )
+  // Always rebuild from the live path/query parameters. The server entry carries a
+  // pre-built `connectionUrl`, but it is computed once with the default parameter values,
+  // so using it would ignore edits the user makes in the parameter table.
+  return buildConnectionUrl({
+    server,
+    channel: props.channel,
+    operation: null,
+    pathParameters: pathParameters.value,
+    queryParameters: queryParameters.value,
+    environmentVariables: environmentVariables.value,
+  })
 })
 
 const authServer = computed((): ServerObject | null =>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/ChannelOperationBlock.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/ChannelOperationBlock.vue
@@ -391,7 +391,8 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="bg-b-1 flex h-full flex-col">
+  <!-- min-w-0 lets this pane shrink so its content scrolls internally instead of squeezing the sidebar -->
+  <div class="bg-b-1 flex h-full min-w-0 flex-col">
     <div
       class="lg:min-h-header t-app__top-container @container flex w-full flex-wrap items-center justify-center p-2">
       <div class="hidden flex-1 @3xl:flex"></div>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/components/AsyncApiServerDropdown.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/components/AsyncApiServerDropdown.vue
@@ -1,0 +1,106 @@
+<script lang="ts">
+export default {
+  name: 'AsyncApiServerDropdown',
+}
+</script>
+
+<script setup lang="ts">
+import { ScalarButton } from '@scalar/components/button'
+import { ScalarFloatingBackdrop } from '@scalar/components/floating'
+import { ScalarListboxCheckbox } from '@scalar/components/listbox'
+import { ScalarMarkdown } from '@scalar/components/markdown'
+import { ScalarPopover } from '@scalar/components/popover'
+import type { AsyncApiServerEntry } from '@scalar/workspace-store/channel-example'
+import { computed } from 'vue'
+
+import { stripTrailingSlash } from '@/v2/blocks/channel-operation-block/helpers/connection-bar-url'
+import ValueEmitter from '@/v2/components/layout/ValueEmitter.vue'
+
+const { target, servers, selectedServer } = defineProps<{
+  /** Popover target element id */
+  target: string
+  /** Available WebSocket servers */
+  servers: AsyncApiServerEntry[]
+  /** Currently selected server entry */
+  selectedServer: AsyncApiServerEntry | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:open', value: boolean): void
+  (e: 'select:server', serverName: string): void
+}>()
+
+const serverUrlWithoutTrailingSlash = computed(() => {
+  const url = selectedServer?.url ?? ''
+  return url ? stripTrailingSlash(url) : ''
+})
+</script>
+
+<template>
+  <ScalarPopover
+    class="max-h-[inherit] p-0 text-base"
+    focus
+    :offset="0"
+    placement="bottom"
+    resize
+    :target="target"
+    :teleport="`#${target}`">
+    <ScalarButton
+      class="hover:bg-b-2 font-code text-c-2 relative z-10 flex h-full max-w-[min(50vw,280px)] shrink-0 items-center gap-0.75 truncate rounded border px-1.5 py-0 text-base leading-none whitespace-nowrap"
+      variant="ghost">
+      <template v-if="selectedServer">
+        <span class="sr-only">Server:</span>
+        <span class="truncate">{{ serverUrlWithoutTrailingSlash }}</span>
+      </template>
+      <template v-else>
+        <span class="sr-only">Select server</span>
+        Select server
+      </template>
+    </ScalarButton>
+
+    <template #popover="{ close }">
+      <div
+        class="custom-scroll flex max-h-[inherit] flex-col gap-1 p-1"
+        @click="close">
+        <button
+          v-for="entry in servers"
+          :key="entry.name"
+          class="flex min-h-8 cursor-pointer items-center gap-1.5 rounded px-1.5"
+          :class="
+            entry.name === selectedServer?.name
+              ? 'text-c-1 bg-b-2'
+              : 'hover:bg-b-2'
+          "
+          type="button"
+          @click="emit('select:server', entry.name)">
+          <ScalarListboxCheckbox
+            :selected="entry.name === selectedServer?.name" />
+          <span class="flex min-w-0 flex-col text-left">
+            <span
+              class="overflow-hidden font-medium text-ellipsis whitespace-nowrap">
+              {{ entry.title ?? entry.name }}
+            </span>
+            <span
+              class="text-c-3 overflow-hidden text-xs text-ellipsis whitespace-nowrap">
+              {{ entry.connectionUrl ?? entry.url }}
+            </span>
+          </span>
+        </button>
+        <div
+          v-if="selectedServer?.server.description"
+          class="text-c-3 border-t px-2 py-1.5 text-xs">
+          <ScalarMarkdown :value="selectedServer.server.description" />
+        </div>
+      </div>
+    </template>
+
+    <template #backdrop="{ open }">
+      <ValueEmitter
+        :value="open"
+        @change="(value) => emit('update:open', value)"
+        @unmount="emit('update:open', false)" />
+
+      <ScalarFloatingBackdrop class="inset-x-px rounded-none rounded-b-lg" />
+    </template>
+  </ScalarPopover>
+</template>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/components/ChannelActionBadge.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/components/ChannelActionBadge.vue
@@ -1,0 +1,47 @@
+<script lang="ts">
+/**
+ * Displays the AsyncAPI operation action (send / receive) in the connection bar,
+ * styled like the HTTP method badge in AddressBar. This is a label, not a button.
+ */
+export default {
+  name: 'ChannelActionBadge',
+}
+</script>
+
+<script setup lang="ts">
+import { cva, cx } from '@scalar/use-hooks/useBindCx'
+import { computed } from 'vue'
+
+import { getChannelActionInfo } from '@/v2/blocks/channel-operation-block/helpers/channel-action-info'
+
+const { action, variant = 'bar' } = defineProps<{
+  /** AsyncAPI operation action */
+  action: 'send' | 'receive'
+  /**
+   * `bar` — address bar cell (border-right, centered).
+   * `inline` — compact label in lists and reference sections.
+   */
+  variant?: 'bar' | 'inline'
+}>()
+
+const actionInfo = computed(() => getChannelActionInfo(action))
+
+const variants = cva({
+  base: 'font-code text-3xs flex shrink-0 items-center justify-center whitespace-nowrap font-bold',
+  variants: {
+    variant: {
+      bar: 'text-center border-r h-fit m-auto px-2.5',
+      inline: 'rounded px-1.5 py-0.5',
+    },
+  },
+})
+</script>
+
+<template>
+  <div
+    class="relative"
+    :class="cx(variants({ variant }), actionInfo.colorClass)"
+    :title="`Operation action: ${action}`">
+    {{ actionInfo.short }}
+  </div>
+</template>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/components/ChannelMessageEditor.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/components/ChannelMessageEditor.vue
@@ -1,0 +1,172 @@
+<script lang="ts">
+export default {
+  name: 'ChannelMessageEditor',
+}
+</script>
+
+<script setup lang="ts">
+import { ScalarButton } from '@scalar/components/button'
+import {
+  ScalarListbox,
+  type ScalarListboxOption,
+} from '@scalar/components/listbox'
+import { ScalarIconCaretDown } from '@scalar/icons'
+import type { ChannelMessageEntry } from '@scalar/workspace-store/channel-example'
+import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
+import { computed } from 'vue'
+
+import { CodeInput } from '@/v2/components/code-input'
+import {
+  DataTable,
+  DataTableHeader,
+  DataTableRow,
+} from '@/v2/components/data-table'
+import { CollapsibleSection } from '@/v2/components/layout'
+
+const { messages, selectedMessageName, payload, environment, canSend } =
+  defineProps<{
+    /** Messages available for this operation */
+    messages: ChannelMessageEntry[]
+    /** Name of the currently selected message */
+    selectedMessageName: string | null
+    /** Outgoing JSON payload */
+    payload: string
+    /** Active environment for variable substitution in the editor */
+    environment: XScalarEnvironment
+    /** Whether sending is allowed for this operation */
+    canSend: boolean
+  }>()
+
+const emit = defineEmits<{
+  (e: 'update:selectedMessageName', value: string): void
+  (e: 'update:payload', value: string): void
+  (e: 'send'): void
+}>()
+
+const CUSTOM_MESSAGE_ID = 'scalar-custom-message'
+const CUSTOM_MESSAGE_OPTION = {
+  id: CUSTOM_MESSAGE_ID,
+  label: 'Custom message',
+} satisfies ScalarListboxOption
+
+const messageOptions = computed<ScalarListboxOption[]>(() => [
+  ...messages.map(({ name, message }) => ({
+    id: name,
+    label: message.title ?? name,
+  })),
+  CUSTOM_MESSAGE_OPTION,
+])
+
+const handleMessageSelect = (option?: ScalarListboxOption): void => {
+  if (!option?.id) {
+    return
+  }
+
+  emit('update:selectedMessageName', option.id)
+
+  if (option.id === CUSTOM_MESSAGE_ID) {
+    emit('update:payload', '{}')
+  }
+}
+
+const selectedMessageOption = computed<ScalarListboxOption | undefined>({
+  get: () =>
+    messageOptions.value.find(({ id }) => id === selectedMessageName) ??
+    messageOptions.value[0],
+  set: handleMessageSelect,
+})
+
+const isCustomMessageSelected = computed(
+  () => selectedMessageOption.value?.id === CUSTOM_MESSAGE_ID,
+)
+
+const sendMessageLabel = computed(() =>
+  canSend ? 'Send message' : 'Connect to send',
+)
+
+const sendMessageTitle = computed(() =>
+  canSend ? 'Send message' : 'Connect before sending a message',
+)
+</script>
+
+<template>
+  <CollapsibleSection
+    :defaultOpen="true"
+    :itemCount="messages.length">
+    <template #title>Message</template>
+
+    <DataTable
+      :columns="['']"
+      presentational>
+      <DataTableHeader
+        class="relative col-span-full flex h-8 cursor-pointer items-center justify-between gap-2 border-r-0 !p-0">
+        <ScalarListbox
+          v-if="messageOptions.length > 1"
+          v-slot="{ open }"
+          v-model="selectedMessageOption"
+          class="font-code min-w-0 text-sm"
+          :options="messageOptions"
+          placement="bottom-start">
+          <ScalarButton
+            class="text-c-2 hover:text-c-1 flex h-full w-fit max-w-full min-w-0 gap-1.5 px-3 font-normal"
+            fullWidth
+            variant="ghost">
+            <span class="min-w-0 truncate">
+              {{ selectedMessageOption?.label ?? 'Select message' }}
+            </span>
+            <ScalarIconCaretDown
+              class="mt-0.25 size-3 shrink-0 transition-transform duration-100"
+              :class="{ 'rotate-180': open }"
+              weight="bold" />
+          </ScalarButton>
+        </ScalarListbox>
+
+        <span
+          v-else
+          class="text-c-2 font-code min-w-0 truncate px-3 text-sm font-normal">
+          {{ selectedMessageOption?.label ?? 'Message body' }}
+        </span>
+
+        <div class="mr-1 flex shrink-0 items-center gap-1">
+          <ScalarButton
+            v-if="!isCustomMessageSelected"
+            class="h-6 px-2 text-xs"
+            size="sm"
+            type="button"
+            variant="ghost"
+            @click="handleMessageSelect(CUSTOM_MESSAGE_OPTION)">
+            New message
+          </ScalarButton>
+          <ScalarButton
+            class="h-6 px-2 text-xs"
+            :disabled="!canSend"
+            size="sm"
+            :title="sendMessageTitle"
+            type="button"
+            @click="emit('send')">
+            {{ sendMessageLabel }}
+          </ScalarButton>
+        </div>
+      </DataTableHeader>
+
+      <DataTableRow>
+        <CodeInput
+          class="border-t px-3"
+          :environment="environment"
+          language="json"
+          lineNumbers
+          lint
+          :modelValue="payload"
+          placeholder="{}"
+          withFakeData
+          @update:modelValue="(value) => emit('update:payload', value)" />
+      </DataTableRow>
+    </DataTable>
+  </CollapsibleSection>
+</template>
+
+<style scoped>
+:deep(.cm-content) {
+  font-size: var(--scalar-small);
+}
+</style>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/components/ChannelOperationsReference.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/components/ChannelOperationsReference.vue
@@ -1,0 +1,43 @@
+<script lang="ts">
+/**
+ * Read-only list of AsyncAPI operations on the active channel (spec reference, not navigation).
+ */
+export default {
+  name: 'ChannelOperationsReference',
+}
+</script>
+
+<script setup lang="ts">
+import type { ChannelOperationSummary } from '@scalar/workspace-store/channel-example'
+
+import ChannelActionBadge from './ChannelActionBadge.vue'
+
+const { operations } = defineProps<{
+  operations: ChannelOperationSummary[]
+}>()
+</script>
+
+<template>
+  <ul
+    v-if="operations.length"
+    class="divide-y divide-dashed first:pt-0">
+    <li
+      v-for="{ operationName, operation, action } in operations"
+      :key="operationName"
+      class="flex gap-2.5 py-2 first:pt-0 last:pb-0">
+      <ChannelActionBadge
+        :action="action"
+        variant="inline" />
+      <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span class="text-c-2 text-sm leading-snug font-medium">
+          {{ operation.title ?? operationName }}
+        </span>
+        <span
+          v-if="operation.summary ?? operation.description"
+          class="text-c-3 text-xs leading-snug">
+          {{ operation.summary ?? operation.description }}
+        </span>
+      </div>
+    </li>
+  </ul>
+</template>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/components/ChannelRequestBlock.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/components/ChannelRequestBlock.vue
@@ -1,0 +1,288 @@
+<script lang="ts">
+export default {
+  name: 'ChannelRequestBlock',
+}
+</script>
+
+<script setup lang="ts">
+import type { ClientPlugin } from '@scalar/oas-utils/helpers'
+import type { AsyncApiChannelObject } from '@scalar/types/asyncapi/3.1'
+import type {
+  ChannelMessageEntry,
+  ChannelOperationSummary,
+  ChannelParametersContext,
+} from '@scalar/workspace-store/channel-example'
+import type { SelectedSecurity } from '@scalar/workspace-store/entities/auth'
+import type {
+  AuthMeta,
+  WorkspaceEventBus,
+} from '@scalar/workspace-store/events'
+import {
+  type MergedSecuritySchemes,
+  type SecuritySchemeObjectSecret,
+} from '@scalar/workspace-store/request-example'
+import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
+import type {
+  OpenApiDocument,
+  ServerObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { computed, ref, useId } from 'vue'
+
+import SectionFilter from '@/components/SectionFilter.vue'
+import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import { createChannelParameterRows } from '@/v2/blocks/channel-operation-block/helpers/create-channel-parameter-rows'
+import { getMessagePayloadExample } from '@/v2/blocks/channel-operation-block/helpers/get-message-payload-example'
+import RequestTable from '@/v2/blocks/request-block/components/RequestTable.vue'
+import { AuthSelector } from '@/v2/blocks/scalar-auth-selector-block'
+import { CollapsibleSection } from '@/v2/components/layout'
+import type { ClientLayout } from '@/v2/types/layout'
+import type { ApiClientOptions } from '@/v2/types/options'
+
+import ChannelMessageEditor from './ChannelMessageEditor.vue'
+import ChannelOperationsReference from './ChannelOperationsReference.vue'
+
+const {
+  authMeta,
+  environment,
+  eventBus,
+  layout,
+  channel,
+  channelName,
+  channelAddress,
+  operations,
+  parameters,
+  messages,
+  selectedMessageName,
+  outgoingPayload,
+  canSend,
+  isConnected,
+  proxyUrl,
+  securityRequirements,
+  securitySchemes,
+  selectedSecurity,
+  selectedSecuritySchemes,
+  server,
+  options,
+} = defineProps<{
+  authMeta: AuthMeta
+  environment: XScalarEnvironment
+  eventBus: WorkspaceEventBus
+  layout: ClientLayout
+  channel: AsyncApiChannelObject
+  channelName: string
+  channelAddress: string
+  operations: ChannelOperationSummary[]
+  parameters: ChannelParametersContext
+  messages: ChannelMessageEntry[]
+  selectedMessageName: string | null
+  outgoingPayload: string
+  canSend: boolean
+  isConnected: boolean
+  proxyUrl: string
+  securityRequirements: OpenApiDocument['security']
+  securitySchemes: MergedSecuritySchemes
+  selectedSecurity: SelectedSecurity
+  selectedSecuritySchemes: SecuritySchemeObjectSecret[]
+  server: ServerObject | null
+  plugins: ClientPlugin[]
+  options?: ApiClientOptions
+}>()
+const emit = defineEmits<{
+  (e: 'update:pathParameter', payload: { name: string; value: string }): void
+  (e: 'update:queryParameter', payload: { name: string; value: string }): void
+  (e: 'update:selectedMessageName', value: string): void
+  (e: 'update:outgoingPayload', value: string): void
+  (e: 'send:message'): void
+}>()
+const CHANNEL_SECTIONS = [
+  'Params',
+  'Query',
+  'Auth',
+  'Operations',
+  'Message',
+] as const
+type Filter = 'All' | (typeof CHANNEL_SECTIONS)[number]
+const FILTER_IDS = {
+  All: useId(),
+  Params: useId(),
+  Query: useId(),
+  Auth: useId(),
+  Operations: useId(),
+  Message: useId(),
+} satisfies Record<Filter, string>
+
+const selectedFilter = ref<Filter>('All')
+const filters = computed<Filter[]>(() => {
+  const available = new Set<Filter>(['All', ...CHANNEL_SECTIONS])
+
+  if (!pathRows.value.length) {
+    available.delete('Params')
+  }
+
+  if (!queryRows.value.length) {
+    available.delete('Query')
+  }
+
+  if (!operations.length) {
+    available.delete('Operations')
+  }
+
+  if (!canSend) {
+    available.delete('Message')
+  }
+
+  return [...available]
+})
+
+const isSectionVisible = (section: Filter): boolean =>
+  selectedFilter.value === 'All' || selectedFilter.value === section
+
+const pathRows = computed(() =>
+  createChannelParameterRows(parameters.definitions, parameters.path),
+)
+
+const queryRows = computed(() =>
+  createChannelParameterRows(parameters.definitions, parameters.query),
+)
+
+const handlePathUpsert = (
+  _index: number,
+  payload: { name: string; value: string | File | undefined },
+): void => {
+  if (payload.value instanceof File) {
+    return
+  }
+
+  emit('update:pathParameter', {
+    name: payload.name,
+    value: payload.value ?? '',
+  })
+}
+
+const handleQueryUpsert = (
+  _index: number,
+  payload: { name: string; value: string | File | undefined },
+): void => {
+  if (payload.value instanceof File) {
+    return
+  }
+
+  emit('update:queryParameter', {
+    name: payload.name,
+    value: payload.value ?? '',
+  })
+}
+
+const handleMessageSelect = (messageName: string): void => {
+  emit('update:selectedMessageName', messageName)
+
+  const entry = messages.find(({ name }) => name === messageName)
+  if (entry) {
+    emit('update:outgoingPayload', getMessagePayloadExample(entry.message))
+  }
+}
+
+const channelTitle = computed(() => channel.title ?? channelName)
+
+const channelSubtitle = computed(() => {
+  const parts: string[] = []
+  if (channel.description) {
+    parts.push(channel.description)
+  }
+  if (channelAddress) {
+    parts.push(channelAddress)
+  }
+  return parts.join(' · ')
+})
+</script>
+
+<template>
+  <ViewLayoutSection :aria-label="`Channel: ${channelTitle}`">
+    <template #title>
+      <div class="flex min-w-0 flex-col gap-0.5">
+        <span class="text-c-1 truncate">{{ channelTitle }}</span>
+        <span
+          v-if="channelSubtitle"
+          class="text-c-3 truncate text-xs font-normal">
+          {{ channelSubtitle }}
+        </span>
+      </div>
+      <SectionFilter
+        v-model="selectedFilter"
+        :filterIds="FILTER_IDS"
+        :filters="filters" />
+    </template>
+
+    <div
+      :id="FILTER_IDS.All"
+      class="request-section-content custom-scroll relative flex flex-1 flex-col"
+      :role="selectedFilter === 'All' ? 'tabpanel' : 'none'">
+      <CollapsibleSection
+        v-show="isSectionVisible('Params') && pathRows.length"
+        :id="FILTER_IDS.Params"
+        :itemCount="pathRows.length">
+        <template #title>Params</template>
+        <RequestTable
+          :data="pathRows"
+          :environment="environment"
+          :showAddRowPlaceholder="false"
+          @upsertRow="handlePathUpsert" />
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        v-show="isSectionVisible('Query') && queryRows.length"
+        :id="FILTER_IDS.Query"
+        :itemCount="queryRows.length">
+        <template #title>Query</template>
+        <RequestTable
+          :data="queryRows"
+          :environment="environment"
+          :showAddRowPlaceholder="false"
+          @upsertRow="handleQueryUpsert" />
+      </CollapsibleSection>
+
+      <AuthSelector
+        v-show="isSectionVisible('Auth')"
+        :id="FILTER_IDS.Auth"
+        :createAnySecurityScheme="layout !== 'modal'"
+        :environment="environment"
+        :eventBus="eventBus"
+        :meta="authMeta"
+        :options="options"
+        :proxyUrl="proxyUrl"
+        :securityRequirements="securityRequirements"
+        :securitySchemes="securitySchemes"
+        :selectedSecurity="selectedSecurity"
+        :selectedSecuritySchemes="selectedSecuritySchemes"
+        :server="server"
+        title="Authentication" />
+
+      <CollapsibleSection
+        v-show="isSectionVisible('Operations') && operations.length"
+        :id="FILTER_IDS.Operations"
+        :defaultOpen="false"
+        :itemCount="operations.length">
+        <template #title>Operations</template>
+        <div class="px-3 pb-3">
+          <p class="text-c-3 mb-3 text-xs">
+            Defined on this channel in your AsyncAPI description (reference
+            only).
+          </p>
+          <ChannelOperationsReference :operations="operations" />
+        </div>
+      </CollapsibleSection>
+
+      <ChannelMessageEditor
+        v-show="isSectionVisible('Message') && canSend"
+        :id="FILTER_IDS.Message"
+        :canSend="canSend && isConnected"
+        :environment="environment"
+        :messages="messages"
+        :payload="outgoingPayload"
+        :selectedMessageName="selectedMessageName"
+        @send="emit('send:message')"
+        @update:payload="(value) => emit('update:outgoingPayload', value)"
+        @update:selectedMessageName="handleMessageSelect" />
+    </div>
+  </ViewLayoutSection>
+</template>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/components/ConnectionBar.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/components/ConnectionBar.vue
@@ -1,0 +1,337 @@
+<script lang="ts">
+/**
+ * WebSocket connection bar — mirrors HTTP AddressBar layout:
+ * [Action | Server base | Path/address | Copy | Connect]
+ */
+export default {
+  name: 'ConnectionBar',
+}
+</script>
+
+<script setup lang="ts">
+import { ScalarButton } from '@scalar/components/button'
+import { ScalarIcon } from '@scalar/components/icon'
+import { ScalarIconCopy } from '@scalar/icons'
+import { EditorView } from '@scalar/use-codemirror'
+import type { AsyncApiServerEntry } from '@scalar/workspace-store/channel-example'
+import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
+import { computed, ref, useId } from 'vue'
+
+import {
+  mergeConnectionUrl,
+  splitConnectionUrl,
+} from '@/v2/blocks/channel-operation-block/helpers/connection-bar-url'
+import type { WebSocketSessionState } from '@/v2/blocks/channel-operation-block/helpers/websocket-session'
+import { useLoadingAnimation } from '@/v2/blocks/scalar-address-bar-block/hooks/use-loading-animation'
+import { CodeInput } from '@/v2/components/code-input'
+import type { ClientLayout } from '@/v2/types/layout'
+
+import AsyncApiServerDropdown from './AsyncApiServerDropdown.vue'
+import WebSocketProtocolBadge from './WebSocketProtocolBadge.vue'
+
+const {
+  connectionUrl,
+  environment,
+  layout,
+  selectedServer,
+  servers,
+  sessionState,
+} = defineProps<{
+  /** Resolved WebSocket connection URL */
+  connectionUrl: string
+  /** Environment variables for URL substitution display */
+  environment: XScalarEnvironment
+  /** Client layout */
+  layout: ClientLayout
+  /** Available servers */
+  servers: AsyncApiServerEntry[]
+  /** Selected server */
+  selectedServer: AsyncApiServerEntry | null
+  /** Current WebSocket session state */
+  sessionState: WebSocketSessionState
+}>()
+
+const emit = defineEmits<{
+  (e: 'connect'): void
+  (e: 'disconnect'): void
+  (e: 'copy:url'): void
+  (e: 'update:connectionUrl', value: string): void
+  (e: 'select:server', serverName: string): void
+}>()
+
+const id = useId()
+const isServerDropdownOpen = ref(false)
+
+const { percentage, startLoading, stopLoading, isLoading } =
+  useLoadingAnimation()
+
+const isConnected = computed(() => sessionState === 'open')
+const isConnecting = computed(() => sessionState === 'connecting')
+const canDisconnect = computed(
+  () =>
+    sessionState === 'open' ||
+    sessionState === 'connecting' ||
+    sessionState === 'closing',
+)
+
+const serverBaseUrl = computed(() => selectedServer?.url ?? '')
+
+const connectionPath = computed(
+  () => splitConnectionUrl(connectionUrl, serverBaseUrl.value).path,
+)
+
+const addressBarAccentVar = 'var(--scalar-color-purple)'
+
+const addressBarScrollMargins = EditorView.scrollMargins.of(() => ({
+  right: 24,
+}))
+
+const style = computed(() => ({
+  backgroundColor: `color-mix(in srgb, transparent 90%, ${addressBarAccentVar})`,
+  transform: `translate3d(-${percentage.value}%,0,0)`,
+}))
+
+const connectLabel = computed(() => {
+  if (canDisconnect.value) {
+    return isConnected.value ? 'Disconnect' : 'Cancel'
+  }
+  return 'Connect'
+})
+
+const handlePathUpdate = (path: string): void => {
+  emit('update:connectionUrl', mergeConnectionUrl(serverBaseUrl.value, path))
+}
+
+const handleConnectClick = (): void => {
+  if (canDisconnect.value) {
+    emit('disconnect')
+    return
+  }
+
+  startLoading()
+  emit('connect')
+}
+
+defineExpose({
+  startLoading,
+  stopLoading,
+})
+</script>
+
+<template>
+  <div
+    class="order-last flex h-auto w-full max-w-3xl grow-3 flex-wrap items-stretch [--scalar-address-bar-height:32px] @3xl:order-0 @3xl:flex-nowrap">
+    <div
+      :id="id"
+      class="address-bar-bg-states text-xxs group relative flex h-(--scalar-address-bar-height) w-full flex-1 flex-row items-stretch rounded-lg p-0.75"
+      :class="{ 'rounded-b-none': isServerDropdownOpen }">
+      <div
+        class="pointer-events-none absolute top-0 left-0 block h-full w-full overflow-hidden rounded-lg border"
+        :class="{ 'rounded-b-none': isServerDropdownOpen }">
+        <div
+          class="absolute top-0 left-0 h-full w-full"
+          :style />
+      </div>
+
+      <div class="relative z-10 flex h-full min-w-0 flex-1 items-center">
+        <div class="hidden shrink-0 @3xl:flex">
+          <WebSocketProtocolBadge />
+        </div>
+
+        <AsyncApiServerDropdown
+          v-if="servers.length"
+          class="shrink-0 self-center"
+          :selectedServer="selectedServer"
+          :servers="servers"
+          :target="id"
+          @select:server="
+            (name) => {
+              isServerDropdownOpen = false
+              emit('select:server', name)
+            }
+          "
+          @update:open="(value) => (isServerDropdownOpen = value)" />
+
+        <div
+          class="channel-connection-path scroll-timeline-x scroll-timeline-x-address scroll-timeline-x-hidden relative flex h-full min-w-0 flex-1 items-center bg-blend-normal">
+          <CodeInput
+            alwaysEmitChange
+            aria-label="Connection path"
+            class="ml-1 h-full w-full min-w-0 pl-px leading-[27px] outline-none"
+            disableCloseBrackets
+            :disabled="layout === 'modal'"
+            disableEnter
+            disableTabIndent
+            :emitOnBlur="false"
+            :environment="environment"
+            :extensions="[addressBarScrollMargins]"
+            :layout="layout"
+            :modelValue="connectionPath"
+            :placeholder="
+              serverBaseUrl ? 'Channel path or query' : 'Enter a WebSocket URL'
+            "
+            @update:modelValue="handlePathUpdate" />
+        </div>
+      </div>
+
+      <ScalarButton
+        class="hover:bg-b-3 mx-1 hidden @3xl:flex"
+        size="xs"
+        variant="ghost"
+        @click="emit('copy:url')">
+        <ScalarIconCopy />
+        <span class="sr-only">Copy connection URL</span>
+      </ScalarButton>
+
+      <ScalarButton
+        class="relative hidden h-auto shrink-0 overflow-hidden py-1 pr-2.5 pl-2 font-bold @3xl:flex"
+        data-addressbar-action="connect"
+        :disabled="isLoading && isConnecting"
+        @click="handleConnectClick">
+        <span
+          aria-hidden="true"
+          class="inline-flex items-center gap-1">
+          <ScalarIcon
+            v-if="!canDisconnect"
+            class="relative shrink-0 fill-current"
+            icon="Play"
+            size="xs" />
+          <ScalarIcon
+            v-else
+            class="relative shrink-0 fill-current"
+            icon="Close"
+            size="xs" />
+          <span class="text-xxs flex">{{ connectLabel }}</span>
+        </span>
+        <span class="sr-only">
+          {{ connectLabel }} WebSocket connection to {{ connectionUrl }}
+        </span>
+      </ScalarButton>
+    </div>
+
+    <div
+      class="mt-2 flex h-(--scalar-address-bar-height) w-full min-w-0 items-stretch gap-1 @3xl:hidden">
+      <WebSocketProtocolBadge />
+      <AsyncApiServerDropdown
+        v-if="servers.length"
+        class="min-w-0 shrink-0"
+        :selectedServer="selectedServer"
+        :servers="servers"
+        :target="id"
+        @select:server="
+          (name) => {
+            isServerDropdownOpen = false
+            emit('select:server', name)
+          }
+        "
+        @update:open="(value) => (isServerDropdownOpen = value)" />
+      <ScalarButton
+        class="hover:bg-b-3 ml-auto"
+        size="xs"
+        variant="ghost"
+        @click="emit('copy:url')">
+        <ScalarIconCopy />
+        <span class="sr-only">Copy connection URL</span>
+      </ScalarButton>
+      <ScalarButton
+        class="relative h-auto shrink-0 overflow-hidden py-1 pr-2.5 pl-2 font-bold"
+        data-addressbar-action="connect"
+        :disabled="isLoading && isConnecting"
+        @click="handleConnectClick">
+        <span
+          aria-hidden="true"
+          class="inline-flex items-center gap-1">
+          <ScalarIcon
+            v-if="!canDisconnect"
+            class="relative shrink-0 fill-current"
+            icon="Play"
+            size="xs" />
+          <ScalarIcon
+            v-else
+            class="relative shrink-0 fill-current"
+            icon="Close"
+            size="xs" />
+          <span class="text-xxs">{{ connectLabel }}</span>
+        </span>
+      </ScalarButton>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* Override CodeInput defaults (max-height / padding) so path text aligns with the server control. */
+.channel-connection-path :deep(.cm-editor) {
+  height: 100%;
+  outline: none;
+  width: 100%;
+}
+.channel-connection-path :deep(.cm-line) {
+  padding: 0;
+}
+.channel-connection-path :deep(.cm-content) {
+  padding: 0;
+  max-height: none;
+  display: flex;
+  align-items: center;
+  font-size: var(--scalar-small);
+  line-height: 27px;
+}
+.channel-connection-path :deep(.cm-scroller) {
+  display: flex;
+  align-items: center;
+  min-height: 100%;
+}
+.channel-connection-path :deep(> div) {
+  display: flex;
+  height: 100%;
+  align-items: center;
+}
+.scroll-timeline-x-address {
+  line-height: 27px;
+  scrollbar-width: none;
+}
+/* Fade only the path field on the right — server control sits outside this mask. */
+.channel-connection-path.scroll-timeline-x {
+  -ms-overflow-style: none;
+  mask-image: linear-gradient(
+    to right,
+    black 0,
+    black calc(100% - 24px),
+    transparent 100%
+  );
+}
+.scroll-timeline-x-hidden {
+  overflow-x: auto;
+}
+.scroll-timeline-x-hidden :deep(.cm-scroller) {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  padding-right: 20px;
+  overflow: auto;
+}
+.scroll-timeline-x-hidden::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+  display: none;
+}
+.scroll-timeline-x-hidden :deep(.cm-scroller::-webkit-scrollbar) {
+  width: 0;
+  height: 0;
+  display: none;
+}
+
+.address-bar-bg-states {
+  --scalar-address-bar-bg: color-mix(
+    in srgb,
+    var(--scalar-background-1),
+    var(--scalar-background-2)
+  );
+  background: var(--scalar-address-bar-bg);
+}
+.address-bar-bg-states:has(.cm-focused) {
+  --scalar-address-bar-bg: var(--scalar-background-1);
+  border-color: var(--scalar-border-color);
+  outline-width: 1px;
+  outline-style: solid;
+}
+</style>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/components/ConnectionPanel.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/components/ConnectionPanel.vue
@@ -1,0 +1,88 @@
+<script lang="ts">
+export default {
+  name: 'ConnectionPanel',
+}
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import ViewLayoutSection from '@/components/ViewLayout/ViewLayoutSection.vue'
+import type {
+  WebSocketConnectionLogEntry,
+  WebSocketFrame,
+  WebSocketSessionState,
+} from '@/v2/blocks/channel-operation-block/helpers/websocket-session'
+
+import MessageLog from './MessageLog.vue'
+
+const { sessionState, frames, connectionLogEntries } = defineProps<{
+  /** WebSocket session state */
+  sessionState: WebSocketSessionState
+  /** Message frames */
+  frames: WebSocketFrame[]
+  /** Connection lifecycle entries */
+  connectionLogEntries: WebSocketConnectionLogEntry[]
+}>()
+const emit = defineEmits<{
+  (e: 'clear:messages'): void
+}>()
+
+const stateLabel = computed(() => {
+  switch (sessionState) {
+    case 'connecting':
+      return 'Connecting'
+    case 'open':
+      return 'Connected'
+    case 'closing':
+      return 'Closing'
+    case 'closed':
+      return 'Disconnected'
+    case 'error':
+      return 'Error'
+    default:
+      return 'Idle'
+  }
+})
+
+const stateColorClass = computed(() => {
+  switch (sessionState) {
+    case 'open':
+      return 'bg-[var(--scalar-color-green)]'
+    case 'connecting':
+    case 'closing':
+      return 'bg-[var(--scalar-color-yellow)]'
+    case 'error':
+      return 'bg-[var(--scalar-color-red)]'
+    default:
+      return 'bg-[var(--scalar-color-3)]'
+  }
+})
+</script>
+
+<template>
+  <ViewLayoutSection aria-label="Connection">
+    <template #title>
+      <div class="text-c-1 flex items-center gap-2">
+        <span
+          class="block h-2 w-2 rounded-full"
+          :class="stateColorClass" />
+        <span>{{ stateLabel }}</span>
+        <span
+          v-if="frames.length"
+          class="text-c-3 text-sm">
+          · {{ frames.length }}
+          {{ frames.length === 1 ? 'message' : 'messages' }}
+        </span>
+      </div>
+    </template>
+
+    <div class="relative flex min-h-0 flex-1 flex-col">
+      <MessageLog
+        :connectionLogEntries="connectionLogEntries"
+        :frames="frames"
+        :sessionState="sessionState"
+        @clear="emit('clear:messages')" />
+    </div>
+  </ViewLayoutSection>
+</template>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/components/MessageLog.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/components/MessageLog.vue
@@ -1,0 +1,491 @@
+<script lang="ts">
+export default {
+  name: 'MessageLog',
+}
+</script>
+
+<script setup lang="ts">
+import { ScalarButton } from '@scalar/components/button'
+import { ScalarCodeBlock } from '@scalar/components/code-block'
+import {
+  ScalarListbox,
+  type ScalarListboxOption,
+} from '@scalar/components/listbox'
+import {
+  ScalarIconArrowUp,
+  ScalarIconCaretDown,
+  ScalarIconMagnifyingGlass,
+  ScalarIconTrash,
+} from '@scalar/icons'
+import { computed, ref } from 'vue'
+
+import {
+  formatFrameData,
+  type WebSocketFrameDisplayFormat,
+} from '@/v2/blocks/channel-operation-block/helpers/format-frame-data'
+import type {
+  WebSocketConnectionLogEntry,
+  WebSocketFrame,
+  WebSocketSessionState,
+} from '@/v2/blocks/channel-operation-block/helpers/websocket-session'
+
+type MessageLogFilter = 'all' | 'incoming' | 'outgoing'
+
+const { frames, connectionLogEntries, sessionState } = defineProps<{
+  /** Chronological WebSocket frames */
+  frames: WebSocketFrame[]
+  /** Connection lifecycle entries */
+  connectionLogEntries: WebSocketConnectionLogEntry[]
+  /** Current WebSocket session state */
+  sessionState: WebSocketSessionState
+}>()
+
+const emit = defineEmits<{
+  (e: 'clear'): void
+}>()
+
+const MESSAGE_LOG_FILTER_OPTIONS = [
+  { id: 'all', label: 'All Messages' },
+  { id: 'incoming', label: 'Incoming' },
+  { id: 'outgoing', label: 'Outgoing' },
+] satisfies ScalarListboxOption[]
+const MESSAGE_DISPLAY_FORMAT_OPTIONS = [
+  { id: 'text', label: 'Text' },
+  { id: 'html', label: 'HTML' },
+  { id: 'json', label: 'JSON' },
+  { id: 'xml', label: 'XML' },
+] satisfies ScalarListboxOption[]
+
+const contentContainer = ref<HTMLElement | null>(null)
+const expandedConnectionEntryIds = ref<Set<string>>(new Set())
+const expandedMessageEntryIds = ref<Set<string>>(new Set())
+const selectedMessageDisplayFormats = ref<
+  Record<string, WebSocketFrameDisplayFormat>
+>({})
+const showJumpToLatest = ref(false)
+const selectedFilter = ref<MessageLogFilter>('all')
+const searchQuery = ref('')
+
+type WebSocketMessageLogEntry = WebSocketFrame & {
+  type: 'message'
+}
+
+type WebSocketLogEntry = WebSocketMessageLogEntry | WebSocketConnectionLogEntry
+type FormattedWebSocketMessageLogEntry = WebSocketMessageLogEntry & {
+  formatted: string
+  time: string
+}
+type FormattedWebSocketConnectionLogEntry = WebSocketConnectionLogEntry & {
+  formatted: string
+  time: string
+}
+type FormattedWebSocketLogEntry =
+  | FormattedWebSocketMessageLogEntry
+  | FormattedWebSocketConnectionLogEntry
+
+const logEntries = computed<WebSocketLogEntry[]>(() =>
+  [
+    ...frames.map((frame) => ({
+      ...frame,
+      type: 'message' as const,
+    })),
+    ...connectionLogEntries,
+  ].sort((a, b) => a.timestamp - b.timestamp),
+)
+
+const visibleLogEntries = computed(() => {
+  if (selectedFilter.value === 'incoming') {
+    return logEntries.value.filter(
+      (entry) => entry.type === 'message' && entry.direction === 'incoming',
+    )
+  }
+
+  if (selectedFilter.value === 'outgoing') {
+    return logEntries.value.filter(
+      (entry) => entry.type === 'message' && entry.direction === 'outgoing',
+    )
+  }
+
+  return logEntries.value
+})
+
+const getMessageEntryId = (entry: WebSocketMessageLogEntry): string =>
+  `${entry.direction}-${entry.timestamp}-${entry.opcode}`
+
+const getMessagePreview = (formatted: string): string => {
+  const preview = formatted.replace(/\s+/g, ' ').trim()
+
+  return preview.length > 96 ? `${preview.slice(0, 96)}…` : preview
+}
+
+const isMessageDisplayFormat = (
+  value: ScalarListboxOption['id'] | undefined,
+): value is WebSocketFrameDisplayFormat =>
+  value === 'text' || value === 'html' || value === 'json' || value === 'xml'
+
+const getMessageDisplayFormat = (
+  entry: WebSocketMessageLogEntry,
+): WebSocketFrameDisplayFormat =>
+  selectedMessageDisplayFormats.value[getMessageEntryId(entry)] ?? 'json'
+
+const getMessageDisplayFormatOption = (
+  entry: WebSocketMessageLogEntry,
+): ScalarListboxOption | undefined =>
+  MESSAGE_DISPLAY_FORMAT_OPTIONS.find(
+    ({ id }) => id === getMessageDisplayFormat(entry),
+  )
+
+const selectedFilterOption = computed(() =>
+  MESSAGE_LOG_FILTER_OPTIONS.find(({ id }) => id === selectedFilter.value),
+)
+
+const getMessageHighlightLanguage = (
+  entry: WebSocketMessageLogEntry,
+): string => {
+  const format = getMessageDisplayFormat(entry)
+
+  return format === 'text' ? 'plaintext' : format
+}
+
+const handleSelectDisplayFormat = (
+  entry: WebSocketMessageLogEntry,
+  option: ScalarListboxOption | undefined,
+): void => {
+  if (!isMessageDisplayFormat(option?.id)) {
+    return
+  }
+
+  selectedMessageDisplayFormats.value = {
+    ...selectedMessageDisplayFormats.value,
+    [getMessageEntryId(entry)]: option.id,
+  }
+}
+
+const isMessageLogFilter = (
+  value: ScalarListboxOption['id'] | undefined,
+): value is MessageLogFilter =>
+  value === 'all' || value === 'incoming' || value === 'outgoing'
+
+const handleSelectFilter = (option: ScalarListboxOption | undefined): void => {
+  if (!isMessageLogFilter(option?.id)) {
+    return
+  }
+
+  selectedFilter.value = option.id
+}
+
+const getSearchableLogEntryText = (
+  entry: FormattedWebSocketLogEntry,
+): string => {
+  if (entry.type === 'message') {
+    return [entry.direction, entry.opcode, entry.formatted, entry.time].join(
+      '\n',
+    )
+  }
+
+  return [
+    entry.status,
+    entry.message,
+    entry.detail,
+    entry.time,
+    ...(entry.details ?? []).flatMap(({ label, value }) => [label, value]),
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+const matchesSearchQuery = (entry: FormattedWebSocketLogEntry): boolean => {
+  const query = searchQuery.value.trim().toLowerCase()
+
+  if (!query) {
+    return true
+  }
+
+  return getSearchableLogEntryText(entry).toLowerCase().includes(query)
+}
+
+const formattedLogEntries = computed(() =>
+  [...visibleLogEntries.value]
+    .reverse()
+    .map((entry): FormattedWebSocketLogEntry => {
+      if (entry.type === 'message') {
+        return {
+          ...entry,
+          formatted: formatFrameData(
+            entry.data,
+            getMessageDisplayFormat(entry),
+          ),
+          time: new Date(entry.timestamp).toLocaleTimeString(),
+        }
+      }
+
+      return {
+        ...entry,
+        formatted: entry.message,
+        time: new Date(entry.timestamp).toLocaleTimeString(),
+      }
+    })
+    .filter(matchesSearchQuery),
+)
+
+const hasLogEntries = computed(() => logEntries.value.length > 0)
+const hasMessageFrames = computed(() => frames.length > 0)
+
+const emptyLogMessage = computed(() =>
+  sessionState === 'open'
+    ? 'Waiting for messages...'
+    : 'Connect to start receiving messages',
+)
+
+const showWaitingForMessages = computed(
+  () =>
+    sessionState === 'open' &&
+    !hasMessageFrames.value &&
+    selectedFilter.value === 'all' &&
+    !searchQuery.value.trim(),
+)
+
+const emptyFilterMessage = computed(() => {
+  if (searchQuery.value.trim()) {
+    return `No messages match "${searchQuery.value.trim()}"`
+  }
+
+  return selectedFilter.value === 'all'
+    ? 'No messages'
+    : `No ${selectedFilterOption.value?.label.toLowerCase()} messages`
+})
+
+const jumpToTop = (): void => {
+  if (contentContainer.value) {
+    contentContainer.value.scrollTop = 0
+  }
+  showJumpToLatest.value = false
+}
+
+const handleScroll = (event: Event): void => {
+  const target = event.currentTarget
+  if (!(target instanceof HTMLElement)) {
+    return
+  }
+
+  showJumpToLatest.value = target.scrollTop > 48
+}
+
+const isConnectionEntryExpanded = (id: string): boolean =>
+  expandedConnectionEntryIds.value.has(id)
+
+const toggleConnectionEntry = (id: string): void => {
+  const nextIds = new Set(expandedConnectionEntryIds.value)
+
+  if (nextIds.has(id)) {
+    nextIds.delete(id)
+  } else {
+    nextIds.add(id)
+  }
+
+  expandedConnectionEntryIds.value = nextIds
+}
+
+const isMessageEntryExpanded = (entry: WebSocketMessageLogEntry): boolean =>
+  expandedMessageEntryIds.value.has(getMessageEntryId(entry))
+
+const toggleMessageEntry = (entry: WebSocketMessageLogEntry): void => {
+  const id = getMessageEntryId(entry)
+  const nextIds = new Set(expandedMessageEntryIds.value)
+
+  if (nextIds.has(id)) {
+    nextIds.delete(id)
+  } else {
+    nextIds.add(id)
+  }
+
+  expandedMessageEntryIds.value = nextIds
+}
+</script>
+
+<template>
+  <div class="relative flex min-h-0 flex-1 flex-col">
+    <div
+      v-if="hasLogEntries"
+      class="flex flex-wrap items-center gap-2 border-b p-2">
+      <label
+        class="bg-b-2 focus-within:border-c-3/40 focus-within:bg-b-1 flex h-7 w-56 max-w-full items-center gap-1.5 rounded border border-transparent px-2 text-xs transition-colors">
+        <span class="sr-only">Search messages</span>
+        <ScalarIconMagnifyingGlass class="text-c-3 size-3.5 shrink-0" />
+        <input
+          v-model="searchQuery"
+          class="placeholder:text-c-3 text-c-1 min-w-0 flex-1 border-0 bg-transparent p-0 outline-none"
+          placeholder="Search"
+          spellcheck="false"
+          type="search" />
+      </label>
+      <ScalarListbox
+        :modelValue="selectedFilterOption"
+        :options="MESSAGE_LOG_FILTER_OPTIONS"
+        placement="bottom-start"
+        teleport
+        @update:modelValue="handleSelectFilter">
+        <ScalarButton
+          class="text-c-2 hover:text-c-1 flex gap-1.5 px-2 py-1 text-xs font-normal"
+          size="sm"
+          variant="ghost">
+          {{ selectedFilterOption?.label ?? 'All Messages' }}
+          <ScalarIconCaretDown
+            class="ui-open:rotate-180 size-3 transition-transform duration-100"
+            weight="bold" />
+        </ScalarButton>
+      </ScalarListbox>
+      <div class="flex-1" />
+      <ScalarButton
+        class="text-c-2 hover:text-c-1 gap-1.5 px-2 py-1 text-xs font-normal"
+        size="sm"
+        variant="ghost"
+        @click="emit('clear')">
+        <template #icon>
+          <ScalarIconTrash class="size-3.5" />
+        </template>
+        Clear Messages
+      </ScalarButton>
+    </div>
+    <div
+      v-if="!hasLogEntries"
+      class="text-c-3 flex flex-1 items-center justify-center p-4 text-sm">
+      {{ emptyLogMessage }}
+    </div>
+    <ScalarButton
+      v-if="hasLogEntries && showJumpToLatest"
+      class="absolute top-14 left-1/2 z-10 -translate-x-1/2 rounded-full shadow-lg"
+      size="sm"
+      variant="outlined"
+      @click="jumpToTop">
+      <template #icon>
+        <ScalarIconArrowUp class="size-full" />
+      </template>
+      Jump to latest
+    </ScalarButton>
+    <div
+      v-if="hasLogEntries"
+      ref="contentContainer"
+      class="custom-scroll flex flex-1 flex-col gap-2 overflow-y-auto p-3"
+      @scroll="handleScroll">
+      <div
+        v-if="showWaitingForMessages"
+        class="text-c-3 bg-b-2/60 rounded p-3 text-center text-xs">
+        Waiting for messages...
+      </div>
+      <div
+        v-if="formattedLogEntries.length === 0"
+        class="text-c-3 flex flex-1 items-center justify-center p-4 text-sm">
+        {{ emptyFilterMessage }}
+      </div>
+      <div
+        v-for="(entry, index) in formattedLogEntries"
+        :key="`${entry.timestamp}-${index}`"
+        class="flex flex-col gap-1">
+        <div v-if="entry.type === 'connection'">
+          <button
+            class="hover:bg-b-2 flex w-full cursor-pointer items-center gap-2 rounded p-2 text-left text-xs"
+            type="button"
+            @click="toggleConnectionEntry(entry.id)">
+            <span
+              class="font-code rounded px-1.5 py-0.5 font-bold"
+              :class="
+                entry.status === 'connected'
+                  ? 'bg-[var(--scalar-color-green)]/20 text-[var(--scalar-color-green)]'
+                  : entry.status === 'error'
+                    ? 'bg-[var(--scalar-color-red)]/20 text-[var(--scalar-color-red)]'
+                    : 'bg-b-2 text-c-2'
+              ">
+              {{ entry.status.toUpperCase() }}
+            </span>
+            <span class="text-c-1 min-w-0 flex-1 truncate">
+              {{ entry.message }}
+            </span>
+            <span class="text-c-3">{{ entry.time }}</span>
+            <ScalarIconCaretDown
+              class="text-c-3 size-3 shrink-0 transition-transform"
+              :class="{ 'rotate-180': isConnectionEntryExpanded(entry.id) }" />
+          </button>
+          <div
+            v-if="isConnectionEntryExpanded(entry.id)"
+            class="border-l-c-3/20 ml-5 flex flex-col gap-2 border-l pb-2 pl-3">
+            <div class="text-c-3 text-xs font-medium">Handshake Details</div>
+            <dl
+              class="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-1 text-xs">
+              <template
+                v-for="detail in entry.details ?? []"
+                :key="detail.label">
+                <dt class="text-c-3 whitespace-nowrap">{{ detail.label }}</dt>
+                <dd class="text-c-1 font-code min-w-0 break-all">
+                  {{ detail.value }}
+                </dd>
+              </template>
+            </dl>
+            <p
+              v-if="entry.detail"
+              class="text-c-2 font-code text-xs">
+              {{ entry.detail }}
+            </p>
+          </div>
+        </div>
+        <div v-else>
+          <button
+            class="hover:bg-b-2 flex w-full cursor-pointer items-center gap-2 rounded p-2 text-left text-xs"
+            type="button"
+            @click="toggleMessageEntry(entry)">
+            <span
+              class="font-code min-w-8 rounded px-1.5 py-0.5 text-center font-bold"
+              :class="
+                entry.direction === 'incoming'
+                  ? 'bg-[var(--scalar-color-blue)]/20 text-[var(--scalar-color-blue)]'
+                  : 'bg-[var(--scalar-color-green)]/20 text-[var(--scalar-color-green)]'
+              ">
+              {{ entry.direction === 'incoming' ? 'IN' : 'OUT' }}
+            </span>
+            <span
+              v-if="entry.opcode === 'binary'"
+              class="text-c-3">
+              binary
+            </span>
+            <span class="text-c-1 font-code min-w-0 flex-1 truncate">
+              {{ getMessagePreview(entry.formatted) }}
+            </span>
+            <span class="text-c-3">{{ entry.time }}</span>
+            <ScalarIconCaretDown
+              class="text-c-3 size-3 shrink-0 transition-transform"
+              :class="{ 'rotate-180': isMessageEntryExpanded(entry) }" />
+          </button>
+          <div
+            v-if="isMessageEntryExpanded(entry)"
+            class="ml-5 flex flex-col gap-1">
+            <div class="flex items-center justify-end">
+              <ScalarListbox
+                :modelValue="getMessageDisplayFormatOption(entry)"
+                :options="MESSAGE_DISPLAY_FORMAT_OPTIONS"
+                placement="bottom-end"
+                teleport
+                @update:modelValue="
+                  (option) => handleSelectDisplayFormat(entry, option)
+                ">
+                <ScalarButton
+                  class="text-c-2 hover:text-c-1 flex gap-1.5 px-2 py-1 text-xs font-normal"
+                  size="sm"
+                  variant="ghost">
+                  {{ getMessageDisplayFormatOption(entry)?.label ?? 'JSON' }}
+                  <ScalarIconCaretDown
+                    class="ui-open:rotate-180 size-3 transition-transform duration-100"
+                    weight="bold" />
+                </ScalarButton>
+              </ScalarListbox>
+            </div>
+            <ScalarCodeBlock
+              class="bg-b-2 rounded text-xs"
+              copy="hover"
+              :lang="getMessageHighlightLanguage(entry)"
+              :prettyPrintedContent="entry.formatted" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/components/WebSocketProtocolBadge.vue
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/components/WebSocketProtocolBadge.vue
@@ -1,0 +1,31 @@
+<script lang="ts">
+/**
+ * WebSocket protocol label for the channel connection bar (like HTTP method badges).
+ */
+export default {
+  name: 'WebSocketProtocolBadge',
+}
+</script>
+
+<script setup lang="ts">
+import { cva, cx } from '@scalar/use-hooks/useBindCx'
+
+const variants = cva({
+  base: 'text-center font-code text-3xs justify-center items-center flex',
+  variants: {
+    isSquare: {
+      true: 'px-2.5 whitespace-nowrap font-bold border-r h-fit m-auto',
+      false: 'rounded-full',
+    },
+  },
+})
+</script>
+
+<template>
+  <div
+    class="text-purple relative gap-1 whitespace-nowrap"
+    :class="cx(variants({ isSquare: true }))"
+    title="WebSocket channel">
+    WS
+  </div>
+</template>

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/apply-auth-to-websocket-url.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/apply-auth-to-websocket-url.test.ts
@@ -1,0 +1,209 @@
+import type { SecuritySchemeObjectSecret } from '@scalar/workspace-store/request-example'
+import { describe, expect, it } from 'vitest'
+
+import { WEBSOCKET_BEARER_TOKEN_QUERY_PARAM, applyAuthToWebSocketUrl } from './apply-auth-to-websocket-url'
+
+describe('applyAuthToWebSocketUrl', () => {
+  it('returns the URL unchanged when no schemes are provided', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [])
+
+    expect(result.url).toBe('wss://echo.example.com/socket')
+    expect(result.unsupported).toEqual([])
+  })
+
+  it('returns the URL unchanged when the input is not a valid URL', () => {
+    const result = applyAuthToWebSocketUrl('not-a-url', [
+      {
+        type: 'apiKey',
+        name: 'apiKey',
+        in: 'query',
+        'x-scalar-secret-token': 'abc',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe('not-a-url')
+    expect(result.unsupported).toEqual([])
+  })
+
+  it('appends apiKey-in-query credentials to the URL', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'apiKey',
+        name: 'apiKey',
+        in: 'query',
+        'x-scalar-secret-token': 'secret-token',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe('wss://echo.example.com/socket?apiKey=secret-token')
+    expect(result.unsupported).toEqual([])
+  })
+
+  it('overwrites an existing query parameter with the same name', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket?apiKey=old', [
+      {
+        type: 'apiKey',
+        name: 'apiKey',
+        in: 'query',
+        'x-scalar-secret-token': 'new-value',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe('wss://echo.example.com/socket?apiKey=new-value')
+  })
+
+  it('skips apiKey schemes that have no value yet', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'apiKey',
+        name: 'apiKey',
+        in: 'query',
+        'x-scalar-secret-token': '',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe('wss://echo.example.com/socket')
+  })
+
+  it('reports apiKey-in-header schemes as unsupported', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+        'x-scalar-secret-token': 'secret',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe('wss://echo.example.com/socket')
+    expect(result.unsupported).toEqual([expect.objectContaining({ name: 'X-API-Key' })])
+  })
+
+  it('leaves apiKey-in-cookie credentials to the browser', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'apiKey',
+        name: 'session',
+        in: 'cookie',
+        'x-scalar-secret-token': 'abc',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe('wss://echo.example.com/socket')
+    expect(result.unsupported).toEqual([])
+  })
+
+  it('embeds HTTP basic credentials in the URL userinfo', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'http',
+        scheme: 'basic',
+        'x-scalar-secret-username': 'user',
+        'x-scalar-secret-password': 'pass',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe('wss://user:pass@echo.example.com/socket')
+  })
+
+  it('percent-encodes basic auth credentials containing reserved characters', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'http',
+        scheme: 'basic',
+        'x-scalar-secret-username': 'us er',
+        'x-scalar-secret-password': 'p@ss',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe('wss://us%20er:p%40ss@echo.example.com/socket')
+  })
+
+  it('appends HTTP bearer tokens as the standard access_token query parameter', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'http',
+        scheme: 'bearer',
+        'x-scalar-secret-token': 'bearer-value',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe(`wss://echo.example.com/socket?${WEBSOCKET_BEARER_TOKEN_QUERY_PARAM}=bearer-value`)
+  })
+
+  it('appends OAuth2 access tokens from any flow with a stored secret', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {
+            'x-scalar-secret-token': 'oauth-token',
+          },
+        },
+      } as unknown as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe(`wss://echo.example.com/socket?${WEBSOCKET_BEARER_TOKEN_QUERY_PARAM}=oauth-token`)
+  })
+
+  it('appends OpenID Connect access tokens like OAuth2 tokens', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'openIdConnect',
+        openIdConnectUrl: 'https://issuer.example.com/.well-known/openid-configuration',
+        flows: {
+          authorizationCode: {
+            'x-scalar-secret-token': 'oidc-token',
+          },
+        },
+      } as unknown as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe(`wss://echo.example.com/socket?${WEBSOCKET_BEARER_TOKEN_QUERY_PARAM}=oidc-token`)
+  })
+
+  it('applies multiple schemes in a single pass', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'apiKey',
+        name: 'apiKey',
+        in: 'query',
+        'x-scalar-secret-token': 'key-value',
+      } as SecuritySchemeObjectSecret,
+      {
+        type: 'http',
+        scheme: 'bearer',
+        'x-scalar-secret-token': 'bearer-value',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    const url = new URL(result.url)
+    expect(url.searchParams.get('apiKey')).toBe('key-value')
+    expect(url.searchParams.get(WEBSOCKET_BEARER_TOKEN_QUERY_PARAM)).toBe('bearer-value')
+  })
+
+  it('skips bearer schemes when no token is present', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'http',
+        scheme: 'bearer',
+        'x-scalar-secret-token': '',
+      } as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe('wss://echo.example.com/socket')
+  })
+
+  it('skips OAuth flows when none carries a token', () => {
+    const result = applyAuthToWebSocketUrl('wss://echo.example.com/socket', [
+      {
+        type: 'oauth2',
+        flows: {
+          authorizationCode: {},
+        },
+      } as unknown as SecuritySchemeObjectSecret,
+    ])
+
+    expect(result.url).toBe('wss://echo.example.com/socket')
+  })
+})

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/apply-auth-to-websocket-url.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/apply-auth-to-websocket-url.ts
@@ -1,0 +1,115 @@
+import type { SecuritySchemeObjectSecret } from '@scalar/workspace-store/request-example'
+
+/**
+ * Conventional URL query parameter name used to carry bearer tokens on
+ * WebSocket handshakes. RFC 6750 §2.3 allows OAuth bearer tokens to travel
+ * via a URI query parameter and many WebSocket servers adopt the same name.
+ */
+export const WEBSOCKET_BEARER_TOKEN_QUERY_PARAM = 'access_token'
+
+export type UnsupportedAuthScheme = {
+  /** Display name of the security scheme that could not be applied. */
+  name: string
+  /** Human-readable explanation of why the scheme was skipped. */
+  reason: string
+}
+
+export type AppliedWebSocketAuth = {
+  /** The connection URL with applicable credentials inserted. */
+  url: string
+  /** Security schemes that could not be applied in the browser. */
+  unsupported: UnsupportedAuthScheme[]
+}
+
+const BROWSER_HEADER_REASON =
+  'Browser WebSocket clients cannot send custom request headers. Move this credential to a URL query parameter or a cookie.'
+
+/**
+ * Apply selected security schemes to a WebSocket connection URL.
+ *
+ * Browser `WebSocket` cannot set arbitrary handshake headers, so this helper
+ * only writes credentials that survive in the URL itself:
+ *
+ * - `apiKey` in `query`: added as `<name>=<value>` to the URL search.
+ * - `apiKey` in `cookie`: no-op, since the browser attaches cookies automatically.
+ * - `apiKey` in `header`: returned as unsupported (cannot be applied in browsers).
+ * - `http` `basic`: embedded as URL userinfo (`wss://user:pass@host`).
+ * - `http` `bearer`, `oauth2`, `openIdConnect`: appended as `?access_token=<token>`.
+ *
+ * Empty secrets are skipped so the URL stays clean until the user fills them in.
+ * When `connectionUrl` is not parseable as a URL the input is returned unchanged.
+ */
+export const applyAuthToWebSocketUrl = (
+  connectionUrl: string,
+  selectedSecuritySchemes: SecuritySchemeObjectSecret[],
+): AppliedWebSocketAuth => {
+  const unsupported: UnsupportedAuthScheme[] = []
+
+  let url: URL
+  try {
+    url = new URL(connectionUrl)
+  } catch {
+    return { url: connectionUrl, unsupported }
+  }
+
+  for (const scheme of selectedSecuritySchemes) {
+    if (scheme.type === 'apiKey') {
+      const value = scheme['x-scalar-secret-token']
+      if (!value) {
+        continue
+      }
+
+      if (scheme.in === 'query') {
+        url.searchParams.set(scheme.name, value)
+        continue
+      }
+
+      if (scheme.in === 'header') {
+        unsupported.push({
+          name: scheme.name || 'API key',
+          reason: BROWSER_HEADER_REASON,
+        })
+        continue
+      }
+
+      // `cookie` is set automatically by the browser when the user has a session
+      // for the origin, so there is nothing for the client to do here.
+      continue
+    }
+
+    if (scheme.type === 'http') {
+      if (scheme.scheme === 'basic') {
+        const username = scheme['x-scalar-secret-username']
+        const password = scheme['x-scalar-secret-password']
+        if (!username && !password) {
+          continue
+        }
+        // The URL setters apply the userinfo percent-encode set automatically, so
+        // raw values are safe to assign here without manual `encodeURIComponent`.
+        url.username = username ?? ''
+        url.password = password ?? ''
+        continue
+      }
+
+      // Bearer token — falls through to the OAuth-style query parameter path
+      // because browser WebSocket cannot send an `Authorization` header.
+      const token = scheme['x-scalar-secret-token']
+      if (!token) {
+        continue
+      }
+      url.searchParams.set(WEBSOCKET_BEARER_TOKEN_QUERY_PARAM, token)
+      continue
+    }
+
+    if (scheme.type === 'oauth2' || scheme.type === 'openIdConnect') {
+      const flows = Object.values(scheme.flows ?? {})
+      const token = flows.find((flow) => flow?.['x-scalar-secret-token'])?.['x-scalar-secret-token']
+      if (!token) {
+        continue
+      }
+      url.searchParams.set(WEBSOCKET_BEARER_TOKEN_QUERY_PARAM, token)
+    }
+  }
+
+  return { url: url.toString(), unsupported }
+}

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/channel-action-info.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/channel-action-info.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { getChannelActionInfo } from './channel-action-info'
+
+describe('getChannelActionInfo', () => {
+  it('uses green text styling for send operations', () => {
+    expect(getChannelActionInfo('send')).toEqual({
+      short: 'SEND',
+      colorClass: 'text-green',
+      colorVar: 'var(--scalar-color-green)',
+    })
+  })
+
+  it('uses blue text styling for receive operations', () => {
+    expect(getChannelActionInfo('receive')).toEqual({
+      short: 'RECV',
+      colorClass: 'text-blue',
+      colorVar: 'var(--scalar-color-blue)',
+    })
+  })
+})

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/channel-action-info.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/channel-action-info.ts
@@ -1,0 +1,21 @@
+/** Visual styling for AsyncAPI channel operation action badges in the connection bar. */
+type ChannelActionInfo = {
+  short: string
+  colorClass: `text-${string}`
+  colorVar: `var(--scalar-color-${string})`
+}
+
+const CHANNEL_ACTIONS = {
+  send: {
+    short: 'SEND',
+    colorClass: 'text-green',
+    colorVar: 'var(--scalar-color-green)',
+  },
+  receive: {
+    short: 'RECV',
+    colorClass: 'text-blue',
+    colorVar: 'var(--scalar-color-blue)',
+  },
+} as const satisfies Record<'send' | 'receive', ChannelActionInfo>
+
+export const getChannelActionInfo = (action: 'send' | 'receive'): ChannelActionInfo => CHANNEL_ACTIONS[action]

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connection-bar-url.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connection-bar-url.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { mergeConnectionUrl, splitConnectionUrl } from './connection-bar-url'
+
+describe('splitConnectionUrl', () => {
+  it('returns an empty path when the connection URL equals the server base', () => {
+    expect(splitConnectionUrl('wss://echo.websocket.org', 'wss://echo.websocket.org')).toEqual({
+      base: 'wss://echo.websocket.org',
+      path: '',
+    })
+  })
+
+  it('returns the channel address as the path suffix', () => {
+    expect(splitConnectionUrl('wss://galaxy.scalar.com/planets/mars/events', 'wss://galaxy.scalar.com')).toEqual({
+      base: 'wss://galaxy.scalar.com',
+      path: '/planets/mars/events',
+    })
+  })
+})
+
+describe('mergeConnectionUrl', () => {
+  it('rebuilds the full URL from base and path', () => {
+    expect(mergeConnectionUrl('wss://echo.websocket.org', '/chat')).toBe('wss://echo.websocket.org/chat')
+  })
+
+  it('returns only the base when the path is empty', () => {
+    expect(mergeConnectionUrl('wss://echo.websocket.org', '')).toBe('wss://echo.websocket.org')
+  })
+})

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connection-bar-url.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/connection-bar-url.ts
@@ -1,0 +1,46 @@
+/** Strips a trailing slash for stable server base / path comparison. */
+export const stripTrailingSlash = (url: string): string => (url.endsWith('/') ? url.slice(0, -1) : url)
+
+/**
+ * Splits a WebSocket connection URL into server base and path suffix,
+ * matching the HTTP address bar pattern (server dropdown + path field).
+ */
+export const splitConnectionUrl = (connectionUrl: string, serverBaseUrl: string): { base: string; path: string } => {
+  const full = stripTrailingSlash(connectionUrl)
+  const base = stripTrailingSlash(serverBaseUrl)
+
+  if (!base) {
+    return { base: '', path: connectionUrl }
+  }
+
+  if (full === base) {
+    return { base, path: '' }
+  }
+
+  if (full.startsWith(`${base}/`)) {
+    return { base, path: full.slice(base.length) }
+  }
+
+  if (full.startsWith(base)) {
+    const remainder = full.slice(base.length)
+    return { base, path: remainder.startsWith('/') ? remainder : `/${remainder}` }
+  }
+
+  return { base, path: connectionUrl }
+}
+
+/** Merges server base and path segment into a full connection URL. */
+export const mergeConnectionUrl = (serverBaseUrl: string, path: string): string => {
+  const base = stripTrailingSlash(serverBaseUrl)
+
+  if (!base) {
+    return path
+  }
+
+  if (!path) {
+    return base
+  }
+
+  const suffix = path.startsWith('/') ? path : `/${path}`
+  return `${base}${suffix}`
+}

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/create-channel-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/create-channel-parameter-rows.ts
@@ -1,0 +1,20 @@
+import type { AsyncApiParameterObject } from '@scalar/types/asyncapi/3.1'
+
+import type { TableRow } from '@/v2/blocks/request-block/components/RequestTableRow.vue'
+
+/**
+ * Converts channel path or query parameter maps into request table rows.
+ */
+export const createChannelParameterRows = (
+  definitions: Record<string, AsyncApiParameterObject>,
+  values: Record<string, string>,
+): TableRow[] =>
+  Object.entries(values).map(([name, value]) => {
+    const parameter = definitions[name]
+
+    return {
+      name,
+      value,
+      description: parameter?.description,
+    }
+  })

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/format-frame-data.test.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/format-frame-data.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatFrameData } from './format-frame-data'
+
+describe('formatFrameData', () => {
+  it('pretty-prints JSON strings', () => {
+    expect(formatFrameData('{"type":"ping"}')).toBe('{\n  "type": "ping"\n}')
+  })
+
+  it('pretty-prints JSONC strings', () => {
+    expect(formatFrameData('{"type":"ping",// comment\n}')).toBe('{\n  "type": "ping", // comment\n}')
+  })
+
+  it('returns raw text for non-JSON display formats', () => {
+    expect(formatFrameData('{"type":"ping"}', 'text')).toBe('{"type":"ping"}')
+    expect(formatFrameData('<message>hello</message>', 'xml')).toBe('<message>hello</message>')
+  })
+
+  it('returns plain text when JSON parsing fails', () => {
+    expect(formatFrameData('hello')).toBe('hello')
+  })
+
+  it('describes binary payloads', () => {
+    expect(formatFrameData(new ArrayBuffer(4))).toBe('[Binary 4 bytes]')
+  })
+})

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/format-frame-data.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/format-frame-data.ts
@@ -1,0 +1,15 @@
+/**
+ * Formats WebSocket frame payload for display in the message log.
+ */
+
+import { prettifyJsoncString } from '@/v2/blocks/response-block/helpers/prettify-jsonc-string'
+
+export type WebSocketFrameDisplayFormat = 'text' | 'html' | 'json' | 'xml'
+
+export const formatFrameData = (data: string | ArrayBuffer, format: WebSocketFrameDisplayFormat = 'json'): string => {
+  if (typeof data === 'string') {
+    return format === 'json' ? prettifyJsoncString(data) : data
+  }
+
+  return `[Binary ${data.byteLength} bytes]`
+}

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/get-message-payload-example.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/get-message-payload-example.ts
@@ -1,0 +1,29 @@
+import { isObject } from '@scalar/helpers/object/is-object'
+import type { AsyncApiMessageObject } from '@scalar/types/asyncapi/3.1'
+import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
+import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+
+const isJsonSchema = (value: unknown): value is SchemaObject =>
+  isObject(value) && ('type' in value || 'properties' in value || '$ref' in value)
+
+/**
+ * Builds a JSON string sample for the message payload editor from schema or examples.
+ */
+export const getMessagePayloadExample = (message: AsyncApiMessageObject): string => {
+  const payload = message.payload
+
+  if (payload == null) {
+    return '{}'
+  }
+
+  if (isObject(payload) && 'example' in payload && payload.example != null) {
+    return JSON.stringify(payload.example, null, 2)
+  }
+
+  if (isJsonSchema(payload)) {
+    const example = getExampleFromSchema(payload)
+    return JSON.stringify(example, null, 2)
+  }
+
+  return JSON.stringify(payload, null, 2)
+}

--- a/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/helpers/websocket-session.ts
@@ -21,6 +21,19 @@ export type WebSocketFrame = {
   opcode: WebSocketFrameOpcode
 }
 
+export type WebSocketConnectionLogEntry = {
+  id: string
+  type: 'connection'
+  status: 'connected' | 'disconnected' | 'error'
+  timestamp: number
+  message: string
+  detail?: string
+  details?: {
+    label: string
+    value: string
+  }[]
+}
+
 export type WebSocketCloseInfo = {
   code: number
   reason: string

--- a/packages/api-client/src/v2/blocks/channel-operation-block/index.ts
+++ b/packages/api-client/src/v2/blocks/channel-operation-block/index.ts
@@ -1,3 +1,10 @@
+export { default as ChannelOperationBlock } from './ChannelOperationBlock.vue'
+export {
+  type AppliedWebSocketAuth,
+  type UnsupportedAuthScheme,
+  WEBSOCKET_BEARER_TOKEN_QUERY_PARAM,
+  applyAuthToWebSocketUrl,
+} from './helpers/apply-auth-to-websocket-url'
 export {
   type ConnectWebSocketData,
   type ConnectWebSocketFailureCode,
@@ -10,6 +17,7 @@ export {
 export {
   type WebSocketCloseInfo,
   type WebSocketConnectOptions,
+  type WebSocketConnectionLogEntry,
   type WebSocketFrame,
   type WebSocketFrameOpcode,
   type WebSocketSession,

--- a/packages/api-client/src/v2/features/channel-operation/ChannelOperation.vue
+++ b/packages/api-client/src/v2/features/channel-operation/ChannelOperation.vue
@@ -1,0 +1,114 @@
+<script lang="ts">
+/**
+ * Channel operation page
+ *
+ * Displays an AsyncAPI channel with a WebSocket connection editor, auth, messages,
+ * and a live frame log.
+ */
+export default {
+  name: 'ChannelOperation',
+}
+
+type ChannelOperationProps = {
+  /** The slug of the currently selected document in the workspace */
+  documentSlug: string
+  /** The currently active document - AsyncAPI-only, the channel page has no OpenAPI path */
+  document: AsyncApiDocument | null
+  /** The workspace event bus */
+  eventBus: WorkspaceEventBus
+  /** The layout of the client */
+  layout: ClientLayout
+  /** The AsyncAPI channel currently selected */
+  channelName?: string
+  /** The currently active environment */
+  environment: XScalarEnvironment
+  /** The workspace store */
+  workspaceStore: WorkspaceStore
+  /** Client plugins */
+  plugins: ClientPlugin[]
+  /** App or modal options forwarded to channel/auth blocks */
+  options?: MaybeRefOrGetter<ApiClientOptions>
+}
+</script>
+
+<script setup lang="ts">
+import type { ClientPlugin } from '@scalar/oas-utils/helpers'
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import {
+  getChannelConnectionContext,
+  type BuildChannelConnectionContext,
+} from '@scalar/workspace-store/channel-example'
+import type { WorkspaceStore } from '@scalar/workspace-store/client'
+import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
+import type { XScalarEnvironment } from '@scalar/workspace-store/schemas/extensions/document/x-scalar-environments'
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+
+import { ChannelOperationBlock } from '@/v2/blocks/channel-operation-block'
+import type { ClientLayout } from '@/v2/types/layout'
+import type { ApiClientOptions } from '@/v2/types/options'
+
+const {
+  channelName,
+  document,
+  documentSlug,
+  environment,
+  eventBus,
+  layout,
+  options,
+  plugins,
+  workspaceStore,
+} = defineProps<ChannelOperationProps>()
+
+const channelConnection = computed((): BuildChannelConnectionContext | null => {
+  if (!channelName || !document) {
+    return null
+  }
+
+  const result = getChannelConnectionContext(
+    workspaceStore,
+    documentSlug,
+    { channelName },
+    {
+      authentication: toValue(options)?.authentication,
+      fallbackDocument: document,
+    },
+  )
+
+  return result.ok ? result.data : null
+})
+
+const resolvedOptions = computed(() => toValue(options))
+</script>
+
+<template>
+  <ChannelOperationBlock
+    v-if="channelConnection"
+    :authMeta="channelConnection.security.meta"
+    :channel="channelConnection.channel"
+    :channelAddress="channelConnection.channelAddress"
+    :channelName="channelConnection.channelName"
+    :connectionUrl="channelConnection.connectionUrl"
+    :documentSlug
+    :environment
+    :eventBus
+    :layout
+    :messages="channelConnection.messages"
+    :operations="channelConnection.operations"
+    :options="resolvedOptions"
+    :parameters="channelConnection.parameters"
+    :plugins
+    :securityRequirements="channelConnection.security.requirements"
+    :securitySchemes="channelConnection.security.schemes"
+    :selectedMessage="channelConnection.selectedMessage"
+    :selectedSecurity="channelConnection.security.selected"
+    :selectedSecuritySchemes="channelConnection.security.selectedSchemes"
+    :selectedServer="channelConnection.servers.selected"
+    :servers="channelConnection.servers.list"
+    :workspaceStore />
+
+  <div
+    v-else
+    class="flex h-full w-full items-center justify-center">
+    <span class="text-c-3">Select a channel to view details</span>
+  </div>
+</template>

--- a/packages/api-client/src/v2/features/channel-operation/index.ts
+++ b/packages/api-client/src/v2/features/channel-operation/index.ts
@@ -1,0 +1,1 @@
+export { default as ChannelOperation } from './ChannelOperation.vue'

--- a/packages/api-client/src/v2/features/modal/Modal.test.ts
+++ b/packages/api-client/src/v2/features/modal/Modal.test.ts
@@ -65,6 +65,7 @@ const documentSlug = computed<string | undefined>(() => 'test-doc')
 const path = computed<string | undefined>(() => '/users')
 const method = computed<'get' | 'post' | undefined>(() => 'get')
 const exampleName = computed<string | undefined>(() => 'default')
+const channel = computed<string | undefined>(() => undefined)
 
 /**
  * Creates fresh per-test reactive wrappers around the shared store.
@@ -74,6 +75,7 @@ const createProps = () => {
   const document = computed<OpenApiDocument | null>(
     () => (store.workspace.documents[documentSlug.value ?? ''] as OpenApiDocument | undefined) ?? null,
   )
+  const asyncApiDocument = computed(() => null)
   const modalState = useModal()
   const requestBodyCompositionSelection = ref<Record<string, number>>({})
 
@@ -83,6 +85,7 @@ const createProps = () => {
     path,
     method,
     exampleName,
+    channel,
     route: vi.fn(),
   })
 
@@ -97,6 +100,8 @@ const createProps = () => {
     props: {
       workspaceStore: store,
       document,
+      asyncApiDocument,
+      channel: computed(() => channel.value),
       path: computed(() => path.value),
       method: computed(() => method.value),
       options: createModalOptions(),
@@ -199,6 +204,7 @@ describe('Modal', () => {
       path: computed<string | undefined>(() => undefined),
       method: computed<'get' | 'post' | undefined>(() => undefined),
       exampleName: computed<string | undefined>(() => undefined),
+      channel: computed<string | undefined>(() => undefined),
       route: vi.fn(),
     })
 
@@ -206,6 +212,8 @@ describe('Modal', () => {
       props: {
         workspaceStore: emptyStore,
         document: emptyDocument,
+        asyncApiDocument: computed(() => null),
+        channel: computed(() => undefined),
         path: computed(() => undefined),
         method: computed(() => undefined),
         options: createModalOptions(),
@@ -400,6 +408,8 @@ describe('Modal', () => {
       props: {
         workspaceStore: rawStore,
         document,
+        asyncApiDocument: computed(() => null),
+        channel: computed(() => undefined),
         path: rawPath,
         method: rawMethod,
         options: createModalOptions(),
@@ -413,6 +423,7 @@ describe('Modal', () => {
           path: rawPath,
           method: rawMethod,
           exampleName: rawExampleName,
+          channel: computed<string | undefined>(() => undefined),
           route: vi.fn(),
         }),
         eventBus: mockEventBus,

--- a/packages/api-client/src/v2/features/modal/Modal.vue
+++ b/packages/api-client/src/v2/features/modal/Modal.vue
@@ -2,14 +2,18 @@
 export type ModalProps = {
   /** The workspace store must be initialized and passed in */
   workspaceStore: WorkspaceStore
-  /** The document must be initialized and passed in. OpenAPI-only — the modal has no AsyncAPI path. */
+  /** The active OpenAPI document, or null when the active document is AsyncAPI. */
   document: ComputedRef<OpenApiDocument | null>
+  /** The active AsyncAPI document, or null when the active document is OpenAPI. */
+  asyncApiDocument: ComputedRef<AsyncApiDocument | null>
   /** The path must be initialized and passed in */
   path: ComputedRef<string | undefined>
   /** The event bus for handling all events */
   eventBus: WorkspaceEventBus
   /** The method must be initialized and passed in */
   method: ComputedRef<HttpMethod | undefined>
+  /** The active AsyncAPI channel key, when the active document is AsyncAPI. */
+  channel: ComputedRef<string | undefined>
   /** The example name must be initialized and passed in */
   exampleName: ComputedRef<string | undefined>
   /** Selected anyOf/oneOf request-body variants keyed by schema path */
@@ -37,6 +41,7 @@ import type { ScalarListboxOption } from '@scalar/components/listbox'
 import type { ModalState } from '@scalar/components/modal'
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import type { ClientPlugin } from '@scalar/oas-utils/helpers'
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import { ScalarToasts } from '@scalar/use-toasts'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { type WorkspaceEventBus } from '@scalar/workspace-store/events'
@@ -54,6 +59,7 @@ import {
 
 import ModalClientContainer from '@/v2/components/modals/ModalClientContainer.vue'
 import { Sidebar, SidebarToggle } from '@/v2/components/sidebar'
+import ChannelOperation from '@/v2/features/channel-operation/ChannelOperation.vue'
 import { type UseModalSidebarReturn } from '@/v2/features/modal/hooks/use-modal-sidebar'
 import { initializeModalEvents } from '@/v2/features/modal/modal-events'
 import Operation from '@/v2/features/operation/Operation.vue'
@@ -63,9 +69,13 @@ import type { ApiClientOptions, ApiClientOptionsRef } from '@/v2/types/options'
 
 const {
   document,
+  asyncApiDocument,
+  channel,
   eventBus,
   modalState,
   options,
+  path,
+  method,
   plugins,
   requestBodyCompositionSelection,
   sidebarState,
@@ -136,13 +146,36 @@ const sidebarWidth = computed(
 const handleSidebarWidthUpdate = (width: number) =>
   workspaceStore?.update('x-scalar-sidebar-width', width)
 
+/** The active document, whichever spec it follows. Used for the sidebar and environment. */
+const activeDocument = computed(() => document.value ?? asyncApiDocument.value)
+
+/** The auth-store key for the active document. */
+const activeDocumentSlug = computed(
+  () => activeDocument.value?.['x-scalar-navigation']?.name ?? '',
+)
+
+/** True when the active document is an AsyncAPI channel connection rather than an OpenAPI operation. */
+const isChannel = computed(() =>
+  Boolean(asyncApiDocument.value && channel.value),
+)
+
+/** True when an OpenAPI operation is fully addressed and ready to render. */
+const isOperation = computed(() =>
+  Boolean(document.value && path.value && method.value),
+)
+
+/** The documents shown in the sidebar (the single active document). */
+const sidebarDocuments = computed(() =>
+  activeDocument.value ? [activeDocument.value] : [],
+)
+
 /**
  * Merged environment variables from workspace and document levels.
  * Variables from both sources are combined, with document variables
  * taking precedence in case of naming conflicts.
  */
 const environment = computed(
-  () => getActiveEnvironment(workspaceStore, document.value).environment,
+  () => getActiveEnvironment(workspaceStore, activeDocument.value).environment,
 )
 
 defineExpose({
@@ -156,9 +189,9 @@ defineExpose({
     <!-- Toasts -->
     <ScalarToasts />
 
-    <!-- If we have a document, path and method, render the operation -->
+    <!-- Render an OpenAPI operation or an AsyncAPI channel connection -->
     <main
-      v-if="document.value && path?.value && method?.value"
+      v-if="isOperation || isChannel"
       class="relative flex h-full min-h-0 w-full flex-1">
       <SidebarToggle
         v-model="isSidebarOpen"
@@ -168,7 +201,7 @@ defineExpose({
         v-model:sidebarWidth="sidebarWidth"
         :activeWorkspace="activeWorkspace"
         class="h-full max-md:absolute! max-md:z-5 max-md:w-full!"
-        :documents="[document.value]"
+        :documents="sidebarDocuments"
         :eventBus
         :isDroppable="() => false"
         layout="modal"
@@ -176,7 +209,20 @@ defineExpose({
         :workspaces="[]"
         @selectItem="sidebarState.handleSelectItem"
         @update:sidebarWidth="handleSidebarWidthUpdate" />
+      <ChannelOperation
+        v-if="isChannel"
+        :channelName="channel?.value"
+        class="flex-1"
+        :document="asyncApiDocument.value"
+        :documentSlug="activeDocumentSlug"
+        :environment
+        :eventBus
+        layout="modal"
+        :options
+        :plugins
+        :workspaceStore />
       <Operation
+        v-else-if="document.value && isOperation"
         :activeWorkspace="activeWorkspace"
         class="flex-1"
         :document="document.value"

--- a/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/create-api-client-modal.ts
@@ -2,7 +2,7 @@ import { type ModalState, useModal } from '@scalar/components/modal'
 import { type ClientPlugin, subscribePluginEvents } from '@scalar/oas-utils/helpers'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { type WorkspaceEventBus, createWorkspaceEventBus } from '@scalar/workspace-store/events'
-import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
+import { isAsyncApiDocument, isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { type App, type MaybeRefOrGetter, computed, createApp, isRef, reactive, ref, toValue, watch } from 'vue'
 
 import {
@@ -78,6 +78,7 @@ export const createApiClientModal = ({
     path: 'default',
     method: 'default',
     example: 'default',
+    channel: 'default',
     documentSlug: workspaceStore.workspace['x-scalar-active-document'] || 'default',
   }
 
@@ -94,10 +95,16 @@ export const createApiClientModal = ({
   const path = computed(() => resolvedParameters.value.path)
   const method = computed(() => resolvedParameters.value.method)
   const exampleName = computed(() => resolvedParameters.value.example)
-  /** The document from the workspace store. Modal is OpenAPI-only; AsyncAPI docs surface as null. */
+  const channel = computed(() => resolvedParameters.value.channel)
+  /** The OpenAPI document from the workspace store. AsyncAPI docs surface as null here. */
   const document = computed(() => {
     const doc = workspaceStore.workspace.documents[documentSlug.value ?? '']
     return isOpenApiDocument(doc) ? doc : null
+  })
+  /** The AsyncAPI document from the workspace store. OpenAPI docs surface as null here. */
+  const asyncApiDocument = computed(() => {
+    const doc = workspaceStore.workspace.documents[documentSlug.value ?? '']
+    return isAsyncApiDocument(doc) ? doc : null
   })
 
   /** Sidebar state and selection handling. */
@@ -107,6 +114,7 @@ export const createApiClientModal = ({
     path: path,
     method: method,
     exampleName: exampleName,
+    channel: channel,
     route,
   })
 
@@ -114,6 +122,8 @@ export const createApiClientModal = ({
 
   const app = createApp(Modal, {
     document,
+    asyncApiDocument,
+    channel,
     eventBus,
     exampleName,
     method,

--- a/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.test.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.test.ts
@@ -1,3 +1,4 @@
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
 import { describe, expect, it } from 'vitest'
@@ -7,6 +8,7 @@ import 'fake-indexeddb/auto'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 import {
+  resolveChannel,
   resolveDocumentSlug,
   resolveExampleName,
   resolveMethod,
@@ -600,5 +602,25 @@ describe('resolve-route-parameters', () => {
     expect(result.documentSlug).toBe('active-doc')
     expect(result.path).toBe('/new')
     expect(result.method).toBe('post')
+  })
+
+  describe('resolveChannel', () => {
+    const asyncDocument = {
+      asyncapi: '3.0.0',
+      info: { title: 'Rooms', version: '1.0.0' },
+      channels: { room: { address: '/room' }, lobby: { address: '/lobby' } },
+    } as unknown as AsyncApiDocument
+
+    it('returns the first channel for the default placeholder', () => {
+      expect(resolveChannel(asyncDocument, 'default')).toBe('room')
+    })
+
+    it('returns the requested channel when it exists', () => {
+      expect(resolveChannel(asyncDocument, 'lobby')).toBe('lobby')
+    })
+
+    it('falls back to the first channel when the requested one is missing', () => {
+      expect(resolveChannel(asyncDocument, 'missing')).toBe('room')
+    })
   })
 })

--- a/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.test.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.test.ts
@@ -92,9 +92,9 @@ describe('resolve-route-parameters', () => {
     expect(result).toBeUndefined()
   })
 
-  it('skips an AsyncAPI active document and falls back to the first OpenAPI document', async () => {
-    // Modal routing is OpenAPI-only — picking the AsyncAPI active doc here
-    // would hand the modal a slug that resolves to `document: null`.
+  it('honors an AsyncAPI active document', async () => {
+    // The modal renders AsyncAPI channels too, so the active document wins even
+    // when an OpenAPI document is also present.
     const store = createWorkspaceStore()
     await store.addDocument({
       name: 'async-doc',
@@ -108,7 +108,7 @@ describe('resolve-route-parameters', () => {
 
     const result = resolveDocumentSlug(store, 'default')
 
-    expect(result).toBe('openapi-doc')
+    expect(result).toBe('async-doc')
   })
 
   it('skips an AsyncAPI first document and returns the first OpenAPI document', async () => {
@@ -127,7 +127,7 @@ describe('resolve-route-parameters', () => {
     expect(result).toBe('openapi-doc')
   })
 
-  it('returns undefined when only AsyncAPI documents exist', async () => {
+  it('returns the AsyncAPI document when only AsyncAPI documents exist', async () => {
     const store = createWorkspaceStore()
     await store.addDocument({
       name: 'async-doc',
@@ -136,7 +136,7 @@ describe('resolve-route-parameters', () => {
 
     const result = resolveDocumentSlug(store, 'default')
 
-    expect(result).toBeUndefined()
+    expect(result).toBe('async-doc')
   })
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.ts
+++ b/packages/api-client/src/v2/features/modal/helpers/resolve-route-parameters.ts
@@ -1,21 +1,31 @@
 import type { HttpMethod } from '@scalar/helpers/http/http-methods'
 import { isHttpMethod } from '@scalar/helpers/http/is-http-method'
+import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { getResolvedPathItem } from '@scalar/workspace-store/helpers/for-each-path-item-operation'
 import { getOperationEntries } from '@scalar/workspace-store/navigation'
 import type { TraversedEntry, TraversedExample } from '@scalar/workspace-store/schemas/navigation'
-import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
+import { isAsyncApiDocument, isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 
 /** Payload for routing and opening the API client modal. */
 export type RoutePayload = {
-  path: string
-  method: HttpMethod
+  /** OpenAPI path. Optional because AsyncAPI documents route by channel instead. */
+  path?: string
+  /** OpenAPI method. Optional because AsyncAPI documents route by channel instead. */
+  method?: HttpMethod
   example?: string
   documentSlug?: string
+  /** AsyncAPI channel key. AsyncAPI documents route by channel instead of path/method. */
+  channel?: string
 }
 
-/** Raw input values that may contain "default" placeholders. */
-export type DefaultEntities = Record<keyof RoutePayload, string>
+/**
+ * Raw input values that may contain "default" placeholders.
+ *
+ * `channel` is optional: OpenAPI callers never set it, and AsyncAPI callers that omit it fall back
+ * to the document's first channel.
+ */
+export type DefaultEntities = Record<keyof Omit<RoutePayload, 'channel'>, string> & { channel?: string }
 
 /** Context for resolving route parameters from the workspace store. */
 type ResolverContext = {
@@ -27,9 +37,9 @@ type ResolverContext = {
 const isExample = (entry: TraversedEntry): entry is TraversedExample => entry.type === 'example'
 
 /**
- * Gets the document from the workspace store.
- * Returns undefined if the document slug is not provided or the document does not exist.
- * Modal routing is OpenAPI-only — AsyncAPI docs surface as undefined here.
+ * Gets the OpenAPI document from the workspace store.
+ * Returns undefined if the document slug is not provided or the document is not OpenAPI.
+ * Path/method/example resolution is OpenAPI-only — AsyncAPI docs surface as undefined here.
  */
 const getDocument = (ctx: ResolverContext) => {
   const doc = ctx.store.workspace.documents[ctx.documentSlug ?? '']
@@ -37,15 +47,38 @@ const getDocument = (ctx: ResolverContext) => {
 }
 
 /**
+ * Gets the AsyncAPI document from the workspace store.
+ * Returns undefined if the document slug is not provided or the document is not AsyncAPI.
+ */
+const getAsyncApiDocument = (ctx: ResolverContext): AsyncApiDocument | undefined => {
+  const doc = ctx.store.workspace.documents[ctx.documentSlug ?? '']
+  return isAsyncApiDocument(doc) ? doc : undefined
+}
+
+/**
+ * Resolves the AsyncAPI channel key from a raw input value.
+ *
+ * When "default" is specified (or the requested channel does not exist), returns the first
+ * channel in the document. AsyncAPI documents connect one channel at a time.
+ */
+export const resolveChannel = (document: AsyncApiDocument, channel: string | undefined): string | undefined => {
+  const channelKeys = Object.keys(document.channels ?? {})
+
+  if (!channel || channel === 'default') {
+    return channelKeys[0]
+  }
+
+  return channelKeys.includes(channel) ? channel : channelKeys[0]
+}
+
+/**
  * Resolves the document slug from a raw input value.
  *
  * When "default" is specified and no document exists with that slug,
  * we fall back to the active document or the first available document.
- * Modal routing is OpenAPI-only, so the fallback skips AsyncAPI documents —
- * otherwise opening the modal with default params on a workspace that has
- * an AsyncAPI active or first document would hand a slug back that
- * `getDocument` then resolves to undefined, rendering the modal with
- * `document: null` even when OpenAPI documents exist.
+ * The modal renders both OpenAPI operations and AsyncAPI channels, so the
+ * fallback accepts either — preferring the active document, then the first
+ * OpenAPI document, and finally the first AsyncAPI document.
  */
 export const resolveDocumentSlug = (store: WorkspaceStore, slug: string | undefined): string | undefined => {
   const hasMatchingDocument = slug !== 'default' || store.workspace.documents[slug] !== undefined
@@ -54,14 +87,19 @@ export const resolveDocumentSlug = (store: WorkspaceStore, slug: string | undefi
     return slug
   }
 
-  // Prefer the active document when it is OpenAPI; otherwise pick the first
-  // OpenAPI document in the workspace.
+  // Prefer the active document when it is one the modal can render.
   const activeSlug = store.workspace['x-scalar-active-document']
-  if (activeSlug && isOpenApiDocument(store.workspace.documents[activeSlug])) {
+  const activeDocument = activeSlug ? store.workspace.documents[activeSlug] : undefined
+  if (activeSlug && (isOpenApiDocument(activeDocument) || isAsyncApiDocument(activeDocument))) {
     return activeSlug
   }
 
-  return Object.entries(store.workspace.documents).find(([, document]) => isOpenApiDocument(document))?.[0]
+  // Otherwise pick the first OpenAPI document, then fall back to the first AsyncAPI document.
+  const entries = Object.entries(store.workspace.documents)
+  return (
+    entries.find(([, document]) => isOpenApiDocument(document))?.[0] ??
+    entries.find(([, document]) => isAsyncApiDocument(document))?.[0]
+  )
 }
 
 /**
@@ -153,6 +191,12 @@ export const resolveExampleName = (
 export const resolveRouteParameters = (store: WorkspaceStore, params: DefaultEntities): Partial<RoutePayload> => {
   const documentSlug = resolveDocumentSlug(store, params.documentSlug)
   const ctx: ResolverContext = { store, documentSlug }
+
+  // AsyncAPI documents route by channel and have no path/method/example.
+  const asyncApiDocument = getAsyncApiDocument(ctx)
+  if (asyncApiDocument) {
+    return { documentSlug, channel: resolveChannel(asyncApiDocument, params.channel) }
+  }
 
   const path = resolvePath(ctx, params.path)
   const method = resolveMethod(ctx, path, params.method)

--- a/packages/api-client/src/v2/features/modal/hooks/use-modal-sidebar.ts
+++ b/packages/api-client/src/v2/features/modal/hooks/use-modal-sidebar.ts
@@ -3,7 +3,7 @@ import { createSidebarState, generateReverseIndex, getChildEntry } from '@scalar
 import type { WorkspaceStore } from '@scalar/workspace-store/client'
 import { getParentEntry } from '@scalar/workspace-store/navigation'
 import type { TraversedEntry } from '@scalar/workspace-store/schemas/navigation'
-import { isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
+import { isAsyncApiDocument, isOpenApiDocument } from '@scalar/workspace-store/schemas/type-guards'
 import { type ComputedRef, computed, toValue, watch } from 'vue'
 
 import type { RoutePayload } from '@/v2/features/modal/helpers/resolve-route-parameters'
@@ -17,8 +17,16 @@ export type UseModalSidebarReturn = {
     path?: string
     method?: HttpMethod
     example?: string
+    /** AsyncAPI channel key. Provided instead of path/method for channel entries. */
+    channel?: string
   }) => TraversedEntry | undefined
 }
+
+/** AsyncAPI navigation entries all carry the channel key they belong to. */
+const getChannelName = (entry: TraversedEntry): string | undefined =>
+  entry.type === 'asyncapi-channel' || entry.type === 'asyncapi-operation' || entry.type === 'asyncapi-message'
+    ? entry.channelName
+    : undefined
 
 /**
  * useSidebarState - Custom hook to manage the sidebar state and navigation logic in the Scalar API client
@@ -43,6 +51,7 @@ export const useModalSidebar = ({
   path,
   method,
   exampleName,
+  channel,
   route,
 }: {
   workspaceStore: WorkspaceStore | null
@@ -50,27 +59,37 @@ export const useModalSidebar = ({
   path: ComputedRef<string | undefined>
   method: ComputedRef<HttpMethod | undefined>
   exampleName: ComputedRef<string | undefined>
+  /** The active AsyncAPI channel key. Omitted by OpenAPI-only callers. */
+  channel?: ComputedRef<string | undefined>
   route: (payload: RoutePayload) => void
 }): UseModalSidebarReturn => {
+  /** Coerce the optional channel into a stable ref so the sync watcher always has a source. */
+  const channelRef = channel ?? computed<string | undefined>(() => undefined)
+
   const entries = computed<TraversedEntry[]>(() => {
     const doc = workspaceStore?.workspace.documents[toValue(documentSlug) ?? '']
-    return isOpenApiDocument(doc) ? (doc['x-scalar-navigation']?.children ?? []) : []
+    // The modal renders both OpenAPI operations and AsyncAPI channels, so surface either tree.
+    return isOpenApiDocument(doc) || isAsyncApiDocument(doc) ? (doc['x-scalar-navigation']?.children ?? []) : []
   })
   const state = createSidebarState(entries)
 
   /**
    * Computed index for fast lookup of sidebar nodes by their unique API location.
    *
-   * - Only indexes nodes of type 'operation', or 'example'.
-   * - The lookup key is a serialized array of: [operationPath, operationMethod, exampleName?].
+   * - Indexes nodes of type 'operation', 'example', and 'asyncapi-channel'.
+   * - The lookup key is a serialized array of either [document, path, method, example?] for
+   *   OpenAPI entries, or [document, channel] for AsyncAPI channels.
    * - Supports precise resolution of sidebar entries given an API "location".
    */
   const locationIndex = computed(() =>
     generateReverseIndex({
       items: entries.value,
       nestedKey: 'children',
-      filter: (node) => node.type === 'operation' || node.type === 'example',
+      filter: (node) => node.type === 'operation' || node.type === 'example' || node.type === 'asyncapi-channel',
       getId: (node) => {
+        if (node.type === 'asyncapi-channel') {
+          return generateLocationId({ document: toValue(documentSlug) ?? '', channel: node.channelName })
+        }
         const operation = getParentEntry('operation', node)
         return generateLocationId({
           document: toValue(documentSlug) ?? '',
@@ -100,6 +119,11 @@ export const useModalSidebar = ({
    *   })
    */
   const getEntryByLocation: UseModalSidebarReturn['getEntryByLocation'] = (location) => {
+    // AsyncAPI channels are located by channel key, not path/method.
+    if (location.channel) {
+      return locationIndex.value.get(generateLocationId({ document: location.document, channel: location.channel }))
+    }
+
     // Try to find an entry with the most-specific location (including example)
     const entryWithExample = locationIndex.value.get(
       generateLocationId({
@@ -138,6 +162,14 @@ export const useModalSidebar = ({
       return
     }
 
+    // Navigate to the channel page. Every AsyncAPI entry (channel, operation, message)
+    // opens its channel — one connection is scoped to one channel.
+    const channelName = getChannelName(entry)
+    if (channelName) {
+      state.setExpanded(id, !state.isExpanded(id))
+      return route({ documentSlug: toValue(documentSlug), channel: channelName })
+    }
+
     // Navigate to the example page
     if (entry.type === 'operation' || entry.type === 'example') {
       // If we are already in the operation, just toggle expansion
@@ -174,8 +206,8 @@ export const useModalSidebar = ({
 
   /** Keep the sidebar state in sync with the modal parameters */
   watch(
-    [documentSlug, path, method, exampleName],
-    ([newDocument, newPath, newMethod, newExample]) => {
+    [documentSlug, path, method, exampleName, channelRef],
+    ([newDocument, newPath, newMethod, newExample, newChannel]) => {
       if (!newDocument) {
         // Reset selection if no document is selected
         state.setSelected(null)
@@ -187,6 +219,7 @@ export const useModalSidebar = ({
         path: newPath,
         method: newMethod,
         example: newExample,
+        channel: newChannel,
       })
 
       if (entry) {

--- a/packages/api-client/src/v2/helpers/generate-location-id.ts
+++ b/packages/api-client/src/v2/helpers/generate-location-id.ts
@@ -5,23 +5,30 @@ import type { HttpMethod } from '@scalar/helpers/http/http-methods'
  * Generates a unique string ID for an API location, based on the document, path, method, and example.
  * Filters out undefined values and serializes the composite array into a stable string.
  *
- * @param params - An object containing document, path, method, and optional example name.
+ * AsyncAPI channels are located by `channel` instead of `path`/`method`. It is kept at the end of
+ * the tuple so existing OpenAPI ids (where `channel` is undefined) serialize unchanged.
+ *
+ * @param params - An object containing document, path, method, example, and optional channel name.
  * @returns A stringified array representing the unique location identifier.
  *
  * Example:
  *   generateLocationId({ document: 'mydoc', path: '/users', method: 'get', example: 'default' })
  *   // => '["mydoc","/users","get","default"]'
+ *   generateLocationId({ document: 'mydoc', channel: 'room' })
+ *   // => '["mydoc","room"]'
  */
 export const generateLocationId = ({
   document,
   path,
   method,
   example,
+  channel,
 }: {
   document: string
   path?: string
   method?: HttpMethod
   example?: string
+  channel?: string
 }) => {
-  return JSON.stringify([document, path, method, example].filter(isDefined))
+  return JSON.stringify([document, path, method, example, channel].filter(isDefined))
 }

--- a/packages/sidebar/src/helpers/filter-items.test.ts
+++ b/packages/sidebar/src/helpers/filter-items.test.ts
@@ -44,6 +44,27 @@ describe('filter-items', () => {
     ])
   })
 
+  it('keeps AsyncAPI channels, operations, and messages for client layout', () => {
+    const items: Item[] = [
+      { id: '0', title: 'Description', type: 'text' },
+      { id: '1', title: 'Room', type: 'asyncapi-channel', channelName: 'room', channelAddress: '/room' },
+      {
+        id: '2',
+        title: 'Post a message',
+        type: 'asyncapi-operation',
+        operationName: 'sendMessage',
+        action: 'receive',
+        channelName: 'room',
+        channelAddress: '/room',
+      },
+      { id: '3', title: 'Send message', type: 'asyncapi-message', messageName: 'SendMessage', channelName: 'room' },
+    ]
+
+    const result = filterItems('client', items)
+
+    expect(result.map((item) => item.id)).toEqual(['1', '2', '3'])
+  })
+
   it('returns empty array for client layout when no matching types exist', () => {
     const items: Item[] = [
       { id: '1', title: 'Description', type: 'text' },

--- a/packages/sidebar/src/helpers/filter-items.ts
+++ b/packages/sidebar/src/helpers/filter-items.ts
@@ -1,7 +1,18 @@
 import type { Item, Layout } from '@/types'
 
-/** The type of items we want to  */
-const API_CLIENT_TYPES_SET = new Set(['document', 'operation', 'example', 'tag'])
+/**
+ * Entry types the API client sidebar renders. OpenAPI contributes documents, operations,
+ * examples, and tags; AsyncAPI contributes channels, operations, and messages.
+ */
+const API_CLIENT_TYPES_SET = new Set([
+  'document',
+  'operation',
+  'example',
+  'tag',
+  'asyncapi-channel',
+  'asyncapi-operation',
+  'asyncapi-message',
+])
 
 export const filterItems = (layout: Layout, items: Item[], hideOperationDefaultExamples?: boolean) => {
   // If we are hiding the default examples and there is only one example and it is the default example, we don't want to show it
@@ -18,6 +29,6 @@ export const filterItems = (layout: Layout, items: Item[], hideOperationDefaultE
     return items
   }
 
-  // For client layout, filter to only show documents, operations, examples, and tags
+  // For the client layout, only show the entry types the API client can open.
   return items.filter((c) => API_CLIENT_TYPES_SET.has(c.type))
 }

--- a/packages/workspace-store/src/channel-example/get-all-channel-messages.test.ts
+++ b/packages/workspace-store/src/channel-example/get-all-channel-messages.test.ts
@@ -1,0 +1,58 @@
+import type { AsyncApiChannelObject, AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
+import { describe, expect, it } from 'vitest'
+
+import { getAllChannelMessages, getSendChannelMessages } from '@/channel-example/get-all-channel-messages'
+import { getChannelOperations } from '@/channel-example/get-channel-operations'
+
+const channel = {
+  address: '/api/rooms/{roomId}/ws',
+  messages: {
+    sendMessage: { name: 'SendMessage', payload: { type: 'object' } },
+    welcome: { name: 'Welcome', payload: { type: 'object' } },
+    newMessage: { name: 'NewMessage', payload: { type: 'object' } },
+  },
+} as unknown as AsyncApiChannelObject
+
+const document = {
+  asyncapi: '3.0.0',
+  info: { title: 'Room', version: '1.0.0' },
+  channels: { room: channel },
+  operations: {
+    // Described from the server's point of view: it receives what the client sends.
+    sendMessage: {
+      action: 'receive',
+      channel: { $ref: '#/channels/room' },
+      messages: [{ $ref: '#/channels/room/messages/sendMessage' }],
+    },
+    // The server sends these events; the client only receives them.
+    receiveEvents: {
+      action: 'send',
+      channel: { $ref: '#/channels/room' },
+      messages: [{ $ref: '#/channels/room/messages/welcome' }, { $ref: '#/channels/room/messages/newMessage' }],
+    },
+  },
+} as unknown as AsyncApiDocument
+
+describe('get-all-channel-messages', () => {
+  it('lists every message defined on a channel', () => {
+    expect(getAllChannelMessages(document, channel).map(({ name }) => name)).toEqual([
+      'sendMessage',
+      'welcome',
+      'newMessage',
+    ])
+  })
+
+  it('returns only messages the client can send (operations the server receives)', () => {
+    const operations = getChannelOperations(document, 'room')
+
+    expect(getSendChannelMessages(document, 'room', channel, operations).map(({ name }) => name)).toEqual([
+      'sendMessage',
+    ])
+  })
+
+  it('returns nothing when no operation is sendable from the client', () => {
+    const receiveOnlyOperations = getChannelOperations(document, 'room').filter(({ action }) => action === 'send')
+
+    expect(getSendChannelMessages(document, 'room', channel, receiveOnlyOperations)).toEqual([])
+  })
+})

--- a/packages/workspace-store/src/channel-example/get-all-channel-messages.ts
+++ b/packages/workspace-store/src/channel-example/get-all-channel-messages.ts
@@ -1,6 +1,8 @@
 import { objectEntries } from '@scalar/helpers/object/object-entries'
 import type { AsyncApiChannelObject, AsyncApiDocument, AsyncApiMessageObject } from '@scalar/types/asyncapi/3.1'
 
+import type { ChannelOperationSummary } from '@/channel-example/get-channel-operations'
+import { getNameFromRef } from '@/helpers/get-name-from-ref'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
 
 export type ChannelMessageEntry = {
@@ -25,4 +27,43 @@ export const getAllChannelMessages = (
       return { name, message }
     })
     .filter((entry): entry is ChannelMessageEntry => entry.message != null)
+}
+
+/**
+ * Resolves the messages that are valid outbound payloads for a channel.
+ */
+export const getSendChannelMessages = (
+  document: AsyncApiDocument,
+  channelName: string,
+  channel: AsyncApiChannelObject,
+  operations: ChannelOperationSummary[],
+): ChannelMessageEntry[] => {
+  const allMessages = getAllChannelMessages(document, channel)
+  const sendOperations = operations.filter(({ action }) => action === 'send')
+
+  if (!sendOperations.length) {
+    return []
+  }
+
+  if (sendOperations.some(({ operation }) => operation.messages == null)) {
+    return allMessages
+  }
+
+  const messagesByName = new Map(allMessages.map((entry) => [entry.name, entry]))
+  const sendMessages = new Map<string, ChannelMessageEntry>()
+
+  sendOperations.forEach(({ operation }) => {
+    operation.messages?.forEach((messageRef) => {
+      const messageName = getNameFromRef(messageRef.$ref, ['channels', channelName, 'messages'])
+      const messageEntry =
+        (messageName ? messagesByName.get(messageName) : undefined) ??
+        allMessages.find(({ message }) => message === getResolvedRef(messageRef))
+
+      if (messageEntry) {
+        sendMessages.set(messageEntry.name, messageEntry)
+      }
+    })
+  })
+
+  return [...sendMessages.values()]
 }

--- a/packages/workspace-store/src/channel-example/get-all-channel-messages.ts
+++ b/packages/workspace-store/src/channel-example/get-all-channel-messages.ts
@@ -31,6 +31,10 @@ export const getAllChannelMessages = (
 
 /**
  * Resolves the messages that are valid outbound payloads for a channel.
+ *
+ * AsyncAPI describes operations from the application's (server's) point of view, so an operation
+ * the client can send is one the application `receive`s. The API client is the counterpart, so we
+ * collect the messages on `receive` operations.
  */
 export const getSendChannelMessages = (
   document: AsyncApiDocument,
@@ -39,7 +43,7 @@ export const getSendChannelMessages = (
   operations: ChannelOperationSummary[],
 ): ChannelMessageEntry[] => {
   const allMessages = getAllChannelMessages(document, channel)
-  const sendOperations = operations.filter(({ action }) => action === 'send')
+  const sendOperations = operations.filter(({ action }) => action === 'receive')
 
   if (!sendOperations.length) {
     return []

--- a/packages/workspace-store/src/channel-example/get-channel-connection-context.test.ts
+++ b/packages/workspace-store/src/channel-example/get-channel-connection-context.test.ts
@@ -21,6 +21,10 @@ const echoChannelDocument = {
           name: 'echoPayload',
           payload: { type: 'object', properties: { message: { type: 'string' } } },
         },
+        receivedPayload: {
+          name: 'receivedPayload',
+          payload: { type: 'object', properties: { received: { type: 'boolean' } } },
+        },
       },
     },
   },
@@ -33,6 +37,7 @@ const echoChannelDocument = {
     listenOnEcho: {
       action: 'receive',
       channel: { $ref: '#/channels/echo' },
+      messages: [{ $ref: '#/channels/echo/messages/receivedPayload' }],
     },
   },
 } as unknown as AsyncApiDocument

--- a/packages/workspace-store/src/channel-example/get-channel-connection-context.test.ts
+++ b/packages/workspace-store/src/channel-example/get-channel-connection-context.test.ts
@@ -58,7 +58,8 @@ describe('getChannelConnectionContext', () => {
 
     expect(result.data.channelName).toBe('echo')
     expect(result.data.connectionUrl).toBe('wss://echo.websocket.org')
-    expect(result.data.messages.map(({ name }) => name)).toEqual(['echoPayload'])
+    // The client sends the message the server receives: `listenOnEcho` (action `receive`).
+    expect(result.data.messages.map(({ name }) => name)).toEqual(['receivedPayload'])
     expect(result.data.operations.map(({ operationName }) => operationName).sort()).toEqual([
       'listenOnEcho',
       'sendEchoMessage',

--- a/packages/workspace-store/src/channel-example/get-channel-connection-context.ts
+++ b/packages/workspace-store/src/channel-example/get-channel-connection-context.ts
@@ -1,7 +1,7 @@
 import type { AuthenticationConfiguration } from '@scalar/types/api-reference'
 
 import { buildConnectionUrl } from '@/channel-example/build-connection-url'
-import { getAllChannelMessages } from '@/channel-example/get-all-channel-messages'
+import { getSendChannelMessages } from '@/channel-example/get-all-channel-messages'
 import { getChannelConnectionSecurityRequirements } from '@/channel-example/get-channel-connection-security'
 import { getChannelOperations } from '@/channel-example/get-channel-operations'
 import { getChannelParameters } from '@/channel-example/get-channel-parameters'
@@ -100,7 +100,7 @@ export const getChannelConnectionContext = (
       environmentVariables,
     })
 
-  const messages = getAllChannelMessages(document, channel)
+  const messages = getSendChannelMessages(document, channelName, channel, channelOperations)
   const selectedMessage = messages[0] ?? null
 
   const documentSelectedSecurity = workspaceStore.auth.getAuthSelectedSchemas({

--- a/packages/workspace-store/src/channel-example/index.ts
+++ b/packages/workspace-store/src/channel-example/index.ts
@@ -10,7 +10,7 @@ export {
   mergeWsBindings,
 } from './build-connection-url'
 export type { ChannelMessageEntry } from './get-all-channel-messages'
-export { getAllChannelMessages } from './get-all-channel-messages'
+export { getAllChannelMessages, getSendChannelMessages } from './get-all-channel-messages'
 export type {
   AsyncApiProtocolOption,
   AsyncApiReachabilityContext,


### PR DESCRIPTION
Adds basic WebSocket support for AsyncAPI channels in the API client. Pick a channel, connect, send messages, and watch the live message log.

Builds on #9345.