### PR TITLE
ci: adopt the Chromium-only playwright-runner 1.62.1 image

### DIFF
--- a/.changeset/playwright-runner-1-62-1.md
+++ b/.changeset/playwright-runner-1-62-1.md
@@ -1,0 +1,7 @@
+---
+'@scalar/helpers': patch
+---
+
+chore: bump the default Playwright runner image to 1.62.1
+
+`getDockerServer` now defaults to the Chromium-only `scalarapi/playwright-runner:1.62.1` image, matching the `@playwright/test` version used across the workspace so the client and container speak the same protocol.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
-      image: scalarapi/playwright-runner:1.59.1
+      image: scalarapi/playwright-runner:1.62.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}
@@ -218,7 +218,7 @@ jobs:
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
-      image: scalarapi/playwright-runner:1.59.1
+      image: scalarapi/playwright-runner:1.62.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}
@@ -240,7 +240,7 @@ jobs:
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
-      image: scalarapi/playwright-runner:1.59.1
+      image: scalarapi/playwright-runner:1.62.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -252,7 +252,7 @@ jobs:
     needs: [build]
     runs-on: blacksmith-4vcpu-ubuntu-2204
     container:
-      image: scalarapi/playwright-runner:1.59.1
+      image: scalarapi/playwright-runner:1.62.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}
@@ -310,7 +310,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     environment: production-netlify
     container:
-      image: scalarapi/playwright-runner:1.59.1
+      image: scalarapi/playwright-runner:1.62.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}
@@ -359,7 +359,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     environment: production-netlify
     container:
-      image: scalarapi/playwright-runner:1.59.1
+      image: scalarapi/playwright-runner:1.62.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}
@@ -404,7 +404,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2204
     environment: production-netlify
     container:
-      image: scalarapi/playwright-runner:1.59.1
+      image: scalarapi/playwright-runner:1.62.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}
@@ -452,7 +452,7 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2204
     environment: production-netlify
     container:
-      image: scalarapi/playwright-runner:1.59.1
+      image: scalarapi/playwright-runner:1.62.1
       options: --privileged
       env:
         VM_ID: ${{ env.VM_ID }}

--- a/packages/helpers/src/playwright/docker.ts
+++ b/packages/helpers/src/playwright/docker.ts
@@ -3,7 +3,7 @@ import type { FullConfig } from '@playwright/test'
 export type WebServer = NonNullable<FullConfig['webServer']>
 
 /** Default playwright version */
-export const DEFAULT_PLAYWRIGHT_VERSION = '1.59.1'
+export const DEFAULT_PLAYWRIGHT_VERSION = '1.62.1'
 
 /** Options for getting a docker server */
 type GetDockerServerOptions = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ catalogs:
       specifier: ^11.1.11
       version: 11.1.11
     '@playwright/test':
-      specifier: 1.59.1
-      version: 1.59.1
+      specifier: 1.62.1
+      version: 1.62.1
     '@scalar/sdk':
       specifier: 0.2.6
       version: 0.2.6
@@ -315,7 +315,7 @@ importers:
         version: 4.4.1(@vue/compiler-sfc@3.5.40)(prettier@3.8.0)
       '@playwright/test':
         specifier: catalog:*
-        version: 1.59.1
+        version: 1.62.1
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^5.2.2
         version: 5.2.2(@vue/compiler-sfc@3.5.40)(prettier@3.8.0)(svelte@5.55.2)
@@ -542,7 +542,7 @@ importers:
         version: link:../../integrations/nextjs
       next:
         specifier: catalog:*
-        version: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: catalog:*
         version: 19.2.3
@@ -1064,7 +1064,7 @@ importers:
         version: 6.0.1(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))
       next:
         specifier: catalog:*
-        version: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: catalog:*
         version: 19.2.3
@@ -1523,7 +1523,7 @@ importers:
         version: 1.19.11(hono@4.12.9)
       '@playwright/test':
         specifier: catalog:*
-        version: 1.59.1
+        version: 1.62.1
       '@scalar/core':
         specifier: workspace:*
         version: link:../core
@@ -1814,7 +1814,7 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: catalog:*
-        version: 1.59.1
+        version: 1.62.1
       '@storybook/addon-docs':
         specifier: 10.3.5
         version: 10.3.5(@types/react@19.2.7)(esbuild@0.27.3)(rollup@4.59.0)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))(webpack@5.103.0(esbuild@0.27.3))
@@ -1915,7 +1915,7 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: catalog:*
-        version: 1.59.1
+        version: 1.62.1
       '@scalar/themes':
         specifier: workspace:*
         version: link:../themes
@@ -2097,7 +2097,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       next:
         specifier: catalog:*
-        version: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -2948,7 +2948,7 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: catalog:*
-        version: 1.59.1
+        version: 1.62.1
       '@tailwindcss/vite':
         specifier: catalog:*
         version: 4.3.3(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))
@@ -7785,13 +7785,8 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@playwright/test@1.62.0':
-    resolution: {integrity: sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==}
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -11713,6 +11708,7 @@ packages:
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -15247,23 +15243,13 @@ packages:
     resolution: {integrity: sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==}
     engines: {node: '>=16.0.0'}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright-core@1.62.0:
-    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
     engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.62.0:
-    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -25359,14 +25345,9 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.62.1':
     dependencies:
-      playwright: 1.59.1
-
-  '@playwright/test@1.62.0':
-    dependencies:
-      playwright: 1.62.0
-    optional: true
+      playwright: 1.62.1
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -33760,7 +33741,7 @@ snapshots:
 
   neverpanic@0.0.8: {}
 
-  next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.62.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
@@ -33779,7 +33760,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.5.15
       '@next/swc-win32-x64-msvc': 15.5.15
       '@opentelemetry/api': 1.9.1
-      '@playwright/test': 1.62.0
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -34945,23 +34926,13 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.62.1: {}
 
-  playwright-core@1.62.0:
-    optional: true
-
-  playwright@1.59.1:
+  playwright@1.62.1:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
-
-  playwright@1.62.0:
-    dependencies:
-      playwright-core: 1.62.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    optional: true
 
   plimit-lit@1.6.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalogs:
     '@nestjs/schematics': '^11.0.9'
     '@nestjs/swagger': '^7.3.1'
     '@nestjs/testing': '^11.1.11'
-    '@playwright/test': 1.59.1
+    '@playwright/test': 1.62.1
     '@scalar/typebox': 0.1.3
     '@tailwindcss/cli': ^4.3.3
     '@scalar/sdk': 0.2.6


### PR DESCRIPTION
Follow-up to #9648. That PR flips to the new image, all in lockstep so the local `@playwright/test` and the container always speak the same protocol:

- workflow container `image:` tags (`pr.yml`, `main.yml`) → `1.62.1`
- `@playwright/test` catalog (+ lockfile) → `1.62.1`
- `DEFAULT_PLAYWRIGHT_VERSION` in `@scalar/helpers` → `1.62.1`

Size: 1622.8 MB → 1105.6 MB (amd64, compressed): ~517 MB / 32% smaller per job pull.