### PR TITLE
fix(json-magic): skip the correct diff entry on delete/delete merges

### DIFF
--- a/.changeset/json-magic-merge-delete-skip-index.md
+++ b/.changeset/json-magic-merge-delete-skip-index.md
@@ -3,3 +3,5 @@
 ---
 
 Skip the correct entry when `merge` resolves a delete against a delete. The matching entry was skipped using an index into the first diff list to address the second one, so whenever the two matching deletes sat at different positions in their lists, an unrelated change was silently dropped and the shared delete was duplicated. Merging `[delete x, delete a]` with `[delete a, delete y]` returned `[delete x, delete a, delete a]` instead of `[delete x, delete a, delete y]`.
+
+One case changes for the worse and is pinned by a test: when a delete is subsumed by a delete on the other side that itself ends up in `conflicts`, the subsumed delete is dropped from the result. That gap already existed, but skipping the wrong index used to hide it for some orderings of the second diff list, so it is now consistent rather than order-dependent.

--- a/.changeset/json-magic-merge-delete-skip-index.md
+++ b/.changeset/json-magic-merge-delete-skip-index.md
@@ -1,0 +1,5 @@
+---
+'@scalar/json-magic': patch
+---
+
+Skip the correct entry when `merge` resolves a delete against a delete. The matching entry was skipped using an index into the first diff list to address the second one, so whenever the two matching deletes sat at different positions in their lists, an unrelated change was silently dropped and the shared delete was duplicated. Merging `[delete x, delete a]` with `[delete a, delete y]` returned `[delete x, delete a, delete a]` instead of `[delete x, delete a, delete y]`.

--- a/packages/json-magic/src/diff/merge.test.ts
+++ b/packages/json-magic/src/diff/merge.test.ts
@@ -1107,6 +1107,7 @@ describe('mergeDiff', () => {
       conflicts: [],
     })
   })
