### PR TITLE
docs(json-magic): document reference-sharing in diff, merge and apply

### DIFF
--- a/.changeset/json-magic-diff-reference-sharing.md
+++ b/.changeset/json-magic-diff-reference-sharing.md
@@ -1,0 +1,16 @@
+---
+'@scalar/json-magic': patch
+---
+
+Explain the root-level change `apply` cannot handle, and document that `diff`, `merge` and `apply` share references with the documents they work on.
+
+A change with an empty path asks to replace the document itself, which `apply` cannot do since it writes through the parent container of each path. It used to fail with `Process aborted. Path  at depth 0 is undefined, check diff object` halfway through a changeset, and now says so up front and leaves the document untouched:
+
+```ts
+// `diff` emits a change with an empty path whenever the two documents differ at the root
+apply({ name: 'John' }, [{ path: [], changes: [1, 2], type: 'update' }])
+// InvalidChangesDetectedError: Process aborted. Root-level replacement is not supported, the
+// change targets the document itself instead of a property inside it
+```
+
+The changes a diff carries are live references into the documents it compared, so `merge` writes into the document behind its second diff list and an applied document stays structurally shared with the diff. That contract is now spelled out on `diff`, `merge` and `apply` — deep clone the documents when a caller needs isolation.

--- a/packages/json-magic/README.md
+++ b/packages/json-magic/README.md
@@ -495,7 +495,9 @@ Compare two JSON objects, merge changes made in parallel, and surface the confli
 | `merge(diffA, diffB)` | Combines two changesets made against the same base into `{ diffs, conflicts }` |
 | `apply(base, diffs)` | Applies a changeset to a document and returns it |
 
-Note that `apply` mutates the document it is given. Clone it first if you need to keep the original around. It throws an `InvalidChangesDetectedError` when a change points at a path that does not exist.
+These three functions work on the documents themselves, not on copies of them. `apply` mutates the document it is given, `merge` merges one changeset into the entries of the other, and the changes a diff carries are live references into the documents that were compared. That means an applied document keeps sharing subtrees with the document it was diffed against, and a merge writes into the document behind its second changeset. Deep clone the documents before diffing them whenever you need the originals to stay untouched — cloning only the document you apply to is not enough.
+
+`apply` throws an `InvalidChangesDetectedError` when a change points at a path that does not exist, when a change targets the document itself (an empty path, which a diff produces whenever the two documents differ at the root), and when a path reaches the prototype chain through `__proto__`, `constructor` or `prototype`.
 
 ### Quickstart
 

--- a/packages/json-magic/src/diff/apply.test.ts
+++ b/packages/json-magic/src/diff/apply.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'vitest'
 
 import { InvalidChangesDetectedError, apply } from '@/diff/apply'
+import { diff } from '@/diff/diff'
 
 const deepClone = <T extends object>(obj: T) => JSON.parse(JSON.stringify(obj)) as T
 
@@ -319,6 +320,61 @@ describe('apply', () => {
       expect(() => apply({}, [{ path: ['info', 'constructor'], changes: 'yes', type: 'add' }])).toThrowError(
         'Process aborted. Path info.constructor contains the unsafe segment "constructor", which can modify the prototype chain',
       )
+    })
+  })
+
+  describe('rejects root level changes', () => {
+    test('explains that the document itself cannot be replaced', () => {
+      expect(() => apply({ name: 'John' }, [{ path: [], changes: { name: 'Jeremy' }, type: 'update' }])).toThrowError(
+        'Process aborted. Root-level replacement is not supported, the change targets the document itself instead of a property inside it',
+      )
+    })
+
+    test('rejects the root level change a container type swap produces', () => {
+      const doc = { name: 'John' }
+
+      expect(() => apply(doc, diff(doc, [1, 2] as unknown as Record<string, unknown>))).toThrowError(
+        'Process aborted. Root-level replacement is not supported, the change targets the document itself instead of a property inside it',
+      )
+    })
+
+    test('leaves the document untouched when a later change targets the root', () => {
+      const doc = { name: 'John' }
+
+      expect(() =>
+        apply(doc, [
+          { path: ['age'], changes: 25, type: 'add' },
+          { path: [], changes: { name: 'Jeremy' }, type: 'update' },
+        ]),
+      ).toThrowError(InvalidChangesDetectedError)
+      expect(doc).toEqual({ name: 'John' })
+    })
+  })
+
+  // `apply` writes changes in by reference, so the result stays structurally shared with the
+  // documents the diff was built from. The behavior is pinned here so a future switch to cloning
+  // is a deliberate change rather than a silent one.
+  describe('shares structure with the documents the diff came from', () => {
+    test('returns the document it was given', () => {
+      const doc = { name: 'John' }
+
+      expect(apply(doc, [{ path: ['age'], changes: 25, type: 'add' }])).toBe(doc)
+      expect(doc).toEqual({ name: 'John', age: 25 })
+    })
+
+    test('writes the change in by reference', () => {
+      const location = { city: 'New York' }
+      const result = apply({ name: 'John' }, [{ path: ['location'], changes: location, type: 'add' }])
+
+      expect(result.location).toBe(location)
+    })
+
+    test('a full diff and apply round trip aliases the target document', () => {
+      const doc2 = { nested: { value: 1 } }
+      const result = apply({}, diff({}, doc2))
+
+      result.nested.value = 999
+      expect(doc2.nested.value).toBe(999)
     })
   })
 })

