### PR TITLE
feat(api-reference): export AsyncAPI content components

### DIFF
--- a/.changeset/export-asyncapi-components.md
+++ b/.changeset/export-asyncapi-components.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': minor
+---
+
+Export the AsyncAPI content components (AsyncApiChannel, AsyncApiOperation, AsyncApiMessage, AsyncApiTraversedEntry) from `@scalar/api-reference/components` so downstream renderers can render an individual channel/operation/message on its own page.

--- a/packages/api-reference/src/components/Content/AsyncApi/index.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/index.ts
@@ -1,1 +1,4 @@
 export { default as AsyncApiTraversedEntry } from './AsyncApiTraversedEntry.vue'
+export { default as AsyncApiChannel } from './Channel.vue'
+export { default as AsyncApiMessage } from './Message.vue'
+export { default as AsyncApiOperation } from './Operation.vue'

--- a/packages/api-reference/src/components/index.ts
+++ b/packages/api-reference/src/components/index.ts
@@ -10,6 +10,7 @@ export {
   Tag,
   TraversedEntry,
 } from './Content'
+export { AsyncApiChannel, AsyncApiMessage, AsyncApiOperation, AsyncApiTraversedEntry } from './Content/AsyncApi'
 export { Auth } from './Content/Auth'
 export { default as ApiReferenceContent } from './Content/Content.vue'
 export { HttpMethod } from './HttpMethod'


### PR DESCRIPTION
## What

Export the AsyncAPI content components from `@scalar/api-reference/components`:

- `AsyncApiChannel` (`Channel.vue`)
- `AsyncApiOperation` (`Operation.vue`)
- `AsyncApiMessage` (`Message.vue`)
- `AsyncApiTraversedEntry` (`AsyncApiTraversedEntry.vue`, already exported)

Previously only the whole-document `Content` component was reachable, which forced AsyncAPI to render as a single scrolling page.

## Why

Needed to render AsyncAPI in our platform. :)

The prefixed names avoid collisions with the existing OpenAPI-side barrel exports (`TraversedEntry`, `Model`, `Schema`, `Tag`, etc.).