### PR TITLE
fix(json-magic): apply array deletions in descending index order

### DIFF
--- a/.changeset/json-magic-diff-array-delete-order.md
+++ b/.changeset/json-magic-diff-array-delete-order.md
@@ -1,0 +1,5 @@
+---
+'@scalar/json-magic': patch
+---
+
+Emit array deletions highest-index-first in diff so removing more than one element applies correctly. Before, `diff({ items: [1, 2, 3, 4] }, { items: [1] })` emitted the deletes in ascending index order, and because `apply` removes array elements with `splice`, every delete after the first hit a stale index and left elements behind (`{ items: [1, 3] }`). Deletes on arrays are now ordered from the end of the array, so `apply(a, diff(a, b))` round-trips for arrays that lose any number of elements.

--- a/packages/json-magic/src/diff/diff.test.ts
+++ b/packages/json-magic/src/diff/diff.test.ts
@@ -280,6 +280,100 @@ describe('diff', () => {
 
       expect(diff(doc1, doc2)).toEqual([{ path: ['hobbies', '1'], changes: doc1.hobbies[1], type: 'delete' }])
     })
+
+    test('emits deletes from the end of the array first', () => {
+      const doc1 = { items: [1, 2, 3, 4] }
+      const doc2 = { items: [1] }
+
+      expect(diff(doc1, doc2)).toEqual([
+        { path: ['items', '3'], changes: 4, type: 'delete' },
+        { path: ['items', '2'], changes: 3, type: 'delete' },
+        { path: ['items', '1'], changes: 2, type: 'delete' },
+      ])
+    })
+
+    test('keeps additions in ascending index order', () => {
+      const doc1 = { items: [1] }
+      const doc2 = { items: [1, 2, 3] }
+
+      expect(diff(doc1, doc2)).toEqual([
+        { path: ['items', '1'], changes: 2, type: 'add' },
+        { path: ['items', '2'], changes: 3, type: 'add' },
+      ])
+    })
+
+    test('emits changes on arrays of the same length from the last index first', () => {
+      const doc1 = { items: [1, 2, 3] }
+      const doc2 = { items: [9, 8, 7] }
+
+      expect(diff(doc1, doc2)).toEqual([
+        { path: ['items', '2'], changes: 7, type: 'update' },
+        { path: ['items', '1'], changes: 8, type: 'update' },
+        { path: ['items', '0'], changes: 9, type: 'update' },
+      ])
+    })
+
+    test('removes multiple elements from the end of the array', () => {
+      const doc1 = { items: [1, 2, 3, 4] }
+      const doc2 = { items: [1] }
+
+      expect(apply(structuredClone(doc1), diff(doc1, doc2))).toEqual(doc2)
+    })
+
+    test('removes multiple elements from the middle of the array', () => {
+      const doc1 = { tags: ['a', 'b', 'c', 'd', 'e'] }
+      const doc2 = { tags: ['a', 'e'] }
+
+      expect(apply(structuredClone(doc1), diff(doc1, doc2))).toEqual(doc2)
+    })
+
+    test('removes every element of the array', () => {
+      const doc1 = { tags: ['a', 'b', 'c'] }
+      const doc2 = { tags: [] }
+
+      expect(apply(structuredClone(doc1), diff(doc1, doc2))).toEqual(doc2)
+    })
+
+    test('removes multiple objects from an array of objects', () => {
+      const doc1 = {
+        list: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
+      }
+      const doc2 = {
+        list: [{ id: 1 }],
+      }
+
+      expect(apply(structuredClone(doc1), diff(doc1, doc2))).toEqual(doc2)
+    })
+
+    test('removes elements from arrays nested inside objects inside arrays', () => {
+      const doc1 = {
+        paths: [
+          { path: '/a', tags: ['x', 'y', 'z'] },
+          { path: '/b', tags: ['1', '2', '3', '4'] },
+        ],
+      }
+      const doc2 = {
+        paths: [
+          { path: '/a', tags: ['x'] },
+          { path: '/b', tags: ['1', '2'] },
+        ],
+      }
+
+      expect(apply(structuredClone(doc1), diff(doc1, doc2))).toEqual(doc2)
+    })
+
+    test('keeps adding and removing elements in the same document consistent', () => {
+      const doc1 = {
+        servers: [{ url: 'a' }, { url: 'b' }, { url: 'c' }],
+        tags: ['one'],
+      }
+      const doc2 = {
+        servers: [{ url: 'a' }],
+        tags: ['one', 'two', 'three'],
+      }
+
+      expect(apply(structuredClone(doc1), diff(doc1, doc2))).toEqual(doc2)
+    })
   })
 
   describe('Should treat container type changes as a single update', () => {

--- a/packages/json-magic/src/diff/diff.ts
+++ b/packages/json-magic/src/diff/diff.ts
@@ -81,9 +81,20 @@ export const diff = <T extends Record<string, unknown>>(doc1: Record<string, unk
         return
       }
 
-      const keys = new Set([...Object.keys(el1), ...Object.keys(el2)])
+      const keys = [...new Set([...Object.keys(el1), ...Object.keys(el2)])]
 
-      for (const key of keys) {
+      // Removed array elements are applied with `splice` (see `apply`), which re-indexes every
+      // element after the removed one. Emitting the highest index first keeps the remaining indices
+      // valid, so an array that loses more than one element still applies correctly. Please keep
+      // this ordering in place, applying the same deletes in ascending order corrupts the array.
+      // Only an array that shrinks can lose elements, so an array that grows keeps the natural
+      // ascending order. Equal length arrays cannot lose elements either, they take the reversed
+      // branch to keep the guard simple. Deletes nested inside elements are object keys rather than
+      // array indices, so they never reach `splice` and are unaffected by the order.
+      // `keys` is a fresh array, so reversing it in place is safe.
+      const orderedKeys = Array.isArray(el1) && Array.isArray(el2) && el1.length >= el2.length ? keys.reverse() : keys
+
+      for (const key of orderedKeys) {
         bfs(el1[key], el2[key], [...prefix, key])
       }
       return


### PR DESCRIPTION
## What

`diff()` emitted array element deletions in **ascending** index order, but `apply()` removes array elements with `splice`, which re-indexes everything after the removed element. Every delete after the first hit a stale index, so any document sync that removed **two or more** array elements silently corrupted the array:

```ts
diff({ items: [1, 2, 3, 4] }, { items: [1] })
// → delete items.1, delete items.2, delete items.3
apply({ items: [1, 2, 3, 4] }, ...)   // → { items: [1, 3] }   ❌ expected { items: [1] }
```

This reached users through three-way document sync (`workspace-store`'s `client.ts` → `merge` → `apply`), so pulling an upstream change that dropped several `tags`/`servers`/`parameters` entries left stale elements behind.

## How

When both sides are arrays and the array does not grow, the key iteration is reversed so deletes are emitted highest-index-first, which keeps every following `splice` index valid. Arrays that grow keep their natural ascending order — additions are applied by index assignment and never go through `splice`. The comment in `diff.ts` ties the ordering to `apply` so it does not get "cleaned up" later.

## Tests

New cases in `diff.test.ts` cover both the diff shape and the full `diff → apply` round-trip:

- deletes emitted from the end of the array first, additions still ascending, same-length arrays
- removing multiple elements from the tail, from the middle, and down to an empty array
- arrays of objects, and arrays nested inside objects inside arrays
- a document that grows one array while shrinking another

All 7 round-trip tests fail on `main` and pass with this change. `packages/json-magic` (72 tests) and `packages/workspace-store` (2904 tests) are green, along with `types:check`, `build`, and `knip`.

## Notes

Out of scope, worth a follow-up: `workspace-store/src/client.ts` concatenates user-resolved conflicts after the merged diffs, which can put a higher-index delete after a lower-index one and re-introduce the same `splice` hazard. That behaviour is unchanged by this PR — it is broken identically before and after.