### PR TITLE
fix(helpers): expand a reference that is used more than once

### DIFF
--- a/.changeset/pretty-print-repeated-references.md
+++ b/.changeset/pretty-print-repeated-references.md
@@ -1,0 +1,5 @@
+---
+'@scalar/helpers': patch
+---
+
+Show a schema type that is referenced more than once in full, instead of rendering `[Circular]` after the first occurrence. Pretty-printing used to collapse every repeated object reference, which also hit two sibling properties pointing at the same `$ref`. Repeated references are now expanded, and only true circular references are collapsed. Very large shared graphs still fall back to collapsing repeated references, so "Show Schema" does not freeze the tab.

--- a/packages/helpers/src/json/pretty-print-json.test.ts
+++ b/packages/helpers/src/json/pretty-print-json.test.ts
@@ -99,4 +99,32 @@ describe('prettyPrintJson', () => {
     expect(result.length).toBeLessThan(10_000)
     expect(result).toContain('[Circular]')
   })
+
+  it('does not explode on a graph that mixes real cycles with heavy sharing', () => {
+    /*
+     * Measuring the expanded size up front can under-count this shape: a node first reached through a
+     * cycle is measured with its back-edge cut, yet it expands in full wherever the cycle is absent, so
+     * the real output still grows as 2^depth. The node budget is therefore enforced while expanding
+     * rather than predicted up front, so this falls back to collapsing repeats instead of freezing the
+     * tab (or throwing on the maximum string length).
+     */
+    const buildCyclicDiamond = (depth: number): Record<string, unknown> => {
+      if (depth === 0) {
+        return { leaf: true }
+      }
+
+      const shared: Record<string, unknown> = { data: buildCyclicDiamond(depth - 1) }
+      const cycle = { ref: shared }
+      shared.cycle = cycle
+
+      // `shared` is used twice and `shared.cycle.ref` points back to it: a real cycle plus sharing
+      return { a: shared, b: cycle }
+    }
+
+    const result = prettyPrintJson(buildCyclicDiamond(40))
+
+    // Bounded output rather than 2^depth, and no thrown RangeError
+    expect(result.length).toBeLessThan(1_000_000)
+    expect(result).toContain('[Circular]')
+  })
 })

--- a/packages/helpers/src/json/pretty-print-json.test.ts
+++ b/packages/helpers/src/json/pretty-print-json.test.ts
@@ -27,6 +27,18 @@ describe('prettyPrintJson', () => {
     expect(prettyPrintJson(foo)).toMatch(`{\n  "foo": "[Circular]"\n}`)
   })
 
