### PR TITLE
fix(api-reference): keep the variant's name when flattening a single-$ref allOf

### DIFF
--- a/.changeset/fix-9964-oneof-variant-name.md
+++ b/.changeset/fix-9964-oneof-variant-name.md
@@ -2,4 +2,4 @@
 '@scalar/api-reference': patch
 ---
 
-Fix oneOf selector labels showing the shared allOf base name instead of the variant's own name. When a oneOf branch extended a common base through a single-`$ref` allOf (a common inheritance pattern), flattening that allOf for display left the base schema's own `$ref` on the flattened variant, so the selector picked up the base's name for every branch instead of each branch's own name.
+Fix oneOf selector labels showing the shared allOf base name instead of the variant's own name. When a oneOf branch extended a common base through a single-`$ref` allOf (a common inheritance pattern), flattening that allOf for display left the base schema's own identity (`$ref`, `title`, or `name`) on the flattened variant, so the selector picked up the base's name for every branch instead of each branch's own name.

--- a/.changeset/fix-9964-oneof-variant-name.md
+++ b/.changeset/fix-9964-oneof-variant-name.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix oneOf selector labels showing the shared allOf base name instead of the variant's own name. When a oneOf branch extended a common base through a single-`$ref` allOf (a common inheritance pattern), flattening that allOf for display left the base schema's own `$ref` on the flattened variant, so the selector picked up the base's name for every branch instead of each branch's own name.

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
@@ -387,6 +387,52 @@ describe('optimizeValueForDisplay', () => {
     })
   })
 
