### PR TITLE
fix(openapi-upgrader): keep items on formData array parameters

### DIFF
--- a/.changeset/openapi-upgrader-form-data-items.md
+++ b/.changeset/openapi-upgrader-form-data-items.md
@@ -2,4 +2,4 @@
 '@scalar/openapi-upgrader': patch
 ---
 
-Keep the full schema of a Swagger 2.0 `formData` parameter when upgrading to OpenAPI 3.0. The request body property was rebuilt from `type`, `description` and `format` only, so a parameter with `type: 'array'` lost its `items` and consumers of the upgraded document saw an array of unknown values. `items`, `enum`, `default` and the other validation keywords now survive.
+Keep the full schema of a Swagger 2.0 `formData` parameter when upgrading to OpenAPI 3.0. The request body property was rebuilt from `type`, `description` and `format` only, so a parameter with `type: 'array'` lost its `items` and consumers of the upgraded document saw an array of unknown values. `items`, `enum`, `default` and the other validation keywords now survive, and the array `collectionFormat` is carried over as an OpenAPI 3.0 `encoding` entry (`style`/`explode`) instead of being dropped.

--- a/.changeset/openapi-upgrader-form-data-items.md
+++ b/.changeset/openapi-upgrader-form-data-items.md
@@ -2,4 +2,4 @@
 '@scalar/openapi-upgrader': patch
 ---
 
-Keep the full schema of a Swagger 2.0 `formData` parameter when upgrading to OpenAPI 3.x. The request body property was rebuilt from `type`, `description` and `format` only, so a parameter like `{ name: 'tags', in: 'formData', type: 'array', items: { type: 'string' } }` upgraded to `{ type: 'array' }` and every consumer of the upgraded document saw an array of unknown values. The same transformation the upgrade already applies to query and path parameters now runs for form data parameters, so `items`, `enum`, `default` and the other validation keywords survive.
+Keep the full schema of a Swagger 2.0 `formData` parameter when upgrading to OpenAPI 3.0. The request body property was rebuilt from `type`, `description` and `format` only, so a parameter with `type: 'array'` lost its `items` and consumers of the upgraded document saw an array of unknown values. `items`, `enum`, `default` and the other validation keywords now survive.

--- a/.changeset/openapi-upgrader-form-data-items.md
+++ b/.changeset/openapi-upgrader-form-data-items.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-upgrader': patch
+---
+
+Keep the full schema of a Swagger 2.0 `formData` parameter when upgrading to OpenAPI 3.x. The request body property was rebuilt from `type`, `description` and `format` only, so a parameter like `{ name: 'tags', in: 'formData', type: 'array', items: { type: 'string' } }` upgraded to `{ type: 'array' }` and every consumer of the upgraded document saw an array of unknown values. The same transformation the upgrade already applies to query and path parameters now runs for form data parameters, so `items`, `enum`, `default` and the other validation keywords survive.

--- a/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.test.ts
+++ b/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.test.ts
@@ -521,12 +521,22 @@ describe('upgradeFromTwoToThree', () => {
       },
     })
 
