### PR TITLE
docs(docs): use "API document" instead of OpenAPI-only wording

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -32,15 +32,15 @@ app.get(
 )
 ```
 
-## OpenAPI Documents
+## API Documents
 
 There is just one thing that is really required to render at least something: The content.
 
-There are a bunch of ways to pass your OpenAPI document:
+There are a bunch of ways to pass your API document:
 
 ### URL
 
-Pass an absolute or relative URL to your OpenAPI document.
+Pass an absolute or relative URL to your API document.
 
 ```javascript
 Scalar.createApiReference('#app', {
@@ -50,13 +50,13 @@ Scalar.createApiReference('#app', {
 
 This can be JSON or YAML.
 
-It's the recommended way to pass your OpenAPI document. In most cases, the OpenAPI document can be cached by the browser and subsequent requests are pretty fast then, even if the document grows over time.
+It's the recommended way to pass your API document. In most cases, the document can be cached by the browser and subsequent requests are pretty fast then, even if the document grows over time.
 
 > No OpenAPI document? All backend frameworks have some kind of OpenAPI generator. Just search for "yourframework generate openapi document".
 
 ### Content
 
-> While this approach is convenient for quick setup, it may impact performance for large documents. For optimal performance with extensive OpenAPI specifications, consider using a URL to an external OpenAPI document instead.
+> While this approach is convenient for quick setup, it may impact performance for large documents. For optimal performance with large API documents, consider using a URL to an external document instead.
 
 You can just directly pass JSON/YAML content:
 
@@ -77,7 +77,7 @@ Scalar.createApiReference('#app', {
 
 ### Multiple Documents
 
-Add multiple OpenAPI documents to render all of them. We will need a slug and title to distinguish them in the UI and in the URL. You can just omit those attributes, and we will try our best to still distinguish them, though.
+Add multiple API documents to render all of them. We will need a slug and title to distinguish them in the UI and in the URL. You can just omit those attributes, and we will try our best to still distinguish them, though.
 
 ```javascript
 Scalar.createApiReference('#app', {
@@ -112,7 +112,7 @@ Scalar.createApiReference('#app', {
     // API #2
     {
       url: 'https://example.com/openapi.json',
-      // This will make it the default OpenAPI document:
+      // This will make it the default document:
       default: true,
     }
   ]
@@ -121,7 +121,7 @@ Scalar.createApiReference('#app', {
 
 ### Multiple Configurations
 
-Sometimes, you want to modify the configuration for your OpenAPI documents. And the good news is: You can.
+Sometimes, you want to modify the configuration for your API documents. And the good news is: You can.
 
 Pass an array of configurations to render multiple documents with specific configurations:
 
@@ -182,7 +182,7 @@ Scalar.createApiReference('#app', [
       // API #2
       {
         url: 'https://example.com/openapi.json',
-        // This will make it the default OpenAPI document:
+        // This will make it the default document:
         default: true,
       }
     ]
@@ -390,7 +390,7 @@ If you want to prefix all relative servers with a base URL, you can do so here.
 
 **Type:** `string | Record<string, any> | () => Record<string, any>`
 
-Directly pass an OpenAPI/Swagger document (JSON or YAML) as a string:
+Directly pass an API document (JSON or YAML) as a string:
 
 ```javascript
 {
@@ -1053,7 +1053,7 @@ Key used with CTRL/CMD to open the search modal.
 
 **Type:** `Server[]`
 
-Pass a list of servers to override the servers in your OpenAPI document.
+Pass a list of servers to override the servers in your API document.
 
 ```javascript
 {
@@ -1125,7 +1125,7 @@ Can be one of: **alternate**, **default**, **moon**, **purple**, **solarized**, 
 
 **Type:** `string`
 
-Pass the URL of an OpenAPI document (JSON or YAML).
+Pass the URL of an API document (JSON or YAML).
 
 ```javascript
 {
@@ -1154,7 +1154,7 @@ Custom functions to control specific behaviors and URL generation.
 
 **Type:** `(input: string | URL | globalThis.Request, init?: RequestInit) => Promise<Response>`
 
-Custom [fetch function](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) used both when loading the OpenAPI document and when sending "Test Request" calls from the API client. Can be used to add custom headers, attach credentials (for example `credentials: 'include'`), handle auth, etc.
+Custom [fetch function](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) used both when loading the API document and when sending "Test Request" calls from the API client. Can be used to add custom headers, attach credentials (for example `credentials: 'include'`), handle auth, etc.
 
 ```javascript
 {
@@ -1272,7 +1272,7 @@ Customize how webhook URLs are generated. This function receives the webhook obj
 
 **Type:** `(input: { title: string; document: { title: string; slug: string } }) => string`
 
-Customize the browser tab title. The function is called whenever the section in view changes — on sidebar clicks, on scroll, and when switching documents — and receives the title of the section currently in view together with the active OpenAPI document.
+Customize the browser tab title. The function is called whenever the section in view changes — on sidebar clicks, on scroll, and when switching documents — and receives the title of the section currently in view together with the active API document.
 
 > Note: This must be passed through JavaScript, setting a data attribute will not work.
 

--- a/documentation/guides/api-references/getting-started.md
+++ b/documentation/guides/api-references/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-The API Reference renders a modern documentation for your OpenAPI/Swagger documents and all you need is a few lines of code.
+The API Reference renders a modern documentation for your API documents and all you need is a few lines of code.
 
 The quickest way to start is a HTML page, that loads our JavaScript:
 
@@ -24,7 +24,7 @@ The quickest way to start is a HTML page, that loads our JavaScript:
     <!-- Initialize the API Reference -->
     <script>
       Scalar.createApiReference('#app', {
-        // The URL of the OpenAPI/Swagger document
+        // The URL of the API document
         url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=json',
         // Avoid CORS issues
         proxyUrl: 'https://proxy.scalar.com',

--- a/documentation/guides/app/authentication.md
+++ b/documentation/guides/app/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-Scalar reads security schemes from your OpenAPI description and lets you fill in credentials once, then reuses them for every request that needs them. Authentication can be set at the collection level or overridden on a single operation.
+Scalar reads security schemes from your OpenAPI document and lets you fill in credentials once, then reuses them for every request that needs them. Authentication can be set at the collection level or overridden on a single operation.
 
 All auth fields accept environment variables — reference them with `{{ variableName }}` to avoid hard-coding secrets. See [Environments](./environments.md).
 

--- a/documentation/guides/app/environments.md
+++ b/documentation/guides/app/environments.md
@@ -65,7 +65,7 @@ See [Scripts](./scripts.md) and [Testing](./testing.md) for more examples.
 
 ## Adding Environments to OpenAPI Documents
 
-Define environments directly in your OpenAPI description with the `x-scalar-environments` extension. They are imported automatically and appear in the environment picker.
+Define environments directly in your OpenAPI document with the `x-scalar-environments` extension. They are imported automatically and appear in the environment picker.
 
 ```yaml
 openapi: 3.1.0

--- a/documentation/guides/app/getting-started.md
+++ b/documentation/guides/app/getting-started.md
@@ -17,7 +17,7 @@ Enter a URL, choose an HTTP method, and send the request to inspect the response
 
   </scalar-step>
 
-  <scalar-step id="step-3" title="Import your OpenAPI description">
+  <scalar-step id="step-3" title="Import your OpenAPI document">
 
 Drag and drop an OpenAPI file or import from a URL to generate a complete collection with requests, authentication, and documentation.
 
@@ -25,7 +25,7 @@ Drag and drop an OpenAPI file or import from a URL to generate a complete collec
 
   <scalar-step id="step-4" title="Keep everything in sync">
 
-When your OpenAPI description changes on disk, API Client can watch for updates and keep requests and collections aligned.
+When your OpenAPI document changes on disk, API Client can watch for updates and keep requests and collections aligned.
 
   </scalar-step>
 
@@ -38,7 +38,7 @@ Use [post-response scripts](./testing.md) to validate responses and automate che
 
 ## Import and sync OpenAPI
 
-Bring an OpenAPI description into API Client to generate requests, authentication, and collection structure from the API your team already maintains.
+Bring an OpenAPI document into API Client to generate requests, authentication, and collection structure from the API your team already maintains.
 
 Use [Import](./import.md) to bring in local files or URLs, then use [environments](./environments.md) and [dynamic variables](./dynamic-variables.md) to move between local, staging, and production without duplicating requests.
 

--- a/documentation/guides/app/import.md
+++ b/documentation/guides/app/import.md
@@ -6,7 +6,7 @@ The API Client supports several formats to get your API collections into the app
 
 ### OpenAPI 3.x
 
-The native format used internally by the API Client. OpenAPI descriptions can be auto-generated from your codebase or hand-written. Both JSON and YAML are supported.
+The native format used internally by the API Client. OpenAPI documents can be auto-generated from your codebase or hand-written. Both JSON and YAML are supported.
 
 This is the recommended format. All features of the API Client, including environments, authentication schemes, and server configuration, map directly to the OpenAPI specification.
 

--- a/documentation/guides/app/index.md
+++ b/documentation/guides/app/index.md
@@ -31,7 +31,7 @@ A modern, open-source API client built on the OpenAPI standard. Send requests, o
         <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
         OpenAPI-native
       </b>
-      <p class="leading-6">Generate collections from OpenAPI descriptions and keep them close to your source of truth.</p>
+      <p class="leading-6">Generate collections from OpenAPI documents and keep them close to your source of truth.</p>
     </div>
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-orange">

--- a/documentation/guides/app/scripts.md
+++ b/documentation/guides/app/scripts.md
@@ -70,7 +70,7 @@ pm.request.method = 'POST'
 
 ## Adding Scripts to OpenAPI Documents
 
-Add pre-request scripts to your OpenAPI description using the `x-pre-request` extension. Scripts can be set at the operation level, the document level, or both. When both are present, the document-level script runs first.
+Add pre-request scripts to your OpenAPI document using the `x-pre-request` extension. Scripts can be set at the operation level, the document level, or both. When both are present, the document-level script runs first.
 
 ### Operation level
 

--- a/documentation/guides/app/testing.md
+++ b/documentation/guides/app/testing.md
@@ -112,7 +112,7 @@ pm.test("Response contains expected object", () => {
 
 ## Adding Scripts to OpenAPI Documents
 
-You can add post-response scripts directly to your OpenAPI description using the `x-post-response` extension. When the API Client imports the document, scripts are automatically attached to the corresponding operations.
+You can add post-response scripts directly to your OpenAPI document using the `x-post-response` extension. When the API Client imports the document, scripts are automatically attached to the corresponding operations.
 
 ```yaml
 openapi: 3.1.0

--- a/documentation/guides/docs/components/tabs.mdx
+++ b/documentation/guides/docs/components/tabs.mdx
@@ -28,7 +28,7 @@ Each tab can hold rich markdown — headings, lists, links, and emphasis.
 <Preview>
   <Tabs>
     <Tab title="Documentation">
-      Generate beautiful, interactive API reference docs straight from your OpenAPI document.
+      Generate beautiful, interactive API reference docs straight from your API document.
 
       - Try requests right in the browser
       - Auto-generated code samples
@@ -42,7 +42,7 @@ Each tab can hold rich markdown — headings, lists, links, and emphasis.
       - Works offline as a desktop app
     </Tab>
     <Tab title="Registry">
-      Host and version your OpenAPI documents in one place.
+      Host and version your API documents in one place.
 
       - Share docs with your whole team
       - Automatic versioning on every push
@@ -55,7 +55,7 @@ Each tab can hold rich markdown — headings, lists, links, and emphasis.
 ````md Markdown
 <scalar-tabs>
   <scalar-tab title="Documentation">
-Generate beautiful, interactive API reference docs straight from your OpenAPI document.
+Generate beautiful, interactive API reference docs straight from your API document.
 
 - Try requests right in the browser
 - Auto-generated code samples
@@ -69,7 +69,7 @@ A standalone client for testing and debugging your APIs.
 - Works offline as a desktop app
   </scalar-tab>
   <scalar-tab title="Registry">
-Host and version your OpenAPI documents in one place.
+Host and version your API documents in one place.
 
 - Share docs with your whole team
 - Automatic versioning on every push
@@ -80,7 +80,7 @@ Host and version your OpenAPI documents in one place.
 ````mdx MDX
 <Tabs>
   <Tab title="Documentation">
-    Generate beautiful, interactive API reference docs straight from your OpenAPI document.
+    Generate beautiful, interactive API reference docs straight from your API document.
 
     - Try requests right in the browser
     - Auto-generated code samples
@@ -94,7 +94,7 @@ Host and version your OpenAPI documents in one place.
     - Works offline as a desktop app
   </Tab>
   <Tab title="Registry">
-    Host and version your OpenAPI documents in one place.
+    Host and version your API documents in one place.
 
     - Share docs with your whole team
     - Automatic versioning on every push
@@ -139,7 +139,7 @@ Tabs can hold any other component — cards, callouts, images, and more.
     <Tab title="Cards">
       <Row cols={2}>
         <Card title="Fast" icon="phosphor/regular/lightning">
-          Renders instantly, even for large API descriptions.
+          Renders instantly, even for large API documents.
         </Card>
         <Card title="Themeable" icon="phosphor/regular/palette">
           Match your brand with CSS variables and design tokens.
@@ -163,7 +163,7 @@ Tabs can hold any other component — cards, callouts, images, and more.
   <Tab title="Cards">
     <Row cols={2}>
       <Card title="Fast" icon="phosphor/regular/lightning">
-        Renders instantly, even for large API descriptions.
+        Renders instantly, even for large API documents.
       </Card>
       <Card title="Themeable" icon="phosphor/regular/palette">
         Match your brand with CSS variables and design tokens.

--- a/documentation/guides/docs/deployment/automatic-deployment.md
+++ b/documentation/guides/docs/deployment/automatic-deployment.md
@@ -4,7 +4,7 @@ Docs can automatically publish your documentation whenever changes are merged in
 
 Enable automatic deployment and configure which branch triggers it in the [Scalar Dashboard](https://dashboard.scalar.com) under your project settings. Every time you merge changes into your default branch, your documentation will be automatically published.
 
-If your Docs project references an OpenAPI document from the Registry, updating that Registry document also triggers the Docs project to publish again. Once your document is in the Registry, your documentation stays up to date automatically.
+If your Docs project references an API document from the Registry, updating that Registry document also triggers the Docs project to publish again. Once your document is in the Registry, your documentation stays up to date automatically.
 
 ## Other Deployment Options
 

--- a/documentation/guides/docs/getting-started.md
+++ b/documentation/guides/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Create and publish your first documentation site with Scalar Docs in minutes. Write guides in Markdown or MDX, add OpenAPI documents for interactive API references, and deploy from GitHub, the CLI, or the web editor.
+Create and publish your first documentation site with Scalar Docs in minutes. Write guides in Markdown or MDX, add API documents for interactive API references, and deploy from GitHub, the CLI, or the web editor.
 
 ## Create docs in three steps
 
@@ -14,7 +14,7 @@ npx @scalar/cli project preview
   </scalar-step>
 
   <scalar-step title="Add guides and APIs" icon="phosphor/regular/book-open">
-Write guides in Markdown or MDX, then add OpenAPI documents for interactive API references.
+Write guides in Markdown or MDX, then add API documents for interactive API references.
 
 ```json
 {
@@ -43,7 +43,7 @@ npx @scalar/cli project publish
 
 | Source | Description |
 | ------ | ----------- |
-| **GitHub** | Keep content and OpenAPI documents in your repository. Use [preview deployments](deployment/preview-deployments.md), [automatic deployment](deployment/automatic-deployment.md), [GitHub Actions](deployment/github-actions.md), and [scalar.config.json](configuration/scalar.config.json.md). |
+| **GitHub** | Keep content and API documents in your repository. Use [preview deployments](deployment/preview-deployments.md), [automatic deployment](deployment/automatic-deployment.md), [GitHub Actions](deployment/github-actions.md), and [scalar.config.json](configuration/scalar.config.json.md). |
 | **Any folder or CLI** | Work from any folder or repository without granting repository access. Publish with [`npx @scalar/cli project publish`](deployment/cli.md). |
 | **Web editor** | Edit and store docs at [docs.scalar.com](https://docs.scalar.com). No Git required. |
 

--- a/documentation/guides/docs/index.md
+++ b/documentation/guides/docs/index.md
@@ -111,7 +111,7 @@ Product guides and API references in one developer portal. Write in Markdown or 
 
 ## The modern API documentation
 
-Include interactive API references for a single API or hundreds of APIs. Everything is based on the OpenAPI standard, so your documentation can stay in sync with the API description your team already maintains.
+Include interactive API references for a single API or hundreds of APIs. Everything is based on the OpenAPI standard, so your documentation can stay in sync with the API document your team already maintains.
 
 <scalar-callout type="info" icon="phosphor/regular/info">
   Just need an API reference? Use the [API Reference](../../guides/api-references/getting-started.md). It is open source, free, and has integrations for REST API frameworks.

--- a/documentation/guides/docs/starter-kit.md
+++ b/documentation/guides/docs/starter-kit.md
@@ -4,7 +4,7 @@ The [Docs Starter Kit](https://github.com/scalar/starter) is a ready-to-use temp
 
 ## Project structure
 
-The starter includes a minimal layout: a `docs/` folder (with `api-reference/` for OpenAPI documents and `content/` for free-form content) and a `scalar.config.json` file at the repository root.
+The starter includes a minimal layout: a `docs/` folder (with `api-reference/` for API documents and `content/` for free-form content) and a `scalar.config.json` file at the repository root.
 
 ## 1. Preview your docs
 
@@ -18,9 +18,9 @@ This starts a live preview at `http://localhost:7970` where every edit you make 
 
 Read more about [Preview deployments](deployment/preview-deployments.md) and the [CLI](deployment/cli.md).
 
-## 2. Include OpenAPI documents
+## 2. Include API documents
 
-Drop your OpenAPI files into `docs/api-reference/`, and add them to `scalar.config.json` to have them automatically become interactive API references.
+Drop your API documents into `docs/api-reference/`, and add them to `scalar.config.json` to have them automatically become interactive API references.
 
 The starter kit includes an example OpenAPI document to show you how it works.
 

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -5,12 +5,12 @@
 <a href="https://discord.gg/scalar" aria-label="Join Scalar community on Discord"><img alt="Discord" src="https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2"></a>
 </div>
 
-A powerful Node.js mock server that automatically generates realistic API responses from your OpenAPI/Swagger documents. It creates fully-functional endpoints with mock data, handles authentication, and respects content types - making it perfect for frontend development, API prototyping, and integration testing.
+A powerful Node.js mock server that automatically generates realistic API responses from your API documents. It creates fully-functional endpoints with mock data, handles authentication, and respects content types - making it perfect for frontend development, API prototyping, and integration testing.
 
 ## Features
 
 - Perfect for frontend development and testing
-- Creates endpoints automatically from OpenAPI documents
+- Creates endpoints automatically from your API documents
 - Generates realistic mock data based on your schemas
 - Handles authentication and responds with defined HTTP headers
 - Supports Swagger 2.0 and OpenAPI 3.x documents

--- a/documentation/guides/registry/cli.md
+++ b/documentation/guides/registry/cli.md
@@ -3,15 +3,15 @@ This guide will help you interact with our registry with our CLI, programmatical
 
 Before running any of the commands below, make sure you are [authenticated](../cli/authentication.md) with the Scalar CLI using your [API key](../cli/authentication.md#login-with-an-api-key).
 
-## Publishing OpenAPI Documents
-To add an OpenAPI document to the registry, use the `publish` command:
+## Publishing API Documents
+To add an API document to the registry, use the `publish` command:
 
 ```bash
 scalar registry publish ./openapi.yaml --namespace your-team --slug your-api
 ```
 
 ### Required Parameters
-- `file`: Path to your OpenAPI file
+- `file`: Path to your API document
 - `--namespace`: Your Scalar team namespace
 - `--slug`: Unique identifier for the registry entry (defaults to title if not specified)
 
@@ -57,7 +57,7 @@ scalar registry delete your-team your-api
 ```
 
 ## Validation and Quality
-Before publishing, you can validate your OpenAPI document:
+Before publishing, you can validate your API document:
 
 ```bash
 scalar document validate ./openapi.yaml

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -19,7 +19,7 @@ Once authenticated, you can work with Registry from:
   size="full">
 </scalar-image>
 
-## Upload your first API description
+## Upload your first API document
 
 From the [dashboard](https://dashboard.scalar.com), create a new API and upload an OpenAPI document, or publish one from your terminal with the [CLI](cli.md). Once the document is in Registry, docs, SDKs, and automation can all consume the same source.
 

--- a/documentation/guides/registry/index.md
+++ b/documentation/guides/registry/index.md
@@ -19,7 +19,7 @@ Store, version, and manage OpenAPI documents, JSON Schema, and Spectral rules in
 
 Managing OpenAPI can get messy fast. Teams need to know where the source of truth lives, how versions are managed, who has access, and how downstream consumers discover updates.
 
-Registry gives your team a central place for API descriptions and the workflows around them. Once an API description is in Registry, you can power docs, SDKs, publishing, and automation from the same source.
+Registry gives your team a central place for API documents and the workflows around them. Once an API document is in Registry, you can power docs, SDKs, publishing, and automation from the same source.
 
 ## Create docs and SDKs
 
@@ -50,7 +50,7 @@ Generate SDKs from the same OpenAPI documents. Keep client libraries aligned wit
         <scalar-icon src="phosphor/bold/git-branch"></scalar-icon>
         Single source of truth
       </b>
-      <p class="leading-6">Keep API descriptions, schemas, and rules in one managed place.</p>
+      <p class="leading-6">Keep API documents, schemas, and rules in one managed place.</p>
     </div>
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
@@ -71,7 +71,7 @@ Generate SDKs from the same OpenAPI documents. Keep client libraries aligned wit
         <scalar-icon src="phosphor/bold/brackets-curly"></scalar-icon>
         JSON Schema support
       </b>
-      <p class="leading-6">Manage shared schemas alongside the API descriptions that depend on them.</p>
+      <p class="leading-6">Manage shared schemas alongside the API documents that depend on them.</p>
     </div>
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
@@ -85,7 +85,7 @@ Generate SDKs from the same OpenAPI documents. Keep client libraries aligned wit
         <scalar-icon src="phosphor/bold/lock-simple"></scalar-icon>
         Private or public
       </b>
-      <p class="leading-6">Control whether API descriptions are internal, shared with a team, or public.</p>
+      <p class="leading-6">Control whether API documents are internal, shared with a team, or public.</p>
     </div>
   </div>
 </div>

--- a/documentation/guides/registry/upload.md
+++ b/documentation/guides/registry/upload.md
@@ -1,26 +1,26 @@
-# Upload OpenAPI documents
+# Upload API documents
 This guide will help you interact with our registry with our [dashboard on scalar.com](https://dashboard.scalar.com), which can be done alongside [our command-line interface](cli.md).
 
 Make sure you have created a Scalar Account & are logged in ([see create account guide](getting-started.md#create-your-scalar-account))
 
-## Add an OpenAPI Document
-Now let's add an OpenAPI document to the registry ✨
+## Add an API Document
+Now let's add an API document to the registry ✨
 
 From the [dashboard](https://dashboard.scalar.com) click Import API from the right hand pane, or navigate to registry in the sidebar under Products then click Create new API
 
 ![Scalar Import OpenAPI Document Modal](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/WnMVG8hrR_f-6t-lOtDYb.png "Scalar Import OpenAPI Document")
 
-You can upload any version of OpenAPI (even Swagger) or a Postman Collection!
+You can upload any version of OpenAPI or AsyncAPI (even Swagger) or a Postman Collection!
 
 ![Scalar Importing OpenAPI Document](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/RWZLxUdaySzCyELtwopSq.png "Scalar Importing OpenAPI Document")
 
 ![Scalar Imported OpenAPI Document](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/glhdU91VygnDIlywcnUsL.png "Scalar Imported OpenAPI Document")
 
-Awesome, now your OpenAPI Document is in the Registry under your company's namespace!
+Awesome, now your API document is in the Registry under your company's namespace!
 
 
-## Update an OpenAPI Document
-You can use our [OpenAPI Editor](https://editor.scalar.com) to make changes to your OpenAPI Document, or click Edit Document from the [Registry Page](https://dashboard.scalar.com/registry).
+## Update an API Document
+You can use our [OpenAPI Editor](https://editor.scalar.com) to make changes to your API document, or click Edit Document from the [Registry Page](https://dashboard.scalar.com/registry).
 
 ![Registry Overview](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/glhdU91VygnDIlywcnUsL.png "Registry Overview")
 
@@ -30,5 +30,5 @@ Once you make edits, you can click Publish in the top right to upsert a new vers
 
 ![Scalar Upsert Document](https://api.scalar.com/cdn/images/UCkGjASrXpR8OxgWEj32i/ToaCj4ycSecX799jl6DZ7.png "Scalar Upsert Document")
 
-## Delete an OpenAPI Document
-You can delete an OpenAPI document from the Registry > Overview page, however please consider the downstream effects of which products are depending on that OpenAPI document before deleting that resource.
+## Delete an API Document
+You can delete an API document from the Registry > Overview page, however please consider the downstream effects of which products are depending on that API document before deleting that resource.

--- a/documentation/guides/sdks/asyncapi.md
+++ b/documentation/guides/sdks/asyncapi.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > AsyncAPI support is experimental. It generates working code, but the surface it produces may change: talk to us before you depend on it.
 
-The SDK generator reads [AsyncAPI](https://www.asyncapi.com/) documents as well as OpenAPI ones. Point it at an AsyncAPI description and it generates the same kind of client you get from OpenAPI — typed models, authentication, environments, a resource tree — with each channel exposed as a method on that tree.
+The SDK generator reads [AsyncAPI](https://www.asyncapi.com/) documents as well as OpenAPI ones. Point it at an AsyncAPI document and it generates the same kind of client you get from OpenAPI — typed models, authentication, environments, a resource tree — with each channel exposed as a method on that tree.
 
 The document format is detected from the file itself, so nothing extra needs to be configured. A document with an `asyncapi` field takes the AsyncAPI path, and one with an `openapi` field takes the OpenAPI path.
 
@@ -309,7 +309,7 @@ The starter config a first run writes has two rough edges for HTTP channels, bot
 
 **Not produced**
 
-- **No augmented API description.** Generation from an OpenAPI document writes an `openapi.augmented.json` carrying `x-codeSamples` for every target. There is no AsyncAPI counterpart yet, so an AsyncAPI-backed SDK produces no augmented document and injects no code samples back into your description.
+- **No augmented API document.** Generation from an OpenAPI document writes an `openapi.augmented.json` carrying `x-codeSamples` for every target. There is no AsyncAPI counterpart yet, so an AsyncAPI-backed SDK produces no augmented document and injects no code samples back into your document.
 
 ## Rendering AsyncAPI
 

--- a/documentation/guides/sdks/configuration.md
+++ b/documentation/guides/sdks/configuration.md
@@ -211,7 +211,7 @@ Supported array formats are `comma`, `repeat`, `indices`, and `brackets`. Suppor
 
 ## OpenAPI Overrides
 
-Use `openapi` for SDK-specific overrides that sit next to the source API description.
+Use `openapi` for SDK-specific overrides that sit next to the source API document.
 
 ```json
 {

--- a/documentation/guides/sdks/index.md
+++ b/documentation/guides/sdks/index.md
@@ -286,7 +286,7 @@ Across a large API that consistency is the difference between guessing a method 
 <scalar-steps>
   <scalar-step id="step-openapi" title="Start from your OpenAPI document">
 
-Put your API description in [Registry](../registry/index.md), or import it while creating the SDK. OpenAPI 3.0 and 3.1 are supported, and Swagger 2.0 documents are upgraded on load. [AsyncAPI](asyncapi.md) documents work too — experimentally — with each channel becoming a WebSocket connect method or an HTTP streaming method.
+Put your API document in [Registry](../registry/index.md), or import it while creating the SDK. OpenAPI 3.0 and 3.1 are supported, and Swagger 2.0 documents are upgraded on load. [AsyncAPI](asyncapi.md) documents work too — experimentally — with each channel becoming a WebSocket connect method or an HTTP streaming method.
 
   </scalar-step>
 


### PR DESCRIPTION
Reopened from #9952, which GitHub closed when the branch was renamed. Same commit, nothing else changed.

Now that navigation entries accept `asyncapi`, a bunch of the docs still said "OpenAPI document" where they mean whatever document you passed in.

* Generalizes the wording on the surfaces that actually support AsyncAPI — `configuration.md`, api-references, mock-server, registry, and the docs guides
* Swaps "API description" → "API document" in the product docs since that's the term we use

Left the genuinely OpenAPI-specific stuff alone (code samples, version support, Spectral rules, the upgrader, integrations). One open question: does Agent handle AsyncAPI? `configuration.md` still says "your OpenAPI document" there.

## Ticket

Part of DOC-6001

## Checklist
- [x] I explained why the change is needed.
- [ ] I added a changeset.
- [ ] I added tests.
- [x] I updated the documentation.