+
   test('deleting different paths on both documents keeps every delete when the shared delete sits at different indices', () => {
     const base = {
       openapi: '3.0.0',
@@ -1165,7 +1166,7 @@ describe('mergeDiff', () => {
     })
   })
 
-  test('a shallower delete in the second diff only skips its own matching entry', () => {
+  test('a shallower delete in the second diff drops only the matching deeper entry of the first', () => {
     const diff1: Difference<unknown>[] = [
       { path: ['x'], changes: 'x', type: 'delete' },
       { path: ['paths', '/users', 'get'], changes: 'get', type: 'delete' },
@@ -1187,7 +1188,7 @@ describe('mergeDiff', () => {
     })
   })
 
-  test('a deeper delete in the second diff only skips its own matching entry', () => {
+  test('a deeper delete in the second diff drops only its own entry', () => {
     const diff1: Difference<unknown>[] = [
       { path: ['x'], changes: 'x', type: 'delete' },
       { path: ['paths', '/users'], changes: 'users', type: 'delete' },
@@ -1226,12 +1227,16 @@ describe('mergeDiff', () => {
       conflicts: [],
     })
   })
+
   // TODO: a delete that is subsumed by a delete on the other side is discarded before we know
   // whether the covering delete ends up in `conflicts`. When it does, the subsumed delete
   // survives in neither `diffs` nor `conflicts`, so resolving the conflict toward the side that
-  // owns it brings the deleted value back. Pinned here so a future fix is a deliberate change.
-  // Note this is not caused by the index fix above: before it, the same inputs produced this
-  // result or the correct one depending on the order of the second diff list.
+  // owns it brings the deleted value back. The gap is symmetric: the mirrored input loses the
+  // entry through the first list instead. Pinned here so a future fix is a deliberate change.
+  //
+  // The flaw predates the index fix above, which only changed how consistently it shows up.
+  // Before the fix this exact ordering happened to keep the subsumed delete, because skipping
+  // the wrong index left it in place, while the reversed ordering already lost it.
   test('a delete subsumed by a delete that also conflicts is currently dropped', () => {
     const diff1: Difference<unknown>[] = [{ path: ['a'], changes: { b: 1, a: 2 }, type: 'delete' }]
     const diff2: Difference<unknown>[] = [

--- a/packages/json-magic/src/diff/merge.test.ts
+++ b/packages/json-magic/src/diff/merge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
-import { diff } from '@/diff/diff'
+import { type Difference, diff } from '@/diff/diff'
 import { merge } from '@/diff/merge'
 
 const deepClone = <T extends object>(obj: T) => JSON.parse(JSON.stringify(obj)) as T
@@ -1103,6 +1103,125 @@ describe('mergeDiff', () => {
           changes: doc2.paths['/users'].post,
           path: ['paths', '/users', 'post'],
         },
+      ],
+      conflicts: [],
+    })
+  })
+  test('deleting different paths on both documents keeps every delete when the shared delete sits at different indices', () => {
+    const base = {
+      openapi: '3.0.0',
+      info: {
+        title: 'Sample API',
+        version: '1.0',
+      },
+      paths: {
+        '/users': {
+          get: {
+            summary: 'Get users',
+          },
+        },
+        '/pets': {
+          get: {
+            summary: 'Get pets',
+          },
+        },
+        '/orders': {
+          get: {
+            summary: 'Get orders',
+          },
+        },
+      },
+    }
+
+    const doc1 = deepClone<DeepPartial<typeof base>>(base)
+    delete doc1.paths?.['/users']
+    delete doc1.paths?.['/pets']
+
+    const doc2 = deepClone<DeepPartial<typeof base>>(base)
+    delete doc2.paths?.['/pets']
+    delete doc2.paths?.['/orders']
+
+    // '/pets' is deleted by both documents, but it is the second entry of the first diff
+    // and the first entry of the second diff
+    expect(merge(diff(base, doc1), diff(base, doc2))).toEqual({
+      diffs: [
+        {
+          type: 'delete',
+          changes: base.paths['/users'],
+          path: ['paths', '/users'],
+        },
+        {
+          type: 'delete',
+          changes: base.paths['/pets'],
+          path: ['paths', '/pets'],
+        },
+        {
+          type: 'delete',
+          changes: base.paths['/orders'],
+          path: ['paths', '/orders'],
+        },
+      ],
+      conflicts: [],
+    })
+  })
+
+  test('a shallower delete in the second diff only skips its own matching entry', () => {
+    const diff1: Difference<unknown>[] = [
+      { path: ['x'], changes: 'x', type: 'delete' },
+      { path: ['paths', '/users', 'get'], changes: 'get', type: 'delete' },
+    ]
+    const diff2: Difference<unknown>[] = [
+      { path: ['paths', '/users'], changes: 'users', type: 'delete' },
+      { path: ['y'], changes: 'y', type: 'delete' },
+    ]
+
+    // The deeper delete is dropped because deleting '/users' already removes it,
+    // and the unrelated deletes on both sides survive untouched
+    expect(merge(diff1, diff2)).toEqual({
+      diffs: [
+        { path: ['x'], changes: 'x', type: 'delete' },
+        { path: ['paths', '/users'], changes: 'users', type: 'delete' },
+        { path: ['y'], changes: 'y', type: 'delete' },
+      ],
+      conflicts: [],
+    })
+  })
+
+  test('a deeper delete in the second diff only skips its own matching entry', () => {
+    const diff1: Difference<unknown>[] = [
+      { path: ['x'], changes: 'x', type: 'delete' },
+      { path: ['paths', '/users'], changes: 'users', type: 'delete' },
+    ]
+    const diff2: Difference<unknown>[] = [
+      { path: ['paths', '/users', 'get'], changes: 'get', type: 'delete' },
+      { path: ['y'], changes: 'y', type: 'delete' },
+    ]
+
+    expect(merge(diff1, diff2)).toEqual({
+      diffs: [
+        { path: ['x'], changes: 'x', type: 'delete' },
+        { path: ['paths', '/users'], changes: 'users', type: 'delete' },
+        { path: ['y'], changes: 'y', type: 'delete' },
+      ],
+      conflicts: [],
+    })
+  })
+
+  test('an identical delete at different indices is kept once and drops nothing else', () => {
+    const diff1: Difference<unknown>[] = [
+      { path: ['x'], changes: 'x', type: 'delete' },
+      { path: ['a'], changes: 'a', type: 'delete' },
+    ]
+    const diff2: Difference<unknown>[] = [
+      { path: ['a'], changes: 'a', type: 'delete' },
+      { path: ['y'], changes: 'y', type: 'delete' },
+    ]
+
+    expect(merge(diff1, diff2)).toEqual({
+      diffs: [
+        { path: ['x'], changes: 'x', type: 'delete' },
+        { path: ['a'], changes: 'a', type: 'delete' },
+        { path: ['y'], changes: 'y', type: 'delete' },
       ],
       conflicts: [],
     })

--- a/packages/json-magic/src/diff/merge.test.ts
+++ b/packages/json-magic/src/diff/merge.test.ts
@@ -1226,4 +1226,27 @@ describe('mergeDiff', () => {
       conflicts: [],
     })
   })
+  // TODO: a delete that is subsumed by a delete on the other side is discarded before we know
+  // whether the covering delete ends up in `conflicts`. When it does, the subsumed delete
+  // survives in neither `diffs` nor `conflicts`, so resolving the conflict toward the side that
+  // owns it brings the deleted value back. Pinned here so a future fix is a deliberate change.
+  // Note this is not caused by the index fix above: before it, the same inputs produced this
+  // result or the correct one depending on the order of the second diff list.
+  test('a delete subsumed by a delete that also conflicts is currently dropped', () => {
+    const diff1: Difference<unknown>[] = [{ path: ['a'], changes: { b: 1, a: 2 }, type: 'delete' }]
+    const diff2: Difference<unknown>[] = [
+      { path: ['a', 'b'], changes: 14, type: 'update' },
+      { path: ['a', 'a'], changes: 2, type: 'delete' },
+    ]
+
+    expect(merge(diff1, diff2)).toEqual({
+      diffs: [],
+      conflicts: [
+        [
+          [{ path: ['a'], changes: { b: 1, a: 2 }, type: 'delete' }],
+          [{ path: ['a', 'b'], changes: 14, type: 'update' }],
+        ],
+      ],
+    })
+  })
 })

--- a/packages/json-magic/src/diff/merge.ts
+++ b/packages/json-magic/src/diff/merge.ts
@@ -73,6 +73,7 @@ export const merge = <T>(diff1: Difference<T>[], diff2: Difference<T>[]) => {
         if (value.changes.type === 'delete') {
           // Keep the shallowest delete operation and skip the other, since deleting an
           // ancestor already removes everything the deeper delete would have removed.
+          // On equal paths the first list keeps the entry and the second one is skipped.
           // Note the two sets are indexed differently: `value.index` points into `diff1`,
           // while `index` points into `diff2`.
           if (value.changes.path.length > diff.path.length) {

--- a/packages/json-magic/src/diff/merge.ts
+++ b/packages/json-magic/src/diff/merge.ts
@@ -71,11 +71,14 @@ export const merge = <T>(diff1: Difference<T>[], diff2: Difference<T>[]) => {
     trie.findMatch(diff.path, (value) => {
       if (diff.type === 'delete') {
         if (value.changes.type === 'delete') {
-          // Keep the highest depth delete operation and skip the other
+          // Keep the shallowest delete operation and skip the other, since deleting an
+          // ancestor already removes everything the deeper delete would have removed.
+          // Note the two sets are indexed differently: `value.index` points into `diff1`,
+          // while `index` points into `diff2`.
           if (value.changes.path.length > diff.path.length) {
             skipDiff1.add(value.index)
           } else {
-            skipDiff2.add(value.index)
+            skipDiff2.add(index)
           }
         } else {
           // Take care of updates/add on the same path (we are sure they will be on the


### PR DESCRIPTION
## Problem

`merge()` resolves a `delete` in one diff list against a `delete` in the other by keeping the shallower of the two and skipping the deeper one. When the entry to skip belonged to the **second** list, it was skipped using `value.index` — which is an index into the **first** list.

The two lists only line up by coincidence, so whenever the matching deletes sat at different positions, `merge` skipped an innocent bystander and let the duplicate through:

```ts
diff1 = [delete ['x'], delete ['a']]
diff2 = [delete ['a'], delete ['y']]

merge(diff1, diff2).diffs
// before → [delete x, delete a, delete a]   ❌ 'y' dropped, 'a' duplicated
// after  → [delete x, delete a, delete y]   ✅
```

This is user-visible in document sync: at [`client.ts:1594`](https://github.com/scalar/scalar/blob/main/packages/workspace-store/src/client.ts#L1594) the second list is the **local** diff, so a path deleted both upstream and locally silently discarded an unrelated local edit. The duplicated delete is not always a harmless no-op either — `apply` removes array elements with `splice`, so a duplicated array-index delete removes a second, wrong element.

## Change

- [`merge.ts`](packages/json-magic/src/diff/merge.ts) — `skipDiff2.add(value.index)` → `skipDiff2.add(index)`, and the neighbouring comment now records which set is indexed by which list. The old comment also claimed the code keeps the *highest depth* delete; it keeps the shallowest.

The sibling branches already used `index` for `skipDiff2`, so this restores internal consistency rather than inventing a new rule.

## Tests

Four new tests in [`merge.test.ts`](packages/json-magic/src/diff/merge.test.ts). Every pre-existing test happened to place matching entries at the *same* index in both lists, which is exactly why this was invisible — the new ones break that symmetry:

- deletes of different paths on real documents, with the shared delete at index 1 in one list and index 0 in the other
- subsumption in both directions (deeper delete in the first list, deeper delete in the second)
- an identical delete at different indices

Three of the four fail against the pre-fix code; the fourth covers the already-correct `skipDiff1` branch.

## Known gap, pinned not fixed

A fifth test pins a **pre-existing** flaw with a `TODO`: a delete subsumed by a delete that itself lands in `conflicts` survives in neither `diffs` nor `conflicts`, so resolving that conflict toward the side that owns it resurrects the deleted value. The gap is symmetric and reachable on `main` too — but for some orderings of the second list, skipping the wrong index used to mask it. This fix makes the outcome consistent instead of order-dependent, which for that one input family is consistently wrong rather than accidentally right. Called out in the changeset, and left for a follow-up that defers the subsumption decision until conflicts are known.

## Verification

- `packages/json-magic` — 583 tests pass
- `packages/workspace-store` (consumer of the diff API) — 2904 pass, 1 skipped, 4 todo
- `types:check`, `biome check`, `prettier --check`, `knip` clean
- `patch` changeset added

Note: running `pnpm vitest packages/json-magic --run` from the repo root fails on `@/` path-alias resolution — a pre-existing environment quirk documented in `AGENTS.md`. Tests were run from inside the package.