### PR TITLE
docs(compare): add Scalar vs Speakeasy and Scalar vs Stainless pages

### DIFF
--- a/documentation/compare/index.md
+++ b/documentation/compare/index.md
@@ -10,6 +10,12 @@ Each guide is written by us, so read it with that in mind. We link every claim w
 <scalar-page-link filepath="documentation/compare/fern.md" title="Fern" description="A comparison of Scalar and Fern across documentation and SDK generation: licensing, self-hosting, generated code, framework integrations, and pricing">
 </scalar-page-link>
 
+<scalar-page-link filepath="documentation/compare/speakeasy.md" title="Speakeasy" description="A comparison of Scalar and Speakeasy for SDK generation: language coverage, generated code, Terraform and MCP targets, licensing, testing, and pricing">
+</scalar-page-link>
+
+<scalar-page-link filepath="documentation/compare/stainless.md" title="Stainless" description="A comparison of Scalar and Stainless for SDK generation: the Anthropic wind-down, language coverage, generated code conventions, stainless.yml, and documentation">
+</scalar-page-link>
+
 <scalar-page-link filepath="documentation/compare/readme.md" title="ReadMe" description="A comparison of Scalar and ReadMe for developer portals and API documentation: licensing, self-hosting, API analytics, SDK generation, and pricing">
 </scalar-page-link>
 

