### PR TITLE
docs: surface configuration options in the table of contents

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -247,13 +247,11 @@ Scalar.createApiReference('#app', {
 })
 ```
 
-## Configuration Options
-
-### Properties
+## Properties
 
 Configuration properties to customize the behavior and appearance of your API reference.
 
-#### authentication
+### authentication
 
 **Type:** `AuthenticationConfiguration`
 
@@ -376,7 +374,7 @@ The `authentication` configuration accepts:
 - `securitySchemes`: An object mapping security scheme names to their configurations. Each security scheme can be configured with type-specific options.
 - `createAnySecurityScheme`: When `true`, shows generic "Add new authentication" options (API Key, HTTP Basic, OAuth2 flows, etc.) in the auth dropdown alongside the schemes defined in your OpenAPI document. Default: `false`.
 
-#### baseServerURL
+### baseServerURL
 
 **Type:** `string`
 
@@ -388,7 +386,7 @@ If you want to prefix all relative servers with a base URL, you can do so here.
 }
 ```
 
-#### content
+### content
 
 **Type:** `string | Record<string, any> | () => Record<string, any>`
 
@@ -422,7 +420,7 @@ Or as a callback returning the actual document:
 }
 ```
 
-#### customCss
+### customCss
 
 **Type:** `string`
 
@@ -436,7 +434,7 @@ In Vue or React you'd probably use other ways to add custom CSS.
 }
 ```
 
-#### darkMode
+### darkMode
 
 **Type:** `boolean`
 
@@ -450,7 +448,7 @@ Whether dark mode is on or off initially (light mode).
 }
 ```
 
-#### defaultHttpClient
+### defaultHttpClient
 
 **Type:** `HttpClientState`
 
@@ -469,7 +467,7 @@ You can explicitly set the default HTTP client, though:
 }
 ```
 
-#### defaultOpenFirstTag
+### defaultOpenFirstTag
 
 **Type:** `boolean`
 
@@ -483,7 +481,7 @@ Whether to open the first tag if the URL doesn't contain a specific target.
 }
 ```
 
-#### defaultOpenAllTags
+### defaultOpenAllTags
 
 **Type:** `boolean`
 
@@ -497,7 +495,7 @@ Whether to always start with all tags open, regardless of the URL.
 }
 ```
 
-#### documentDownloadType
+### documentDownloadType
 
 **Type:** `'json' | 'yaml' | 'both' | 'direct' | 'none'`
 
@@ -513,7 +511,7 @@ Sets the file type of the document to download, set to `'none'` to hide the down
 
 When `'direct'` is passed, it just outputs a regular link to the passed URL.
 
-#### expandAllModelSections
+### expandAllModelSections
 
 **Type:** `boolean`
 
@@ -527,7 +525,7 @@ By default the models are all closed in the model section at the bottom, this fl
 }
 ```
 
-#### expandAllResponses
+### expandAllResponses
 
 **Type:** `boolean`
 
@@ -542,7 +540,7 @@ By default response sections are closed in the operations. This flag will open t
 ```
 
 
-#### expandAllSchemaProperties
+### expandAllSchemaProperties
 
 **Type:** `boolean`
 
@@ -560,7 +558,7 @@ Warning: this can cause performance issues on big documents.
 }
 ```
 
-#### favicon
+### favicon
 
 **Type:** `string`
 
@@ -572,7 +570,7 @@ You can specify the path to a favicon to be used for the documentation.
 }
 ```
 
-#### forceDarkModeState
+### forceDarkModeState
 
 **Type:** `'dark' | 'light'`
 
@@ -584,7 +582,7 @@ Force dark mode to always be this state no matter what.
 }
 ```
 
-#### hideClientButton
+### hideClientButton
 
 **Type:** `boolean`
 
@@ -598,7 +596,7 @@ Whether to show the client button from the reference sidebar and modal.
 }
 ```
 
-#### hideDarkModeToggle
+### hideDarkModeToggle
 
 **Type:** `boolean`
 
