### PR TITLE
docs(docs): replace legacy navigation url and path with to

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -104,7 +104,7 @@ Links at the bottom of the sidebar:
 
 ```json
 "sidebar": [
-  { "title": "Log in", "url": "https://...", "style": "button", "newTab": true }
+  { "title": "Log in", "to": "https://...", "newTab": true }
 ]
 ```
 
@@ -114,7 +114,7 @@ Tabs for quick access to sections:
 
 ```json
 "tabs": [
-  { "title": "API", "path": "/api", "icon": "phosphor/regular/plug" }
+  { "title": "API", "to": "/api", "icon": "phosphor/regular/plug" }
 ]
 ```
 
@@ -317,8 +317,7 @@ For `scripts` and `styles`: path relative to config root. For `links` (favicon):
 
 ```json
 "footer": {
-  "filepath": "docs/footer.html",
-  "belowSidebar": true
+  "filepath": "docs/footer.html"
 }
 ```
 

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -95,7 +95,7 @@ The `navigation.sidebar` array defines links that appear in the footer of the si
     "sidebar": [
       {
         "title": "Log in",
-        "url": "https://dashboard.scalar.com/login",
+        "to": "https://dashboard.scalar.com/login",
         "icon": "phosphor/regular/sign-in"
       }
     ],
@@ -108,12 +108,12 @@ The `navigation.sidebar` array defines links that appear in the footer of the si
 
 ### Properties
 
-| Property | Type                 | Required | Description                           |
-| -------- | -------------------- | -------- | ------------------------------------- |
-| `title`  | `string`             | Yes      | The display text for the sidebar link |
-| `url`    | `string`             | Yes      | The URL the link points to            |
-| `icon`   | `string`             | No       | An icon to display next to the link   |
-| `newTab` | `boolean`            | No       | Whether to open the link in a new tab |
+| Property | Type                 | Required | Description                              |
+| -------- | -------------------- | -------- | ---------------------------------------- |
+| `title`  | `string`             | Yes      | The display text for the sidebar link    |
+| `to`     | `string`             | Yes      | The route path or URL the link points to |
+| `icon`   | `string`             | No       | An icon to display next to the link      |
+| `newTab` | `boolean`            | No       | Whether to open the link in a new tab    |
 
 ## Tabs
 
@@ -132,7 +132,7 @@ Tabs and a header work together, and you do not need both. If you use tabs witho
     "tabs": [
       {
         "title": "API",
-        "path": "/api",
+        "to": "/api",
         "icon": "phosphor/regular/plug"
       }
     ],
@@ -145,11 +145,11 @@ Tabs and a header work together, and you do not need both. If you use tabs witho
 
 ### Properties
 
-| Property | Type     | Required | Description                        |
-| -------- | -------- | -------- | ---------------------------------- |
-| `title`  | `string` | Yes      | The display text for the tab       |
-| `path`   | `string` | Yes      | The URL path the tab links to      |
-| `icon`   | `string` | No       | An icon to display next to the tab |
+| Property | Type     | Required | Description                            |
+| -------- | -------- | -------- | -------------------------------------- |
+| `title`  | `string` | Yes      | The display text for the tab           |
+| `to`     | `string` | Yes      | The route path or URL the tab links to |
+| `icon`   | `string` | No       | An icon to display next to the tab     |
 
 ### Multiple Tabs
 
@@ -159,12 +159,12 @@ You can define multiple tabs to provide quick access to different sections:
 "tabs": [
   {
     "title": "API",
-    "path": "/tools/api",
+    "to": "/tools/api",
     "icon": "phosphor/regular/plug"
   },
   {
     "title": "SDKs",
-    "path": "/products/sdk-generator",
+    "to": "/products/sdk-generator",
     "icon": "phosphor/regular/package"
   }
 ]

--- a/documentation/guides/docs/configuration/versions.md
+++ b/documentation/guides/docs/configuration/versions.md
@@ -102,7 +102,7 @@ You can organize your documentation to share common pages across versions while 
       "tabs": [
         {
           "title": "API Reference",
-          "path": "/api",
+          "to": "/api",
           "icon": "phosphor/regular/plug"
         }
       ],
@@ -142,7 +142,7 @@ You can organize your documentation to share common pages across versions while 
       "tabs": [
         {
           "title": "API Reference",
-          "path": "/api",
+          "to": "/api",
           "icon": "phosphor/regular/plug"
         }
       ],

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -966,12 +966,12 @@
     "sidebar": [
       {
         "title": "Email",
-        "url": "mailto:support@scalar.com",
+        "to": "mailto:support@scalar.com",
         "icon": "phosphor/regular/envelope-simple-open"
       },
       {
         "title": "Demo",
-        "url": "https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a",
+        "to": "https://scalar.cal.com/forms/142d1e65-97d2-4d03-94c3-96f98ddef95a",
         "icon": "phosphor/regular/user-rectangle",
         "newTab": true
       }


### PR DESCRIPTION
## Problem

The published config schema at `registry.scalar.com/@scalar/schemas/config` is about to be republished from the current `scalarConfigSchema`, and a few navigation fields changed since it was frozen. Our config, docs and agent skill were all still on the old keys — they parse fine at runtime, but `to` is required in the new schema so editors flag them.

## Solution

* `navigation.sidebar` and `navigation.tabs` now use `to` instead of `url` / `path`
* Drops `style` from the sidebar example in the agent skill (dead on sidebar items)
* Drops `footer.belowSidebar` from the agent skill, the field no longer exists

`routes` links still legitimately use `url` and header links keep `style`, so those are untouched.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- pnpm changeset -->
- [ ] I added tests.
- [x] I updated the documentation