### PR TITLE
fix(proxy): omit Cookie header when X-Scalar-Cookie is not provided

### DIFF
--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -388,18 +388,21 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 		return err
 	}
 
-	// Copy the headers but exclude Origin. It's not required and might confuse some target servers.
+	// Copy the headers but exclude Origin and Cookie.
+	// Origin is not required and might confuse some target servers.
+	// Cookies are excluded by default so browser cookies are not leaked;
+	// users need to specifically set cookies via X-Scalar-Cookie.
 	for key, values := range r.Header {
-		if !strings.EqualFold(strings.ToLower(key), "origin") {
+		lowerKey := strings.ToLower(key)
+		if lowerKey != "origin" && lowerKey != "cookie" {
 			outreq.Header[key] = values
 		}
 	}
 
 	// Users need to specifically set their cookies in X-Scalar-Cookie
-	xScalarCookie := r.Header.Get("X-Scalar-Cookie")
-
-	// Set the cookie
-	outreq.Header.Set("Cookie", xScalarCookie)
+	if xScalarCookie := r.Header.Get("X-Scalar-Cookie"); xScalarCookie != "" {
+		outreq.Header.Set("Cookie", xScalarCookie)
+	}
 	// Remove the X-Scalar-Cookie header
 	outreq.Header.Del("X-Scalar-Cookie")
 

--- a/projects/proxy-scalar-com/main_test.go
+++ b/projects/proxy-scalar-com/main_test.go
@@ -519,9 +519,9 @@ func TestProxyBehavior(t *testing.T) {
 	t.Run("Does not forward any cookies by default", func(t *testing.T) {
 		// Create a test server that checks for the Cookie header
 		targetServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
-			// Check that Cookie header is empty
-			if cookie := r.Header.Get("Cookie"); cookie != "" {
-				t.Errorf("Expected Cookie header to be empty, got '%s'", cookie)
+			// Check that Cookie header is omitted completely rather than sent as empty value
+			if _, exists := r.Header["Cookie"]; exists {
+				t.Errorf("Expected Cookie header to be omitted, but was present: %v", r.Header["Cookie"])
 			}
 			w.Write([]byte("success"))
 		})
@@ -566,6 +566,26 @@ func TestProxyBehavior(t *testing.T) {
 		proxyServer.handleRequest(w, req)
 
 		// Check response
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("Omits Cookie header completely when X-Scalar-Cookie is empty string", func(t *testing.T) {
+		targetServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
+			if _, exists := r.Header["Cookie"]; exists {
+				t.Errorf("Expected Cookie header to be omitted, but got: %v", r.Header["Cookie"])
+			}
+			w.Write([]byte("success"))
+		})
+		defer targetServer.server.Close()
+
+		req := httptest.NewRequest(http.MethodGet, "/?scalar_url="+targetServer.url, nil)
+		req.Header.Set("X-Scalar-Cookie", "")
+		w := httptest.NewRecorder()
+
+		proxyServer.handleRequest(w, req)
+
 		if w.Code != http.StatusOK {
 			t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
 		}


### PR DESCRIPTION
## Summary

Fixes #9943.

When making requests through `proxy-scalar-com` without setting `X-Scalar-Cookie`, `outreq.Header.Set("Cookie", xScalarCookie)` was called with `""`. In Go's `net/http`, this set an empty `Cookie: ` header on the outbound request sent across the wire. Certain WAFs (Web Application Firewalls) and upstream reverse proxies reject empty header values as an HTTP protocol violation (`400 Bad Request: Header name with no header value`).

Additionally, browser cookies sent to the proxy should not be leaked to the upstream API by default.

## Changes

1. In `projects/proxy-scalar-com/main.go`:
   - Excluded `Cookie` from the header copy loop alongside `Origin`.
   - Only set `Cookie` on `outreq.Header` when `X-Scalar-Cookie` is non-empty.
2. In `projects/proxy-scalar-com/main_test.go`:
   - Updated test assertion in `Does not forward any cookies by default` to check that the `Cookie` key is omitted from request headers.
   - Added unit test `Omits Cookie header completely when X-Scalar-Cookie is empty string`.

## Verification

- `go test -v .` in `projects/proxy-scalar-com` passed 100% (all 26 tests passed).