--- a/packages/json-magic/src/diff/apply.ts
+++ b/packages/json-magic/src/diff/apply.ts
@@ -17,10 +17,22 @@ export class InvalidChangesDetectedError extends Error {
  * Paths that reach the prototype chain (`__proto__`, `constructor` or `prototype`) are rejected
  * before anything is written, so a hostile changeset cannot poison `Object.prototype`.
  *
- * @param document - The original document to apply changes to
+ * A change with an empty path asks to replace the document itself, which is not supported: the
+ * function writes through the parent container of each path and the root has no parent. `diff`
+ * emits such a change whenever the two documents differ at the root, which covers a different
+ * `typeof`, `null` against an object, and an array on one side against a plain object on the
+ * other. Those changesets have to be handled by the caller instead of being applied.
+ *
+ * ⚠️ `document` is mutated in place and the result shares structure with the document the diff was
+ * built from: every `add` and `update` writes the change into the document by reference, and those
+ * changes are live references into the target document `diff` compared (see `diff`). A later write
+ * into the result can therefore be seen through that document, and the other way around. Callers
+ * that need an isolated result have to deep clone the document and the changes first.
+ *
+ * @param document - The original document to apply changes to, mutated in place
  * @param diff - Array of differences to apply, each containing a path and change type
- * @returns The modified document with all changes applied
- * @throws {InvalidChangesDetectedError} When a path is unusable or reaches the prototype chain
+ * @returns The modified document with all changes applied, structurally shared with the changes
+ * @throws {InvalidChangesDetectedError} When a path is unusable, empty or reaches the prototype chain
  *
  * @example
  * const original = {
@@ -79,11 +91,22 @@ export const apply = <T extends Record<string, unknown>>(
     applyChange(current[path[depth]], path, d, depth + 1)
   }
 
-  // Reject prototype-polluting paths up front, so an unsafe changeset is turned away before any of
-  // its entries touch the document. A path segment such as `__proto__` would make the traversal walk
-  // onto `Object.prototype` and write there, poisoning every object in the runtime. `diff` never
-  // emits these segments, so only a hand-crafted changeset reaches this guard.
+  // Reject the two kinds of unusable entry we can spot without walking the document - a root level
+  // change and a prototype reaching path - before any entry touches it. A path that does not exist
+  // is only found while traversing, so that one can still leave the document half updated.
   for (const d of diff) {
+    // An empty path targets the document itself. We only ever write through the parent container of
+    // a path, so there is nothing to write into for the root, and the caller has to swap the
+    // document out on its own.
+    if (d.path.length === 0) {
+      throw new InvalidChangesDetectedError(
+        'Process aborted. Root-level replacement is not supported, the change targets the document itself instead of a property inside it',
+      )
+    }
+
+    // A path segment such as `__proto__` would make the traversal walk onto `Object.prototype` and
+    // write there, poisoning every object in the runtime. `diff` never emits these segments, so
+    // only a hand-crafted changeset reaches this guard.
     const unsafeSegment = d.path.find(isPollutionKey)
 
     if (unsafeSegment !== undefined) {

--- a/packages/json-magic/src/diff/diff.test.ts
+++ b/packages/json-magic/src/diff/diff.test.ts
@@ -549,4 +549,42 @@ describe('diff', () => {
       expect(({} as Record<string, unknown>).pollutedByRoundTrip).toBeUndefined()
     })
   })
+
+  // The changes a diff carries are live references into the documents, never clones. The behavior
+  // is pinned here so a future switch to cloning is a deliberate change rather than a silent one.
+  describe('shares references with the source documents', () => {
+    test('an `add` carries the subtree of the target document', () => {
+      const doc2 = { info: { title: 'Pets' } }
+      const [change] = diff({}, doc2)
+
+      expect(change.changes).toBe(doc2.info)
+
+      // Writing into the change writes into the document it came from
+      change.changes.title = 'Rebased'
+      expect(doc2.info.title).toBe('Rebased')
+    })
+
+    test('an `update` carries the subtree of the target document', () => {
+      const doc2 = { info: { title: 'Pets' } }
+      const [change] = diff({ info: 'Pets' }, doc2)
+
+      expect(change).toEqual({ path: ['info'], changes: { title: 'Pets' }, type: 'update' })
+      expect(change.changes).toBe(doc2.info)
+    })
+
+    test('a `delete` carries the subtree of the source document', () => {
+      const doc1 = { info: { title: 'Pets' } }
+      const [change] = diff(doc1, {})
+
+      expect(change).toEqual({ path: ['info'], changes: { title: 'Pets' }, type: 'delete' })
+      expect(change.changes).toBe(doc1.info)
+    })
+
+    test('applying a diff leaves the result sharing structure with the target document', () => {
+      const doc2 = { info: { title: 'Pets' } }
+      const result = apply({}, diff({}, doc2))
+
+      expect(result.info).toBe(doc2.info)
+    })
+  })
 })