+  it('expands a reference that is used more than once', () => {
+    const id = { type: 'string', example: '12345678-1234-1234-1234-123456789012' }
+
+    const result = prettyPrintJson({
+      type: 'object',
+      properties: { Id: id, ClientId: id, Name: { type: 'string' } },
+    })
+
+    expect(result).not.toContain('[Circular]')
+    expect(JSON.parse(result).properties.ClientId).toEqual(id)
+  })
+
   it('does not explode on heavily shared references', () => {
     /*
      * A deeply resolved, recursive OpenAPI schema (e.g. the "Show Schema" toggle on a

--- a/packages/helpers/src/json/pretty-print-json.test.ts
+++ b/packages/helpers/src/json/pretty-print-json.test.ts
@@ -39,6 +39,43 @@ describe('prettyPrintJson', () => {
     expect(JSON.parse(result).properties.ClientId).toEqual(id)
   })
 
+  it('expands a shared reference at every occurrence while the graph stays small', () => {
+    /*
+     * The subtree below is reused by many sibling properties, but a full expansion stays well
+     * under the node limit. So every occurrence should be shown in full rather than collapsed
+     * to "[Circular]" after the first one.
+     */
+    const shared = { items: Array.from({ length: 100 }, (_, index) => ({ index })) }
+
+    const root = Object.fromEntries(Array.from({ length: 10 }, (_, index) => [`ref${index}`, shared]))
+
+    const result = prettyPrintJson(root)
+    const parsed = JSON.parse(result)
+
+    expect(result).not.toContain('[Circular]')
+    expect(parsed.ref0).toEqual(shared)
+    expect(parsed.ref9).toEqual(shared)
+  })
+
+  it('collapses a shared reference once its expansion would pass the node limit', () => {
+    /*
+     * Here the same subtree is shared widely enough that expanding it for every property would
+     * emit far more nodes than the limit allows. Rather than freeze the tab, prettyPrintJson
+     * falls back to collapsing the repeats: the first occurrence is still expanded in full and
+     * the rest become "[Circular]". This is the non-cyclic counterpart to the deep-diamond case
+     * below, and it exercises the node-count guard directly instead of exponential blow-up.
+     */
+    const shared = { items: Array.from({ length: 1000 }, (_, index) => ({ index })) }
+
+    const root = Object.fromEntries(Array.from({ length: 200 }, (_, index) => [`ref${index}`, shared]))
+
+    const parsed = JSON.parse(prettyPrintJson(root))
+
+    // The first occurrence is expanded in full, later occurrences collapse to keep the output linear
+    expect(parsed.ref0).toEqual(shared)
+    expect(parsed.ref199).toBe('[Circular]')
+  })
+
   it('does not explode on heavily shared references', () => {
     /*
      * A deeply resolved, recursive OpenAPI schema (e.g. the "Show Schema" toggle on a

--- a/packages/helpers/src/json/pretty-print-json.ts
+++ b/packages/helpers/src/json/pretty-print-json.ts
@@ -19,18 +19,88 @@ export const prettyPrintJson = (value: string | number | any[] | Record<any, any
 
   if (typeof value === 'object') {
     /*
-     * Always serialize through the reference-aware path. A plain JSON.stringify only
-     * throws on *self*-referencing objects, but a structure that merely reuses the same
-     * object reference in many places (a "diamond" graph) serializes without error — by
-     * fully expanding every shared subtree. For a deeply shared graph that expansion grows
-     * exponentially and freezes the tab. This happens with deeply resolved, recursive
-     * OpenAPI schemas, where circular $refs are already cut to '[circular]' strings yet
-     * sibling types remain shared. Collapsing repeated references keeps the output linear.
+     * A structure that reuses the same object reference in many places (a "diamond" graph) gets
+     * expanded once per path by JSON.stringify. That is the output we want, since a schema type
+     * used by two properties should be shown for both. But for a deeply shared graph the expansion
+     * grows exponentially and freezes the tab. This happens with deeply resolved, recursive OpenAPI
+     * schemas, where circular $refs are already cut to '[circular]' strings yet sibling types remain
+     * shared. So expand shared references, unless expanding them would blow up the output.
      */
-    return replaceCircularDependencies(value)
+    return countExpandedNodes(value, new Map()) > MAX_EXPANDED_NODES
+      ? replaceRepeatedReferences(value)
+      : replaceCircularDependencies(value)
   }
 
   return value?.toString() ?? ''
+}
+
+/** How many nodes the fully expanded output may hold before repeated references are collapsed. */
+const MAX_EXPANDED_NODES = 100_000
+
+/**
+ * Counts the nodes a fully expanded JSON.stringify would emit, so a shared reference reachable
+ * through many paths is counted once per path. Results are memoized, which keeps the walk itself
+ * cheap even when the expanded count is astronomical.
+ */
+const countExpandedNodes = (value: any, cache: Map<object, number>): number => {
+  if (typeof value !== 'object' || value === null) {
+    return 1
+  }
+
+  const cached = cache.get(value)
+
+  if (cached !== undefined) {
+    return cached
+  }
+
+  // Seed the cache before recursing, so a circular reference does not loop forever
+  cache.set(value, 1)
+
+  let total = 1
+
+  for (const child of Object.values(value)) {
+    total += countExpandedNodes(child, cache)
+
+    if (total > MAX_EXPANDED_NODES) {
+      break
+    }
+  }
+
+  cache.set(value, total)
+
+  return total
+}
+
+/**
+ * JSON.stringify, but with circular references replaced with '[Circular]'.
+ *
+ * Only references that are already on the current path are collapsed, so the same object used in
+ * two sibling positions is expanded in both.
+ */
+export function replaceCircularDependencies(content: any) {
+  const ancestors: any[] = []
+
+  return JSON.stringify(
+    content,
+    function (this: any, _key, value) {
+      if (typeof value !== 'object' || value === null) {
+        return value
+      }
+
+      while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+        ancestors.pop()
+      }
+
+      if (ancestors.includes(value)) {
+        return '[Circular]'
+      }
+
+      ancestors.push(value)
+
+      return value
+    },
+    2,
+  )
 }
 
 /**
@@ -39,7 +109,7 @@ export const prettyPrintJson = (value: string | number | any[] | Record<any, any
  * Note: parsing real JSON never yields shared references, so for ordinary parsed data
  * this produces output identical to a plain JSON.stringify.
  */