@@ -612,7 +610,7 @@ Whether to show the dark mode toggle.
 }
 ```
 
-#### showOperationId
+### showOperationId
 
 **Type:** `boolean`
 
@@ -628,7 +626,7 @@ By default we don't render it in the UI. If it's helpful to show it to your user
 }
 ```
 
-#### hideModels
+### hideModels
 
 **Type:** `boolean`
 
@@ -642,7 +640,7 @@ Whether models (`components.schemas` or `definitions`) should be shown in the si
 }
 ```
 
-#### modelsSectionLabel
+### modelsSectionLabel
 
 **Type:** `'Models' | 'Schemas' | string`
 
@@ -656,7 +654,7 @@ Label for the `components.schemas` section in the sidebar, main content, and sea
 }
 ```
 
-#### localization
+### localization
 
 **Type:** `{ locale?: string, direction?: 'ltr' | 'rtl' | 'auto', translations?: object }`
 
@@ -672,7 +670,7 @@ to override individual labels.
 }
 ```
 
-#### hideSearch
+### hideSearch
 
 **Type:** `boolean`
 
@@ -686,7 +684,7 @@ Whether to show the sidebar search bar.
 }
 ```
 
-#### hideTestRequestButton
+### hideTestRequestButton
 
 **Type:** `boolean`
 
@@ -700,7 +698,7 @@ Whether to show the "Test Request" button. When `true`, the authentication panel
 }
 ```
 
-#### hiddenClients
+### hiddenClients
 
 **Type:** `array | true | object`
 
@@ -807,7 +805,7 @@ and each **value** specifies the visibility behavior for the clients of that lan
 }
 ```
 
-#### layout
+### layout
 
 **Type:** `'modern' | 'classic'`
 
@@ -821,7 +819,7 @@ The layout style to use for the API reference.
 }
 ```
 
-#### metaData
+### metaData
 
 **Type:** `object`
 
@@ -841,7 +839,7 @@ You can pass information to the config object to configure meta information out 
 }
 ```
 
-#### mcp
+### mcp
 
 **Type:** `{ name: string; url: string; disabled?: boolean }` (optional)
 
@@ -874,7 +872,7 @@ To disable MCP explicitly:
 }
 ```
 
-#### operationTitleSource
+### operationTitleSource
 
 **Type:** `'summary' | 'path'`
 
@@ -888,7 +886,7 @@ Whether the sidebar display text and search should use the operation summary or 
 }
 ```
 
-#### orderRequiredPropertiesFirst
+### orderRequiredPropertiesFirst
 
 **Type:** `boolean`
 
@@ -902,7 +900,7 @@ Whether to order required properties first in schema objects. When enabled, requ
 }
 ```
 
-#### orderSchemaPropertiesBy
+### orderSchemaPropertiesBy
 
 **Type:** `'alpha' | 'preserve'`
 
@@ -920,7 +918,7 @@ Control how schema properties are ordered in model definitions. Can be set to:
 }
 ```
 
-#### pathRouting
+### pathRouting
 
 **Type:** `{ basePath: string }`
 
@@ -934,7 +932,7 @@ Configuration for path-based routing instead of hash-based routing. Your server 
 }
 ```
 
-#### persistAuth
+### persistAuth
 
 **Type:** `boolean`
 
@@ -951,7 +949,7 @@ Whether to persist authentication credentials in local storage. This allows the 
 > [!WARNING]
 > Persisting authentication information in the browser's local storage may present security risks in certain environments. Use this feature with caution based on your security requirements.
 
-#### telemetry
+### telemetry
 
 **Type:** `boolean`
 
@@ -969,7 +967,7 @@ If the analytics plugin is loaded and you still want to disable tracking, set `t
 }
 ```
 
-#### plugins
+### plugins
 
 **Type:** `ApiReferencePlugin[]`
 
@@ -983,7 +981,7 @@ Pass an array of custom plugins that you want. [Read more about plugins here.](p
 }
 ```
 
-#### pluginUrls
+### pluginUrls
 
 **Type:** `string[]`
 
