### PR TITLE
ci: build the playwright-runner image multi-arch with buildx

### DIFF
--- a/tooling/scripts/README.md
+++ b/tooling/scripts/README.md
@@ -148,12 +148,18 @@ This command builds and pushes Docker images for Playwright testing. It creates 
 - `scalarapi/playwright:${version}` - Base Playwright image
 - `scalarapi/playwright-runner:${version}` - Runner image
 
+Both images are built for `linux/amd64` and `linux/arm64` with buildx and pushed as a
+multi-arch manifest, so the runner works on amd64 CI runners as well as arm64 (Apple
+Silicon) machines. The command creates a reusable `scalar-multiarch` buildx builder on
+first run.
+
 **Usage:**
 ```bash
 pnpm --filter @scalar-internal/build-scripts start update-playwright-docker
 ```
 
-**Note:** This command requires Docker to be installed and configured, and you must have push access to the `scalarapi` Docker Hub organization.
+**Note:** This command requires Docker (with buildx) to be installed and configured, and
+you must have push access to the `scalarapi` Docker Hub organization.
 
 ### `generate-blog`
 

--- a/tooling/scripts/src/commands/playwright-docker/push-container.ts
+++ b/tooling/scripts/src/commands/playwright-docker/push-container.ts
@@ -7,14 +7,28 @@ export const updatePlaywrightDocker = new Command('update-playwright-docker')
   .action(async () => {
     const version = '1.62.1'
 
+    // The runner image runs on linux/amd64 CI runners and is also launched with
+    // `--platform linux/amd64` locally, so the published image must contain amd64.
+    // A plain `docker build` only produces the host architecture, which silently
+    // ships an arm64-only image when the release is cut from an Apple Silicon
+    // machine and breaks CI. Build both architectures with buildx instead.
+    const platforms = 'linux/amd64,linux/arm64'
+
+    // Multi-platform builds need a container-driver builder; the default `docker`
+    // driver can only build a single platform. Create it once, then reuse it.
+    const builder = 'scalar-multiarch'
     await runCommand(
-      `docker build -t "scalarapi/playwright:${version}" --build-arg PLAYWRIGHT_VERSION=${version} ${import.meta.dirname}`,
+      `docker buildx inspect ${builder} > /dev/null 2>&1 || docker buildx create --name ${builder} --driver docker-container --bootstrap`,
+    )
+
+    // `--push` publishes the multi-arch manifest directly, so no separate
+    // `docker push` step is needed.
+    await runCommand(
+      `docker buildx build --builder ${builder} --platform ${platforms} --build-arg PLAYWRIGHT_VERSION=${version} -t "scalarapi/playwright:${version}" --push ${import.meta.dirname}`,
     )
     await runCommand(
-      `docker build -t "scalarapi/playwright-runner:${version}" -f ${import.meta.dirname}/DockerfileRunner --build-arg PLAYWRIGHT_VERSION=${version} ${import.meta.dirname}`,
+      `docker buildx build --builder ${builder} --platform ${platforms} -f ${import.meta.dirname}/DockerfileRunner --build-arg PLAYWRIGHT_VERSION=${version} -t "scalarapi/playwright-runner:${version}" --push ${import.meta.dirname}`,
     )
-    await runCommand(`docker push "scalarapi/playwright:${version}"`)
-    await runCommand(`docker push "scalarapi/playwright-runner:${version}"`)
 
     process.exit()
   })


### PR DESCRIPTION
`update-playwright-docker` used a plain `docker build`, which only builds the host architecture. Cutting a release from an Apple Silicon machine pushes an **arm64-only** image, which then breaks the `linux/amd64` CI runners (and the `--platform linux/amd64` launch in `getDockerServer`) with a platform/manifest mismatch. The existing published tags are multi-arch, so they must have been built by hand — the script never reproduced them.

This switches both image builds to `docker buildx build --platform linux/amd64,linux/arm64 --push`, so every release publishes a multi-arch manifest regardless of the machine it runs on. The script creates a reusable `scalar-multiarch` buildx builder on first run (the default `docker` driver cannot build multiple platforms), and `--push` replaces the separate `docker push` steps.
