### PR TITLE
fix(json-magic): detect array/object mismatches in collision checks

### DIFF
--- a/.changeset/json-magic-diff-container-mismatch.md
+++ b/.changeset/json-magic-diff-container-mismatch.md
@@ -1,0 +1,12 @@
+---
+'@scalar/json-magic': patch
+---
+
+Treat an array and a plain object on the same path as a merge conflict. `isKeyCollisions` compared the two containers key by key, so an array and an object holding the same values under the same indices looked mergeable:
+
+```ts
+isKeyCollisions([1, 2], { 0: 1, 1: 2 }) // → false, so the two were merged
+mergeObjects([1, 2], { 0: 1, 1: 2 }) // → [1, 2], the object silently absorbed
+```
+
+In practice that meant one side turning `servers: ['https://example.com']` into `servers: { 0: 'https://example.com' }` merged cleanly and lost the container the user picked. Both sides now surface as a conflict to resolve, matching the guard `diff` already applies when a container changes type.

--- a/packages/json-magic/src/diff/merge.test.ts
+++ b/packages/json-magic/src/diff/merge.test.ts
@@ -1228,6 +1228,42 @@ describe('mergeDiff', () => {
     })
   })
 
+  test('an array and a plain object holding the same values on the same path produce a conflict', () => {
+    // The two sides describe the same values in different containers, so a key-by-key comparison
+    // finds nothing to disagree about even though one document ends up with a list and the other
+    // with a map. Only a conflict lets the user pick the container they meant.
+    const diff1: Difference<unknown>[] = [{ path: ['servers'], changes: { 0: 'https://example.com' }, type: 'update' }]
+    const diff2: Difference<unknown>[] = [{ path: ['servers'], changes: ['https://example.com'], type: 'update' }]
+
+    expect(merge(diff1, diff2)).toEqual({
+      diffs: [],
+      conflicts: [
+        [
+          [{ path: ['servers'], changes: { 0: 'https://example.com' }, type: 'update' }],
+          [{ path: ['servers'], changes: ['https://example.com'], type: 'update' }],
+        ],
+      ],
+    })
+  })
+
+  test('two arrays on the same path still merge without a conflict', () => {
+    const diff1: Difference<unknown>[] = [{ path: ['servers'], changes: ['https://example.com'], type: 'update' }]
+    const diff2: Difference<unknown>[] = [
+      { path: ['servers'], changes: ['https://example.com', 'https://staging.example.com'], type: 'update' },
+    ]
+
+    expect(merge(diff1, diff2)).toEqual({
+      diffs: [
+        {
+          path: ['servers'],
+          changes: ['https://example.com', 'https://staging.example.com'],
+          type: 'update',
+        },
+      ],
+      conflicts: [],
+    })
+  })
+
   // TODO: a delete that is subsumed by a delete on the other side is discarded before we know
   // whether the covering delete ends up in `conflicts`. When it does, the subsumed delete
   // survives in neither `diffs` nor `conflicts`, so resolving the conflict toward the side that

--- a/packages/json-magic/src/diff/utils.test.ts
+++ b/packages/json-magic/src/diff/utils.test.ts
@@ -38,6 +38,39 @@ describe('isKeyCollisions', () => {
     expect(isKeyCollisions(a, b)).toBe(false)
   })
 