@@ -997,7 +995,7 @@ Pass URLs of ESM modules that export a plugin as their default export. The modul
 }
 ```
 
-#### proxyUrl
+### proxyUrl
 
 **Type:** `string`
 
@@ -1021,7 +1019,7 @@ If you like to run your own, check out our [example proxy written in Go](https:/
 
 Please note: You may not use just any reverse proxy, but need to use a proxy that adheres to the Scalar Proxy API. See the example to learn more.
 
-#### oauth2RedirectUri
+### oauth2RedirectUri
 
 **Type:** `string`
 
@@ -1035,7 +1033,7 @@ This is useful for desktop wrappers like Electron where the page URL is often `f
 }
 ```
 
-#### searchHotKey
+### searchHotKey
 
 **Type:** `string`
 
@@ -1049,7 +1047,7 @@ Key used with CTRL/CMD to open the search modal.
 }
 ```
 
-#### servers
+### servers
 
 **Type:** `Server[]`
 
@@ -1075,7 +1073,7 @@ Pass a list of servers to override the servers in your OpenAPI document.
 }
 ```
 
-#### showSidebar
+### showSidebar
 
 **Type:** `boolean`
 
@@ -1089,7 +1087,7 @@ Whether the sidebar should be shown.
 }
 ```
 
-#### showDeveloperTools
+### showDeveloperTools
 
 **Type:** `'always' | 'localhost' | 'never'`
 
@@ -1105,7 +1103,7 @@ To disable the toolbar set:
 }
 ```
 
-#### theme
+### theme
 
 **Type:** `string`
 
@@ -1121,7 +1119,7 @@ Can be one of: **alternate**, **default**, **moon**, **purple**, **solarized**, 
 }
 ```
 
-#### url
+### url
 
 **Type:** `string`
 
@@ -1133,7 +1131,7 @@ Pass the URL of an OpenAPI document (JSON or YAML).
 }
 ```
 
-#### withDefaultFonts
+### withDefaultFonts
 
 **Type:** `boolean`
 
@@ -1147,11 +1145,10 @@ By default we're using Inter and JetBrains Mono, served from our fonts CDN at `h
 }
 ```
 
-### Methods
-
+## Methods
 Custom functions to control specific behaviors and URL generation.
 
-#### customFetch
+### customFetch
 
 **Type:** `(input: string | URL | globalThis.Request, init?: RequestInit) => Promise<Response>`
 
@@ -1167,7 +1164,7 @@ Custom [fetch function](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_A
 
 > The previous `fetch` option is deprecated. It still works and is migrated automatically (with a console warning), but new code should use `customFetch`.
 
-#### generateHeadingSlug
+### generateHeadingSlug
 
 **Type:** `(heading: Heading) => string`
 
@@ -1187,7 +1184,7 @@ Customize how heading URLs are generated. This function receives the heading and
 }
 ```
 
-#### generateModelSlug
+### generateModelSlug
 
 **Type:** `(model: { name: string }) => string`
 
@@ -1207,7 +1204,7 @@ Customize how model URLs are generated. This function receives the model object 
 }
 ```
 
-#### generateOperationSlug
+### generateOperationSlug
 
 **Type:** `(operation: Operation) => string`
 
@@ -1228,7 +1225,7 @@ Customize how operation URLs are generated. This function receives the operation
 }
 ```
 
-#### generateTagSlug
+### generateTagSlug
 
 **Type:** `(tag: Tag) => string`
 
@@ -1248,7 +1245,7 @@ Customize how tag URLs are generated. This function receives the tag object and 
 }
 ```
 
-#### generateWebhookSlug
+### generateWebhookSlug
 
 **Type:** `(webhook: { name: string; method?: string }) => string`
 
@@ -1269,7 +1266,7 @@ Customize how webhook URLs are generated. This function receives the webhook obj
 }
 ```
 
-#### setPageTitle
+### setPageTitle
 
 **Type:** `(input: { title: string; document: { title: string; slug: string } }) => string`
 
@@ -1284,7 +1281,7 @@ Customize the browser tab title. The function is called whenever the section in 
 }
 ```
 
-#### tagsSorter
+### tagsSorter
 
 **Type:** `'alpha' | (a: Tag, b: Tag) => number`
 
@@ -1296,7 +1293,7 @@ Sort tags alphanumerically (`'alpha'`):
 }
 ```
 