--- a/packages/json-magic/src/diff/diff.ts
+++ b/packages/json-magic/src/diff/diff.ts
@@ -25,6 +25,13 @@ export type Difference<_T> = { path: string[]; changes: any; type: ChangeType }
  * Keys that reach the prototype chain (`__proto__`, `constructor` and `prototype`) are skipped, so
  * an untrusted document cannot produce a diff that poisons `Object.prototype` once applied.
  *
+ * ⚠️ The returned `changes` are live references into the documents, not clones. An `add` or an
+ * `update` carries the very subtree `doc2` holds, and a `delete` carries the subtree from `doc1`,
+ * so writing into a change writes into the document it came from. This matters downstream:
+ * `merge` merges values into these objects, and `apply` writes them into its target document,
+ * which leaves the result structurally shared with `doc2`. Callers that need isolation have to
+ * deep clone the documents before diffing them, or the changes afterwards.
+ *
  * @param doc1 - The source object to compare from
  * @param doc2 - The target object to compare to
  * @returns A list of operations (add/update/delete) with their paths and changes

--- a/packages/json-magic/src/diff/merge.test.ts
+++ b/packages/json-magic/src/diff/merge.test.ts
@@ -1264,6 +1264,30 @@ describe('mergeDiff', () => {
     })
   })
 
+  // `merge` folds two compatible changes together with `mergeObjects`, which writes in place, and
+  // the changes a diff carries point straight into the documents it compared. Merging therefore
+  // writes into the document behind the second diff list. The behavior is pinned here so a future
+  // switch to cloning is a deliberate change rather than a silent one.
+  describe('mutates the second diff list while merging', () => {
+    test('merges the changes of the first list into the entries of the second one', () => {
+      const diff1: Difference<unknown>[] = [{ path: ['info'], changes: { title: 'Pets' }, type: 'add' }]
+      const changes = { version: '1.0.0' }
+      const diff2: Difference<unknown>[] = [{ path: ['info'], changes, type: 'add' }]
+
+      merge(diff1, diff2)
+
+      expect(changes).toEqual({ version: '1.0.0', title: 'Pets' })
+    })
+
+    test('writes into the document the second diff list was built from', () => {
+      const remote = { info: { version: '1.0.0' } }
+
+      merge(diff({}, { info: { title: 'Pets' } }), diff({}, remote))
+
+      expect(remote).toEqual({ info: { version: '1.0.0', title: 'Pets' } })
+    })
+  })
+
   // TODO: a delete that is subsumed by a delete on the other side is discarded before we know
   // whether the covering delete ends up in `conflicts`. When it does, the subsumed delete
   // survives in neither `diffs` nor `conflicts`, so resolving the conflict toward the side that

