### PR TITLE
fix(api-reference): move the schema pattern chip next to the example chip

### DIFF
--- a/.changeset/pattern-margin-fix.md
+++ b/.changeset/pattern-margin-fix.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Move the schema `Pattern` hover chip next to the `Example` chip so it no longer collides with the preceding constraint (for example `max length: 26Pattern`). Real constraints like length and `nullable` now stay together in the dotted list.

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -408,11 +408,6 @@ const patternValue = computed(() => {
         {{ property.value }}
       </SchemaPropertyDetail>
 
-      <!-- Pattern: shown as hover dropdown to handle long regex -->
-      <SchemaPropertyPattern
-        v-if="patternValue"
-        :pattern="patternValue" />
-
       <!-- Enum indicator -->
       <SchemaPropertyDetail v-if="props.enum">
         {{ translate('common.enum') }}
@@ -462,6 +457,14 @@ const patternValue = computed(() => {
       {{ translate('common.required') }}
     </div>
     <SchemaPropertyDefault :value="props.value?.default" />
+    <!--
+      Pattern is a hover dropdown chip like Examples, not an inline constraint,
+      so it sits beside the example. This keeps the real constraints (length,
+      nullable, …) together in the dotted list. See #9966.
+    -->
+    <SchemaPropertyPattern
+      v-if="patternValue"
+      :pattern="patternValue" />
     <SchemaPropertyExamples
       v-if="props.withExamples"
       :example="exampleValue"


### PR DESCRIPTION
The `Pattern` label was stuck to the constraint before it, so schemas showed `max length: 26Pattern`.

`Pattern` is a hover chip like `Example`, not a real constraint. It was rendered in the middle of the constraint list, which broke the `·` separators and left it with no space. Moving it next to `Example` fixes the spacing and lets the real constraints (length, `nullable`, …) stay together in the dotted list.

## Visual

Before: `max length: 26Pattern  nullable  Example`
After: `string · Id · min length: 26 · max length: 26 · nullable  Pattern  Example`

## Ticket

Fixes #9966