### PR TITLE
feat(Scalar.AspNetCore): Add async configure options overloads.

### DIFF
--- a/.changeset/wise-clowns-notice.md
+++ b/.changeset/wise-clowns-notice.md
@@ -1,0 +1,5 @@
+---
+'@scalar/aspnetcore': minor
+---
+
+Add async parameter overloads to MapScalarApiReference, so async services can be used to configure options.

--- a/documentation/integrations/aspnetcore/integration.md
+++ b/documentation/integrations/aspnetcore/integration.md
@@ -134,6 +134,19 @@ app.MapScalarApiReference("/docs", (options, httpContext) =>
 });
 ```
 
+## MapScalarApiReference Async Overloads
+
+The `MapScalarApiReference` method provides several overloads to allow for asynchronous code in the `configureOptions` parameter.
+
+### Basic Async Example
+
+```csharp
+app.MapScalarApiReference(async options =>
+{
+    options.HeaderContent = await File.ReadAllTextAsync("header.html");
+});
+```
+
 ## Configuration Options
 
 The `options` parameter provides a fluent API to customize Scalar. The fluent methods make configuration more intuitive and readable:

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -149,7 +149,7 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// <br />
     /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
     /// </remarks>
-    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string endpointPrefix, Action<ScalarOptions, HttpContext>? configureOptions) =>
+    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string endpointPrefix, Action<ScalarOptions, HttpContext>? configureOptions = null) =>
         endpoints.MapScalarApiReference(endpointPrefix, (options, httpContext) =>
         {
             configureOptions?.Invoke(options, httpContext);
@@ -169,7 +169,7 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// <br />
     /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
     /// </remarks>
-    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string endpointPrefix, Func<ScalarOptions, HttpContext, Task> configureOptions = null)
+    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string endpointPrefix, Func<ScalarOptions, HttpContext, Task> configureOptions)
     {
         // Validate the endpoint prefix. The {documentName} placeholder is reserved for the '{documentName?}' route parameter.
         if (endpointPrefix.Contains(DocumentName))

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -29,10 +29,8 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// <br />
     /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
     /// </remarks>
-    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints)
-    {
-        return endpoints.MapScalarApiReference(DefaultEndpointPrefix);
-    }
+    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints) =>
+        endpoints.MapScalarApiReference(DefaultEndpointPrefix);
 
     /// <summary>
     /// Maps the Scalar API reference endpoint with the default endpoint prefix <c>"/scalar"</c> and custom options.
@@ -45,10 +43,26 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// <br />
     /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
     /// </remarks>
-    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, Action<ScalarOptions> configureOptions)
-    {
-        return endpoints.MapScalarApiReference(DefaultEndpointPrefix, (options, _) => configureOptions(options));
-    }
+    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, Action<ScalarOptions> configureOptions) =>
+        endpoints.MapScalarApiReference(DefaultEndpointPrefix, (options, _) => 
+        { 
+            configureOptions?.Invoke(options); 
+            return Task.CompletedTask; 
+        });
+
+    /// <summary>
+    /// Maps the Scalar API reference endpoint with the default endpoint prefix <c>"/scalar"</c> and custom options configured asynchronously.
+    /// </summary>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder" /> to which the endpoint will be added.</param>
+    /// <param name="configureOptions">An asynchronous function to configure <see cref="ScalarOptions" />.</param>
+    /// <returns>An <see cref="IEndpointConventionBuilder" /> that can be used to further customize the endpoint.</returns>
+    /// <remarks>
+    /// Redirects to the trailing slash from <c>"/scalar"</c> to <c>"/scalar/"</c>.
+    /// <br />
+    /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
+    /// </remarks>
+    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, Func<ScalarOptions, Task> configureOptions) =>
+        endpoints.MapScalarApiReference(DefaultEndpointPrefix, (options, _) => configureOptions(options));
 
     /// <summary>
     /// Maps the Scalar API reference endpoint with the default endpoint prefix <c>"/scalar"</c> and custom options, providing access to the <see cref="HttpContext" />.
@@ -62,6 +76,24 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
     /// </remarks>
     public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, Action<ScalarOptions, HttpContext>? configureOptions) =>
+        endpoints.MapScalarApiReference(DefaultEndpointPrefix, (options, context) => 
+        { 
+            configureOptions?.Invoke(options, context); 
+            return Task.CompletedTask; 
+        });
+
+    /// <summary>
+    /// Maps the Scalar API reference endpoint with the default endpoint prefix <c>"/scalar"</c> and custom options configured asynchronously, providing access to the <see cref="HttpContext" />.
+    /// </summary>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder" /> to which the endpoint will be added.</param>
+    /// <param name="configureOptions">An asynchronous function to configure <see cref="ScalarOptions" />, which includes access to the <see cref="HttpContext" />.</param>
+    /// <returns>An <see cref="IEndpointConventionBuilder" /> that can be used to further customize the endpoint.</returns>
+    /// <remarks>
+    /// Redirects to the trailing slash from <c>"/scalar"</c> to <c>"/scalar/"</c>.
+    /// <br />
+    /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
+    /// </remarks>
+    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, Func<ScalarOptions, HttpContext, Task> configureOptions) =>
         endpoints.MapScalarApiReference(DefaultEndpointPrefix, configureOptions);
 
     /// <summary>
@@ -80,8 +112,29 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// The <paramref name="endpointPrefix" /> parameter allows you to customize the base path where the Scalar API reference will be served.
     /// </remarks>
     public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string endpointPrefix, Action<ScalarOptions> configureOptions) =>
-        endpoints.MapScalarApiReference(endpointPrefix, (options, _) => configureOptions(options));
+        endpoints.MapScalarApiReference(endpointPrefix, (options, _) => 
+        { 
+            configureOptions?.Invoke(options); 
+            return Task.CompletedTask; 
+        });
 
+    /// <summary>
+    /// Maps the Scalar API reference endpoint with a custom endpoint prefix and options configured asynchronously.
+    /// </summary>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder" /> to which the endpoint will be added.</param>
+    /// <param name="endpointPrefix">The prefix for the endpoint.</param>
+    /// <param name="configureOptions">An asynchronous function to configure <see cref="ScalarOptions" />.</param>
+    /// <returns>An <see cref="IEndpointConventionBuilder" /> that can be used to further customize the endpoint.</returns>
+    /// <exception cref="ArgumentException">Thrown when the <paramref name="endpointPrefix" /> contains the <c>'{documentName}'</c> placeholder.</exception>
+    /// <remarks>
+    /// Redirects to the trailing slash if <paramref name="endpointPrefix" /> does not end with a slash (e.g., from <c>"/scalar"</c> to <c>"/scalar/"</c>).
+    /// <br />
+    /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
+    /// <br />
+    /// The <paramref name="endpointPrefix" /> parameter allows you to customize the base path where the Scalar API reference will be served.
+    /// </remarks>
+    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string endpointPrefix, Func<ScalarOptions, Task> configureOptions) =>
+        endpoints.MapScalarApiReference(endpointPrefix, (options, _) => configureOptions(options));
 
     /// <summary>
     /// Maps the Scalar API reference endpoint with a custom endpoint prefix and options, providing access to the <see cref="HttpContext" />.
@@ -96,7 +149,27 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// <br />
     /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
     /// </remarks>
-    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string endpointPrefix, Action<ScalarOptions, HttpContext>? configureOptions = null)
+    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string endpointPrefix, Action<ScalarOptions, HttpContext>? configureOptions) =>
+        endpoints.MapScalarApiReference(endpointPrefix, (options, httpContext) =>
+        {
+            configureOptions?.Invoke(options, httpContext);
+            return Task.CompletedTask;
+        });
+
+    /// <summary>
+    /// Maps the Scalar API reference endpoint with a custom endpoint prefix and options configured asynchronously, providing access to the <see cref="HttpContext" />.
+    /// </summary>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder" /> to which the endpoint will be added.</param>
+    /// <param name="endpointPrefix">The prefix for the endpoint.</param>
+    /// <param name="configureOptions">An asynchronous function to configure <see cref="ScalarOptions" />, which includes access to the <see cref="HttpContext" />.</param>
+    /// <returns>An <see cref="IEndpointConventionBuilder" /> that can be used to further customize the endpoint.</returns>
+    /// <exception cref="ArgumentException">Thrown when the <paramref name="endpointPrefix" /> contains the <c>'{documentName}'</c> placeholder.</exception>
+    /// <remarks>
+    /// Redirects to the trailing slash if <paramref name="endpointPrefix" /> does not end with a slash (e.g., from <c>"/scalar"</c> to <c>"/scalar/"</c>).
+    /// <br />
+    /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
+    /// </remarks>
+    public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string endpointPrefix, Func<ScalarOptions, HttpContext, Task> configureOptions = null)
     {
         // Validate the endpoint prefix. The {documentName} placeholder is reserved for the '{documentName?}' route parameter.
         if (endpointPrefix.Contains(DocumentName))
@@ -109,7 +182,7 @@ public static class ScalarEndpointRouteBuilderExtensions
         // Handle static assets
         scalarEndpointGroup.MapStaticAssetsEndpoints();
 
-        scalarEndpointGroup.MapGet("/{documentName?}", (HttpContext httpContext, IOptionsSnapshot<ScalarOptions> optionsSnapshot, string? documentName) =>
+        scalarEndpointGroup.MapGet("/{documentName?}", async (HttpContext httpContext, IOptionsSnapshot<ScalarOptions> optionsSnapshot, string? documentName) =>
         {
             if (ShouldRedirectToTrailingSlash(httpContext, documentName, out var redirectUrl))
             {
@@ -117,7 +190,10 @@ public static class ScalarEndpointRouteBuilderExtensions
             }
 
             var options = optionsSnapshot.Value;
-            configureOptions?.Invoke(options, httpContext);
+            if (configureOptions is not null)
+            {
+                await configureOptions.Invoke(options, httpContext);
+            }
 
             // If a document name is provided as route parameter, clear the document names and add the provided document name
             if (!string.IsNullOrEmpty(documentName))

--- a/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
+++ b/integrations/dotnet/aspnetcore/src/Scalar.AspNetCore/Extensions/ScalarEndpointRouteBuilderExtensions.cs
@@ -44,10 +44,10 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
     /// </remarks>
     public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, Action<ScalarOptions> configureOptions) =>
-        endpoints.MapScalarApiReference(DefaultEndpointPrefix, (options, _) => 
-        { 
-            configureOptions?.Invoke(options); 
-            return Task.CompletedTask; 
+        endpoints.MapScalarApiReference(DefaultEndpointPrefix, (options, _) =>
+        {
+            configureOptions?.Invoke(options);
+            return Task.CompletedTask;
         });
 
     /// <summary>
@@ -76,10 +76,10 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// You can also provide a document name as a route parameter in the browser (e.g., <c>"/scalar/v1"</c>).
     /// </remarks>
     public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, Action<ScalarOptions, HttpContext>? configureOptions) =>
-        endpoints.MapScalarApiReference(DefaultEndpointPrefix, (options, context) => 
-        { 
-            configureOptions?.Invoke(options, context); 
-            return Task.CompletedTask; 
+        endpoints.MapScalarApiReference(DefaultEndpointPrefix, (options, httpContext) =>
+        {
+            configureOptions?.Invoke(options, httpContext);
+            return Task.CompletedTask;
         });
 
     /// <summary>
@@ -112,10 +112,10 @@ public static class ScalarEndpointRouteBuilderExtensions
     /// The <paramref name="endpointPrefix" /> parameter allows you to customize the base path where the Scalar API reference will be served.
     /// </remarks>
     public static IEndpointConventionBuilder MapScalarApiReference(this IEndpointRouteBuilder endpoints, [StringSyntax("Route")] string endpointPrefix, Action<ScalarOptions> configureOptions) =>
-        endpoints.MapScalarApiReference(endpointPrefix, (options, _) => 
-        { 
-            configureOptions?.Invoke(options); 
-            return Task.CompletedTask; 
+        endpoints.MapScalarApiReference(endpointPrefix, (options, _) =>
+        {
+            configureOptions?.Invoke(options);
+            return Task.CompletedTask;
         });
 
     /// <summary>
@@ -190,10 +190,7 @@ public static class ScalarEndpointRouteBuilderExtensions
             }
 
             var options = optionsSnapshot.Value;
-            if (configureOptions is not null)
-            {
-                await configureOptions.Invoke(options, httpContext);
-            }
+            await configureOptions(options, httpContext);
 
             // If a document name is provided as route parameter, clear the document names and add the provided document name
             if (!string.IsNullOrEmpty(documentName))

--- a/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
+++ b/integrations/dotnet/aspnetcore/tests/Scalar.AspNetCore.Tests/ScalarEndpointTests.cs
@@ -292,6 +292,35 @@ public class ScalarEndpointTests(WebApplicationFactory<Program> factory) : IClas
     }
 
     [Fact]
+    public async Task MapScalarApiReference_ShouldAwaitConfigureOptions_WhenAsyncOverloadUsed()
+    {
+        // Arrange
+        var localFactory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.Configure(options =>
+            {
+                options.UseRouting();
+                options.UseEndpoints(endpoints => endpoints.MapScalarApiReference(async o =>
+                {
+                    // Yield first so the title is only applied after the callback resumes. If the endpoint
+                    // did not await the async callback, the title would not be set before the HTML is rendered.
+                    await Task.Yield();
+                    o.Title = "Async Title";
+                }));
+            });
+        });
+        var client = localFactory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/scalar", TestContext.Current.CancellationToken);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        content.Should().Contain("<title>Async Title</title>");
+    }
+
+    [Fact]
     public async Task MapScalarApiReference_ShouldUseNonce_WhenRequested()
     {
         // Arrange


### PR DESCRIPTION
## Problem

I wanted to pre-fill the `ClientId` field for oauth using the logged in users credentials. These credentials are saved in the database, so I need to use async code to access these credentials, something like:

```csharp
app.MapScalarApiReference("/scalar", async (options, httpContext) =>
{
    if (httpContext.User.Identity?.IsAuthenticated == true)
    {
        var userManager = httpContext.RequestServices.GetRequiredService<UserManager<UserEntity>>();
        var dbUser = await userManager.GetUserAsync(httpContext.User);
        if (dbUser is not null)
        {
            options.AddOAuth2Authentication("OAuth2Token", oauth =>
            {
                oauth.Flows ??= new ScalarFlows();
                oauth.Flows.ClientCredentials ??= new ClientCredentialsFlow();
                oauth.Flows.ClientCredentials.ClientId = dbUser.ClientId;
            });
        }
    }
});
```

Except the `async`/`await` wasn't available here.

Another use case that currently "fails" would be:

```csharp
app.MapScalarApiReference(async options =>
{
    options.HeaderContent = await File.ReadAllTextAsync("header.html");
});
```

## Solution

I modified the scalar ASP.NET package to add overloads that do support async/await, and redirected the existing overloads to call the new async version with a `return Task.CompletedTask;` at the end. All existing code would keep working and keep using the existing overloads, but now async version are also supported.

## Checklist

- [X] I explained why the change is needed.
- [X] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests. _(There were no existing test covering these method calls, and I am not sure what kind of tests would be necessary/useful here.)_
- [X] I updated the documentation.