+  it('drops a flattened allOf base $ref so it does not overwrite the variant (#9964)', () => {
+    // Mirrors the reported bug: a oneOf variant (Cat) extends a base (Animal)
+    // through a single-$ref allOf. Flattening that allOf must not leave the
+    // base's own $ref on the variant, or the selector shows the base's name
+    // instead of the variant's.
+    const input = {
+      oneOf: [
+        {
+          type: 'object',
+          allOf: [
+            {
+              '$ref': '#/components/schemas/Animal',
+              '$ref-value': {
+                type: 'object',
+                properties: { id: { type: 'string' } },
+              },
+            },
+          ],
+          properties: { type: { type: 'string', const: 'cat' } },
+        },
+        {
+          type: 'object',
+          properties: { type: { type: 'string', const: 'dog' } },
+        },
+      ],
+    } as unknown as SchemaObject
+
+    const result = optimizeValueForDisplay(input)
+
+    expect(result).toEqual({
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            type: { type: 'string', const: 'cat' },
+          },
+        },
+        {
+          type: 'object',
+          properties: { type: { type: 'string', const: 'dog' } },
+        },
+      ],
+    })
+  })
+
   it('should not merge allOf when it contains multiple items', () => {
     const input = {
       type: 'object',

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
@@ -475,6 +475,54 @@ describe('optimizeValueForDisplay', () => {
     })
   })
 
+  it('drops a flattened allOf base title/name so it does not overwrite the variant (#9964)', () => {
+    // The base's identity is not only its `$ref`: `getModelNameFromSchema`
+    // prefers `title` (then `name`) over `$ref`, so a base that carries a
+    // `title` would still mislabel every variant even after the base's `$ref`
+    // is dropped. Here the variant (Cat) keeps its own `$ref`, and the base
+    // (Animal) contributes only its properties, not its title.
+    const input = {
+      oneOf: [
+        {
+          '$ref': '#/components/schemas/Cat',
+          type: 'object',
+          allOf: [
+            {
+              '$ref': '#/components/schemas/Animal',
+              title: 'Animal',
+              type: 'object',
+              properties: { id: { type: 'string' } },
+            },
+          ],
+          properties: { meow: { type: 'boolean' } },
+        },
+        {
+          type: 'object',
+          properties: { bark: { type: 'boolean' } },
+        },
+      ],
+    } as unknown as SchemaObject
+
+    const result = optimizeValueForDisplay(input)
+
+    expect(result).toEqual({
+      oneOf: [
+        {
+          '$ref': '#/components/schemas/Cat',
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            meow: { type: 'boolean' },
+          },
+        },
+        {
+          type: 'object',
+          properties: { bark: { type: 'boolean' } },
+        },
+      ],
+    })
+  })
+
   it('should not merge allOf when it contains multiple items', () => {
     const input = {
       type: 'object',

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.test.ts
@@ -433,6 +433,48 @@ describe('optimizeValueForDisplay', () => {
     })
   })
 
+  it('keeps the allOf base $ref when the variant is a bare wrapper with no identity of its own (#9964)', () => {
+    // A variant that only wraps a single allOf member, with no properties,
+    // required, or $ref of its own, has nothing to protect from the base's
+    // $ref, so the base's $ref is kept as a fallback label instead of being
+    // dropped and leaving the variant unlabeled.
+    const input = {
+      oneOf: [
+        {
+          allOf: [
+            {
+              '$ref': '#/components/schemas/Animal',
+              '$ref-value': {
+                type: 'object',
+                properties: { id: { type: 'string' } },
+              },
+            },
+          ],
+        },
+        {
+          type: 'object',
+          properties: { type: { type: 'string', const: 'dog' } },
+        },
+      ],
+    } as unknown as SchemaObject
+
+    const result = optimizeValueForDisplay(input)
+
+    expect(result).toEqual({
+      oneOf: [
+        {
+          '$ref': '#/components/schemas/Animal',
+          type: 'object',
+          properties: { id: { type: 'string' } },
+        },
+        {
+          type: 'object',
+          properties: { type: { type: 'string', const: 'dog' } },
+        },
+      ],
+    })
+  })
+
   it('should not merge allOf when it contains multiple items', () => {
     const input = {
       type: 'object',

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
@@ -123,18 +123,21 @@ export function optimizeValueForDisplay(value: SchemaObject | undefined): Schema
 
       // Flatten single-item allOf and merge with root properties. If the
       // variant has its own properties/required/$ref, the allOf member's own
-      // `$ref` is dropped before merging so it cannot overwrite the variant's
-      // identity, which would otherwise mislabel the flattened schema as the
-      // base it extends instead of the variant itself (#9964). A variant that
-      // is a bare wrapper around the allOf member has no identity of its own
-      // to protect, so the base's `$ref` is kept as a fallback label.
+      // identity (`$ref`, `title`, `name`) is dropped before merging so it
+      // cannot overwrite the variant's, which would otherwise mislabel the
+      // flattened schema as the base it extends instead of the variant itself
+      // (#9964). `getModelNameFromSchema` labels a variant by title → name →
+      // $ref, so any of those leaking from the base is enough to mislabel it.
+      // A variant that is a bare wrapper around the allOf member has no
+      // identity of its own to protect, so the base's identity is kept as a
+      // fallback label.
       if (schema.allOf?.length === 1) {
         const { allOf, ...otherProps } = schema
         const allOfMember = resolve.schema(allOf[0])!
         const variantHasOwnIdentity = 'properties' in otherProps || 'required' in otherProps || '$ref' in otherProps
         if (variantHasOwnIdentity) {
-          const { $ref: _allOfRef, ...allOfMemberWithoutRef } = allOfMember
-          return mergeSchemaProperties(rootProperties, otherProps, allOfMemberWithoutRef)
+          const { $ref: _ref, title: _title, name: _name, ...allOfMemberWithoutIdentity } = allOfMember
+          return mergeSchemaProperties(rootProperties, otherProps, allOfMemberWithoutIdentity)
         }
         return mergeSchemaProperties(rootProperties, otherProps, allOfMember)
       }

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
@@ -121,10 +121,14 @@ export function optimizeValueForDisplay(value: SchemaObject | undefined): Schema
     const mergedSchemas = filteredSchemas.map((_schema) => {
       const schema = resolve.schema(_schema)
 
-      // Flatten single-item allOf and merge with root properties
+      // Flatten single-item allOf and merge with root properties. The allOf
+      // member's own `$ref` is dropped before merging so it cannot overwrite
+      // the variant's `$ref`, which would otherwise mislabel the flattened
+      // schema as the base it extends instead of the variant itself (#9964).
       if (schema.allOf?.length === 1) {
         const { allOf, ...otherProps } = schema
-        return mergeSchemaProperties(rootProperties, otherProps, resolve.schema(allOf[0]))
+        const { $ref: _allOfRef, ...allOfMember } = resolve.schema(allOf[0])!
+        return mergeSchemaProperties(rootProperties, otherProps, allOfMember)
       }
       return mergeSchemaProperties(rootProperties, schema)
     })

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
@@ -121,13 +121,21 @@ export function optimizeValueForDisplay(value: SchemaObject | undefined): Schema
     const mergedSchemas = filteredSchemas.map((_schema) => {
       const schema = resolve.schema(_schema)
 
-      // Flatten single-item allOf and merge with root properties. The allOf
-      // member's own `$ref` is dropped before merging so it cannot overwrite
-      // the variant's `$ref`, which would otherwise mislabel the flattened
-      // schema as the base it extends instead of the variant itself (#9964).
+      // Flatten single-item allOf and merge with root properties. If the
+      // variant has its own properties/required/$ref, the allOf member's own
+      // `$ref` is dropped before merging so it cannot overwrite the variant's
+      // identity, which would otherwise mislabel the flattened schema as the
+      // base it extends instead of the variant itself (#9964). A variant that
+      // is a bare wrapper around the allOf member has no identity of its own
+      // to protect, so the base's `$ref` is kept as a fallback label.
       if (schema.allOf?.length === 1) {
         const { allOf, ...otherProps } = schema
-        const { $ref: _allOfRef, ...allOfMember } = resolve.schema(allOf[0])!
+        const allOfMember = resolve.schema(allOf[0])!
+        const variantHasOwnIdentity = 'properties' in otherProps || 'required' in otherProps || '$ref' in otherProps
+        if (variantHasOwnIdentity) {
+          const { $ref: _allOfRef, ...allOfMemberWithoutRef } = allOfMember
+          return mergeSchemaProperties(rootProperties, otherProps, allOfMemberWithoutRef)
+        }
         return mergeSchemaProperties(rootProperties, otherProps, allOfMember)
       }
       return mergeSchemaProperties(rootProperties, schema)


### PR DESCRIPTION
## Problem

A `oneOf` selector shows the shared `allOf` base name for every variant, instead of each variant's own name. This happens when a variant extends a common base through a single-`$ref` `allOf`, a common inheritance pattern.

### Before

<img alt="Before: the oneOf selector shows Animal for every variant" src="https://raw.githubusercontent.com/lazerg/scalar/assets-9964/before-9964.png" width="660" />

### After

<img alt="After: the oneOf selector shows the variant's own name, Cat" src="https://raw.githubusercontent.com/lazerg/scalar/assets-9964/after-9964.png" width="660" />

## Solution

`optimizeValueForDisplay` flattens a variant's single-item `allOf` by merging the resolved base schema into it. The resolved base keeps its own `$ref` (so refs still work elsewhere), and that `$ref` was merged in last, overwriting the variant's own identity. The base's `$ref` is now dropped before merging, so the variant keeps its own name.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

Closes #9964