--- a/packages/json-magic/src/diff/merge.ts
+++ b/packages/json-magic/src/diff/merge.ts
@@ -8,8 +8,15 @@ import { isArrayEqual, isKeyCollisions, mergeObjects } from '@/diff/utils'
  * that arise when both diffs modify the same paths. It uses a trie data structure for
  * efficient path matching and conflict detection.
  *
+ * ⚠️ This function mutates the entries of `diff2`. When two changes on the same path can be folded
+ * together without a collision, the value from `diff1` is merged into the `changes` of the `diff2`
+ * entry, in place. Diffs built by `diff` carry live references into the documents they came from
+ * (see `diff`), so folding two changes together also writes into the document behind `diff2`.
+ * Callers that need the source documents to stay untouched have to deep clone them before diffing,
+ * or clone the changes afterwards.
+ *
  * @param diff1 - First list of differences
- * @param diff2 - Second list of differences
+ * @param diff2 - Second list of differences, whose entries are mutated, see the note above
  * @returns Object containing:
  *   - diffs: Combined list of non-conflicting differences
  *   - conflicts: Array of conflicting difference pairs that need manual resolution

--- a/packages/json-magic/src/diff/utils.test.ts
+++ b/packages/json-magic/src/diff/utils.test.ts
@@ -228,6 +228,37 @@ describe('mergeObjects', () => {
       expect(({} as Record<string, unknown>).pollutedBesideSafeMerge).toBeUndefined()
     })
   })
+
+  // The merge happens in place and the subtrees of the source are attached by reference, which is
+  // how `merge` ends up writing into the documents its diffs were built from. The behavior is
+  // pinned here so a future switch to cloning is a deliberate change rather than a silent one.
+  describe('shares structure with both operands', () => {
+    test('returns the target it was given', () => {
+      const a: Record<string, unknown> = { keep: 1 }
+
+      expect(mergeObjects(a, { added: 2 })).toBe(a)
+      expect(a).toEqual({ keep: 1, added: 2 })
+    })
+
+    test('attaches the subtrees of the source by reference', () => {
+      const a: Record<string, unknown> = {}
+      const nested = { title: 'Pets' }
+
+      mergeObjects(a, { info: nested })
+
+      expect(a.info).toBe(nested)
+    })
+
+    test('merges into the subtree the target already holds instead of replacing it', () => {
+      const a: Record<string, unknown> = { info: { title: 'Pets' } }
+      const b = { info: { version: '1.0.0' } }
+
+      mergeObjects(a, b)
+
+      expect(a.info).toEqual({ title: 'Pets', version: '1.0.0' })
+      expect(b.info).toEqual({ version: '1.0.0' })
+    })
+  })
 })
 
 describe('isArrayEqual', () => {

--- a/packages/json-magic/src/diff/utils.ts
+++ b/packages/json-magic/src/diff/utils.ts
@@ -68,8 +68,14 @@ export const isKeyCollisions = (a: unknown, b: unknown): boolean => {
  * ⚠️ Note: This operation assumes there are no key collisions between the objects.
  * Use isKeyCollisions() to check for collisions before merging.
  *
- * @param a - Target object to merge into
- * @param b - Source object to merge from
+ * ⚠️ Note: `a` is mutated in place and the subtrees `b` contributes are attached by reference, not
+ * cloned. Those subtrees stay shared with `b`, so a later write into one of them is seen through
+ * `b` as well. A key both objects already hold keeps the subtree of `a` and merges into it, so
+ * only what `b` brings along is shared. `merge` relies on this to fold two changes into one, which
+ * is how a merge ends up writing into the documents its diffs were built from.
+ *
+ * @param a - Target object to merge into, mutated in place
+ * @param b - Source object to merge from, whose subtrees are shared with the result
  * @returns The merged object (mutates and returns a)
  *
  * @example

--- a/projects/scalar-app/src/features/app/helpers/detect-document-conflicts.test.ts
+++ b/projects/scalar-app/src/features/app/helpers/detect-document-conflicts.test.ts
@@ -63,4 +63,21 @@ describe('detectDocumentConflicts', () => {
       }),
     ).toBe(true)
   })
