### PR TITLE
feat(json-magic): export path, content-sniffing, and ref helpers

### DIFF
--- a/.changeset/json-magic-export-helpers.md
+++ b/.changeset/json-magic-export-helpers.md
@@ -1,0 +1,5 @@
+---
+'@scalar/json-magic': minor
+---
+
+Export the `get-value-by-path`, `set-value-at-path`, `is-yaml`, and `is-json-object` helpers, and expose `isLocalRef`, `prefixInternalRef`, and `prefixInternalRefRecursive` from the bundle entry point.

--- a/packages/json-magic/package.json
+++ b/packages/json-magic/package.json
@@ -61,6 +61,11 @@
       "types": "./dist/helpers/get-segments-from-path.d.ts",
       "default": "./dist/helpers/get-segments-from-path.js"
     },
+    "./helpers/get-value-by-path": {
+      "import": "./dist/helpers/get-value-by-path.js",
+      "types": "./dist/helpers/get-value-by-path.d.ts",
+      "default": "./dist/helpers/get-value-by-path.js"
+    },
     "./helpers/is-file-path": {
       "import": "./dist/helpers/is-file-path.js",
       "types": "./dist/helpers/is-file-path.d.ts",
@@ -71,10 +76,25 @@
       "types": "./dist/helpers/is-http-url.d.ts",
       "default": "./dist/helpers/is-http-url.js"
     },
+    "./helpers/is-json-object": {
+      "import": "./dist/helpers/is-json-object.js",
+      "types": "./dist/helpers/is-json-object.d.ts",
+      "default": "./dist/helpers/is-json-object.js"
+    },
+    "./helpers/is-yaml": {
+      "import": "./dist/helpers/is-yaml.js",
+      "types": "./dist/helpers/is-yaml.d.ts",
+      "default": "./dist/helpers/is-yaml.js"
+    },
     "./helpers/normalize": {
       "import": "./dist/helpers/normalize.js",
       "types": "./dist/helpers/normalize.d.ts",
       "default": "./dist/helpers/normalize.js"
+    },
+    "./helpers/set-value-at-path": {
+      "import": "./dist/helpers/set-value-at-path.js",
+      "types": "./dist/helpers/set-value-at-path.d.ts",
+      "default": "./dist/helpers/set-value-at-path.js"
     },
     "./helpers/unescape-json-pointer": {
       "import": "./dist/helpers/unescape-json-pointer.js",

--- a/packages/json-magic/src/bundle/index.ts
+++ b/packages/json-magic/src/bundle/index.ts
@@ -1,2 +1,2 @@
 export type { LifecyclePlugin, LoaderPlugin, Plugin, ResolveResult } from './bundle'
-export { bundle, resolveAndCopyReferences } from './bundle'
+export { bundle, isLocalRef, prefixInternalRef, prefixInternalRefRecursive, resolveAndCopyReferences } from './bundle'


### PR DESCRIPTION
## Problem

`@scalar/json-magic` ships several helpers in `dist` that are unreachable through the package's `exports` map, so consumers end up re-implementing them: dot-path lookup and assignment (`getValueByPath`, `setValueAtPath`), YAML/JSON content sniffing (`isYaml`, `isJsonObject`), and local-ref classification/prefixing (`isLocalRef`, `prefixInternalRef`, `prefixInternalRefRecursive`). The implementations are already built and published — there is just no import specifier that resolves to them.

## Solution

Add subpath exports for the four helper modules, matching the pattern of the already-exported helpers (`escape-json-pointer`, `is-http-url`, `normalize`, …), and re-export the three ref utilities from the `/bundle` barrel where they are implemented. The change is purely additive and semver-minor: no existing entry point changes behavior. New import specifiers:

- `@scalar/json-magic/helpers/get-value-by-path`
- `@scalar/json-magic/helpers/set-value-at-path`
- `@scalar/json-magic/helpers/is-yaml`
- `@scalar/json-magic/helpers/is-json-object`
- `isLocalRef`, `prefixInternalRef`, `prefixInternalRefRecursive` from `@scalar/json-magic/bundle`

Verified by building the package and importing every new specifier against the built output; the package's unit tests pass (27 files, 564 tests).

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests. (No new tests: the exported functions are unchanged and already covered by the existing suites.)
- [ ] I updated the documentation.
