### PR TITLE
docs(docs): fix header item in the full config example

### DIFF
--- a/documentation/guides/docs/configuration/scalar.config.json.md
+++ b/documentation/guides/docs/configuration/scalar.config.json.md
@@ -164,7 +164,7 @@ Here is a more complete example showing common configuration options:
   },
   "navigation": {
     "header": [
-      { "title": "Dashboard", "url": "https://dashboard.example.com" }
+      { "type": "link", "title": "Dashboard", "to": "https://dashboard.example.com" }
     ],
     "routes": {
       "/": {


### PR DESCRIPTION
The header item in the full config example was missing `type` and used `url` instead of `to`. This fixes it to match the schema.