+
+  // The check is not free of side effects: `merge` folds two compatible changes together in place
+  // and the changes point straight into the documents, so local values land in the remote document.
+  // Pinned here so a future fix in `@scalar/json-magic` is a deliberate change, not a silent one.
+  it('writes auto-mergeable local values into the remote document', () => {
+    const remote = { info: { version: '1.1.0' } }
+
+    expect(
+      detectDocumentConflicts({
+        original: {},
+        local: { info: { title: 'Pets API' } },
+        remote,
+      }),
+    ).toBe(false)
+
+    expect(remote).toEqual({ info: { version: '1.1.0', title: 'Pets API' } })
+  })
 })

--- a/projects/scalar-app/src/features/app/helpers/detect-document-conflicts.ts
+++ b/projects/scalar-app/src/features/app/helpers/detect-document-conflicts.ts
@@ -14,8 +14,13 @@ import { diff, merge } from '@scalar/json-magic/diff'
  *     sides in incompatible ways. Any non-empty array means the user must
  *     resolve the conflicts manually.
  *
- * The function is pure - callers are responsible for fetching the remote
- * document and persisting the result on the workspace document.
+ * ⚠️ The check is not free of side effects. `merge` folds two compatible changes into one by
+ * merging in place, and the changes a diff carries are live references into the documents it
+ * compared, so detecting conflicts can write local values into the `remote` document. Pass a copy
+ * whenever the caller needs the remote document to stay untouched.
+ *
+ * Callers remain responsible for fetching the remote document and for merging
+ * and persisting it on the workspace document once the conflicts are settled.
  */
 export const detectDocumentConflicts = ({
   original,


### PR DESCRIPTION
## What

Fifth PR of the `json-magic/diff` review series. It covers the two findings we deliberately **document rather than fix** (`merge` mutating the caller's document, `apply` aliasing its changes into the result), plus the confusing error a root-level change used to produce.

### Documentation

The diff primitives work on the documents themselves, never on copies, and nothing said so:

- `diff` — the `changes` it returns are live references into the documents it compared (`doc2` for add/update, `doc1` for delete).
- `merge` — folds two compatible changes together with `mergeObjects`, which writes in place, so merging writes into the document behind `diff2`.
- `mergeObjects` — mutates its target and shares the subtrees the source contributes.
- `apply` — mutates the document it is given and leaves the result structurally shared with the document the diff was built from.
- `detectDocumentConflicts` in `scalar-app` claimed "The function is pure". It is not: detecting conflicts writes local values into the `remote` document. The comment now says so.
- `README.md` told readers to clone the document before applying, which is not enough on its own. It now describes the real contract and lists all three `InvalidChangesDetectedError` triggers.

The aliasing itself stays as it is, per the plan for this series. Characterization tests pin it so a future switch to cloning is a deliberate break rather than a silent one.

### One behavior change

A change with an empty path asks to replace the document itself, which `apply` cannot do since it writes through the parent container of each path. It used to fail mid-changeset with a confusing message, leaving the document half updated:

```ts
apply({ name: 'John' }, [{ path: [], changes: [1, 2], type: 'update' }])
// before: InvalidChangesDetectedError: Process aborted. Path  at depth 0 is undefined, check diff object
// after:  InvalidChangesDetectedError: Process aborted. Root-level replacement is not supported,
//         the change targets the document itself instead of a property inside it
```

The check now runs up front, next to the prototype-pollution guard, so such a changeset is turned away before any of its entries touch the document. The set of rejected inputs is unchanged — only the message and the timing. No consumer matches on the old message.

`diff` deliberately keeps emitting these root-level changes: it is called for `.length` checks in `workspace-store`, and throwing there would be a wider behavior change than this bug warrants.

## Testing

- `pnpm vitest --run` in `packages/json-magic` — 631 passed
- `pnpm vitest --run` in `packages/workspace-store` — 2904 passed
- `pnpm --filter @scalar/json-magic types:check`, `pnpm --filter scalar-app types:check`, `pnpm knip`, `pnpm changeset status` — clean

No visual surface is touched: this PR only changes comments, one error message and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)