### PR TITLE
docs(docs): document multiple RSS feeds

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -339,6 +339,15 @@ Publishes an RSS feed for your changelog so readers can subscribe. Written to `<
 | `title`       | `string` | No       | Feed title. Defaults to your site title plus `Changelog` |
 | `description` | `string` | No       | Feed description                                         |
 
+To publish several feeds, set `rss` to a list of these objects. Each needs its own unique `path` and is written to `<path>/rss.xml`:
+
+```json
+"rss": [
+  { "path": "/changelog", "title": "Scalar Changelog" },
+  { "path": "/blog", "title": "Scalar Blog" }
+]
+```
+
 Entries come from dated headings (`## 1.2.0 (2026-07-24)`) on the page at `path` or any page beneath it, merged newest-first. Only the top-most dated heading level starts entries; deeper headings (dated or not) fold into the release above them. Hidden pages are skipped. Every page advertises the feed with a `<link rel="alternate" type="application/rss+xml">` tag, and pages under `path` show a subscribe button in the page header.
 
 ### routing

--- a/documentation/guides/docs/configuration/site-config.md
+++ b/documentation/guides/docs/configuration/site-config.md
@@ -447,6 +447,35 @@ Point `path` at the route your changelog lives on. The feed is written to `rss.x
 | `title`       | `string` | No       | Title of the feed, shown in feed readers. Defaults to your site title plus `Changelog` |
 | `description` | `string` | No       | Description of the feed, shown in feed readers                                      |
 
+### Multiple Feeds
+
+To publish more than one feed, set `rss` to a list. Each entry is a feed with its own `path`, and each is written to `rss.xml` under that path — so `/changelog` and `/blog` publish `/changelog/rss.xml` and `/blog/rss.xml` side by side:
+
+```json
+// scalar.config.json
+{
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
+  "scalar": "2.0.0",
+  "siteConfig": {
+    "rss": [
+      {
+        "path": "/changelog",
+        "title": "Scalar Changelog",
+        "description": "Every Scalar release, as a feed"
+      },
+      {
+        "path": "/blog",
+        "title": "Scalar Blog"
+      }
+    ]
+  }
+}
+```
+
+Every feed takes the same properties as a single one, and each path must be unique. A single feed still works exactly as shown above — the list is only needed when you want more than one.
+
+When a page sits under more than one feed, its header shows a subscribe button for each, with the nearest feed first.
+
 ### Writing Entries
 
 Each entry in the feed comes from a heading that carries a date in `YYYY-MM-DD` form:
@@ -487,7 +516,7 @@ Every page on your site advertises the feed in its `<head>`, so feed readers and
 <link rel="alternate" type="application/rss+xml" href="https://example.com/changelog/rss.xml">
 ```
 
-Pages at `path` and beneath it also show a subscribe button in the page header, next to Copy Page.
+Pages at `path` and beneath it also show a subscribe button in the page header, next to Copy Page — one per feed the page belongs to.
 
 ## Routing
 


### PR DESCRIPTION
You can now set `rss` to a list to publish more than one feed. This documents that.