-#### operationsSorter
+### operationsSorter
 
 **Type:** `'alpha' | 'method' | ((a: OperationSortValue, b: OperationSortValue) => number)`
 
@@ -1329,7 +1326,7 @@ Or specify a custom function to sort the operations:
 
 > Note: `method` is the HTTP method of the operation, represented as a lowercase string.
 
-#### redirect
+### redirect
 
 **Type:** `(path: string) => string | null | undefined`
 
@@ -1354,11 +1351,10 @@ Function to handle redirects in the API reference. Receives either:
 }
 ```
 
-### Events
-
+## Events
 Callback functions that are triggered by user interactions and system events.
 
-#### onBeforeRequest
+### onBeforeRequest
 
 **Type:** `({ request: Request; requestBuilder: RequestFactory }) => void | Promise<void>`
 
@@ -1378,7 +1374,7 @@ Callback fired before the outbound request is sent from the embedded API client.
 }
 ```
 
-##### RequestFactory reference
+#### RequestFactory reference
 
 The `requestBuilder` object exposes the following fields:
 
@@ -1402,7 +1398,7 @@ The `requestBuilder` object exposes the following fields:
 | `disableSecurity` | `boolean` | `false` | When `true`, Scalar skips its built-in security handling entirely. Security headers, query parameters, and cookies from the `security` array are **not** applied automatically, giving you full control. |
 | `isElectron` | `boolean` | `false` | Indicates the request runs in an Electron (Node-like) context. |
 
-##### Examples
+#### Examples
 
 **Add a custom header**
 
@@ -1477,13 +1473,13 @@ By default, Scalar applies security schemes automatically (e.g. prefixing bearer
 
 > When `disableSecurity` is `true`, only the security-related headers, query parameters, and cookies are skipped. All other fields on the request (custom headers, path, body, non-security cookies, etc.) are unaffected.
 
-#### onDocumentSelect
+### onDocumentSelect
 
 **Type:** `() => Promise<void> | void`
 
 Triggered when multiple documents are configured and the users switches between them.
 
-#### onLoaded
+### onLoaded
 
 **Type:** `(slug: string) => Promise<void> | void`
 
@@ -1499,7 +1495,7 @@ Callback that triggers as soon as the references are lazy loaded.
 }
 ```
 
-#### onRequestBuilt
+### onRequestBuilt
 
 **Type:** `({ request: Request; requestBuilder: RequestFactory; envVariables: Record<string, string> }) => void | Promise<void>`
 
@@ -1525,7 +1521,7 @@ Use [`onBeforeRequest`](#onbeforerequest) instead when you need to mutate the re
 }
 ```
 
-#### onRequestSent
+### onRequestSent
 
 **Type:** `(request: string) => void`
 
@@ -1539,7 +1535,7 @@ Callback function that is triggered when a request is sent through the API clien
 }
 ```
 
-#### onServerChange
+### onServerChange
 
 **Type:** `(server: string) => void`
 
@@ -1553,7 +1549,7 @@ You can listen to changes with onServerChange that runs on server change.
 }
 ```
 
-#### onShowMore
+### onShowMore
 
 **Type:** `(tagId: string) => void | Promise<void>`
 
@@ -1567,7 +1563,7 @@ Callback function that is triggered when a user clicks the "Show more" button in
 }
 ```
 
-#### onSidebarClick
+### onSidebarClick
 
 **Type:** `(href: string) => void | Promise<void>`
 


### PR DESCRIPTION
Config options like `theme`, `url` and `authentication` weren't showing up in the page's table of contents.

The ToC only lists heading levels 2 and 3, but every option was a level-4 heading. This bumps each option up one level so they all show in the "On This Page" list.

Links to each option (like `#theme`) still work.

<img width="301" height="1373" alt="Screenshot 2026-08-12 at 12 10 18" src="https://github.com/user-attachments/assets/5c3a823b-a101-4767-ad28-a6dcd45a5781" />
