### PR TITLE
fix(api-reference): only render oauth scopes for `oauth2`/`openIdConnect` schemes

### DIFF
--- a/.changeset/fix-9972-oauth-scopes-non-oauth-schemes.md
+++ b/.changeset/fix-9972-oauth-scopes-non-oauth-schemes.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix the "OAuth scopes" section rendering for any security scheme with a non-empty scope array, including `http` and `apiKey` schemes. Scopes are only meaningful for `oauth2` and `openIdConnect` schemes, so the section is now skipped when the resolved scheme is of a different type.

--- a/packages/api-reference/src/features/Operation/components/OperationScopes.test.ts
+++ b/packages/api-reference/src/features/Operation/components/OperationScopes.test.ts
@@ -51,6 +51,19 @@ const scopedOrScopeFree: RequiredSecurity = {
   ],
 }
 
+/**
+ * One OAuth2 alternative with scopes, plus an HTTP bearer alternative that carries
+ * scope-shaped strings. Those strings are not OAuth scopes, so the bearer alternative is
+ * still scope-free and the OAuth scopes remain optional.
+ */
+const scopedOrScopeShapedNonOauth: RequiredSecurity = {
+  state: 'required',
+  requirements: [
+    { schemes: [{ name: 'oauth2', scheme: { type: 'oauth2', flows: {} }, scopes: ['read:items'] }] },
+    { schemes: [{ name: 'bearerToken', scheme: { type: 'http', scheme: 'bearer' }, scopes: ['some:custom:scope'] }] },
+  ],
+}
+
 describe('OperationScopes', () => {
   it('lists every required scope under the heading', () => {
     const wrapper = mount(OperationScopes, { props: { requiredSecurity: withScopes } })
@@ -80,6 +93,16 @@ describe('OperationScopes', () => {
     // scopes are not mandatory because the API key alternative satisfies auth without them.
     expect(wrapper.findAll('ul')).toHaveLength(1)
     expect(wrapper.text()).toContain('read:items')
+    expect(wrapper.text()).toContain('one of:')
+  })
+
+  it('still hints that scopes are optional when the other alternative only carries scope-shaped strings', () => {
+    const wrapper = mount(OperationScopes, { props: { requiredSecurity: scopedOrScopeShapedNonOauth } })
+    // The HTTP bearer alternative lists a scope-shaped string, but it is not an OAuth scope,
+    // so the bearer path counts as scope-free and the "one of" hint must still appear.
+    expect(wrapper.findAll('ul')).toHaveLength(1)
+    expect(wrapper.text()).toContain('read:items')
+    expect(wrapper.text()).not.toContain('some:custom:scope')
     expect(wrapper.text()).toContain('one of:')
   })
 

--- a/packages/api-reference/src/features/Operation/components/OperationScopes.vue
+++ b/packages/api-reference/src/features/Operation/components/OperationScopes.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 
 import { useLocalization } from '@/features/localization'
 import {
+  getEffectiveScopes,
   getRequiredScopeGroups,
   type RequiredSecurity,
 } from '@/features/Operation/helpers/get-required-security'
@@ -28,7 +29,7 @@ const scopeGroups = computed(() => getRequiredScopeGroups(requiredSecurity))
  */
 const hasScopeFreeAlternative = computed(() =>
   requiredSecurity.requirements.some((group) =>
-    group.schemes.every((scheme) => scheme.scopes.length === 0),
+    group.schemes.every((scheme) => getEffectiveScopes(scheme).length === 0),
   ),
 )
 

--- a/packages/api-reference/src/features/Operation/helpers/get-required-security.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-required-security.test.ts
@@ -237,46 +237,79 @@ describe('getRequiredSecurity', () => {
       expect(result.requirements[0]?.schemes.map((s) => s.name)).toStrictEqual(['oauth2', 'apiKey'])
     })
   })
-})
 
