### PR TITLE
fix(json-magic): treat array/object container mismatches as updates in diff

### DIFF
--- a/.changeset/json-magic-diff-container-type-mismatch.md
+++ b/.changeset/json-magic-diff-container-type-mismatch.md
@@ -1,0 +1,5 @@
+---
+'@scalar/json-magic': patch
+---
+
+Treat array/object container mismatches as a single update in diff instead of descending into per-index adds. Before, `diff({ tags: {} }, { tags: ['x', 'y'] })` walked the array's indices as object keys and emitted per-index `add` differences, so `apply` wrote numeric string properties onto the existing object and produced the corrupted hybrid `{ tags: { '0': 'x', '1': 'y' } }`. A container type change (either direction) is now one `update` difference carrying the full new value, and applying it replaces the container correctly.

--- a/packages/json-magic/src/diff/diff.test.ts
+++ b/packages/json-magic/src/diff/diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { diff } from '@/diff'
+import { apply, diff } from '@/diff'
 
 describe('diff', () => {
   describe('Should correctly detect `add` type diff', () => {
@@ -279,6 +279,71 @@ describe('diff', () => {
       }
 
       expect(diff(doc1, doc2)).toEqual([{ path: ['hobbies', '1'], changes: doc1.hobbies[1], type: 'delete' }])
+    })
+  })
+
+  describe('Should treat container type changes as a single update', () => {
+    test('detects an object changing into an array as a single update', () => {
+      const doc1 = { tags: {} }
+      const doc2 = { tags: ['x', 'y'] }
+
+      expect(diff(doc1, doc2)).toEqual([{ path: ['tags'], changes: doc2.tags, type: 'update' }])
+    })
+
+    test('detects an array changing into an object as a single update', () => {
+      const doc1 = { tags: ['x', 'y'] }
+      const doc2 = { tags: { note: 'hi' } }
+
+      expect(diff(doc1, doc2)).toEqual([{ path: ['tags'], changes: doc2.tags, type: 'update' }])
+    })
+
+    test('detects container type changes on nested properties', () => {
+      const doc1 = {
+        info: {
+          contact: { emails: { primary: 'a@example.com' } },
+        },
+      }
+
+      const doc2 = {
+        info: {
+          contact: { emails: ['a@example.com', 'b@example.com'] },
+        },
+      }
+
+      expect(diff(doc1, doc2)).toEqual([
+        {
+          path: ['info', 'contact', 'emails'],
+          changes: doc2.info.contact.emails,
+          type: 'update',
+        },
+      ])
+    })
+
+    test('applying the diff replaces the container instead of corrupting it', () => {
+      const doc1 = { tags: {} }
+      const doc2 = { tags: ['x', 'y'] }
+
+      const result = apply(structuredClone(doc1), diff(doc1, doc2))
+
+      expect(Array.isArray(result.tags)).toBe(true)
+      expect(result).toEqual(doc2)
+
+      const reverse = apply(structuredClone(doc2), diff(doc2, doc1))
+
+      expect(Array.isArray(reverse.tags)).toBe(false)
+      expect(reverse).toEqual(doc1)
+    })
+
+    test('consumers applying only add differences leave the existing container untouched', () => {
+      const doc1 = { tags: {} }
+      const doc2 = { tags: ['x', 'y'] }
+
+      // A type change is an update, so add-only consumers no longer write
+      // numeric string keys onto the existing object
+      const additions = diff(doc1, doc2).filter((d) => d.type === 'add')
+
+      expect(additions).toEqual([])
+      expect(apply(structuredClone(doc1), additions)).toEqual(doc1)
     })
   })
 

--- a/packages/json-magic/src/diff/diff.ts
+++ b/packages/json-magic/src/diff/diff.ts
@@ -73,6 +73,14 @@ export const diff = <T extends Record<string, unknown>>(doc1: Record<string, unk
 
     // For nested objects, we need to recursively check the properties
     if (typeof el1 === 'object' && typeof el2 === 'object' && el1 !== null && el2 !== null) {
+      // A container type change (array to plain object or vice versa) is a single update.
+      // Recursing would treat array indices as object keys and produce per-key
+      // differences that corrupt the container when applied.
+      if (Array.isArray(el1) !== Array.isArray(el2)) {
+        diff.push({ path: prefix, changes: el2, type: 'update' })
+        return
+      }
+
       const keys = new Set([...Object.keys(el1), ...Object.keys(el2)])
 
       for (const key of keys) {


### PR DESCRIPTION
## Problem

`diff(a, b)` from `@scalar/json-magic/diff` corrupts documents when the same key holds a plain object on one side and an array on the other. Both containers satisfy `typeof === 'object'`, so the comparison recurses key-by-key and walks the array's numeric indices as object keys:

```js
diff({ tags: {} }, { tags: ['x', 'y'] })
// [
//   { path: ['tags', '0'], changes: 'x', type: 'add' },
//   { path: ['tags', '1'], changes: 'y', type: 'add' }
// ]
```

`apply` then writes those numeric string properties onto the existing object and produces `{ tags: { '0': 'x', '1': 'y' } }` — a corrupted hybrid that is neither side. The reverse direction (array → object) is broken the same way: it emits per-index deletes plus per-key adds, and applying them splices the array instead of replacing it.

## Solution

A container type change is not a set of per-key edits — it is one change. When one side is an array and the other a plain object (either direction), `diff` now emits a single `update` difference for that path carrying the full new value, the same shape it already uses for scalar type changes, instead of descending. `apply` already handles that update by assignment, so the container is replaced correctly:

```js
diff({ tags: {} }, { tags: ['x', 'y'] })
// [{ path: ['tags'], changes: ['x', 'y'], type: 'update' }]

apply({ tags: {} }, ...)
// { tags: ['x', 'y'] }   Array.isArray → true
```

Behavioral scope: only inputs that previously produced corrupted results change behavior. Both-arrays element diffs and both-objects key diffs are untouched, and `merge`/`Trie` operate on difference lists so they need no changes. Consumers that filter to `add`-only differences now correctly skip container type changes instead of mangling the existing container.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.
