### PR TITLE
fix(api-reference): show a composed schema's own description

### DIFF
--- a/.changeset/api-reference-allof-own-description.md
+++ b/.changeset/api-reference-allof-own-description.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Show a composed schema's own description when it has no properties of its own. A schema that only carries `allOf` plus a top-level `description` dropped that description and rendered the first `allOf` member's description instead, which was visible when browsing the schema standalone in the Models section.

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -186,7 +186,14 @@ describe('Schema', () => {
         },
       })
 
-      expect(wrapper.text()).toContain('A job.')
+      const text = wrapper.text()
+
+      // The schema's own description renders exactly once. The member cards must
+      // not repeat it, otherwise the same text would show twice.
+      expect(text.split('A job.').length - 1).toBe(1)
+
+      // The allOf member still renders its own description, so nothing is lost.
+      expect(text).toContain('Base class for all searchable entities.')
     })
 
     it('shows the parent description for discriminator-based oneOf schemas', () => {

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -161,6 +161,34 @@ describe('Schema', () => {
       expect(text).toContain('This description should not be shown')
     })
 
+    it('shows the own description of a standalone allOf schema', () => {
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          level: 1,
+          noncollapsible: true,
+          hideHeading: true,
+          schema: coerceValue(SchemaObjectSchema, {
+            description: 'A job.',
+            allOf: [
+              {
+                type: 'object',
+                description: 'Base class for all searchable entities.',
+                properties: { entityType: { type: 'string' } },
+              },
+              {
+                type: 'object',
+                properties: { jobNumber: { type: 'string' } },
+              },
+            ],
+          }),
+          options: {},
+        },
+      })
+
+      expect(wrapper.text()).toContain('A job.')
+    })
+
     it('shows the parent description for discriminator-based oneOf schemas', () => {
       const wrapper = mount(Schema, {
         props: {

--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -227,11 +227,14 @@ const schemaDescription = computed(() => {
     return null
   }
 
-  // Will be shown in the properties anyway
+  // Will be shown in the properties anyway. A composed schema is the exception:
+  // its members render as their own cards with their own descriptions, so the
+  // schema's own description has nowhere else to go.
   if (
     !('properties' in value) &&
     !('patternProperties' in value) &&
-    !('additionalProperties' in value)
+    !('additionalProperties' in value) &&
+    !('allOf' in value)
   ) {
     return null
   }


### PR DESCRIPTION
## Problem

A schema that composes with `allOf` and carries its own top-level `description` lost that description. Browsing such a schema standalone in the Models section showed the first `allOf` member's description instead, so a `Job` schema described as "A job." rendered as "Base class for all searchable entities." from the `Entity` base it extends.

The description was dropped because the schema itself has no `properties`, `patternProperties` or `additionalProperties`, and the card skips the description in that case on the assumption that the property rows will show it. For a composition there are no property rows on that card, so the text had nowhere to go.

### Before

<img src="https://raw.githubusercontent.com/lazerg/scalar/assets-9926/before-9926.png" alt="Before" />

### After

<img src="https://raw.githubusercontent.com/lazerg/scalar/assets-9926/after-9926.png" alt="After" />

## Solution

Keep the description when the schema has an `allOf`. The composition members still render their own cards with their own descriptions, so nothing is duplicated and nothing is lost.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Closes #9926