-describe('getRequiredScopeGroups', () => {
-  it('collects scopes for oauth2 schemes', () => {
-    const result = getRequiredSecurity(
-      { security: [{ oauth2: ['read:items'] }] },
-      { components: { securitySchemes: { oauth2: { type: 'oauth2', flows: {} } } } },
-    )
-    expect(getRequiredScopeGroups(result)).toEqual([['read:items']])
-  })
+  describe('getRequiredScopeGroups', () => {
+    it('collects scopes for oauth2 schemes', () => {
+      const result = getRequiredSecurity(
+        { security: [{ oauth2: ['read:items'] }] },
+        { components: { securitySchemes: { oauth2: { type: 'oauth2', flows: {} } } } },
+      )
+      expect(getRequiredScopeGroups(result)).toEqual([['read:items']])
+    })
 
-  it('collects scopes for openIdConnect schemes', () => {
-    const result = getRequiredSecurity(
-      { security: [{ oidc: ['read:items'] }] },
-      { components: { securitySchemes: { oidc: { type: 'openIdConnect', openIdConnectUrl: 'https://example.com' } } } },
-    )
-    expect(getRequiredScopeGroups(result)).toEqual([['read:items']])
-  })
+    it('collects scopes for openIdConnect schemes', () => {
+      const result = getRequiredSecurity(
+        { security: [{ oidc: ['read:items'] }] },
+        {
+          components: { securitySchemes: { oidc: { type: 'openIdConnect', openIdConnectUrl: 'https://example.com' } } },
+        },
+      )
+      expect(getRequiredScopeGroups(result)).toEqual([['read:items']])
+    })
 
-  it('ignores scope-shaped entries on http schemes', () => {
-    const result = getRequiredSecurity(
-      { security: [{ bearerToken: ['some:custom:scope'] }] },
-      { components: { securitySchemes: { bearerToken: { type: 'http', scheme: 'bearer' } } } },
-    )
-    expect(getRequiredScopeGroups(result)).toEqual([])
-  })
+    it('ignores scope-shaped entries on http schemes', () => {
+      const result = getRequiredSecurity(
+        { security: [{ bearerToken: ['some:custom:scope'] }] },
+        { components: { securitySchemes: { bearerToken: { type: 'http', scheme: 'bearer' } } } },
+      )
+      expect(getRequiredScopeGroups(result)).toEqual([])
+    })
 
-  it('ignores scope-shaped entries on apiKey schemes', () => {
-    const result = getRequiredSecurity(
-      { security: [{ apiKey: ['some:custom:scope'] }] },
-      { components: { securitySchemes: { apiKey: { type: 'apiKey', name: 'X-API-Key', in: 'header' } } } },
-    )
-    expect(getRequiredScopeGroups(result)).toEqual([])
-  })
+    it('ignores scope-shaped entries on apiKey schemes', () => {
+      const result = getRequiredSecurity(
+        { security: [{ apiKey: ['some:custom:scope'] }] },
+        { components: { securitySchemes: { apiKey: { type: 'apiKey', name: 'X-API-Key', in: 'header' } } } },
+      )
+      expect(getRequiredScopeGroups(result)).toEqual([])
+    })
 
-  it('keeps scopes for an unresolved scheme (e.g. the AsyncAPI path, which leaves schemes unresolved on purpose)', () => {
-    const result = getRequiredSecurity(
-      { security: [{ unknownScheme: ['some:custom:scope'] }] },
-      { components: { securitySchemes: {} } },
-    )
-    expect(getRequiredScopeGroups(result)).toEqual([['some:custom:scope']])
+    it('keeps scopes for an unresolved scheme (e.g. the AsyncAPI path, which leaves schemes unresolved on purpose)', () => {
+      const result = getRequiredSecurity(
+        { security: [{ unknownScheme: ['some:custom:scope'] }] },
+        { components: { securitySchemes: {} } },
+      )
+      expect(getRequiredScopeGroups(result)).toEqual([['some:custom:scope']])
+    })
+
+    it('collects only the oauth2 scopes from an AND group mixing oauth2 and apiKey', () => {
+      const result = getRequiredSecurity(
+        { security: [{ oauth2: ['read:items'], apiKey: [] }] },
+        {
+          components: {
+            securitySchemes: {
+              oauth2: { type: 'oauth2', flows: {} },
+              apiKey: { type: 'apiKey', name: 'X-API-Key', in: 'header' },
+            },
+          },
+        },
+      )
+      expect(getRequiredScopeGroups(result)).toEqual([['read:items']])
+    })
+
+    it('returns one entry per OR alternative that has scopes, skipping scope-free ones', () => {
+      const result = getRequiredSecurity(
+        { security: [{ oauth2: ['read:items'] }, { bearerToken: ['some:custom:scope'] }, { apiKey: [] }] },
+        {
+          components: {
+            securitySchemes: {
+              oauth2: { type: 'oauth2', flows: {} },
+              bearerToken: { type: 'http', scheme: 'bearer' },
+              apiKey: { type: 'apiKey', name: 'X-API-Key', in: 'header' },
+            },
+          },
+        },
+      )
+      expect(getRequiredScopeGroups(result)).toEqual([['read:items']])
+    })
   })
 })

--- a/packages/api-reference/src/features/Operation/helpers/get-required-security.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-required-security.test.ts
@@ -272,11 +272,11 @@ describe('getRequiredScopeGroups', () => {
     expect(getRequiredScopeGroups(result)).toEqual([])
   })
 
-  it('ignores scopes for schemes not defined on the document', () => {
+  it('keeps scopes for an unresolved scheme (e.g. the AsyncAPI path, which leaves schemes unresolved on purpose)', () => {
     const result = getRequiredSecurity(
       { security: [{ unknownScheme: ['some:custom:scope'] }] },
       { components: { securitySchemes: {} } },
     )
-    expect(getRequiredScopeGroups(result)).toEqual([])
+    expect(getRequiredScopeGroups(result)).toEqual([['some:custom:scope']])
   })
 })

--- a/packages/api-reference/src/features/Operation/helpers/get-required-security.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-required-security.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getRequiredScopeGroups, getRequiredSecurity } from './get-required-security'
+import { getEffectiveScopes, getRequiredScopeGroups, getRequiredSecurity } from './get-required-security'
 
 describe('getRequiredSecurity', () => {
   describe('fallback (operation.security ?? document.security)', () => {
@@ -310,6 +310,44 @@ describe('getRequiredSecurity', () => {
         },
       )
       expect(getRequiredScopeGroups(result)).toEqual([['read:items']])
+    })
+  })
+
+  describe('getEffectiveScopes', () => {
+    it('keeps scopes for oauth2 schemes', () => {
+      expect(
+        getEffectiveScopes({ name: 'oauth2', scheme: { type: 'oauth2', flows: {} }, scopes: ['read:items'] }),
+      ).toEqual(['read:items'])
+    })
+
+    it('keeps scopes for openIdConnect schemes', () => {
+      expect(
+        getEffectiveScopes({
+          name: 'oidc',
+          scheme: { type: 'openIdConnect', openIdConnectUrl: 'https://example.com' },
+          scopes: ['read:items'],
+        }),
+      ).toEqual(['read:items'])
+    })
+
+    it('drops scope-shaped strings for http schemes', () => {
+      expect(
+        getEffectiveScopes({ name: 'bearerToken', scheme: { type: 'http', scheme: 'bearer' }, scopes: ['some:scope'] }),
+      ).toEqual([])
+    })
+
+    it('drops scope-shaped strings for apiKey schemes', () => {
+      expect(
+        getEffectiveScopes({
+          name: 'apiKey',
+          scheme: { type: 'apiKey', name: 'X-API-Key', in: 'header' },
+          scopes: ['some:scope'],
+        }),
+      ).toEqual([])
+    })
+
+    it('keeps scopes for an unresolved scheme, whose type is unknown', () => {
+      expect(getEffectiveScopes({ name: 'unknown', scheme: undefined, scopes: ['some:scope'] })).toEqual(['some:scope'])
     })
   })
 })

