### PR TITLE
feat(hono): serve the API reference and OpenAPI document together with Scalar.serve()

### DIFF
--- a/.changeset/hono-scalar-serve.md
+++ b/.changeset/hono-scalar-serve.md
@@ -2,4 +2,4 @@
 '@scalar/hono-api-reference': minor
 ---
 
-Add `Scalar.serve()` to render the API reference and serve its OpenAPI document from a single mount. Instead of wiring a separate document route and keeping the reference's `url` in sync, mount it once with `app.route('/reference', Scalar.serve({ document }))`. `document` accepts an OpenAPI object or a function that returns one (for example `() => app.getOpenAPI31Document(...)` from Zod OpenAPI Hono), and the JSON path is configurable via `specPath`.
+Add `Scalar.serve()` to render the API reference and serve its OpenAPI document from a single mount. Instead of wiring a separate document route and keeping the reference's `url` in sync, mount it once with `app.route('/scalar', Scalar.serve({ document }))`. `document` accepts an OpenAPI object or a function that returns one (for example `() => app.getOpenAPI31Document(...)` from Zod OpenAPI Hono), and the JSON path is configurable via `specPath`.

--- a/.changeset/hono-scalar-serve.md
+++ b/.changeset/hono-scalar-serve.md
@@ -1,0 +1,5 @@
+---
+'@scalar/hono-api-reference': minor
+---
+
+Add `Scalar.serve()` to render the API reference and serve its OpenAPI document from a single mount. Instead of wiring a separate document route and keeping the reference's `url` in sync, mount it once with `app.route('/reference', Scalar.serve({ document }))`. `document` accepts an OpenAPI object or a function that returns one (for example `() => app.getOpenAPI31Document(...)` from Zod OpenAPI Hono), and the JSON path is configurable via `specPath`.

--- a/.changeset/hono-scalar-serve.md
+++ b/.changeset/hono-scalar-serve.md
@@ -2,4 +2,4 @@
 '@scalar/hono-api-reference': minor
 ---
 
-Add `Scalar.serve()` to render the API reference and serve its OpenAPI document from a single mount. Instead of wiring a separate document route and keeping the reference's `url` in sync, mount it once with `app.route('/scalar', Scalar.serve({ document }))`. `document` accepts an OpenAPI object or a function that returns one (for example `() => app.getOpenAPI31Document(...)` from Zod OpenAPI Hono), and the JSON path is configurable via `specPath`.
+Add `Scalar.serve()` to render the API reference and serve its OpenAPI document from a single mount. Instead of wiring a separate document route and keeping the reference's `url` in sync, mount it once with `app.route('/scalar', Scalar.serve({ document }))`. `document` accepts an OpenAPI object or a function that returns one (for example `() => app.getOpenAPI31Document(...)` from Zod OpenAPI Hono), and the JSON path is configurable via `documentPath`.

--- a/documentation/integrations/hono.md
+++ b/documentation/integrations/hono.md
@@ -48,9 +48,9 @@ const app = new OpenAPIHono()
 
 // ... register your routes ...
 
