### PR TITLE
docs(docs): document asyncapi support and gaps

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -221,6 +221,8 @@ Agent adds an AI chat interface to your API reference. Users can ask questions a
 - Requires an [Agent key](guides/agent/key.md) for production deployments
 - Your OpenAPI document is uploaded on first message
 
+We do not currently support AsyncAPI for Agent. An [AsyncAPI](asyncapi.md) document still renders as an API reference, but Agent skips it, so it will not answer questions about your channels or messages. Need it? Tell us on [GitHub](https://github.com/scalar/scalar/issues/new) or email [support@scalar.com](mailto:support@scalar.com).
+
 Related: [How to get an Agent key](guides/agent/key.md)
 
 ```js

--- a/documentation/guides/app/import.md
+++ b/documentation/guides/app/import.md
@@ -28,6 +28,14 @@ curl -X POST https://api.example.com/users \
   -d '{"name": "Jane"}'
 ```
 
+### AsyncAPI
+
+We do not currently support AsyncAPI for the API Client. The client is built around OpenAPI operations — a request, a method, a response — while an [AsyncAPI](../../asyncapi.md) document describes channels and the messages that flow over them, so AsyncAPI documents are skipped rather than imported into a collection.
+
+You can still read one as an [API reference](../../asyncapi.md), which renders its channels, operations, and message payloads.
+
+Need it? Tell us on [GitHub](https://github.com/scalar/scalar/issues/new) or email [support@scalar.com](mailto:support@scalar.com).
+
 ## Sources
 
 You can import from different sources:

--- a/documentation/guides/docs/configuration/ask-ai.md
+++ b/documentation/guides/docs/configuration/ask-ai.md
@@ -8,6 +8,12 @@ Ask AI is enabled by default for all Scalar Docs projects. No setup required.
 
 When a user asks a question, Ask AI searches through all your published documentation. It can combine information from multiple sources to give a complete answer, even when the answer spans several pages.
 
+## AsyncAPI documents
+
+We do not currently support AsyncAPI for Ask AI. [AsyncAPI](../../../asyncapi.md) documents render as API references on your site, but they are not part of the context Ask AI answers from, so it cannot describe your channels or messages.
+
+Need it? Tell us on [GitHub](https://github.com/scalar/scalar/issues/new) or email [support@scalar.com](mailto:support@scalar.com).
+
 ## MCP integration
 
 You can connect your docs AI to LLMs like Cursor, Claude Code, Windsurf, and other tools that support Model Context Protocol (MCP). This gives the LLM the full context of your documentation, so it can answer questions about your API and product without you copy-pasting docs into the chat.

--- a/documentation/guides/registry/cli.md
+++ b/documentation/guides/registry/cli.md
@@ -10,6 +10,12 @@ To add an API document to the registry, use the `publish` command:
 scalar registry publish ./openapi.yaml --namespace your-team --slug your-api
 ```
 
+`publish` accepts OpenAPI and [AsyncAPI](../../asyncapi.md) documents alike. The format is detected when the document reaches the registry, so the command is the same either way:
+
+```bash
+scalar registry publish ./asyncapi.yaml --namespace your-team --slug your-events-api
+```
+
 ### Required Parameters
 - `file`: Path to your API document
 - `--namespace`: Your Scalar team namespace
@@ -74,6 +80,11 @@ And use Rules from the Registry:
 ```bash
 scalar document lint ./openapi.yaml --rule https://registry.scalar.com/@your-team/rules/your-rule
 ```
+
+> [!NOTE]
+> We do not currently support AsyncAPI for `validate` and `lint`. `validate` checks your document against the OpenAPI specification, and `lint` runs the `spectral:oas` ruleset, so pointing either one at an [AsyncAPI](../../asyncapi.md) document reports errors that do not apply to it. Publishing an AsyncAPI document to the registry works as normal.
+>
+> Need it? Tell us on [GitHub](https://github.com/scalar/scalar/issues/new) or email [support@scalar.com](mailto:support@scalar.com).
 
 ## Team Management
 If you're part of multiple teams, you can manage which team is active:

--- a/documentation/guides/registry/getting-started.md
+++ b/documentation/guides/registry/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Get your first OpenAPI document into the Registry and start powering docs, SDKs, and automation from a single source of truth.
+Get your first API document into the Registry and start powering docs, SDKs, and automation from a single source of truth.
 
 ## Create your Scalar account
 
@@ -21,7 +21,7 @@ Once authenticated, you can work with Registry from:
 
 ## Upload your first API document
 
-From the [dashboard](https://dashboard.scalar.com), create a new API and upload an OpenAPI document, or publish one from your terminal with the [CLI](cli.md). Once the document is in Registry, docs, SDKs, and automation can all consume the same source.
+From the [dashboard](https://dashboard.scalar.com), create a new API and upload an OpenAPI or [AsyncAPI](../../asyncapi.md) document, or publish one from your terminal with the [CLI](cli.md). Once the document is in Registry, docs, SDKs, and automation can all consume the same source.
 
 ## Next steps
 

--- a/documentation/guides/registry/index.md
+++ b/documentation/guides/registry/index.md
@@ -64,7 +64,7 @@ Generate SDKs from the same OpenAPI documents. Keep client libraries aligned wit
         <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
         OpenAPI and AsyncAPI
       </b>
-      <p class="leading-6">Version and publish both kinds of API document, used by docs, SDKs, and automation.</p>
+      <p class="leading-6">Version and publish OpenAPI and AsyncAPI documents used by docs, SDKs, and automation.</p>
     </div>
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">

--- a/documentation/guides/registry/index.md
+++ b/documentation/guides/registry/index.md
@@ -1,6 +1,6 @@
 # Registry
 
-Store, version, and manage OpenAPI documents, JSON Schema, and Spectral rules in one source of truth with a deep Git integration.
+Store, version, and manage OpenAPI and AsyncAPI documents, JSON Schema, and Spectral rules in one source of truth with a deep Git integration.
 
 <div class="flex gap-2">
   <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>
@@ -17,9 +17,9 @@ Store, version, and manage OpenAPI documents, JSON Schema, and Spectral rules in
 
 ## Why a Registry?
 
-Managing OpenAPI can get messy fast. Teams need to know where the source of truth lives, how versions are managed, who has access, and how downstream consumers discover updates.
+Managing APIs can get messy fast. Teams need to know where the source of truth lives, how versions are managed, who has access, and how downstream consumers discover updates.
 
-Registry gives your team a central place for API documents and the workflows around them. Once an API document is in Registry, you can power docs, SDKs, publishing, and automation from the same source.
+Registry gives your team a central place for OpenAPI and AsyncAPI documents and the workflows around them. Once an API document is in Registry, you can power docs, SDKs, publishing, and automation from the same source.
 
 ## Create docs and SDKs
 
@@ -62,9 +62,9 @@ Generate SDKs from the same OpenAPI documents. Keep client libraries aligned wit
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
         <scalar-icon src="phosphor/bold/arrow-up-right"></scalar-icon>
-        OpenAPI documents
+        OpenAPI and AsyncAPI
       </b>
-      <p class="leading-6">Version and publish OpenAPI documents used by docs, SDKs, and automation.</p>
+      <p class="leading-6">Version and publish both kinds of API document, used by docs, SDKs, and automation.</p>
     </div>
     <div class="feature-item">
       <b class="flex items-center icon-text gap-3 font-medium min-h-8 text-purple">
@@ -92,7 +92,7 @@ Generate SDKs from the same OpenAPI documents. Keep client libraries aligned wit
 
 ## Ready to manage your APIs?
 
-Follow the [Getting Started guide](getting-started.md) to create an account and upload your first OpenAPI document.
+Follow the [Getting Started guide](getting-started.md) to create an account and upload your first API document.
 
 <div class="flex gap-2">
   <a class="t-editor__button button__primary" href="https://dashboard.scalar.com/register">Get started</a>


### PR DESCRIPTION
## Problem

The dashboard has supported AsyncAPI in the Registry for a while — uploads detect the format from the document, and the list groups OpenAPI and AsyncAPI separately — but the docs never mentioned it anywhere. A few surfaces don't support AsyncAPI at all and didn't say that either, so you'd only find out by trying.

<img width="2938" height="1952" alt="CleanShot 2026-08-21 at 15 59 30@2x" src="https://github.com/user-attachments/assets/ad2b9042-041e-423c-849c-666853d199a9" />
<img width="2938" height="1952" alt="CleanShot 2026-08-21 at 15 59 43@2x" src="https://github.com/user-attachments/assets/789adaf3-547d-490b-8df3-e32c63d01164" />


## Solution

* Registry docs now say you can upload and publish OpenAPI or AsyncAPI, with a `publish` example
* Agent, Ask AI, and the API Client each get a "we don't currently support AsyncAPI" note, plus where to ask for it
* `scalar document validate` and `lint` are OpenAPI-only — called out in the CLI guide, since `registry publish` takes either format fine

Left `asyncapi.md` alone to stay out of the way of #9958. Also filed [DOC-6004](https://linear.app/api-docs/issue/DOC-6004) for the CLI side — it either needs to lint AsyncAPI properly or detect it and say it can't.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset.
- [ ] I added tests.
- [x] I updated the documentation