### PR TITLE
docs: add inspect.software health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![CI](https://github.com/scalar/scalar/actions/workflows/main.yml/badge.svg)](https://github.com/scalar/scalar/actions/workflows/main.yml)
 [![Contributors](https://img.shields.io/github/contributors/scalar/scalar)](https://github.com/scalar/scalar/graphs/contributors)
+[![inspect.software](https://raw.githubusercontent.com/inspect-software/badges/main/v1/s/scalar/scalar.svg)](https://inspect.software/software/scalar/scalar)
 [![GitHub License](https://img.shields.io/github/license/scalar/scalar)](https://github.com/scalar/scalar/blob/main/LICENSE)
 [![Twitter](https://img.shields.io/twitter/follow/scalar)](https://x.com/scalar)
 [![Discord](https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2)](https://discord.gg/scalar)


### PR DESCRIPTION
This PR adds the [inspect.software](https://inspect.software) health badge to the README.

**Why this PR?**
Your project ranks in the upper rating bands of our open-source health index (which measures maintainability, responsiveness, and security). This badge makes that standing objectively visible to your users. Our index is a free public good, and scores cannot be bought.

**Technical details:**
- **No tracking:** Static SVG served via GitHub's CDN. No JavaScript, no third-party tracking.
- **No maintenance:** The badge updates automatically after every inspection.
- **Transparent:** Links directly to [your full report](https://inspect.software/software/scalar/scalar), based on our open [methodology](https://inspect.software/methodology).

If you prefer to keep your README minimal, feel free to close this PR without replying. Your report will remain publicly available and up-to-date either way.