+  test.each([
+    [[1, 2], { 0: 1, 1: 2 }],
+    [{ 0: 1, 1: 2 }, [1, 2]],
+    // The mismatch is nested rather than at the top level
+    [{ servers: ['https://example.com'] }, { servers: { 0: 'https://example.com' } }],
+    // Empty containers still carry a type
+    [[], {}],
+  ])('reports a collision when an array meets a plain object (case %#)', (a, b) => {
+    expect(isKeyCollisions(a, b)).toBe(true)
+  })
+
+  test.each([
+    [null, { a: 1 }],
+    [[1, 2], null],
+    [null, [1, 2]],
+  ])('reports a collision when only one side is null (case %#)', (a, b) => {
+    expect(isKeyCollisions(a, b)).toBe(true)
+  })
+
+  test('does not report a collision for two nulls', () => {
+    expect(isKeyCollisions(null, null)).toBe(false)
+  })
+
+  test('does not report a collision for arrays that only differ in length', () => {
+    // The shorter array has no value at the extra index, so there is nothing to disagree about and
+    // the merge appends the new element
+    expect(isKeyCollisions([1, 2], [1, 2, 3])).toBe(false)
+  })
+
+  test('reports a collision for arrays that disagree on an element', () => {
+    expect(isKeyCollisions([1, 2], [1, 3, 4])).toBe(true)
+  })
+
   test('does not report a collision for an own `__proto__` key', () => {
     // Only one side has `__proto__` as an own key, so the other side would resolve it to its own
     // prototype and look like a mismatch
@@ -145,6 +178,27 @@ describe('mergeObjects', () => {
       },
       b: 1,
     })
+  })
+
+  test('staples the keys of a plain object onto an array', () => {
+    const a = [1, 2] as unknown as Record<string, unknown>
+    const b: Record<string, unknown> = { 0: 1, 1: 2, url: 'https://example.com' }
+
+    // `mergeObjects` trusts the caller to check for collisions first, so it has no container type
+    // guard of its own. The result stays an array and picks up a key that no index can reach, which
+    // is why `isKeyCollisions` has to reject the pair before this merge is ever attempted.
+    const merged = mergeObjects(a, b)
+
+    expect(Array.isArray(merged)).toBe(true)
+    expect(merged).toHaveLength(2)
+    expect(merged.url).toBe('https://example.com')
+  })
+
+  test('appends the elements an array is missing', () => {
+    const a = [1, 2] as unknown as Record<string, unknown>
+    const b = [1, 2, 3] as unknown as Record<string, unknown>
+
+    expect(mergeObjects(a, b)).toEqual([1, 2, 3])
   })
 
   describe('prototype pollution', () => {

--- a/packages/json-magic/src/diff/utils.ts
+++ b/packages/json-magic/src/diff/utils.ts
@@ -20,13 +20,24 @@ import { isPollutionKey } from '@scalar/helpers/object/prevent-pollution'
  *
  * // Nested objects with collision
  * isKeyCollisions({ a: { b: 1 } }, { a: { b: 2 } }) // true
+ *
+ * // An array against a plain object
+ * isKeyCollisions([1, 2], { 0: 1, 1: 2 }) // true
  */
-export const isKeyCollisions = (a: unknown, b: unknown) => {
+export const isKeyCollisions = (a: unknown, b: unknown): boolean => {
   if (typeof a !== typeof b) {
     return true
   }
 
   if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
+    // An array on one side and a plain object on the other is always a collision. Comparing them
+    // key by key matches array indices against object keys, so two containers that hold the same
+    // values look mergeable, and `mergeObjects` then absorbs one into the other and drops its type.
+    // The same guard lives in `diff`, which reports a container type change as a single update.
+    if (Array.isArray(a) !== Array.isArray(b)) {
+      return true
+    }
+
     const keys = new Set([...Object.keys(a), ...Object.keys(b)])
 
     for (const key of keys) {


### PR DESCRIPTION
## Problem

`isKeyCollisions` compares two containers key by key without ever comparing `Array.isArray(a)` with `Array.isArray(b)`. An array and a plain object holding the same values under the same indices therefore look mergeable:

```ts
isKeyCollisions([1, 2], { 0: 1, 1: 2 }) // → false, so the two were merged
mergeObjects([1, 2], { 0: 1, 1: 2 }) // → [1, 2], the object silently absorbed
```

`merge` reaches this check only when both sides changed the *same* path, so this is exactly the case where one document turned `servers: ['https://example.com']` into `servers: { 0: 'https://example.com' }` while the other kept the list. Instead of asking the user which container they meant, the merge quietly picked one and dropped the other.

This is the same class of bug e176c3953 fixed in `diff.ts`, still live in the collision check that gates conflict detection.

## Change

Add an `Array.isArray(a) !== Array.isArray(b)` guard to `isKeyCollisions`, mirroring the guard `diff` already applies when a container changes type. A container mismatch is now a conflict for the user to resolve.

`mergeObjects` is deliberately left alone — it documents that callers check for collisions first, and `isKeyCollisions` is that check. A test pins what it does with a mismatched pair so the reason the guard has to sit upstream is visible.

## Tests

- `isKeyCollisions`: array vs object in both orders, nested, and empty containers; plus control cases that must stay collision-free (arrays differing only in length, `null` operands, two arrays that disagree on an element).
- `mergeObjects`: what a mismatched pair actually does to the array, and that a longer array still appends.
- `merge`: an array/object mismatch on the same path now surfaces as a conflict, and two arrays on the same path still auto-merge.

Removing the guard fails exactly the five assertions that target it, and nothing else.

## Verification

```
pnpm vitest src/diff --run          # from packages/json-magic — 110 passed
pnpm vitest --run                   # from packages/workspace-store — 2904 passed
pnpm --filter @scalar/json-magic types:check   # clean
pnpm knip                                       # clean
```

No UI surface is touched, so there are no visual artifacts. The user-visible effect is that a document-sync conflict dialog appears where a silent, lossy auto-merge used to happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)