--- a/packages/api-reference/src/features/Operation/helpers/get-required-security.test.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-required-security.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getRequiredSecurity } from './get-required-security'
+import { getRequiredScopeGroups, getRequiredSecurity } from './get-required-security'
 
 describe('getRequiredSecurity', () => {
   describe('fallback (operation.security ?? document.security)', () => {
@@ -236,5 +236,47 @@ describe('getRequiredSecurity', () => {
       expect(result.requirements).toHaveLength(1)
       expect(result.requirements[0]?.schemes.map((s) => s.name)).toStrictEqual(['oauth2', 'apiKey'])
     })
+  })
+})
+
+describe('getRequiredScopeGroups', () => {
+  it('collects scopes for oauth2 schemes', () => {
+    const result = getRequiredSecurity(
+      { security: [{ oauth2: ['read:items'] }] },
+      { components: { securitySchemes: { oauth2: { type: 'oauth2', flows: {} } } } },
+    )
+    expect(getRequiredScopeGroups(result)).toEqual([['read:items']])
+  })
+
+  it('collects scopes for openIdConnect schemes', () => {
+    const result = getRequiredSecurity(
+      { security: [{ oidc: ['read:items'] }] },
+      { components: { securitySchemes: { oidc: { type: 'openIdConnect', openIdConnectUrl: 'https://example.com' } } } },
+    )
+    expect(getRequiredScopeGroups(result)).toEqual([['read:items']])
+  })
+
+  it('ignores scope-shaped entries on http schemes', () => {
+    const result = getRequiredSecurity(
+      { security: [{ bearerToken: ['some:custom:scope'] }] },
+      { components: { securitySchemes: { bearerToken: { type: 'http', scheme: 'bearer' } } } },
+    )
+    expect(getRequiredScopeGroups(result)).toEqual([])
+  })
+
+  it('ignores scope-shaped entries on apiKey schemes', () => {
+    const result = getRequiredSecurity(
+      { security: [{ apiKey: ['some:custom:scope'] }] },
+      { components: { securitySchemes: { apiKey: { type: 'apiKey', name: 'X-API-Key', in: 'header' } } } },
+    )
+    expect(getRequiredScopeGroups(result)).toEqual([])
+  })
+
+  it('ignores scopes for schemes not defined on the document', () => {
+    const result = getRequiredSecurity(
+      { security: [{ unknownScheme: ['some:custom:scope'] }] },
+      { components: { securitySchemes: {} } },
+    )
+    expect(getRequiredScopeGroups(result)).toEqual([])
   })
 })