--- a/documentation/compare/speakeasy.md
+++ b/documentation/compare/speakeasy.md
@@ -1,0 +1,181 @@
+# Scalar vs Speakeasy
+
+Speakeasy and Scalar both turn an OpenAPI document into client SDKs. If you are evaluating one, you should evaluate the other.
+
+This page is written by Scalar, so read it with that in mind. Every claim we make about Speakeasy links to Speakeasy's own documentation, pricing page, or public repositories. If we have something wrong, tell us and we will fix it.
+
+**Two things to disclose up front.**
+
+The first is that we work together. Speakeasy [documents a Scalar integration](https://www.speakeasy.com/docs/sdks/sdk-docs/integrations/scalar) for teams who want Speakeasy SDKs and Scalar documentation, and Speakeasy's own [API reference](https://www.speakeasy.com/docs/ai-control-plane/reference/api-reference) is rendered by Scalar. Their [docs vendor comparison](https://www.speakeasy.com/blog/choosing-a-docs-vendor) is complimentary about us. We are not neutral about Speakeasy and we are not going to pretend the relationship does not exist.
+
+The second is that Speakeasy's company focus has moved. As of August 2026 their [pricing page](https://www.speakeasy.com/pricing) covers the AI control plane — MCP gateways, agent identity, AI observability — and SDK generation sits under a separate "API Platform" heading in their navigation. The SDK product is [documented](https://www.speakeasy.com/docs/sdks/introduction), actively developed, and used in production by large APIs. But if you are making a multi-year platform decision, it is worth asking where SDK generation sits on their roadmap, and asking them directly rather than inferring it from a website.
+
+## At a glance
+
+| | Scalar | Speakeasy |
+| --- | --- | --- |
+| Generator source | Closed source | CLI is [Elastic License 2.0](https://github.com/speakeasy-api/speakeasy/blob/main/LICENSE), source-available |
+| Docs renderer | MIT, self-hostable on any plan | Generates an API reference; a full docs site means a docs vendor |
+| Docs + SDKs from one run | Yes, `docs` is a build target | Code samples are published to a docs vendor |
+| Terraform providers | No | [Yes](https://www.speakeasy.com/docs/terraform/create-terraform) |
+| MCP servers | Yes, hosted and configurable | [Yes](https://www.speakeasy.com/docs/standalone-mcp/overview), generated to deploy yourself |
+| Custom code survives regeneration | Yes, three-way merge | [Yes](https://www.speakeasy.com/docs/sdks/customize/basics), three-way merge |
+| Speakeasy call-site compatibility | Yes, generated compat module | n/a |
+| Standalone API client | Yes, open source | No |
+| Published SDK price | $100/month per target | Not published; free tier is [1 SDK, 50 API methods](https://www.speakeasy.com/docs/sdks/introduction) |
+
+## Where Speakeasy is stronger
+
+We would rather you hear this from us than discover it in a trial.
+
+**Terraform providers.** Speakeasy [generates Terraform providers from an annotated OpenAPI document](https://www.speakeasy.com/docs/terraform/create-terraform). Scalar does not generate Terraform providers at all. If your API is infrastructure that people declare rather than call, this is not a close comparison — it is the whole comparison.
+
+**MCP servers you deploy yourself.** Both products do MCP, and they do it differently — see [MCP servers](#mcp-servers) below. Speakeasy's advantage is that the server is generated code you own and run: [custom prompts, custom resources, tool curation, OAuth, Docker, and Cloudflare Workers deployment](https://www.speakeasy.com/docs/standalone-mcp/overview). If you need the server inside your own infrastructure rather than hosted, that is theirs.
+
+**Tree-shakable functions as the primary surface.** Every Speakeasy method is [also exported as a standalone function](https://github.com/vercel/sdk#standalone-functions), so bundlers can drop the operations you do not call. For a browser or edge bundle against a large API that is a real, measurable win. Scalar's idiomatic surface is a client object; we emit Speakeasy-shaped standalone functions through the compatibility module described below, but that exists to keep migrating call sites compiling, not as our recommended surface.
+
+**Contract test generation on an open standard.** Speakeasy generates contract tests using the [Arazzo specification](https://www.speakeasy.com/docs/sdks/sdk-contract-testing), with a generated mock server, so the tests live in a public format rather than a proprietary one. It is marked beta, covers successful scenarios only, supports six languages, and requires an Enterprise account plus an add-on — but the design decision to build on an open workflow spec is the right one and we like it.
+
+**A longer production track record.** Speakeasy-generated SDKs have been shipping for years at scale. You can read [Vercel's](https://github.com/vercel/sdk) and [Dub's](https://github.com/dubinc/dub-node) in full. Scalar's generator is newer, and years of other people's edge cases is not something we can claim.
+
+## The actual architectural choice
+
+Strip away the feature tables and the decision looks like this.
+
+**Speakeasy composes.** Speakeasy [generates an API reference with code snippets for every method](https://www.speakeasy.com/docs/sdks/core-concepts), and for a full documentation site you [integrate the output with a documentation vendor](https://www.speakeasy.com/docs/sdks/sdk-docs/integrations/scalar) — Scalar, Mintlify, ReadMe, or Bump.sh — by publishing a combined OpenAPI document with those samples attached. Each layer is chosen on its own merits. When a better docs product appears you swap it without touching your SDKs.
+
+**Scalar consolidates.** In Scalar's generator, `docs` is a build target alongside the language targets. One generation run emits the SDKs, a static API reference, and `openapi.augmented.json` — the exact artifact the SDKs were generated from — plus a shared manifest used for coverage checks. Your reference and your client libraries cannot describe different APIs, because they are produced from the same compiled document in the same run.
+
+Both are legitimate. Composition gives you leverage and an exit at every layer. Consolidation gives you one artifact, one bill, and one thing to debug when the reference and the SDK disagree. We think consolidation is the better default for most teams, but "most" is doing real work in that sentence, and if you already have a docs setup you like, the composed path — Speakeasy SDKs into Scalar docs — is a path we help people take.
+
+## Moving without breaking your users
+
+If you already ship Speakeasy SDKs, the expensive part of changing generator is not the generation — it is that your users have written code against a public surface, and a new generator produces a different one. New function names, new import paths, a major version bump, and a migration note nobody reads.
+
+Scalar generates a compatibility module for exactly this. Set `compatibility` on a target:
+
+```json
+{
+  "targets": {
+    "typescript": {
+      "compatibility": "speakeasy"
+    }
+  }
+}
+```
+
+That emits `src/compat/speakeasy.ts` — Speakeasy-style standalone functions returning a functional `Result`, matching Speakeasy's tree-shakable `funcs/` surface, marked deprecated and forwarding to the generated Scalar SDK. Existing call sites keep compiling while you migrate, and the deprecation markers give your users a machine-readable path off the old surface rather than a changelog entry.
+
+It is a bridge, not a permanent shim: the compat module reproduces the Speakeasy surface, and the idiomatic Scalar client is what you move people toward. See the [TypeScript configuration reference](../guides/sdks/configuration/typescript.md) for the current options.
+
+## MCP servers
+
+Both products generate MCP servers from OpenAPI. The difference is where the server runs, and it is the same composed-versus-consolidated split as everything else on this page.
+
+**Speakeasy generates the server as code.** You get a [standalone MCP server](https://www.speakeasy.com/docs/standalone-mcp/overview) with custom prompts, custom resources, tool customization, and OAuth, which you deploy — Docker, remote, or Cloudflare Workers. You own the runtime and the operational burden that comes with it.
+
+**Scalar hosts the server.** You pick which endpoints become tools in the dashboard, choose per-tool whether it is exposed for lookup only or makes real authenticated requests, and store the API credentials against the installation so they are never handed to the client. The server runs at `mcp.scalar.com`, private by default, with Personal Access Tokens for your team and OAuth for people outside it. Scalar also exposes a separate Docs MCP at `your-docs-domain/mcp` so AI clients can search and read your published documentation. Full details in the [MCP servers guide](../guides/agent/mcp.md).
+
+Neither is the obviously correct answer. If you have compliance requirements about where API credentials live, or you want the server inside your own network, generated code is the right shape and Speakeasy's is more configurable at the code level. If you would rather not operate another service, and you want tool selection and auth managed alongside the API description they came from, hosted is less work.
+
+## SDK output: the shape of the code
+
+The clearest way to compare two generators is to read what they emit. Below is real, public generated code — Speakeasy's from the [Vercel SDK](https://github.com/vercel/sdk) and the [Dub SDK](https://github.com/dubinc/dub-node), Scalar's from the [Warp TypeScript SDK](https://github.com/TeamWarp/warp-sdk-typescript/tree/scalar-generated).
+
+**Instantiating a client**
+
+```ts
+// Speakeasy
+import { Vercel } from "@vercel/sdk";
+
+const vercel = new Vercel({
+  bearerToken: "<YOUR_BEARER_TOKEN_HERE>",
+});
+```
+
+```ts
+// Scalar
+import WarpAPI from "warp-hr";
+
+const client = new WarpAPI({
+  apiKey: process.env["API_KEY"], // defaults to the API_KEY env var
+});
+```
+
+Two small differences. Scalar exports the client as the default export, so the import reads like the product. And Scalar reads credentials from a conventional environment variable by default, so the quickstart does not require passing a secret inline.
+
+**Method naming**
+
+Speakeasy carries your `operationId` through to the method name. When your OpenAPI document is well curated that is exactly what you want — Dub's SDK reads `dub.links.create()` and `dub.links.upsert()`, which is hard to improve on. When it is not, you get what Vercel's document produces: `vercel.replaceDomainsByDomainRecords()`. Speakeasy gives you [extensions and overlays](https://www.speakeasy.com/docs/sdks/customize/basics) to rename methods and group operations, so the fix exists — it is work you do in the document.
+
+Scalar takes the other position and normalizes by default: it strips the redundant resource noun and maps the verb onto a fixed set, so `list`, `retrieve`, `create`, `update`, and `delete` appear on every resource.
+
+| `operationId` | Carried through | Scalar |
+| --- | --- | --- |
+| `listPets` | `client.pets.listPets()` | `client.pet.list()` |
+| `getPetById` | `client.pets.getPetById()` | `client.pet.retrieve()` |
+| `addPet` | `client.pets.addPet()` | `client.pet.create()` |
+
+This is a genuine trade-off rather than a win. Speakeasy's default gives you the names you wrote, which is predictable and auditable against your specification. Scalar's default gives you names you can guess without reading the reference, at the cost of not matching your `operationId` exactly. Pick the one that matches how much you trust your own document.
+
+**Errors**
+
+Both generators produce a typed error hierarchy. Scalar's generated clients export `BadRequestError`, `AuthenticationError`, `PermissionDeniedError`, `NotFoundError`, `ConflictError`, `UnprocessableEntityError`, `RateLimitError`, and `InternalServerError`, alongside `APIConnectionError`, `APIConnectionTimeoutError`, and `APIUserAbortError` — all readable in [`src/core/error.ts`](https://github.com/TeamWarp/warp-sdk-typescript/blob/scalar-generated/src/core/error.ts). Scalar additionally enumerates the exact set of error statuses each operation can return, generated from the specification.
+
+## Custom code
+
+Scalar supports custom code anywhere in the generated SDK. Edit generated files as you would any other code: every build performs a three-way merge between the previous generation, the new generation, and the current state of your repository, then opens a pull request combining the two. Untouched files update cleanly, your edits ride along, and files you added yourself are left alone. For code you want held in place explicitly, mark a region:
+
+```ts
+// scalar-sdk-generator:custom-code retry-helper:start
+export const withBackoff = async <T>(fn: () => Promise<T>) => {
+  // Anything in here is carried forward on every regeneration.
+};
+// scalar-sdk-generator:custom-code retry-helper:end
+```
+
+Conflicts arrive as a pull request you resolve on GitHub, and the whole flow runs on managed branches you can inspect: `scalar-generated` holds pristine output, `scalar-next` holds output merged with your commits, and `scalar-merge-conflict` carries anything needing a human. See [custom code](../guides/sdks/custom-code.md) for the details.
+
+Speakeasy is comparable here, and we would not pick between the two products on this point. They support [custom code anywhere in the generated SDK, preserved across regeneration through three-way merging](https://www.speakeasy.com/docs/sdks/customize/basics), plus [SDK hooks](https://www.speakeasy.com/docs/sdks/customize/code/sdk-hooks) for lifecycle logic — initialization, before request, after success, after error — which is a cleaner extension point than editing files when what you need is cross-cutting behavior rather than a one-off method.
+
+## Agent readiness
+
+Both products ship Agent Skills. They are aimed at different people, and the distinction matters more than the shared name.
+
+Speakeasy's [skills](https://www.speakeasy.com/docs/speakeasy-reference/skills) are installed with `speakeasy agent setup-skills` and help *you* generate SDKs — starting a project, following generation best practices, generating a server. They make your coding assistant good at Speakeasy.
+
+Scalar's ship inside the generated SDK, for the developers and agents who *consume* your API. Every generated SDK carries a `SKILL.md`, a `.claude/skills/` entry for automatic discovery, a generated `api.md` listing every method grouped by resource, and an `openapi.augmented.json`. All four are readable in the [generated Warp SDK](https://github.com/TeamWarp/warp-sdk-typescript/tree/scalar-generated). The intent is that an agent writing code against your API cannot invent a method name that does not exist.
+
+These are complements, not competitors. If you generate with Speakeasy you can install their skills; the question is whether your *users'* agents get the same treatment.
+
+## Open source, precisely
+
+Neither product is open source end to end, and the open halves are different.
+
+**Scalar's documentation stack is open.** The API reference renderer and the API client are MIT licensed, runnable offline without an account, and forkable. This is why GitBook's interactive API explorer is [powered by Scalar](https://gitbook.com/docs/api-references/openapi). **Scalar's SDK generator is not open source.**
+
+**Speakeasy's CLI is source-available.** [`speakeasy-api/speakeasy`](https://github.com/speakeasy-api/speakeasy) is under the [Elastic License 2.0](https://github.com/speakeasy-api/speakeasy/blob/main/LICENSE) — you can read it, modify it, and run it, but you may not offer it as a hosted service or circumvent the license key. That is not an OSI-approved open source licence, and Speakeasy does not describe it as one. Separately, Speakeasy publishes genuinely permissive OpenAPI tooling that is worth knowing about regardless of which generator you choose: [`speakeasy-api/openapi`](https://github.com/speakeasy-api/openapi) is MIT, and their [documentation site](https://github.com/speakeasy-api/developer-docs) is MIT too.
+
+So if what matters is owning and modifying the documentation layer, Scalar is the open one. If what matters is reading the generator that produces your SDKs, Speakeasy is — with the Elastic License caveat attached.
+
+## What you know before you talk to sales
+
+Speakeasy's free tier is [one SDK with up to 50 API methods](https://www.speakeasy.com/docs/sdks/introduction), and new accounts get a 14-day trial of the business tier. Beyond that, their [pricing page](https://www.speakeasy.com/pricing) as of August 2026 prices the AI control plane and lists a single "Enterprise — Tailored" tier, so SDK pricing is a conversation. [SDK contract testing](https://www.speakeasy.com/docs/sdks/sdk-contract-testing) additionally requires an Enterprise account and an add-on.
+
+Scalar publishes its price: **$100 per month per SDK target**, or $1,000 per year. A target becomes billable when you save a version and queue its build, and drafts are never billed. You can work out what it costs without talking to us.
+
+To be fair about it: unpublished pricing is not the same as expensive pricing, and a company selling mostly to enterprises has real reasons not to publish. But it does mean the two products cannot be compared on cost without a call, and we would rather be the one you can price in advance.
+
+## Which should you choose?
+
+**Choose Speakeasy if** you need Terraform providers, you need the MCP server as code running in your own infrastructure rather than hosted, bundle size makes tree-shakable standalone functions your primary surface, you want Arazzo-based contract tests, or you want to read the generator that produces your code.
+
+**Choose Scalar if** you want documentation and SDKs produced by the same run from the same compiled document, you want a documentation layer you own outright under MIT and can self-host on any plan, you want a hosted MCP server with per-tool control and credentials that never reach the client, you want an Agent Skill shipped to your API's consumers rather than to your own team, you want a real API client alongside your docs, or you want to know the price before the call.
+
+**Choose both if** you already have Speakeasy SDKs and want better documentation. That path is [documented by Speakeasy](https://www.speakeasy.com/docs/sdks/sdk-docs/integrations/scalar) and it works. And if you decide to move the SDKs across later, the compatibility module means you can do it without breaking the call sites your users have already written.
+
+[Start free](https://dashboard.scalar.com/register) or [talk to us](https://scalar.cal.com/).
+
+---
+
+*This comparison is based on Speakeasy's publicly available documentation, pricing page, and public GitHub repositories as of August 2026, and on Scalar's own source and generated output. One correction in the other direction: Speakeasy's docs vendor comparison describes Scalar as lacking MDX, and Scalar Docs [supports MDX](../guides/docs/content/mdx.mdx) — we mention it here rather than asking them to change their page. We have made a genuine effort to be accurate and to state where Speakeasy is better. If you find something wrong or out of date, please [open an issue](https://github.com/scalar/scalar/issues) and we will correct it.*

--- a/documentation/compare/stainless.md
+++ b/documentation/compare/stainless.md
@@ -1,0 +1,124 @@
+# Scalar vs Stainless
+
+Stainless set the bar for what a generated SDK should feel like. If you have used the OpenAI, Anthropic, or Cloudflare client libraries, you have used one.
+
+This page is written by Scalar, so read it with that in mind. Every claim we make about Stainless links to Stainless's own documentation, pricing page, or public repositories. If we have something wrong, tell us and we will fix it.
+
+**The thing that changes this comparison:** on 18 May 2026 Stainless [announced they are joining Anthropic](https://www.stainless.com/blog/stainless-is-joining-anthropic) and winding down their hosted products, including the SDK generator. Their announcement is explicit that new signups, projects, and SDKs are not available.
+
+So this is not a comparison you can act on by signing up for both. It is still worth writing, because "how does this compare to Stainless" is the question we are asked most often — Stainless SDKs are the reference point people carry in their heads, and a lot of teams are now holding one they can no longer regenerate.
+
+If you are looking for the practical steps rather than the product comparison, go straight to the [Stainless migration guide](../migration/stainless.md).
+
+## At a glance
+
+| | Scalar | Stainless |
+| --- | --- | --- |
+| Accepting new customers | Yes | [No, as of May 2026](https://www.stainless.com/blog/stainless-is-joining-anthropic) |
+| Generally available targets | TypeScript, Python, Go, CLI | [TypeScript, Python, Go, Java, Kotlin, Ruby, PHP, C#](https://www.stainless.com/products/sdks) |
+| Terraform providers | No | [Yes](https://www.stainless.com/docs/terraform/) |
+| MCP servers | Yes, hosted and configurable | [Yes](https://www.stainless.com/docs/mcp/), generated to deploy yourself |
+| Docs renderer | MIT, self-hostable on any plan | [Hosted docs platform](https://www.stainless.com/products/docs/) |
+| Standalone API client | Yes, open source | No |
+| Reads `stainless.yml` | Yes | Yes |
+| Published price | $100/month per target | [Published](https://www.stainless.com/pricing/) |
+
+## Where Stainless is stronger
+
+**Scale, and everything that comes with it.** Stainless states that SDKs generated on their platform are [downloaded over 130 million times per week](https://www.stainless.com/docs/compare/speakeasy/), across [OpenAI, Cloudflare, Modern Treasury, Lithic, MUX, Replicate, and Weights & Biases](https://www.stainless.com/). Years of that traffic is years of edge cases found and fixed by someone else. Scalar's generator is newer, and no amount of testing substitutes for that exposure. This is the honest gap.
+
+**More languages past the experimental line.** Stainless ships [TypeScript, Python, Go, Java, Kotlin, Ruby, PHP, and C#](https://www.stainless.com/products/sdks), with [SQL](https://www.stainless.com/docs/sdks/sql/) as an additional target. Scalar has four generally available targets. Stainless is also, as far as we know, the only generator that treats [Kotlin as a distinct SDK rather than a Java wrapper](https://www.stainless.com/docs/design/kotlin-and-java/) — nullable types instead of `Optional`, `Sequence` instead of `Stream`, `suspend` functions instead of `CompletableFuture`. That is a real design commitment, not a checkbox.
+
+**Terraform providers.** Stainless [generates Terraform providers](https://www.stainless.com/docs/terraform/) from an OpenAPI document. Scalar does not, at all. If your API is infrastructure that people declare rather than call, that is the whole comparison.
+
+**MCP servers as code you deploy.** Both products do MCP — Scalar's is hosted, covered below — but Stainless generates the server as code with [Docker publishing, remote deployment, OAuth for pre-registered apps, and per-tool permissions](https://www.stainless.com/docs/mcp/). If the server has to run inside your own infrastructure, that shape is theirs and not ours.
+
+**They wrote down their design decisions.** Stainless publishes the reasoning behind choices most vendors leave implicit — [why they do not do runtime request validation](https://www.stainless.com/docs/design/runtime-request-validation/), [why Kotlin and Java are separate SDKs](https://www.stainless.com/docs/design/kotlin-and-java/). We think that is the right instinct and we have less of it published than they do.
+
+**Enterprise depth.** [Breaking change detection](https://www.stainless.com/docs/enterprise/breaking-change-detection/), [pinned SDK versions](https://www.stainless.com/docs/enterprise/pin-sdk-versions/), [code owners](https://www.stainless.com/docs/enterprise/codeowners/), [GitHub issue triage](https://www.stainless.com/docs/enterprise/issue-triage/), and [SSO and SCIM](https://www.stainless.com/docs/enterprise/sso-and-scim/) are documented features of a mature platform.
+
+## Why the SDKs look so similar
+
+Scalar's generated output is deliberately close to Stainless's. We are not going to pretend otherwise, and it is the single most useful fact on this page.
+
+Compare the error surface. Stainless's TypeScript SDKs export a hierarchy of `BadRequestError`, `AuthenticationError`, `PermissionDeniedError`, `NotFoundError`, `ConflictError`, `UnprocessableEntityError`, `RateLimitError`, and `InternalServerError`, plus connection and abort errors — the full list is in [their own comparison page](https://www.stainless.com/docs/compare/speakeasy/). Scalar's generated clients export the same names — readable in [`src/core/error.ts`](https://github.com/TeamWarp/warp-sdk-typescript/blob/scalar-generated/src/core/error.ts) of the public [Warp SDK](https://github.com/TeamWarp/warp-sdk-typescript/tree/scalar-generated):
+
+```ts
+import { APIError, NotFoundError, RateLimitError } from "warp-hr";
+
+try {
+  const list = await client.customWorkerFields.list();
+} catch (err) {
+  if (err instanceof RateLimitError) {
+    // 429, with typed access to status, name, and headers
+  }
+  if (err instanceof APIError) {
+    console.log(err.status, err.name, err.headers);
+  }
+  throw err;
+}
+```
+
+The same convergence runs through resource-namespaced methods, auto-pagination, `Retry-After` handling, per-call raw response access, and zero runtime dependencies. The Warp package ships `"dependencies": {}`.
+
+This is not an accident and it is not flattery. A generated SDK is a public API contract, and the conventions Stainless established are the ones a large share of working developers already have in their fingers. Diverging for the sake of it would cost users.
+
+It also has a practical consequence: **your call sites keep working.** Scalar reads [`stainless.yml`](https://www.stainless.com/docs/reference/config/) directly, so resources, method names, sub-resources, models, pagination schemes, and per-language package names carry across rather than being re-derived from the OpenAPI document. Regenerating from the specification alone would give you a different SDK — new namespaces, new method names, a breaking change for everyone who installed your package. That is the part of leaving Stainless that actually costs money, and it is the part we built for.
+
+## How we test, and against what
+
+Since we cannot claim Stainless's production exposure, here is what we do instead.
+
+Scalar runs a parity harness that clones production SDKs at pinned commits, extracts the public surface from both ours and theirs, and fails the build on drift in operation coverage, wire shapes, unions, enums, pagination behavior, requiredness, or parameter location. It then drives both clients through every shared operation against a recording mock and diffs the requests they actually send.
+
+The SDKs teams publish today are frequently Stainless-generated, so in practice a good deal of that harness is Scalar being measured against Stainless's output. We would rather say that plainly than imply we arrived at the same conventions independently.
+
+Alongside it, generally available targets carry end-to-end tests that generate, build, and run against a live server on every change, and every target gets smoke tests that call each operation against a mock server.
+
+## Targets, honestly
+
+Scalar's generally available targets are **TypeScript, Python, Go, and the CLI**.
+
+Java, Kotlin, Ruby, and C# are marked experimental. They sit in the same continuous integration matrix as the generally available targets and are the closest behind, but the label is there for a reason. PHP, Rust, Swift, Dart, and C++ generate working code and carry a talk-to-us-first caveat. The [SDK generator page](../guides/sdks/index.md) says the same thing.
+
+If you are on a Stainless Kotlin, Java, C#, or PHP SDK today, that is the honest friction point in moving to Scalar, and it is worth raising with us before you plan a migration rather than after.
+
+## Docs
+
+Stainless's docs platform is [an Astro project](https://www.stainless.com/docs/docs-platform/hosting-and-deploys/) whose repository lives in the `stainless-sdks` GitHub organisation rather than yours, with a component library, AI chat, custom domains, and analytics. Their own guidance for the wind-down is to fork it out and take on the CI, deployment, domain, and operational work yourself.
+
+Scalar's approach differs in two ways that matter if you are deciding where to land.
+
+**The renderer is yours.** The API reference is MIT licensed and self-hostable on any plan. You get themes and CSS variables, arbitrary custom HTML, CSS, and JavaScript on any page, and the option to fork it outright.
+
+**Docs and SDKs come from the same run.** In Scalar's generator, `docs` is a build target alongside the language targets. One run emits the SDKs, a static API reference, and `openapi.augmented.json` — the exact artifact the SDKs were generated from. Your reference and your client libraries cannot describe different APIs.
+
+The site you are reading is the product: scalar.com — this page, the pricing page, the guides, the API reference, and the blog — is built and hosted on Scalar Docs from a single `scalar.config.json`.
+
+## Agents
+
+Both products take agent consumption seriously, and both generate MCP servers from your OpenAPI document. The split is where the server runs.
+
+Stainless generates [the server as code](https://www.stainless.com/docs/mcp/), with per-tool permissions, Docker publishing, remote deployment, and OAuth for pre-registered apps. You deploy and operate it.
+
+Scalar hosts it. You pick which endpoints become tools in the dashboard, choose per tool whether it is exposed for lookup only or makes real authenticated requests, and store API credentials against the installation so they never reach the client. The server runs at `mcp.scalar.com`, private by default, with Personal Access Tokens for your team and OAuth for people outside it. There is a separate Docs MCP at `your-docs-domain/mcp` for searching and reading your published documentation. See the [MCP servers guide](../guides/agent/mcp.md).
+
+If you need the server inside your own network or under your own compliance boundary, generated code is the right shape and Stainless's is the more configurable one. If you would rather not operate another service, hosted is less work.
+
+Scalar also ships agent context inside the SDK itself: a `SKILL.md`, a `.claude/skills/` entry for automatic discovery, a generated `api.md` listing every method grouped by resource, and an `openapi.augmented.json`. All four are readable in the [generated Warp SDK](https://github.com/TeamWarp/warp-sdk-typescript/tree/scalar-generated). That is a narrower goal than an MCP server — stop an agent inventing a method name that does not exist — and it is on by default rather than a separate target to configure.
+
+## Which should you choose?
+
+If you are starting fresh, this is not really a choice: Stainless is [not accepting new customers](https://www.stainless.com/blog/stainless-is-joining-anthropic).
+
+**Stay on Stainless for now if** your SDKs are stable, your API is not changing, and you would rather wait and see. You own the code you have generated and nothing breaks on a deadline. The question is only what happens the next time your API changes.
+
+**Look hard at us if** you want the same SDK conventions without re-authoring your configuration, you want your documentation and SDKs produced by the same run, you want a documentation layer you own under MIT rather than an Astro fork you now maintain, or you want a real API client alongside your docs.
+
+**Look elsewhere if** you depend on Terraform providers, on an MCP server running as code inside your own infrastructure rather than hosted, or on a production-supported Kotlin, Java, C#, or PHP SDK. Those are places we would be overselling.
+
+Ready to move? The [Stainless migration guide](../migration/stainless.md) walks through the config import and the API surface diff, and we will do it with you. [Start free](https://dashboard.scalar.com/register) or [talk to us](https://scalar.cal.com/).
+
+---
+
+*This comparison is based on Stainless's publicly available documentation, pricing page, and public GitHub repositories as of August 2026, and on Scalar's own source and generated output. Stainless announced their wind-down in May 2026, so their documentation may change or be withdrawn and some links here may not survive. We have made a genuine effort to be accurate and to state where Stainless is better. If you find something wrong or out of date, please [open an issue](https://github.com/scalar/scalar/issues) and we will correct it.*

--- a/documentation/guides/sdks/index.md
+++ b/documentation/guides/sdks/index.md
@@ -226,7 +226,7 @@ The third is method naming. Scalar strips the redundant resource noun and normal
 | `getPetById` | `client.pets.getPetById()` | `client.pet.retrieve()` |
 | `addPet` | `client.pets.addPet()` | `client.pet.create()` |
 
-Across a large API that consistency is the difference between guessing a method name and knowing it. For a fuller side-by-side against another generator, see [Scalar vs Fern](../../compare/fern.md).
+Across a large API that consistency is the difference between guessing a method name and knowing it. For fuller side-by-sides against other generators, see [Scalar vs Fern](../../compare/fern.md), [Scalar vs Speakeasy](../../compare/speakeasy.md), and [Scalar vs Stainless](../../compare/stainless.md).
 
 ## Everything a hand-written SDK does
 
@@ -389,7 +389,7 @@ The parity harness is the part we would want to see as a buyer. It clones produc
 
 Stainless is winding down its hosted SDK generator. Scalar reads your existing `stainless.yml` directly, so your resources, method names, pagination schemes, and per-language package names carry across and the call sites your users have already written keep working.
 
-Read the [Stainless migration guide](../../migration/stainless.md).
+Read the [Stainless migration guide](../../migration/stainless.md) for the practical steps, or [Scalar vs Stainless](../../compare/stainless.md) for the product comparison.
 
 ## Plans
 

--- a/documentation/migration/stainless.md
+++ b/documentation/migration/stainless.md
@@ -8,6 +8,8 @@ If you are a Stainless customer, your existing SDKs keep working — Stainless i
 
 Scalar is the closest thing to a drop-in replacement, and we have built the migration around one idea: **you should not have to re-author anything.** Give us your OpenAPI document and your `stainless.yml`, and we generate from the configuration you already have.
 
+This guide is the practical how-to. If you are still deciding rather than moving, read [Scalar vs Stainless](../compare/stainless.md) first — it covers where Stainless is genuinely stronger and where we would be overselling.
+
 ## The short version
 
 1. Export your OpenAPI document.

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -3752,6 +3752,72 @@
                       ]
                     }
                   },
+                  "speakeasy": {
+                    "type": "page",
+                    "title": "Speakeasy",
+                    "filepath": "documentation/compare/speakeasy.md",
+                    "description": "Compare Scalar and Speakeasy for SDK generation: language coverage, generated code, Terraform and MCP targets, licensing, testing, and pricing.",
+                    "head": {
+                      "title": "Scalar vs Speakeasy — SDK Generator Comparison",
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/compare/speakeasy"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Compare Scalar and Speakeasy for SDK generation: language coverage, generated code, Terraform and MCP targets, licensing, testing, and pricing."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Scalar vs Speakeasy — SDK Generator Comparison"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "An honest comparison of Scalar and Speakeasy across SDK generation, language coverage, open source licensing, and pricing."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
+                  "stainless": {
+                    "type": "page",
+                    "title": "Stainless",
+                    "filepath": "documentation/compare/stainless.md",
+                    "description": "Compare Scalar and Stainless for SDK generation: the Anthropic wind-down, language coverage, generated code conventions, stainless.yml, and documentation.",
+                    "head": {
+                      "title": "Scalar vs Stainless — SDK Generator Comparison",
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/resources/compare/stainless"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Compare Scalar and Stainless for SDK generation: the Anthropic wind-down, language coverage, generated code conventions, stainless.yml, and documentation."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Scalar vs Stainless — SDK Generator Comparison"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "An honest comparison of Scalar and Stainless across SDK generation, generated code conventions, documentation, and what the wind-down means."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
                   "readme": {
                     "type": "page",
                     "title": "ReadMe",


### PR DESCRIPTION
## Problem

Scalar's comparison set was built for the docs category — Mintlify, Fern, ReadMe, Redocly, Postman. There is no comparison coverage at all for the SDK generation category, and per the August 2026 Profound brief, Scalar does not register in the SDK Generation topic.

That category is decided almost entirely by vendor-owned comparison pages. The most-cited artifacts in it are `stainless.com/docs/compare/speakeasy/` and Speakeasy's own SDK generator comparison — not benchmarks, not reviews. Two obvious pages are missing: there is no Speakeasy page at all, and Stainless is filed only as a migration guide, i.e. as "people who leave" rather than "people we are evaluated against."

## Solution

Two new comparison pages, written to the register set by `documentation/compare/fern.md`: bias stated up front, every competitor claim linked to a competitor-owned source, an explicit section naming where the competitor is genuinely better, and a dated correction invitation.

**`compare/speakeasy`** frames the decision as an architectural choice — documentation and SDKs from one run versus best-of-breed tools composed together — rather than a winner declaration, and discloses the commercial relationship between the two companies in the opening. Concedes Terraform providers, MCP-as-deployable-code, tree-shakable functions as a primary surface, Arazzo contract tests, and a longer production track record.

**`compare/stainless`** is the durable product head-to-head, distinct from the existing migration guide, which stays and is cross-linked. It opens by stating plainly that Stainless is not accepting new customers, then explains why the two SDKs converge — the generated error hierarchies are name-for-name identical — which is the credible version of the migration story.

Both are linked from the compare index and `/products/sdk-generator`.

### Research notes worth flagging

Several things in the source brief did not survive contact with the competitors' own documentation, and the pages reflect what is actually true:

- **Speakeasy has repositioned.** Their pricing page now covers only the AI control plane with a single "Enterprise — Tailored" tier; SDK generation sits under a separate "API Platform" nav heading. There is no published SDK price. The page notes this factually and suggests asking them about roadmap directly rather than inferring it.
- **Speakeasy already does three-way-merge custom code.** The brief listed this as a Scalar differentiator. It is parity, and the page says so.
- **Agent Skills are not the same product on both sides.** Theirs help you generate SDKs; ours ship inside the generated SDK for your users' agents. The page draws that distinction precisely rather than claiming they lack the feature.
- **MCP is a hosted-versus-generated split, not a gap.** Scalar hosts at `mcp.scalar.com` with per-tool control and credentials stored against the installation; Speakeasy and Stainless generate a server you deploy. Both pages present the trade-off in both directions.
- **`compatibility: "speakeasy"`** is covered — the generated compat module keeps migrating call sites compiling.

All 45 external links verified as resolving. Every factual claim about a competitor links to that competitor's own docs, pricing page, or public repos.

## Reviewer notes

**This is a draft, and it should not be merged before one thing happens:** someone who owns the Speakeasy relationship needs to read `compare/speakeasy.md`. That is an explicit acceptance criterion of the plan this implements, and merging publishes to scalar.com.

One specific thing for that review: the brief describes a **reseller relationship**, but there is no public, linkable source stating that, and the house rule is that unlinkable claims get cut. The disclosure therefore states only what is verifiable — that Speakeasy documents a Scalar integration and that their own API reference is Scalar-rendered. If the reseller relationship is public and citable, that paragraph should say so directly.

Also worth a second opinion: the at-a-glance table includes a "Speakeasy call-site compatibility" row. It is accurate and it is our own documented feature, but in a partner comparison it reads as advertising an exit ramp off their product. Easy to move into the body section only.

Context: a Speakeasy comparison page was built and deliberately dropped in July 2026. This one exists because Plan 02 of the follow-up Profound brief asked for it with the partnership sensitivity called out explicitly.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not required: documentation and site config only, nothing under packages/, integrations/, or projects/ -->
- [ ] I added tests. <!-- Not applicable: prose content -->
- [x] I updated the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