-    const property = (result.paths?.['/planets']?.get?.requestBody as OpenAPIV3.RequestBodyObject).content[
-      'multipart/form-data'
-    ]?.schema as OpenAPIV3.SchemaObject
-
-    expect(property.properties?.name).toStrictEqual({ type: 'string' })
-    expect(Object.hasOwn(property.properties?.name ?? {}, 'description')).toBe(false)
+    // A strict comparison fails if the property carries an explicit `description: undefined`.
+    expect(result.paths?.['/planets']?.get?.requestBody).toStrictEqual({
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            required: ['name'],
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    })
   })
 
   it('migrates formData with an array type', () => {
@@ -573,6 +583,9 @@ describe('upgradeFromTwoToThree', () => {
                   },
                   type: 'object',
                 },
+                encoding: {
+                  tags: { style: 'form', explode: false },
+                },
               },
               'multipart/form-data': {
                 schema: {
@@ -588,8 +601,60 @@ describe('upgradeFromTwoToThree', () => {
                   },
                   type: 'object',
                 },
+                encoding: {
+                  tags: { style: 'form', explode: false },
+                },
               },
             },
+          },
+        },
+      },
+    })
+  })
+
+  it('maps a multi collectionFormat to an exploded form encoding without leaking into the schema', () => {
+    const result: OpenAPIV3.Document = upgradeFromTwoToThree({
+      swagger: '2.0',
+      paths: {
+        '/submit': {
+          post: {
+            consumes: ['multipart/form-data'],
+            parameters: [
+              {
+                name: 'tags',
+                in: 'formData',
+                required: false,
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+                collectionFormat: 'multi',
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    // The strict comparison proves both the exploded encoding and that `collectionFormat` did not
+    // leak onto the property schema.
+    expect(result.paths?.['/submit']?.post?.requestBody).toStrictEqual({
+      content: {
+        'multipart/form-data': {
+          schema: {
+            type: 'object',
+            required: [],
+            properties: {
+              tags: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+          encoding: {
+            tags: { style: 'form', explode: true },
           },
         },
       },

--- a/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.test.ts
+++ b/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.test.ts
@@ -502,6 +502,33 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.paths?.['/planets']?.get?.produces).toBeUndefined()
   })
 
+  it('does not add an undefined description to a formData property without one', () => {
+    const result: OpenAPIV3.Document = upgradeFromTwoToThree({
+      swagger: '2.0',
+      paths: {
+        '/planets': {
+          get: {
+            parameters: [
+              {
+                name: 'name',
+                in: 'formData',
+                required: true,
+                type: 'string',
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    const property = (result.paths?.['/planets']?.get?.requestBody as OpenAPIV3.RequestBodyObject).content[
+      'multipart/form-data'
+    ]?.schema as OpenAPIV3.SchemaObject
+
+    expect(property.properties?.name).toStrictEqual({ type: 'string' })
+    expect(Object.hasOwn(property.properties?.name ?? {}, 'description')).toBe(false)
+  })
+
   it('migrates formData with an array type', () => {
     const result: OpenAPIV3.Document = upgradeFromTwoToThree({
       swagger: '2.0',

--- a/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.test.ts
+++ b/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.test.ts
@@ -508,7 +508,7 @@ describe('upgradeFromTwoToThree', () => {
       paths: {
         '/submit': {
           post: {
-            consumes: ['application/x-www-form-urlencoded'],
+            consumes: ['application/x-www-form-urlencoded', 'multipart/form-data'],
             parameters: [
               {
                 name: 'tags',
@@ -533,6 +533,21 @@ describe('upgradeFromTwoToThree', () => {
           requestBody: {
             content: {
               'application/x-www-form-urlencoded': {
+                schema: {
+                  required: ['tags'],
+                  properties: {
+                    tags: {
+                      type: 'array',
+                      description: 'Tags to attach',
+                      items: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                  type: 'object',
+                },
+              },
+              'multipart/form-data': {
                 schema: {
                   required: ['tags'],
                   properties: {

--- a/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.test.ts
+++ b/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.test.ts
@@ -502,6 +502,58 @@ describe('upgradeFromTwoToThree', () => {
     expect(result.paths?.['/planets']?.get?.produces).toBeUndefined()
   })
 
+  it('migrates formData with an array type', () => {
+    const result: OpenAPIV3.Document = upgradeFromTwoToThree({
+      swagger: '2.0',
+      paths: {
+        '/submit': {
+          post: {
+            consumes: ['application/x-www-form-urlencoded'],
+            parameters: [
+              {
+                name: 'tags',
+                in: 'formData',
+                description: 'Tags to attach',
+                required: true,
+                type: 'array',
+                items: {
+                  type: 'string',
+                },
+                collectionFormat: 'csv',
+              },
+            ],
+          },
+        },
+      },
+    })
+
+    expect(result.paths).toStrictEqual({
+      '/submit': {
+        post: {
+          requestBody: {
+            content: {
+              'application/x-www-form-urlencoded': {
+                schema: {
+                  required: ['tags'],
+                  properties: {
+                    tags: {
+                      type: 'array',
+                      description: 'Tags to attach',
+                      items: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                  type: 'object',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
   it('upgrades securityDefinitions from Swagger 2.0 to OpenAPI 3.0', () => {
     const input = {
       swagger: '2.0',

--- a/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.ts
+++ b/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.ts
@@ -829,6 +829,29 @@ function getParameterSerializationStyle(parameter: OpenAPIV2.ParameterObject): P
   return {}
 }
 
+/**
+ * Translate the Swagger 2.0 `collectionFormat` of a formData array parameter into an OpenAPI 3.0
+ * encoding entry. Form bodies serialize arrays with the same styles as query parameters, so the
+ * query serialization mapping is reused. Returns undefined when there is nothing to preserve, for
+ * example a non-array parameter, one without a `collectionFormat`, or `tsv` which has no OpenAPI
+ * 3.0 equivalent.
+ */
+function getFormDataEncoding(parameter: OpenAPIV2.ParameterObject): OpenAPIV3.EncodingObject | undefined {
+  if (parameter.type !== 'array' || typeof parameter.collectionFormat !== 'string') {
+    return undefined
+  }
+
+  const encoding = querySerialization[parameter.collectionFormat as CollectionFormat] as
+    | ParameterSerializationStyle
+    | undefined
+
+  if (!encoding || Object.keys(encoding).length === 0) {
+    return undefined
+  }
+
+  return encoding
+}
+
 type ParameterMigrationResult = {
   parameters: (OpenAPIV3.ParameterObject | OpenAPIV3.ReferenceObject)[]
   requestBody?: OpenAPIV3.RequestBodyObject
@@ -945,6 +968,14 @@ function migrateFormDataParameter(
               // Only carry the description over when it exists, so a parameter without one does not
               // end up with an explicit `description: undefined` on its schema.
               ...(param.description !== undefined ? { description: param.description } : {}),
+            }
+
+            // Preserve the array serialization hint (Swagger 2.0 `collectionFormat`) as an
+            // OpenAPI 3.0 encoding entry on the media type, so it is not silently dropped.
+            const encoding = getFormDataEncoding(param)
+            if (encoding) {
+              formContent.encoding ??= {}
+              formContent.encoding[param.name] = encoding
             }
 
             // Add to required array if param is required

--- a/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.ts
+++ b/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.ts
@@ -941,9 +941,8 @@ function migrateFormDataParameter(
         for (const param of parameters) {
           if (param.name && formContent.schema.properties) {
             formContent.schema.properties[param.name] = {
-              type: param.type,
+              ...transformItemsObject(structuredClone(param)),
               description: param.description,
-              ...(param.format ? { format: param.format } : {}),
             }
 
             // Add to required array if param is required

--- a/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.ts
+++ b/packages/openapi-upgrader/src/2.0-to-3.0/upgrade-from-two-to-three.ts
@@ -942,7 +942,9 @@ function migrateFormDataParameter(
           if (param.name && formContent.schema.properties) {
             formContent.schema.properties[param.name] = {
               ...transformItemsObject(structuredClone(param)),
-              description: param.description,
+              // Only carry the description over when it exists, so a parameter without one does not
+              // end up with an explicit `description: undefined` on its schema.
+              ...(param.description !== undefined ? { description: param.description } : {}),
             }
 
             // Add to required array if param is required


### PR DESCRIPTION
## Problem

A Swagger 2.0 `formData` parameter with `type: array` came out of the upgrade as a bare `{ type: 'array' }`, without its `items`. Anything reading the upgraded document then has no idea what is in the array, so a code generator like Orval ends up emitting `unknown[]` where the document said `string[]`.

The request body property was built by hand from `type`, `description` and `format`, so every other schema keyword on the parameter (`items`, `enum`, `default`, the min/max ones) was thrown away.

## Solution

Build the property with `transformItemsObject`, the same helper the upgrade already uses for query and path parameters. It copies the schema keywords over, so `items` and friends survive. It is called on a clone because it deletes the keys it moves and the parameter is reused once per content type.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Closes #9908
