### PR TITLE
fix(api-client): drop of a declared header after opening an operation with a request body

### DIFF
--- a/.changeset/fix-dropped-header-9903.md
+++ b/.changeset/fix-dropped-header-9903.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix a header row rendering blank in the client after opening an operation with
+a request body. Reused input cells now repaint when they switch into edit mode.

--- a/packages/api-client/src/v2/components/code-input/CodeInputLite.test.ts
+++ b/packages/api-client/src/v2/components/code-input/CodeInputLite.test.ts
@@ -1056,6 +1056,38 @@ describe('CodeInputLite', () => {
     })
   })
 
+  describe('mode switch into editor', () => {
+    // Reused table rows (RequestTable keys its v-for by index) can flip a cell
+    // from a non-editor mode into editor mode. The editor element only appears
+    // on the next render, after onMounted and the modelValue watch have already
+    // run, so the fresh editor must still be painted (scalar/scalar#9903).
+    it('paints the value when switching from enum-select mode into editor mode', async () => {
+      const wrapper = mountInput({ modelValue: '1', enum: ['1'] })
+      await nextTick()
+      expect(wrapper.find('.code-input-lite__editor').exists()).toBe(false)
+
+      await wrapper.setProps({ modelValue: 'web', enum: undefined })
+      await nextTick()
+      await nextTick()
+
+      const editor = wrapper.get('.code-input-lite__editor').element as HTMLDivElement
+      expect(editor.textContent).toBe('web')
+    })
+
+    it('paints the value when switching from a disabled label into editor mode', async () => {
+      const wrapper = mountInput({ modelValue: '*/*', disabled: true })
+      await nextTick()
+      expect(wrapper.find('.code-input-lite__editor').exists()).toBe(false)
+
+      await wrapper.setProps({ modelValue: 'acme', disabled: false })
+      await nextTick()
+      await nextTick()
+
+      const editor = wrapper.get('.code-input-lite__editor').element as HTMLDivElement
+      expect(editor.textContent).toBe('acme')
+    })
+  })
+
   describe('autofocus', () => {
     it('focuses the editor on mount when the autofocus attribute is present', () => {
       const wrapper = mount(CodeInputLite, {

--- a/packages/api-client/src/v2/components/code-input/CodeInputLite.vue
+++ b/packages/api-client/src/v2/components/code-input/CodeInputLite.vue
@@ -752,6 +752,27 @@ watch(
   },
 )
 
+/**
+ * Paint the editor as soon as its element appears.
+ *
+ * When a reused table row flips a cell from a non-editor mode (a readonly
+ * disabled label, or an `enum`/`examples`/`boolean` select) into editor mode,
+ * the `<div ref="editorRef">` is created only on the next render. `onMounted`
+ * already ran for this instance, and the `modelValue` watch fired while
+ * `editorRef` was still `null`, so `renderModel` bailed and the fresh editor
+ * stays empty forever (scalar/scalar#9903). Repaint once the element exists —
+ * but only while it is still blank, so we never clobber an in-progress edit.
+ */
+watch(editorRef, (editor) => {
+  if (!editor || !isBlankValue(serializeEditor())) {
+    return
+  }
+  const serialized = serializeValue(modelValue)
+  lastPillSignature = pillSignature(serialized, withVariables)
+  renderModel(serialized)
+  isEmpty.value = isBlankValue(serialized)
+})
+
 watch(
   [() => environment, () => withVariables],
   () => {


### PR DESCRIPTION
Opening an operation with a request body could blank out a declared header, both on that operation and on later ones. It kept happening for the rest of the session.

The header table reuses input cells across operations. When a cell switched into edit mode, it was never repainted, so it showed up empty. It now repaints as soon as the editable field appears.

## Ticket

Fixes #9903