### PR TITLE
docs: open the Products sidebar group by default

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1087,7 +1087,7 @@
             "title": "Products",
             "icon": "phosphor/regular/compass",
             "mode": "folder",
-            "open": false,
+            "open": true,
             "children": {
               "docs": {
                 "type": "link",


### PR DESCRIPTION
## Problem

The **Products** group in the scalar.com Home sidebar starts collapsed, so visitors landing on the homepage do not see the product pages (Docs, MCP & Agent, SDK Generator, Registry, API References, API Client) until they click to expand the group. These are the pages we most want people to discover, so they should be visible immediately.

## Solution

Flip `open: false` to `open: true` on the Home navigation's `products` group in `scalar.config.json`. One-line change.

This was the only collapsed-by-default group in the config — the Docs tab has its own Products group, but it uses `mode: "flat"` and is always expanded, so it needed no change.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- not needed: root site config, no package changes -->
- [ ] I added tests. <!-- not applicable: navigation config only -->
- [ ] I updated the documentation. <!-- not applicable -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)