### PR TITLE
fix(workspace-store): oauth2 scope selection freezes in the reference auth panel

### DIFF
--- a/.changeset/fix-oauth2-scope-selection-freeze.md
+++ b/.changeset/fix-oauth2-scope-selection-freeze.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Fix OAuth2 scope selection freezing in the API reference auth panel. Selecting or deselecting scopes (including Select All and Deselect All) now updates the counter and checkboxes after the first change instead of getting stuck.

--- a/packages/workspace-store/src/mutators/auth.test.ts
+++ b/packages/workspace-store/src/mutators/auth.test.ts
@@ -1078,6 +1078,70 @@ describe('updateSelectedScopes', () => {
     assert(selected)
     expect(selected.selectedSchemes[0]).toEqual({ OAuth: ['read', 'write'] })
   })
+
+  it('replaces the selected requirement object on a single-scope toggle instead of mutating it in place (issue #9589)', async () => {
+    const documentName = 'test'
+    const store = createWorkspaceStore()
+    await store.addDocument({ name: documentName, document: createDocument({}) })
+    store.auth.setAuthSelectedSchemas(
+      { type: 'document', documentName },
+      { selectedIndex: 0, selectedSchemes: [{ OAuth: ['read'] }] },
+    )
+
+    const readRequirement = () => {
+      const selected = store.auth.getAuthSelectedSchemas({ type: 'document', documentName })
+      assert(selected)
+      return selected.selectedSchemes[0]
+    }
+
+    const before = readRequirement()
+
+    updateSelectedScopes(store, store.workspace.activeDocument!, {
+      id: ['OAuth'],
+      name: 'OAuth',
+      scope: 'write',
+      selected: true,
+      meta: { type: 'document' },
+    })
+
+    const after = readRequirement()
+
+    // The requirement must be a new object, not the same one mutated in place. The reference-side
+    // Authentication panel passes this object down as a prop, and Vue diffs props by identity — so
+    // reusing the identity leaves the scope counter and checkboxes frozen after the first change.
+    expect(after).not.toBe(before)
+    expect(after).toEqual({ OAuth: ['read', 'write'] })
+  })
+
+  it('replaces the selected requirement object on a bulk update instead of mutating it in place (Select All, issue #9589)', async () => {
+    const documentName = 'test'
+    const store = createWorkspaceStore()
+    await store.addDocument({ name: documentName, document: createDocument({}) })
+    store.auth.setAuthSelectedSchemas(
+      { type: 'document', documentName },
+      { selectedIndex: 0, selectedSchemes: [{ OAuth: ['read'] }] },
+    )
+
+    const readRequirement = () => {
+      const selected = store.auth.getAuthSelectedSchemas({ type: 'document', documentName })
+      assert(selected)
+      return selected.selectedSchemes[0]
+    }
+
+    const before = readRequirement()
+
+    updateSelectedScopes(store, store.workspace.activeDocument!, {
+      id: ['OAuth'],
+      name: 'OAuth',
+      scopes: ['read', 'write'],
+      meta: { type: 'document' },
+    })
+
+    const after = readRequirement()
+
+    expect(after).not.toBe(before)
+    expect(after).toEqual({ OAuth: ['read', 'write'] })
+  })
 })
 
 describe('deleteSecurityScheme', () => {

--- a/packages/workspace-store/src/mutators/auth.ts
+++ b/packages/workspace-store/src/mutators/auth.ts
@@ -453,13 +453,20 @@ export const updateSelectedScopes = (
   if (nextScopes === undefined) {
     return
   }
-  nextScheme[name] = nextScopes
+
+  // Replace the matched requirement with a fresh object instead of mutating it in place, so its
+  // identity changes on every scope update. The reference-side Authentication panel passes this
+  // object down as a prop and Vue diffs props by identity — an in-place mutation keeps the same
+  // reference and leaves the scope counter and checkboxes frozen after the first change. See #9589.
+  const updatedSelectedSchemes = nextSelectedSchemes.map((candidate) =>
+    candidate === nextScheme ? { ...nextScheme, [name]: nextScopes } : candidate,
+  )
 
   store?.auth.setAuthSelectedSchemas(
     meta.type === 'document'
       ? { type: 'document', documentName }
       : { type: 'operation', documentName, path: meta.path, method: meta.method },
-    { selectedIndex: target.selectedIndex, selectedSchemes: nextSelectedSchemes },
+    { selectedIndex: target.selectedIndex, selectedSchemes: updatedSelectedSchemes },
   )
 }
 


### PR DESCRIPTION
Selecting or deselecting OAuth2 scopes in the API reference auth panel (including **Select All** and **Deselect All**) stopped updating the counter and checkboxes after the first change.

The panel reused the same scope object when scopes changed, and Vue compares props by identity, so it never noticed the update. The fix creates a new object on each change, so the UI stays in sync.

Fixes #9589