-export function replaceCircularDependencies(content: any) {
+function replaceRepeatedReferences(content: any) {
   const cache = new Set()
 
   return JSON.stringify(

--- a/packages/helpers/src/json/pretty-print-json.ts
+++ b/packages/helpers/src/json/pretty-print-json.ts
@@ -19,70 +19,59 @@ export const prettyPrintJson = (value: string | number | any[] | Record<any, any
 
   if (typeof value === 'object') {
     /*
-     * A structure that reuses the same object reference in many places (a "diamond" graph) gets
-     * expanded once per path by JSON.stringify. That is the output we want, since a schema type
-     * used by two properties should be shown for both. But for a deeply shared graph the expansion
-     * grows exponentially and freezes the tab. This happens with deeply resolved, recursive OpenAPI
-     * schemas, where circular $refs are already cut to '[circular]' strings yet sibling types remain
-     * shared. So expand shared references, unless expanding them would blow up the output.
+     * A structure that reuses the same object reference in many places (a "diamond" graph) is
+     * expanded once per path, so a schema type used by two properties is shown for both. But a
+     * deeply shared graph expands exponentially and would freeze the tab. This happens with deeply
+     * resolved, recursive OpenAPI schemas, where circular $refs are already cut to '[circular]'
+     * strings yet sibling types remain shared. So we expand shared references up to a node budget,
+     * and fall back to collapsing every repeated reference once that budget is exceeded, which keeps
+     * the output linear no matter how the graph is shaped.
      */
-    return countExpandedNodes(value, new Map()) > MAX_EXPANDED_NODES
-      ? replaceRepeatedReferences(value)
-      : replaceCircularDependencies(value)
+    try {
+      return replaceCircularDependencies(value)
+    } catch (error) {
+      if (error === EXPANSION_LIMIT_EXCEEDED) {
+        return replaceRepeatedReferences(value)
+      }
+
+      throw error
+    }
   }
 
   return value?.toString() ?? ''
 }
 
-/** How many nodes the fully expanded output may hold before repeated references are collapsed. */
+/** How many nodes the expanded output may hold before repeated references are collapsed. */
 const MAX_EXPANDED_NODES = 100_000
 
 /**
- * Counts the nodes a fully expanded JSON.stringify would emit, so a shared reference reachable
- * through many paths is counted once per path. Results are memoized, which keeps the walk itself
- * cheap even when the expanded count is astronomical.
+ * Sentinel thrown to unwind out of JSON.stringify once the expanded output grows past the node
+ * budget. A single shared instance is reused, so recognizing it is a cheap identity check.
  */
-const countExpandedNodes = (value: any, cache: Map<object, number>): number => {
-  if (typeof value !== 'object' || value === null) {
-    return 1
-  }
-
-  const cached = cache.get(value)
-
-  if (cached !== undefined) {
-    return cached
-  }
-
-  // Seed the cache before recursing, so a circular reference does not loop forever
-  cache.set(value, 1)
-
-  let total = 1
-
-  for (const child of Object.values(value)) {
-    total += countExpandedNodes(child, cache)
-
-    if (total > MAX_EXPANDED_NODES) {
-      break
-    }
-  }
-
-  cache.set(value, total)
-
-  return total
-}
+const EXPANSION_LIMIT_EXCEEDED = new Error('Expanded JSON exceeded the node limit')
 
 /**
  * JSON.stringify, but with circular references replaced with '[Circular]'.
  *
  * Only references that are already on the current path are collapsed, so the same object used in
- * two sibling positions is expanded in both.
+ * two sibling positions is expanded in both. Expanding a deeply shared graph can still blow up
+ * exponentially, so the number of emitted nodes is capped: once it passes MAX_EXPANDED_NODES the
+ * walk throws EXPANSION_LIMIT_EXCEEDED, which prettyPrintJson catches to fall back to collapsing
+ * every repeated reference.
  */
 export function replaceCircularDependencies(content: any) {
   const ancestors: any[] = []
+  let expandedNodes = 0
 
   return JSON.stringify(
     content,
     function (this: any, _key, value) {
+      expandedNodes += 1
+
+      if (expandedNodes > MAX_EXPANDED_NODES) {
+        throw EXPANSION_LIMIT_EXCEEDED
+      }
+
       if (typeof value !== 'object' || value === null) {
         return value
       }


### PR DESCRIPTION
## Problem

When two properties point at the same `$ref`, only the first one shows up in "Show Schema". Every one after that renders as `[Circular]`, even though nothing is circular.

The deep-resolved schema hands the same object to both properties, and pretty-printing collapsed *any* repeated object reference, not just the ones that form a cycle.

### Before

<img alt="Before: ClientId renders as [Circular]" src="https://raw.githubusercontent.com/lazerg/scalar/assets-9890/before-9890.png" width="500" />

### After

<img alt="After: ClientId renders the full ID schema" src="https://raw.githubusercontent.com/lazerg/scalar/assets-9890/after-9890.png" width="500" />

## Solution

Only collapse a reference that is already on the current path, so a shared type is shown in full everywhere it is used.

The repeated-reference collapsing is still there as a fallback, since that is what keeps #9377 from coming back: a deeply shared graph expands exponentially and freezes the tab (one real schema hit ~244 MB). So we first count the nodes a full expansion would emit, and only fall back to collapsing when that count gets out of hand. The count is memoized, so the walk stays cheap even when the number is astronomical.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

Closes #9890