### PR TITLE
fix(workspace-store): bind $dynamicRef when the binding schema is referenced by name

### DIFF
--- a/.changeset/dynamic-ref-named-binding-scope.md
+++ b/.changeset/dynamic-ref-named-binding-scope.md
@@ -1,0 +1,9 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Render `$dynamicRef` array items when the binding schema is referenced by name.
+A response that used `$ref: '#/components/schemas/PaginatedUserResponse'` (rather
+than an inline `$id`/`$defs` binding) hid the resource's `$dynamicAnchor` behind
+the `$ref`, so the dynamic scope never grew and the item type rendered empty.
+`pushDynamicScope` now follows a bare `$ref` to reach the named binding resource.

--- a/packages/api-reference/src/components/Content/Schema/dynamic-ref.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/dynamic-ref.test.ts
@@ -1,3 +1,4 @@
+import { createWorkspaceStore } from '@scalar/workspace-store/client'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 
@@ -81,5 +82,61 @@ describe('Schema $dynamicRef rendering', () => {
     }
     const text = mountSchema(template).text()
     expect(text).toContain('items')
+  })
+
+  // Full-store reproduction of https://github.com/scalar/scalar/issues/9883: the binding schema is a
+  // *named* component and the response references it by `$ref`, so Schema receives a bare `$ref` whose
+  // `$id`/`$defs` binding lives behind the ref. The dynamic scope must follow the ref to bind the item.
+  it('binds the array item type when the binding schema is referenced by name (#9883)', async () => {
+    const store = createWorkspaceStore()
+    await store.addDocument({
+      name: 'default',
+      document: {
+        openapi: '3.1.0',
+        info: { title: 'DynamicRef', version: '0.1.0' },
+        paths: {
+          '/users': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'User page',
+                  content: { 'application/json': { schema: { $ref: '#/components/schemas/PaginatedUserResponse' } } },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            User: {
+              type: 'object',
+              required: ['id', 'email'],
+              properties: { id: { type: 'string' }, email: { type: 'string', format: 'email' } },
+            },
+            PaginatedTemplate: {
+              $id: 'https://example.com/schemas/PaginatedTemplate',
+              $defs: { itemType: { $dynamicAnchor: 'itemType', not: true } },
+              type: 'object',
+              required: ['items'],
+              properties: { items: { type: 'array', items: { $dynamicRef: '#itemType' } } },
+            },
+            PaginatedUserResponse: {
+              $id: 'https://example.com/schemas/PaginatedUserResponse',
+              $defs: { itemTypeAAA: { $dynamicAnchor: 'itemType', $ref: '#/components/schemas/User' } },
+              $ref: '#/components/schemas/PaginatedTemplate',
+            },
+          },
+        },
+      } as never,
+    })
+
+    const doc = store.workspace.documents['default'] as any
+    const schema = doc.paths['/users'].get.responses['200'].content['application/json'].schema
+
+    const text = mountSchema(schema).text()
+
+    // The `items: { $dynamicRef: '#itemType' }` slot renders the bound `User` shape (its properties).
+    expect(text).toContain('email')
+    expect(text).toContain('id')
   })
 })

--- a/packages/workspace-store/src/helpers/dynamic-ref.test.ts
+++ b/packages/workspace-store/src/helpers/dynamic-ref.test.ts
@@ -73,6 +73,32 @@ describe('dynamic-ref', () => {
       pushDynamicScope(scope, schema({ $id: 'urn:b' }))
       expect(scope).toHaveLength(1)
     })
+
+    it('follows a bare $ref to a named binding resource so its anchor enters the scope', () => {
+      // A response that references the binding schema by name (`$ref: PaginatedUserResponse`) hides the
+      // resource's `$id`/`$defs` behind the ref. The scope must still grow with the resolved resource so
+      // a `$dynamicRef` inside the referenced template can bind. See https://github.com/scalar/scalar/issues/9883.
+      const resource = schema({
+        $id: 'https://example.com/schemas/PaginatedUserResponse',
+        $defs: { itemTypeAAA: { $dynamicAnchor: 'itemType', type: 'object' } },
+      })
+      const bareRef = schema({ $ref: '#/components/schemas/PaginatedUserResponse', '$ref-value': resource })
+
+      const scope = pushDynamicScope([], bareRef)
+      expect(scope).toHaveLength(1)
+      expect(resolveDynamicRef('#itemType', scope)).toMatchObject({ type: 'object' })
+    })
+
+    it('leaves the scope unchanged for a bare $ref to a schema without an anchor', () => {
+      const bareRef = schema({ $ref: '#/x', '$ref-value': { type: 'string' } })
+      expect(pushDynamicScope([], bareRef)).toEqual([])
+    })
+
+    it('leaves the scope unchanged for an unresolved $ref without throwing', () => {
+      // An unresolved `$ref` dereferences to `undefined`; the scope must be left untouched, not crash.
+      const unresolved = schema({ $ref: '#/missing' })
+      expect(pushDynamicScope([], unresolved)).toEqual([])
+    })
   })
 
   describe('resolveDynamicRef', () => {

--- a/packages/workspace-store/src/helpers/dynamic-ref.ts
+++ b/packages/workspace-store/src/helpers/dynamic-ref.ts
@@ -1,3 +1,5 @@
+import { isObject } from '@scalar/helpers/object/is-object'
+
 import { getResolvedRef, mergeSiblingReferences } from '@/helpers/get-resolved-ref'
 import { unpackProxyObject } from '@/helpers/unpack-proxy'
 import type { SchemaObject } from '@/schemas/v3.1/strict/schema'
@@ -85,9 +87,22 @@ export const collectDynamicAnchors = (resource: SchemaObject): Map<string, Schem
   return anchors
 }
 
-/** Append a schema to the dynamic scope when it could hold a `$dynamicAnchor`, otherwise return it unchanged. */
-export const pushDynamicScope = (scope: DynamicScope, schema: SchemaObject): DynamicScope =>
-  carriesDynamicAnchor(schema) ? [...scope, schema] : scope
+/**
+ * Append a schema resource to the dynamic scope when it could hold a `$dynamicAnchor`.
+ *
+ * A schema that carries the binding inline — its own `$dynamicAnchor`, or the `$id`/`$defs` binding
+ * written next to a `$ref` (how `Paginated<Planet>` is expressed) — enters the scope directly. A bare
+ * `$ref` to a *named* binding resource (e.g. `$ref: '#/components/schemas/PaginatedUserResponse'`)
+ * hides that resource's `$id`/`$defs` behind the ref, so the anchor is invisible here; follow the ref
+ * to reach the resource. Ordinary `$ref`s resolve to a schema without an anchor and are still skipped;
+ * an unresolved `$ref` resolves to `undefined` and is skipped too.
+ *
+ * See https://github.com/scalar/scalar/issues/9883.
+ */
+export const pushDynamicScope = (scope: DynamicScope, schema: SchemaObject): DynamicScope => {
+  const resource = carriesDynamicAnchor(schema) ? schema : getResolvedRef(schema)
+  return isObject(resource) && carriesDynamicAnchor(resource) ? [...scope, resource] : scope
+}
 
 /**
  * Resolve a `$dynamicRef` fragment against the dynamic scope.


### PR DESCRIPTION
`$dynamicRef` array items rendered empty when a response referenced the binding schema by name (`$ref: PaginatedUserResponse`). The dynamic scope now follows the `$ref` to find the binding, so the item shows its real type.

Part of #9883