-// Renders the reference at /reference and serves the document at /reference/openapi.json
+// Renders the reference at /scalar and serves the document at /scalar/openapi.json
 app.route(
-  '/reference',
+  '/scalar',
   Scalar.serve({
     document: () =>
       app.getOpenAPI31Document({

--- a/documentation/integrations/hono.md
+++ b/documentation/integrations/hono.md
@@ -36,6 +36,35 @@ export default app
 
 The Hono middleware takes our universal configuration object, [read more about configuration](../configuration.md) in the core package README.
 
+### Serve the reference and document together
+
+With the middleware above you serve the OpenAPI document on one route and point the reference at it on another. If you generate your document with [Zod OpenAPI Hono](https://github.com/honojs/middleware/tree/main/packages/zod-openapi), `Scalar.serve` does both from a single mount, so you do not have to add a separate document route and keep its `url` in sync:
+
+```typescript
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { Scalar } from '@scalar/hono-api-reference'
+
+const app = new OpenAPIHono()
+
+// ... register your routes ...
+
+// Renders the reference at /reference and serves the document at /reference/openapi.json
+app.route(
+  '/reference',
+  Scalar.serve({
+    document: () =>
+      app.getOpenAPI31Document({
+        openapi: '3.1.0',
+        info: { title: 'Example', version: 'v1' },
+      }),
+  }),
+)
+
+export default app
+```
+
+`document` can be the OpenAPI object itself or a function that returns it. The function receives the Hono `Context`, so you can read `c.env` or `c.req` and build the document per request. Pass any other [configuration option](../configuration.md) (such as `theme` or `pageTitle`) alongside `document`, and change where the JSON is served with `specPath` (defaults to `/openapi.json`).
+
 ### Themes
 
 The middleware comes with a custom theme for Hono. You can use one of [the other predefined themes](https://github.com/scalar/scalar/blob/main/packages/themes/src/index.ts#L15) (`alternate`, `default`, `moon`, `purple`, `solarized`) or overwrite it with `none`. All themes come with a light and dark color scheme.

--- a/documentation/integrations/hono.md
+++ b/documentation/integrations/hono.md
@@ -63,7 +63,7 @@ app.route(
 export default app
 ```
 
-`document` can be the OpenAPI object itself or a function that returns it. The function receives the Hono `Context`, so you can read `c.env` or `c.req` and build the document per request. Pass any other [configuration option](../configuration.md) (such as `theme` or `pageTitle`) alongside `document`, and change where the JSON is served with `specPath` (defaults to `/openapi.json`).
+`document` can be the OpenAPI object itself or a function that returns it. The function receives the Hono `Context`, so you can read `c.env` or `c.req` and build the document per request. Pass any other [configuration option](../configuration.md) (such as `theme` or `pageTitle`) alongside `document`, and change where the JSON is served with `documentPath` (defaults to `/openapi.json`).
 
 ### Themes
 

--- a/integrations/hono/playground/index.ts
+++ b/integrations/hono/playground/index.ts
@@ -197,6 +197,20 @@ app.get(
   }),
 )
 
+// One line to serve the reference and the OpenAPI document together.
+// Renders the reference at `/reference` and the document at `/reference/openapi.json`.
+app.route(
+  '/reference',
+  Scalar.serve({
+    document: () =>
+      app.getOpenAPI31Document({
+        openapi: '3.1.0',
+        info: { title: 'Example', version: 'v1' },
+      }),
+    pageTitle: 'Hono API Reference (Scalar.serve)',
+  }),
+)
+
 // Markdown for LLMs
 const content = app.getOpenAPI31Document({
   openapi: '3.1.0',

--- a/integrations/hono/playground/index.ts
+++ b/integrations/hono/playground/index.ts
@@ -198,9 +198,9 @@ app.get(
 )
 
 // One line to serve the reference and the OpenAPI document together.
-// Renders the reference at `/reference` and the document at `/reference/openapi.json`.
+// Renders the reference at `/scalar` and the document at `/scalar/openapi.json`.
 app.route(
-  '/reference',
+  '/scalar',
   Scalar.serve({
     document: () =>
       app.getOpenAPI31Document({

--- a/integrations/hono/src/index.ts
+++ b/integrations/hono/src/index.ts
@@ -8,4 +8,5 @@ export {
   Scalar as apiReference,
 }
 
+export type { ServeConfiguration } from './scalar'
 export type { ApiReferenceConfiguration } from './types'

--- a/integrations/hono/src/scalar.test.ts
+++ b/integrations/hono/src/scalar.test.ts
@@ -282,9 +282,9 @@ describe('Scalar', () => {
 
     it('serves the OpenAPI document as JSON at the mount point', async () => {
       const app = new Hono()
-      app.route('/reference', Scalar.serve({ document }))
+      app.route('/scalar', Scalar.serve({ document }))
 
-      const response = await app.request('/reference/openapi.json')
+      const response = await app.request('/scalar/openapi.json')
       expect(response.status).toBe(200)
       expect(response.headers.get('content-type')).toContain('application/json')
       expect(await response.json()).toEqual(document)
@@ -292,50 +292,50 @@ describe('Scalar', () => {
 
     it('renders the reference at the mount point, pointing at the served document', async () => {
       const app = new Hono()
-      app.route('/reference', Scalar.serve({ document }))
+      app.route('/scalar', Scalar.serve({ document }))
 
-      const response = await app.request('/reference')
+      const response = await app.request('/scalar')
       expect(response.status).toBe(200)
       expect(response.headers.get('content-type')).toContain('text/html')
 
       const text = await response.text()
       expect(text).toContain('<title>Scalar API Reference</title>')
       // The reference points at the document we serve alongside it
-      expect(text).toContain('/reference/openapi.json')
+      expect(text).toContain('/scalar/openapi.json')
       // The document is referenced by URL, not inlined
       expect(text).not.toContain('Serve API')
     })
 
     it('serves the document at a custom specPath', async () => {
       const app = new Hono()
-      app.route('/reference', Scalar.serve({ document, specPath: '/spec.json' }))
+      app.route('/scalar', Scalar.serve({ document, specPath: '/spec.json' }))
 
-      const json = await app.request('/reference/spec.json')
+      const json = await app.request('/scalar/spec.json')
       expect(json.status).toBe(200)
       expect(await json.json()).toEqual(document)
 
-      const html = await (await app.request('/reference')).text()
-      expect(html).toContain('/reference/spec.json')
+      const html = await (await app.request('/scalar')).text()
+      expect(html).toContain('/scalar/spec.json')
     })
 
     it('resolves the document from a function with access to the context', async () => {
       const app = new Hono()
       app.route(
-        '/reference',
+        '/scalar',
         Scalar.serve({
           document: (c) => ({ ...document, info: { ...document.info, title: c.req.path } }),
         }),
       )
 
-      const response = await app.request('/reference/openapi.json')
-      expect(await response.json()).toMatchObject({ info: { title: '/reference/openapi.json' } })
+      const response = await app.request('/scalar/openapi.json')
+      expect(await response.json()).toMatchObject({ info: { title: '/scalar/openapi.json' } })
     })
 
     it('passes through reference options like pageTitle and theme', async () => {
       const app = new Hono()
-      app.route('/reference', Scalar.serve({ document, pageTitle: 'Serve Title', theme: 'kepler' }))
+      app.route('/scalar', Scalar.serve({ document, pageTitle: 'Serve Title', theme: 'kepler' }))
 
-      const text = await (await app.request('/reference')).text()
+      const text = await (await app.request('/scalar')).text()
       expect(text).toContain('<title>Serve Title</title>')
       // A theme was provided, so the custom Hono theme CSS is not injected
       expect(text).not.toContain('--scalar-color-1: rgba(255, 255, 245, .86);')
@@ -343,9 +343,9 @@ describe('Scalar', () => {
 
     it('includes the hono integration marker and the custom theme by default', async () => {
       const app = new Hono()
-      app.route('/reference', Scalar.serve({ document }))
+      app.route('/scalar', Scalar.serve({ document }))
 
-      const text = await (await app.request('/reference')).text()
+      const text = await (await app.request('/scalar')).text()
       expect(text).toContain('_integration": "hono"')
       expect(text).toContain('--scalar-color-1: rgba(255, 255, 245, .86);')
     })

--- a/integrations/hono/src/scalar.test.ts
+++ b/integrations/hono/src/scalar.test.ts
@@ -272,4 +272,93 @@ describe('Scalar', () => {
     expect(text).toContain('Test API')
     expect(text).toContain('deepSpace')
   })
+
+  describe('serve', () => {
+    const document = {
+      openapi: '3.1.0',
+      info: { title: 'Serve API', version: '1.0.0' },
+      paths: {},
+    }
+
+    it('serves the OpenAPI document as JSON at the mount point', async () => {
+      const app = new Hono()
+      app.route('/reference', Scalar.serve({ document }))
+
+      const response = await app.request('/reference/openapi.json')
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toContain('application/json')
+      expect(await response.json()).toEqual(document)
+    })
+
+    it('renders the reference at the mount point, pointing at the served document', async () => {
+      const app = new Hono()
+      app.route('/reference', Scalar.serve({ document }))
+
+      const response = await app.request('/reference')
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toContain('text/html')
+
+      const text = await response.text()
+      expect(text).toContain('<title>Scalar API Reference</title>')
+      // The reference points at the document we serve alongside it
+      expect(text).toContain('/reference/openapi.json')
+      // The document is referenced by URL, not inlined
+      expect(text).not.toContain('Serve API')
+    })
+
+    it('serves the document at a custom specPath', async () => {
+      const app = new Hono()
+      app.route('/reference', Scalar.serve({ document, specPath: '/spec.json' }))
+
+      const json = await app.request('/reference/spec.json')
+      expect(json.status).toBe(200)
+      expect(await json.json()).toEqual(document)
+
+      const html = await (await app.request('/reference')).text()
+      expect(html).toContain('/reference/spec.json')
+    })
+
+    it('resolves the document from a function with access to the context', async () => {
+      const app = new Hono()
+      app.route(
+        '/reference',
+        Scalar.serve({
+          document: (c) => ({ ...document, info: { ...document.info, title: c.req.path } }),
+        }),
+      )
+
+      const response = await app.request('/reference/openapi.json')
+      expect(await response.json()).toMatchObject({ info: { title: '/reference/openapi.json' } })
+    })
+
+    it('passes through reference options like pageTitle and theme', async () => {
+      const app = new Hono()
+      app.route('/reference', Scalar.serve({ document, pageTitle: 'Serve Title', theme: 'kepler' }))
+
+      const text = await (await app.request('/reference')).text()
+      expect(text).toContain('<title>Serve Title</title>')
+      // A theme was provided, so the custom Hono theme CSS is not injected
+      expect(text).not.toContain('--scalar-color-1: rgba(255, 255, 245, .86);')
+    })
+
+    it('includes the hono integration marker and the custom theme by default', async () => {
+      const app = new Hono()
+      app.route('/reference', Scalar.serve({ document }))
+
+      const text = await (await app.request('/reference')).text()
+      expect(text).toContain('_integration": "hono"')
+      expect(text).toContain('--scalar-color-1: rgba(255, 255, 245, .86);')
+    })
+
+    it('works when mounted at the root', async () => {
+      const app = new Hono()
+      app.route('/', Scalar.serve({ document }))
+
+      const html = await (await app.request('/')).text()
+      expect(html).toContain('/openapi.json')
+
+      const json = await app.request('/openapi.json')
+      expect(await json.json()).toEqual(document)
+    })
+  })
 })

--- a/integrations/hono/src/scalar.test.ts
+++ b/integrations/hono/src/scalar.test.ts
@@ -306,9 +306,9 @@ describe('Scalar', () => {
       expect(text).not.toContain('Serve API')
     })
 
-    it('serves the document at a custom specPath', async () => {
+    it('serves the document at a custom documentPath', async () => {
       const app = new Hono()
-      app.route('/scalar', Scalar.serve({ document, specPath: '/spec.json' }))
+      app.route('/scalar', Scalar.serve({ document, documentPath: '/spec.json' }))
 
       const json = await app.request('/scalar/spec.json')
       expect(json.status).toBe(200)

--- a/integrations/hono/src/scalar.ts
+++ b/integrations/hono/src/scalar.ts
@@ -121,7 +121,7 @@ export type ServeConfiguration<E extends Env> = Omit<Partial<ApiReferenceConfigu
    *
    * @example
    * ```ts
-   * app.route('/reference', Scalar.serve({
+   * app.route('/scalar', Scalar.serve({
    *   document: () => app.getOpenAPI31Document({ openapi: '3.1.0', info: { title: 'Example', version: 'v1' } }),
    * }))
    * ```
@@ -148,8 +148,8 @@ export type ServeConfiguration<E extends Env> = Omit<Partial<ApiReferenceConfigu
  * ```ts
  * import { Scalar } from '@scalar/hono-api-reference'
  *
- * // Serves the reference at `/reference` and the document at `/reference/openapi.json`
- * app.route('/reference', Scalar.serve({ document: myOpenApiDocument }))
+ * // Serves the reference at `/scalar` and the document at `/scalar/openapi.json`
+ * app.route('/scalar', Scalar.serve({ document: myOpenApiDocument }))
  * ```
  */
 const scalarServe = <E extends Env>(options: ServeConfiguration<E>): Hono<E> => {

--- a/integrations/hono/src/scalar.ts
+++ b/integrations/hono/src/scalar.ts
@@ -1,5 +1,6 @@
 import { renderApiReference } from '@scalar/client-side-rendering'
 import type { Context, Env, MiddlewareHandler } from 'hono'
+import { Hono } from 'hono'
 
 import type { ApiReferenceConfiguration } from './types'
 
@@ -72,7 +73,7 @@ type Configuration<E extends Env> =
 /**
  * The Hono middleware for the Scalar API Reference.
  */
-export const Scalar = <E extends Env>(configOrResolver: Configuration<E>): MiddlewareHandler<E> => {
+const scalarMiddleware = <E extends Env>(configOrResolver: Configuration<E>): MiddlewareHandler<E> => {
   return async (c) => {
     let resolvedConfig: Partial<ApiReferenceConfiguration> = {}
 
@@ -93,3 +94,97 @@ export const Scalar = <E extends Env>(configOrResolver: Configuration<E>): Middl
     return c.html(renderApiReference({ config, pageTitle, cdn, nonce }, customTheme))
   }
 }
+
+/**
+ * An OpenAPI document.
+ *
+ * Typed loosely as an object on purpose, so it accepts both plain document objects and the typed
+ * return values of generators like Zod OpenAPI Hono's `getOpenAPI31Document()`, whose interfaces do
+ * not carry an index signature.
+ */
+type OpenApiDocument = object
+
+/**
+ * The configuration for `Scalar.serve`.
+ *
+ * On top of the universal API Reference configuration, this takes the OpenAPI `document` to render
+ * and expose. Because `Scalar.serve` sources the document itself, `content` and `url` are managed for
+ * you and are not accepted here.
+ */
+export type ServeConfiguration<E extends Env> = Omit<Partial<ApiReferenceConfiguration>, 'content' | 'url'> & {
+  /**
+   * The OpenAPI document to render and serve.
+   *
+   * Pass the document directly, or a function that returns it. The function receives the Hono
+   * `Context`, so it can read `c.env` or `c.req` and build the document per request. This is also how
+   * you wire up an `OpenAPIHono` app:
+   *
+   * @example
+   * ```ts
+   * app.route('/reference', Scalar.serve({
+   *   document: () => app.getOpenAPI31Document({ openapi: '3.1.0', info: { title: 'Example', version: 'v1' } }),
+   * }))
+   * ```
+   */
+  document: OpenApiDocument | ((c: Context<E>) => OpenApiDocument | Promise<OpenApiDocument>)
+  /**
+   * Path, relative to the mount point, where the OpenAPI document is served as JSON.
+   *
+   * @default '/openapi.json'
+   */
+  specPath?: string
+}
+
+/**
+ * Serve the API Reference and its OpenAPI document together as a mountable Hono app.
+ *
+ * Unlike the `Scalar` middleware — which only renders the reference and expects the document to live
+ * somewhere else — this exposes both from a single call, so you do not have to wire up a separate
+ * document route and keep its `url` in sync.
+ *
+ * Mount it with `app.route(...)`:
+ *
+ * @example
+ * ```ts
+ * import { Scalar } from '@scalar/hono-api-reference'
+ *
+ * // Serves the reference at `/reference` and the document at `/reference/openapi.json`
+ * app.route('/reference', Scalar.serve({ document: myOpenApiDocument }))
+ * ```
+ */
+const scalarServe = <E extends Env>(options: ServeConfiguration<E>): Hono<E> => {
+  const { document, specPath = '/openapi.json', ...rest } = options
+
+  const app = new Hono<E>()
+
+  const resolveDocument = (c: Context<E>): OpenApiDocument | Promise<OpenApiDocument> =>
+    typeof document === 'function' ? document(c) : document
+
+  // Expose the OpenAPI document as JSON, so a single call powers both the reference and its source.
+  app.get(specPath, async (c) => c.json(await resolveDocument(c)))
+
+  // Render the reference, pointing it at the document we expose above.
+  app.get('/', (c) => {
+    // Build a root-absolute URL to the document from the current request path. This keeps the
+    // reference working wherever it is mounted, and whether or not the request has a trailing slash.
+    const url = `${c.req.path.replace(/\/+$/, '')}${specPath}`
+
+    const { cdn, pageTitle, nonce, ...config } = {
+      ...DEFAULT_CONFIGURATION,
+      ...rest,
+      url,
+    }
+
+    return c.html(renderApiReference({ config, pageTitle, cdn, nonce }, customTheme))
+  })
+
+  return app
+}
+
+/**
+ * Render the Scalar API Reference in a Hono app.
+ *
+ * Use `Scalar(...)` as a middleware to render the reference on a route, or `Scalar.serve(...)` to
+ * serve the reference and its OpenAPI document together from a single mount.
+ */
+export const Scalar = Object.assign(scalarMiddleware, { serve: scalarServe })

--- a/integrations/hono/src/scalar.ts
+++ b/integrations/hono/src/scalar.ts
@@ -132,7 +132,7 @@ export type ServeConfiguration<E extends Env> = Omit<Partial<ApiReferenceConfigu
    *
    * @default '/openapi.json'
    */
-  specPath?: string
+  documentPath?: string
 }
 
 /**
@@ -153,7 +153,7 @@ export type ServeConfiguration<E extends Env> = Omit<Partial<ApiReferenceConfigu
  * ```
  */
 const scalarServe = <E extends Env>(options: ServeConfiguration<E>): Hono<E> => {
-  const { document, specPath = '/openapi.json', ...rest } = options
+  const { document, documentPath = '/openapi.json', ...rest } = options
 
   const app = new Hono<E>()
 
@@ -161,13 +161,13 @@ const scalarServe = <E extends Env>(options: ServeConfiguration<E>): Hono<E> => 
     typeof document === 'function' ? document(c) : document
 
   // Expose the OpenAPI document as JSON, so a single call powers both the reference and its source.
-  app.get(specPath, async (c) => c.json(await resolveDocument(c)))
+  app.get(documentPath, async (c) => c.json(await resolveDocument(c)))
 
   // Render the reference, pointing it at the document we expose above.
   app.get('/', (c) => {
     // Build a root-absolute URL to the document from the current request path. This keeps the
     // reference working wherever it is mounted, and whether or not the request has a trailing slash.
-    const url = `${c.req.path.replace(/\/+$/, '')}${specPath}`
+    const url = `${c.req.path.replace(/\/+$/, '')}${documentPath}`
 
     const { cdn, pageTitle, nonce, ...config } = {
       ...DEFAULT_CONFIGURATION,


### PR DESCRIPTION
Adds `Scalar.serve()` to the Hono integration so you can mount the API reference **and** its OpenAPI document with a single call, instead of wiring a separate document route and keeping the reference's `url` in sync.

```ts
import { OpenAPIHono } from '@hono/zod-openapi'
import { Scalar } from '@scalar/hono-api-reference'

const app = new OpenAPIHono()
// ...routes...

// reference at /scalar, document at /scalar/openapi.json
app.route('/scalar', Scalar.serve({
  document: () => app.getOpenAPI31Document({ openapi: '3.1.0', info: { title: 'Example', version: 'v1' } }),
}))
```

`document` accepts an OpenAPI object or a `(c) => document` function (so it can read `c.env`/`c.req`), and the JSON path is configurable via `documentPath` (default `/openapi.json`). The reference points at a root-absolute URL derived from the request path, so it works at any mount point regardless of trailing slash.

`Scalar.serve()` returns a mountable Hono app, so the route is explicit at the mount (idiomatic Hono) — the examples use `/scalar` to match the existing middleware docs.

Fully additive — the existing `Scalar(...)` middleware is untouched. `.serve` is attached via `Object.assign`, so `Scalar()` and `Scalar<{ Bindings }>()` keep working.

## Why

The most common first step for a Hono user was wiring two routes by hand. This collapses it to one line and is the thinnest fix for the biggest DX gap in the integration.

## Tests

8 new unit tests (mount root, document serving, custom `documentPath`, function document, option pass-through, root mount). Also verified live against the playground in a browser: `GET /scalar` renders the reference and `GET /scalar/openapi.json` returns the document.