--- a/packages/api-reference/src/features/Operation/helpers/get-required-security.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-required-security.ts
@@ -100,6 +100,10 @@ export const getRequiredScopeGroups = (requiredSecurity: RequiredSecurity): stri
     const collected = new Set<string>()
 
     for (const scheme of group.schemes) {
+      if (scheme.scheme?.type !== 'oauth2' && scheme.scheme?.type !== 'openIdConnect') {
+        continue
+      }
+
       for (const scope of scheme.scopes) {
         collected.add(scope)
       }

--- a/packages/api-reference/src/features/Operation/helpers/get-required-security.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-required-security.ts
@@ -82,6 +82,27 @@ export const getRequiredSecurity = (
 }
 
 /**
+ * Scopes that carry OAuth meaning for a scheme. Only `oauth2` and `openIdConnect` schemes
+ * have real scopes; anything else (for example `http` bearer or `apiKey`) can list
+ * scope-shaped strings in a `security` requirement, but those are not OAuth scopes and are
+ * dropped here.
+ *
+ * A scheme with no resolved definition (name not defined on the document, or, as the
+ * AsyncAPI path does on purpose, left unresolved) keeps its scopes — the type is unknown,
+ * so we cannot rule them out.
+ *
+ * This is the single source of truth for "does this scheme contribute scopes?", shared by
+ * every consumer so they never disagree about what counts as a scope.
+ */
+export const getEffectiveScopes = (scheme: RequiredSecurityScheme): string[] => {
+  if (scheme.scheme && scheme.scheme.type !== 'oauth2' && scheme.scheme.type !== 'openIdConnect') {
+    return []
+  }
+
+  return scheme.scopes
+}
+
+/**
  * Required OAuth scopes grouped by security alternative (OR).
  *
  * Each returned array is the de-duplicated set of scopes for one alternative, kept in
@@ -92,9 +113,6 @@ export const getRequiredSecurity = (
  * Grouping is preserved intentionally: unioning scopes across alternatives would imply
  * that mutually exclusive scope sets are all required at once, which misstates OpenAPI
  * OR semantics.
- *
- * A scheme with no resolved definition (name not defined on the document, or, as the
- * AsyncAPI path does on purpose, left unresolved) still contributes its scopes.
  */
 export const getRequiredScopeGroups = (requiredSecurity: RequiredSecurity): string[][] => {
   const groups: string[][] = []
@@ -103,11 +121,7 @@ export const getRequiredScopeGroups = (requiredSecurity: RequiredSecurity): stri
     const collected = new Set<string>()
 
     for (const scheme of group.schemes) {
-      if (scheme.scheme && scheme.scheme.type !== 'oauth2' && scheme.scheme.type !== 'openIdConnect') {
-        continue
-      }
-
-      for (const scope of scheme.scopes) {
+      for (const scope of getEffectiveScopes(scheme)) {
         collected.add(scope)
       }
     }

--- a/packages/api-reference/src/features/Operation/helpers/get-required-security.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-required-security.ts
@@ -100,7 +100,8 @@ export const getRequiredScopeGroups = (requiredSecurity: RequiredSecurity): stri
     const collected = new Set<string>()
 
     for (const scheme of group.schemes) {
-      if (scheme.scheme?.type !== 'oauth2' && scheme.scheme?.type !== 'openIdConnect') {
+      // Skip only schemes resolved to a non-OAuth type; an unresolved scheme (e.g. the AsyncAPI path, which leaves schemes unresolved on purpose) still carries its scopes through.
+      if (scheme.scheme && scheme.scheme.type !== 'oauth2' && scheme.scheme.type !== 'openIdConnect') {
         continue
       }
 

--- a/packages/api-reference/src/features/Operation/helpers/get-required-security.ts
+++ b/packages/api-reference/src/features/Operation/helpers/get-required-security.ts
@@ -92,6 +92,9 @@ export const getRequiredSecurity = (
  * Grouping is preserved intentionally: unioning scopes across alternatives would imply
  * that mutually exclusive scope sets are all required at once, which misstates OpenAPI
  * OR semantics.
+ *
+ * A scheme with no resolved definition (name not defined on the document, or, as the
+ * AsyncAPI path does on purpose, left unresolved) still contributes its scopes.
  */
 export const getRequiredScopeGroups = (requiredSecurity: RequiredSecurity): string[][] => {
   const groups: string[][] = []
@@ -100,7 +103,6 @@ export const getRequiredScopeGroups = (requiredSecurity: RequiredSecurity): stri
     const collected = new Set<string>()
 
     for (const scheme of group.schemes) {
-      // Skip only schemes resolved to a non-OAuth type; an unresolved scheme (e.g. the AsyncAPI path, which leaves schemes unresolved on purpose) still carries its scopes through.
       if (scheme.scheme && scheme.scheme.type !== 'oauth2' && scheme.scheme.type !== 'openIdConnect') {
         continue
       }


### PR DESCRIPTION
## Problem

The "OAuth scopes" section renders for any security scheme that has a non-empty scope array, not just `oauth2`/`openIdConnect` schemes. An `http` bearer scheme with scope-like strings in its `security` requirement gets an "OAuth scopes" section too, even though there's no OAuth2 flow or OIDC discovery document anywhere in the spec.

### Before

<img src="https://raw.githubusercontent.com/lazerg/scalar/assets-9972/before-9972.png" width="600" />

### After

<img src="https://raw.githubusercontent.com/lazerg/scalar/assets-9972/after-9972.png" width="600" />

## Solution

`getRequiredScopeGroups` now checks the resolved scheme's `type` before collecting its scopes, skipping anything that isn't `oauth2` or `openIdConnect`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

Closes #9972