### PR TITLE
docs(json-magic): rewrite readme and fix wrong imports in code samples

### DIFF
--- a/packages/json-magic/README.md
+++ b/packages/json-magic/README.md
@@ -1,10 +1,9 @@
-# json-magic
+# @scalar/json-magic
 
 [![Version](https://img.shields.io/npm/v/%40scalar/json-magic)](https://www.npmjs.com/package/@scalar/json-magic)
 [![Downloads](https://img.shields.io/npm/dm/%40scalar/json-magic)](https://www.npmjs.com/package/@scalar/json-magic)
 [![License](https://img.shields.io/npm/l/%40scalar%2Fjson-magic)](https://www.npmjs.com/package/@scalar/json-magic)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)
-
 
 A collection of utilities for working with JSON objects, including diffing, conflict resolution, bundling and more.
 
@@ -21,9 +20,41 @@ Scalar is an open-source API platform for teams who want beautiful developer int
 
 ---
 
+## Installation
+
+```bash
+npm add @scalar/json-magic
+```
+
+## Entry points
+
+There is no root export. Every module is imported from its own entry point, so you only pay for what you use.
+
+| Entry point | Exports |
+| --- | --- |
+| `@scalar/json-magic/bundle` | `bundle`, `isLocalRef`, `prefixInternalRef`, `prefixInternalRefRecursive`, `resolveAndCopyReferences`, plus the `Plugin`, `LoaderPlugin`, `LifecyclePlugin` and `ResolveResult` types |
+| `@scalar/json-magic/bundle/plugins/browser` | `fetchUrls`, `parseJson`, `parseYaml` |
+| `@scalar/json-magic/bundle/plugins/node` | `fetchUrls`, `parseJson`, `parseYaml`, `readFiles` |
+| `@scalar/json-magic/bundle/value-generator` | `getHash`, `generateUniqueValue`, `uniqueValueGeneratorFactory` |
+| `@scalar/json-magic/dereference` | `dereference` |
+| `@scalar/json-magic/diff` | `diff`, `merge`, `apply`, the `Difference` type |
+| `@scalar/json-magic/magic-proxy` | `createMagicProxy`, `getRaw` |
+| `@scalar/json-magic/helpers/*` | Small standalone helpers, see [Helpers](#helpers) |
+
+## Which module do I need?
+
+| I want to … | Use |
+| --- | --- |
+| Pull external `$ref` documents into a single self-contained document | [`bundle`](#bundle) |
+| Read through `$ref` pointers without rewriting the document | [`magic-proxy`](#magic-proxy) |
+| Resolve every `$ref`, internal and external, in one call | [`dereference`](#dereference) |
+| Compare two documents and merge concurrent edits | [`diff`](#diff) |
+
 ## bundle
 
-Bundle external references in a json object
+`bundle` walks a JSON object, resolves every external `$ref` (URLs, local files, or anything a custom loader plugin can handle) and embeds the result into the document itself. The original `$ref` values are rewritten to point at the embedded copies, so the output is a single self-contained document.
+
+External documents are stored under the `x-ext` key, and the mapping between the generated keys and their original URLs is stored under `x-ext-urls`. Both keys are configurable, see [Options](#options).
 
 ### Quick start
 
@@ -31,23 +62,36 @@ Bundle external references in a json object
 import { bundle } from '@scalar/json-magic/bundle'
 import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
 
-const result = await bundle({
- $ref: 'http://example.com/document.json' 
-}, {
-  plugins: [fetchUrls()],
-  treeShake: false,
-})
+const result = await bundle(
+  { $ref: 'http://example.com/document.json' },
+  {
+    plugins: [fetchUrls()],
+    treeShake: false,
+  },
+)
 
-// get the bundled json object
+// The bundled document
 console.log(result)
 ```
 
-#### Plugins
+When the input is an object it is modified in place, and the same object is returned. When the input is a string it is resolved with the given plugins first.
 
-If you are on a browser environment import plugins from `@scalar/json-magic/bundle/plugins/browser` while if you are on a node environment you can import from `@scalar/json-magic/bundle/plugins/node`
+### Loaders
 
-##### fetchUrls
-This plugins handles all external urls. It works for both node.js and browser environment
+A loader plugin teaches the bundler how to read one kind of reference. Import loaders from `@scalar/json-magic/bundle/plugins/browser` in the browser, or from `@scalar/json-magic/bundle/plugins/node` in Node.js. The Node entry point is a superset: it adds `readFiles`, which needs filesystem access.
+
+| Loader | Handles | Available in |
+| --- | --- | --- |
+| `fetchUrls` | `http://` and `https://` references | browser, node |
+| `readFiles` | Local file paths | node |
+| `parseJson` | A raw JSON string passed as the input | browser, node |
+| `parseYaml` | A raw YAML string passed as the input | browser, node |
+
+You can combine as many loaders as you need. The first one whose `validate` returns `true` wins.
+
+#### fetchUrls
+
+Resolves remote documents over HTTP. It works in both Node.js and the browser.
 
 ```ts
 import { bundle } from '@scalar/json-magic/bundle'
@@ -59,102 +103,104 @@ const document = {
   paths: {},
   components: {
     schemas: {
-      User: { $ref: 'https://example.com/user-schema.json#' }
-    }
-  }
+      User: { $ref: 'https://example.com/user-schema.json#' },
+    },
+  },
 }
 
-// This will bundle all external documents and turn all references from external into internal
+// This bundles all external documents and turns external references into internal ones
 await bundle(document, {
   plugins: [fetchUrls()],
-  treeShake: true  // <------  This flag will try to remove any unused part of the external document
+  // Removes the parts of the external documents that are not referenced
+  treeShake: true,
 })
 
 console.log(document)
 ```
 
-###### Limiting the number of concurrent requests
+##### Limiting the number of concurrent requests
 
 ```ts
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
+
 await bundle(document, {
   plugins: [
     fetchUrls({
-      limit: 10, // it should run at most 10 requests at the same time
+      // Run at most 10 requests at the same time
+      limit: 10,
     }),
   ],
-  treeShake: false
+  treeShake: false,
+})
+```
+
+##### Custom headers
+
+Headers are matched against the host of the reference, so a token is only ever sent to the domains you list.
+
+```ts
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
+
+await bundle(document, {
+  plugins: [
+    fetchUrls({
+      headers: [
+        {
+          domains: ['example.com'],
+          headers: {
+            Authorization: 'Bearer <TOKEN>',
+          },
+        },
+      ],
+    }),
+  ],
+  treeShake: false,
+})
+```
+
+##### Custom fetch function
+
+For advanced use cases like proxying requests or implementing custom network logic, you can provide your own fetch implementation. This allows you to handle things like CORS restrictions, custom authentication flows, or request and response transformations.
+
+```ts
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
+
+await bundle(document, {
+  plugins: [
+    fetchUrls({
+      fetch: async (input, init) => {
+        console.log('Custom fetch logic')
+        return fetch(input, init)
+      },
+    }),
+  ],
+  treeShake: false,
+})
+```
+
+##### Bundle from a remote URL
+
+The input itself can be a URL, as long as a loader can handle it.
+
+```ts
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
+
+const result = await bundle('https://example.com/openapi.json', {
+  plugins: [fetchUrls()],
+  treeShake: false,
 })
 
-```
-
-###### Custom headers
-To pass custom headers to requests for specific domains you can configure the fetch plugin like the example
-
-```ts
-await bundle(
-  document,
-  {
-    plugins: [
-      fetchUrls({
-        // Pass custom headers
-        // The header will only be attached to the list of domains
-        headers: [
-          {
-            domains: ['example.com'],
-            headers: {
-              'Authorization': 'Bearer <TOKEN>'
-            }
-          }
-        ]
-      }),
-      readFiles(),
-    ],
-    treeShake: false
-  },
-)
-```
-
-###### Custom fetch function
-For advanced use cases like proxying requests or implementing custom network logic, you can provide your own fetch implementation. This allows you to handle things like CORS restrictions, custom authentication flows, or request/response transformations.
-
-```ts
-await bundle(
-  document,
-  {
-    plugins: [
-      fetchUrls({
-        // Custom fetcher function
-        fetch: async (input, init) => {
-          console.log('Custom fetch logic')
-          return fetch(input, init)
-        },
-      })
-      readFiles(),
-    ],
-    treeShake: false
-  },
-)
-```
-
-###### Bundle from remote url
-
-```ts
-const result = await bundle(
-  'https://example.com/openapi.json',
-  {
-    plugins: [
-      fetchUrls(),
-    ],
-    treeShake: false
-  },
-)
-
-// Bundled document
+// The bundled document
 console.log(result)
 ```
 
-##### readFiles
-This plugins handles local files. Only works on node.js environment
+#### readFiles
+
+Resolves local files. This loader only works in a Node.js environment.
 
 ```ts
 import { bundle } from '@scalar/json-magic/bundle'
@@ -166,91 +212,137 @@ const document = {
   paths: {},
   components: {
     schemas: {
-      User: { $ref: './user-schema.json#' }
-    }
-  }
+      User: { $ref: './user-schema.json#' },
+    },
+  },
 }
 
-// This will bundle all external documents and turn all references from external into internal
 await bundle(document, {
   plugins: [readFiles()],
-  treeShake: false
+  treeShake: false,
 })
 
 console.log(document)
 ```
 
-###### Bundle from local file
-You can pass the file path directly but make sure to have the correct plugins to handle reading from the local files
+##### Bundle from a local file
+
+You can pass the file path directly, as long as `readFiles` is registered to read it.
 
 ```ts
-const result = await bundle(
-  './input.json',
-  {
-    plugins: [
-      readFiles(),
-    ],
-    treeShake: false
-  },
-)
+import { bundle } from '@scalar/json-magic/bundle'
+import { readFiles } from '@scalar/json-magic/bundle/plugins/node'
 
-// Bundled document
+const result = await bundle('./input.json', {
+  plugins: [readFiles()],
+  treeShake: false,
+})
+
+// The bundled document
 console.log(result)
 ```
 
-##### parseJson
+A document that mixes remote and local references needs both loaders:
 
-You can pass raw json string as input
+```ts
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls, readFiles } from '@scalar/json-magic/bundle/plugins/node'
+
+await bundle('./openapi.json', {
+  plugins: [readFiles(), fetchUrls()],
+  treeShake: false,
+})
+```
+
+#### parseJson
+
+Accepts a raw JSON string as the input.
+
 ```ts
 import { bundle } from '@scalar/json-magic/bundle'
 import { parseJson } from '@scalar/json-magic/bundle/plugins/browser'
 
-const result = await bundle(
-  '{ "openapi": "3.1.1" }',
-  {
-    plugins: [
-      parseJson(),
-    ],
-    treeShake: false
-  },
-)
+const result = await bundle('{ "openapi": "3.1.1" }', {
+  plugins: [parseJson()],
+  treeShake: false,
+})
 
-// Bundled document
+// The bundled document
 console.log(result)
 ```
 
-##### parseYaml
+#### parseYaml
 
-You can pass raw yaml string as input
+Accepts a raw YAML string as the input.
+
 ```ts
 import { bundle } from '@scalar/json-magic/bundle'
 import { parseYaml } from '@scalar/json-magic/bundle/plugins/browser'
 
-const result = await bundle(
-  'openapi: "3.1.1"\n',
-  {
-    plugins: [
-      parseYaml(),
-    ],
-    treeShake: false
-  },
-)
+const result = await bundle('openapi: "3.1.1"\n', {
+  plugins: [parseYaml()],
+  treeShake: false,
+})
 
-// Bundled document
+// The bundled document
 console.log(result)
 ```
 
-#### Bundler Options
+#### Writing a custom loader
 
-##### depth
-
-The `depth` option controls how deeply the bundler will resolve `$ref` references. When you set `depth` to a number, the bundler will only follow references up to that level of nesting. This is useful for creating partial bundles or limiting resource usage.
-
-**Note:** When using `depth`, the resulting bundle may not be fully self-contained—some nested references deeper than the specified depth may remain unresolved. If you use `depth` together with the `visitedNodes` option, be aware that parent nodes may be marked as visited even if their child references have not been fully resolved yet. Use this option with care if you require a complete bundle.
+A loader is a plain object, so you can resolve references from anywhere: a database, an in-memory map, or a custom protocol.
 
 ```ts
-import { bundle } from '@scalar/openapi-parser'
-import { fetchUrls } from '@scalar/openapi-parser/plugins-browser'
+import { bundle, type LoaderPlugin } from '@scalar/json-magic/bundle'
+
+const workspaceFiles: LoaderPlugin = {
+  type: 'loader',
+  validate: (value) => value.startsWith('workspace:'),
+  exec: async (value) => {
+    const raw = await readFromWorkspace(value.replace('workspace:', ''))
+
+    if (raw === undefined) {
+      return { ok: false }
+    }
+
+    return { ok: true, data: JSON.parse(raw), raw }
+  },
+}
+
+await bundle(document, {
+  plugins: [workspaceFiles],
+  treeShake: false,
+})
+```
+
+`exec` returns `{ ok: true, data, raw }` on success and `{ ok: false }` on failure. A failed resolution is reported through the `onResolveError` hook and logged as a warning, it does not throw.
+
+### Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `plugins` | `Plugin[]` | — | Loader and lifecycle plugins used during bundling. Required. |
+| `treeShake` | `boolean` | — | Only keep the parts of external documents that are actually referenced. Required. |
+| `depth` | `number` | unlimited | How deeply nested `$ref` pointers are followed. See the note below. |
+| `root` | `UnknownObject` | the input | Base document to write external documents into, used for partial bundling. |
+| `origin` | `string` | the input | Base path used to resolve relative references. |
+| `cache` | `Map<string, Promise<ResolveResult>>` | new map | Cache of in-flight resolutions, reused across `bundle` calls to avoid refetching. |
+| `visitedNodes` | `Set<unknown>` | new set | Nodes that have already been bundled, used to avoid re-bundling during partial bundles. |
+| `urlMap` | `boolean` | `false` | Keep the mapping of generated keys to their original URLs in the output. |
+| `externalDocumentsKey` | `string` | `'x-ext'` | Key that holds the bundled external documents. |
+| `externalDocumentsMappingsKey` | `string` | `'x-ext-urls'` | Key that holds the mapping between generated keys and original URLs. |
+| `compress` | `(value: string) => string \| Promise<string>` | hash | Function used to shorten URLs and file paths into document keys. |
+| `hooks` | `object` | — | Lifecycle hooks, see [Hooks](#hooks). |
+
+#### depth
+
+The `depth` option controls how deeply the bundler resolves `$ref` references. When you set `depth` to a number, the bundler only follows references up to that level of nesting. This is useful for creating partial bundles or limiting resource usage.
+
+**Note:** When using `depth`, the resulting bundle may not be fully self-contained, since nested references deeper than the given depth stay unresolved. If you use `depth` together with `visitedNodes`, be aware that parent nodes may be marked as visited even if their child references have not been fully resolved yet. Use this option with care if you require a complete bundle.
+
+```ts
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
 
 await bundle(input, {
   plugins: [fetchUrls()],
@@ -259,13 +351,13 @@ await bundle(input, {
 })
 ```
 
-##### externalDocumentsKey
+#### externalDocumentsKey
 
-The `externalDocumentsKey` option controls the key used to store external references. This key will contain all bundled external documents. The key is used to maintain a clean separation between the main OpenAPI document and its bundled external references. **Defaults** to `x-ext`.
+The `externalDocumentsKey` option controls the key used to store external references. This key contains all bundled external documents, which keeps a clean separation between the main document and its bundled references. **Defaults** to `x-ext`.
 
 ```ts
-import { bundle } from '@scalar/openapi-parser'
-import { fetchUrls } from '@scalar/openapi-parser/plugins-browser'
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
 
 await bundle(input, {
   plugins: [fetchUrls()],
@@ -274,65 +366,138 @@ await bundle(input, {
 })
 ```
 
-##### externalDocumentsMappingsKey
+#### externalDocumentsMappingsKey
 
-The `externalDocumentsMappingsKey` option controls the key used to maintain a mapping between hashed keys and their original URLs. This mapping is essential for tracking the source of bundled references. **Defaults** to `x-ext-urls`.
+The `externalDocumentsMappingsKey` option controls the key used to maintain a mapping between generated keys and their original URLs. This mapping is essential for tracking the source of bundled references. It is removed from the output of a full bundle unless `urlMap` is enabled. **Defaults** to `x-ext-urls`.
 
 ```ts
-import { bundle } from '@scalar/openapi-parser'
-import { fetchUrls } from '@scalar/openapi-parser/plugins-browser'
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
 
 await bundle(input, {
   plugins: [fetchUrls()],
   treeShake: false,
   urlMap: true,
-  externalDocumentsKey: 'x-external-urls',
+  externalDocumentsMappingsKey: 'x-external-urls',
+})
+```
+
+### Hooks
+
+Hooks let you observe and extend the bundling process, which is handy for progress reporting and error tracking.
+
+| Hook | Called when |
+| --- | --- |
+| `onResolveStart` | The bundler starts resolving a `$ref` |
+| `onResolveSuccess` | A `$ref` was resolved successfully |
+| `onResolveError` | A `$ref` could not be resolved |
+| `onBeforeNodeProcess` | Before a node is processed, may be async |
+| `onAfterNodeProcess` | After a node is processed, may be async |
+
+```ts
+import { bundle } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
+
+const errors: string[] = []
+
+await bundle(document, {
+  plugins: [fetchUrls()],
+  treeShake: true,
+  hooks: {
+    onResolveStart: (node) => console.log('Resolving:', node.$ref),
+    onResolveSuccess: (node) => console.log('Resolved:', node.$ref),
+    onResolveError: (node) => errors.push(`Failed to resolve ${node.$ref}`),
+  },
+})
+```
+
+The same hooks can be shipped as a reusable lifecycle plugin, which is then passed alongside the loaders:
+
+```ts
+import { bundle, type LifecyclePlugin } from '@scalar/json-magic/bundle'
+import { fetchUrls } from '@scalar/json-magic/bundle/plugins/browser'
+
+const logProgress: LifecyclePlugin = {
+  type: 'lifecycle',
+  onResolveSuccess: (node) => console.log('Resolved:', node.$ref),
+}
+
+await bundle(document, {
+  plugins: [fetchUrls(), logProgress],
+  treeShake: false,
 })
 ```
 
 ## dereference
 
-Dereference all `$ref` pointers in a JSON object, resolving both internal and external references.
+`dereference` resolves the `$ref` pointers of a document and returns the result wrapped in a [magic proxy](#magic-proxy), so referenced values are read through the `$ref-value` property.
 
-The `dereference` function can operate in two modes:
+It works in two modes:
 
-- **Synchronous (`sync: true`)**: Only internal references (within the same object) are resolved. The result is wrapped in a magic proxy for reactive access. No network requests are made.
-- **Asynchronous (`sync: false` or omitted)**: Both internal and external references (e.g., URLs) are resolved. The function returns a Promise that resolves to the fully dereferenced object, also wrapped in a magic proxy.
+- **Synchronous (`sync: true`)**: only internal references are resolved, no network requests are made, and the result is returned directly.
+- **Asynchronous (`sync: false`, the default)**: external references are bundled into the document first, so both internal and external references resolve. A Promise is returned.
 
 ### Options
 
-- `sync` (`boolean`):  
-  - If `true`, resolves only internal references synchronously.
-  - If `false` (default), resolves both internal and external references asynchronously and returns a Promise.
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `sync` | `boolean` | `false` | Resolve internal references only, without returning a Promise. |
+| `plugins` | `Plugin[]` | `[fetchUrls()]` | Loaders used to resolve external references in async mode. |
 
-The result is an object with a `success` property. If dereferencing fails (e.g., due to unresolved external references), the result will include an `errors` array describing the issues encountered.
+The result is an object with a `success` property. On success it carries the dereferenced `data`, and on failure it carries an `errors` array describing the references that could not be resolved.
 
 ```ts
 import { dereference } from '@scalar/json-magic/dereference'
 
 const result = dereference({ a: 'hello', b: { $ref: '#/a' } }, { sync: true })
 
-// Resolve internal references synchronously
-console.log(result)
+if (result.success) {
+  // 'hello'
+  console.log(result.data.b['$ref-value'])
+}
 ```
 
-To resolve also external references you need to set `sync: false`
+To resolve external references as well, drop `sync` (or set it to `false`) and await the result.
 
 ```ts
 import { dereference } from '@scalar/json-magic/dereference'
 
-const result = await dereference({ a: 'hello', b: { $ref: 'http://example.com/document.json#/somepath' } }, { sync: false })
+const result = await dereference({
+  a: 'hello',
+  b: { $ref: 'http://example.com/document.json#/somepath' },
+})
 
-// Result with all internal and external references resolved
-console.log(result)
+if (result.success) {
+  console.log(result.data)
+} else {
+  console.error(result.errors)
+}
+```
+
+To resolve references from somewhere other than HTTP, pass your own loaders:
+
+```ts
+import { dereference } from '@scalar/json-magic/dereference'
+import { fetchUrls, readFiles } from '@scalar/json-magic/bundle/plugins/node'
+
+const result = await dereference(document, {
+  plugins: [readFiles(), fetchUrls()],
+})
 ```
 
 ## diff
 
-This package provides a way to compare two json objects and get the differences, resolve conflicts and return conflicts that need to be resolved manually.
+Compare two JSON objects, merge changes made in parallel, and surface the conflicts that need to be resolved manually.
+
+| Function | Description |
+| --- | --- |
+| `diff(base, updated)` | Returns the list of `add`, `update` and `delete` changes that turn `base` into `updated` |
+| `merge(diffA, diffB)` | Combines two changesets made against the same base into `{ diffs, conflicts }` |
+| `apply(base, diffs)` | Applies a changeset to a document and returns it |
+
+Note that `apply` mutates the document it is given. Clone it first if you need to keep the original around. It throws an `InvalidChangesDetectedError` when a change points at a path that does not exist.
 
 ### Quickstart
-
 
 ```ts
 import { apply, diff, merge } from '@scalar/json-magic/diff'
@@ -366,19 +531,30 @@ const objectV2 = {
 }
 
 // Merge the changes of both versions with the same parent object
-const { diffs, conflicts } = merge(
-  diff(baseObject, objectV1),
-  diff(baseObject, objectV2),
-)
+const { diffs, conflicts } = merge(diff(baseObject, objectV1), diff(baseObject, objectV2))
 
 // Apply changes from v1 and v2 to the parent object to get the final object
 const finalDocument = apply(baseObject, diffs)
 ```
 
+### Conflicts
+
+`merge` only returns the changes it can combine safely. When both sides touch the same path, the pair is returned in `conflicts` for you to resolve, and it is left out of `diffs`.
+
+```ts
+import { diff, merge } from '@scalar/json-magic/diff'
+
+const { diffs, conflicts } = merge(diff(base, mine), diff(base, theirs))
+
+for (const [mineChanges, theirChanges] of conflicts) {
+  // Decide which side wins, then push the winner onto diffs
+  diffs.push(...mineChanges)
+}
+```
 
 ## magic-proxy
 
-A javascript proxy which resolves internal references when accessing a property
+A JavaScript proxy that resolves internal references as you access properties. Nothing is copied or rewritten: the underlying document keeps its `$ref` pointers, and referenced values are read on demand through the virtual `$ref-value` property. Resolved values are cached, and proxies are stable for the same target object, which makes it safe to use with reactive frameworks like Vue.
 
 ### Quick start
 
@@ -388,30 +564,71 @@ import { createMagicProxy, getRaw } from '@scalar/json-magic/magic-proxy'
 const result = createMagicProxy({
   a: 'hello',
   b: {
-    $ref: '#/a'
-  }
+    $ref: '#/a',
+  },
 })
 
-/**
- * Output:
- * {
- *  a: 'hello',
- *  b: {
- *    $ref: '#/a',
- *    '$ref-value': 'hello'
- *  }
- * }
- */
-console.log(result)
+// 'hello', resolved on access
+console.log(result.b['$ref-value'])
 
-const rawObject = getRaw(result)
+// '#/a', the original pointer is still there
+console.log(result.b.$ref)
+
 /**
+ * getRaw returns the untouched object:
  * {
- *  a: 'hello',
- *  b: {
- *    $ref: '#/a'
- *  }
+ *   a: 'hello',
+ *   b: {
+ *     $ref: '#/a'
+ *   }
  * }
  */
+const rawObject = getRaw(result)
 console.log(rawObject)
 ```
+
+Deeply nested values are proxied too, so `$ref-value` works at any depth. Writes pass through to the underlying object, and writing to `$ref-value` updates the value the reference points at.
+
+Properties prefixed with `__scalar_` are treated as internal: they read as `undefined`, they are left out of `Object.keys`, and `in` checks return `false`. Pass `{ showInternal: true }` to expose them.
+
+```ts
+const proxy = createMagicProxy({ __scalar_meta: 'hidden' }, { showInternal: true })
+
+// 'hidden'
+console.log(proxy.__scalar_meta)
+```
+
+## Helpers
+
+Standalone helpers, each with its own entry point.
+
+| Helper | Description |
+| --- | --- |
+| `@scalar/json-magic/helpers/escape-json-pointer` | Escape `~` and `/` in a JSON pointer segment |
+| `@scalar/json-magic/helpers/unescape-json-pointer` | Reverse of `escapeJsonPointer` |
+| `@scalar/json-magic/helpers/get-segments-from-path` | Split a JSON pointer into unescaped segments |
+| `@scalar/json-magic/helpers/get-value-by-path` | Read the value at a list of path segments |
+| `@scalar/json-magic/helpers/set-value-at-path` | Write a value at a JSON pointer, creating missing nodes |
+| `@scalar/json-magic/helpers/is-file-path` | Check whether a string looks like a file path |
+| `@scalar/json-magic/helpers/is-http-url` | Check whether a string is an HTTP or HTTPS URL |
+| `@scalar/json-magic/helpers/is-json-object` | Check whether a string is a JSON object |
+| `@scalar/json-magic/helpers/is-yaml` | Check whether a string is valid YAML |
+| `@scalar/json-magic/helpers/normalize` | Parse a JSON or YAML string into an object |
+
+```ts
+import { getValueByPath } from '@scalar/json-magic/helpers/get-value-by-path'
+
+const { value } = getValueByPath({ components: { schemas: { User: { type: 'object' } } } }, [
+  'components',
+  'schemas',
+  'User',
+])
+```
+
+## Community
+
+We are API nerds. You too? Let's chat on Discord: <https://discord.gg/scalar>
+
+## License
+
+The source code in this repository is licensed under [MIT](https://github.com/scalar/scalar/blob/main/LICENSE).


### PR DESCRIPTION
## Problem

Several code samples in the `@scalar/json-magic` README import from the wrong package, so copy-pasting them does not work. The `depth`, `externalDocumentsKey`, and `externalDocumentsMappingsKey` examples import `bundle` and `fetchUrls` from `@scalar/openapi-parser` and `@scalar/openapi-parser/plugins-browser` — neither resolves to this package.

Checking every snippet against the source turned up more breakage in the same area:

- Several examples use `bundle`, `fetchUrls`, or `readFiles` with no import at all.
- The custom-headers and custom-fetch examples have a stray `readFiles()` in a `fetchUrls` section, and the custom-fetch one is missing a comma, so it does not parse.
- The `externalDocumentsMappingsKey` example sets `externalDocumentsKey` instead, so it does not demonstrate the option it documents.
- The magic-proxy example claims `console.log(result)` prints the resolved `$ref-value`. It does not — `$ref-value` is a virtual property that resolves on access, so a plain log shows it as `undefined`.

Beyond the broken samples, the README was hard to navigate: a flat wall of headings nested up to `######`, no installation step, and no list of the package's entry points — which matters more than usual here, because there is no root export and every module has to be imported from its own path.

## Solution

Fixed the imports to `@scalar/json-magic/bundle` and `@scalar/json-magic/bundle/plugins/{browser,node}`, made every snippet self-contained and syntactically valid, pointed the `externalDocumentsMappingsKey` example at that option, and rewrote the magic-proxy example to use explicit property access.

Restructured the rest around those fixes:

- Installation section and an entry-point table, calling out that there is no root export
- A "which module do I need?" table mapping tasks to modules
- A loader table (`fetchUrls`, `readFiles`, `parseJson`, `parseYaml`) noting which work in the browser vs. Node
- Full options and hooks reference tables for the bundler
- Custom loader and lifecycle plugin examples
- Conflict handling for `diff`
- The helper entry points
- The Community and License sections the other Scalar packages carry

Also documented two behaviors that were undocumented and easy to get bitten by: `apply` mutates the document it is given, and `dereference` in async mode bundles external refs and returns a magic proxy rather than inlining everything.

All claims were verified against the source in `packages/json-magic/src` rather than carried over from the old text.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Documentation-only change with no code impact; AGENTS.md scopes changesets to code changes. Happy to add a patch changeset if you would rather republish the docs to npm. -->
- [ ] I added tests. <!-- Not applicable, no code changes. -->
- [x] I updated the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018sReqV4umEJguCGV91SxSu

---
_Generated by [Claude Code](https://claude.ai/code/session_018sReqV4umEJguCGV91SxSu)_