### PR TITLE
feat(client-side-rendering): default to the ESM build

### DIFF
--- a/.changeset/client-side-rendering-esm-cdn.md
+++ b/.changeset/client-side-rendering-esm-cdn.md
@@ -1,9 +1,11 @@
 ---
 '@scalar/client-side-rendering': minor
+'@scalar/schemas': minor
+'@scalar/types': minor
 ---
 
-Load the API Reference from the ESM CDN build by default
+Add a `bundle` option to load the modern ESM build of the API Reference
 
-When no `cdn` is set, the generated HTML now loads `@scalar/api-reference` from the short ESM entry (`/esm.js`, added in #9871) as a `<script type="module">` and calls `createApiReference` directly, instead of the monolithic UMD bundle via the `window.Scalar` global. The bundle is code-split, so the heavy interactive parts load after the page has painted and less JavaScript blocks the first render.
+By default the generated HTML still loads the classic UMD bundle via `<script src>` and `window.Scalar` — unchanged. Set `bundle: true` to load the code-split ESM build (`.../@scalar/api-reference/esm.js`, added in #9871) as a `<script type="module">` instead, so less JavaScript blocks the first render. Pass a URL string to point at a specific ESM build. `bundle` takes precedence over `cdn`, and the existing `cdn` option keeps working exactly as before.
 
-Passing a `cdn` keeps working exactly as before: a UMD or version-pinned URL still loads through `<script src>` and `window.Scalar`. Point `cdn` at an ESM entry (`.../esm.js`, or any `.mjs`/`*.esm.js` URL) to opt into the module build. Under a strict `script-src` Content Security Policy the module build loads its chunks through the module loader, so add `'strict-dynamic'` (or allow-list the CDN host).
+Under a strict `script-src` Content Security Policy the ESM build loads its chunks through the module loader, so add `'strict-dynamic'` (or allow-list the CDN host).

--- a/.changeset/client-side-rendering-esm-cdn.md
+++ b/.changeset/client-side-rendering-esm-cdn.md
@@ -4,8 +4,10 @@
 '@scalar/types': minor
 ---
 
-Add a `bundle` option to load the modern ESM build of the API Reference
+Load the modern ESM build of the API Reference by default
 
-By default the generated HTML still loads the classic UMD bundle via `<script src>` and `window.Scalar` — unchanged. Set `bundle: true` to load the code-split ESM build (`.../@scalar/api-reference/esm.js`, added in #9871) as a `<script type="module">` instead, so less JavaScript blocks the first render. Pass a URL string to point at a specific ESM build. `bundle` takes precedence over `cdn`, and the existing `cdn` option keeps working exactly as before.
+The generated HTML now loads the code-split ESM build (`.../@scalar/api-reference/esm.js`, added in #9871) as a `<script type="module">` by default, instead of the monolithic UMD bundle. Because it is code-split, less JavaScript blocks the first render.
+
+To keep the classic UMD bundle (loaded via `<script src>` and the `window.Scalar` global), set `cdn` to a UMD URL — for example to pin a version — or pass `bundle: false`. You can also pass `bundle: 'https://.../esm.js'` to load a specific ESM build.
 
 Under a strict `script-src` Content Security Policy the ESM build loads its chunks through the module loader, so add `'strict-dynamic'` (or allow-list the CDN host).

--- a/.changeset/client-side-rendering-esm-cdn.md
+++ b/.changeset/client-side-rendering-esm-cdn.md
@@ -4,6 +4,6 @@
 
 Load the API Reference from the ESM CDN build by default
 
-The generated HTML now loads `@scalar/api-reference` from the short ESM entry (`/esm.js`, added in #9871) as a `<script type="module">` and calls `createApiReference` directly, instead of the monolithic UMD bundle via the `window.Scalar` global. The browser only downloads the lazy chunks the page actually needs, so the initial JavaScript drops from about 1.04 MB to about 665 KB gzip.
+When no `cdn` is set, the generated HTML now loads `@scalar/api-reference` from the short ESM entry (`/esm.js`, added in #9871) as a `<script type="module">` and calls `createApiReference` directly, instead of the monolithic UMD bundle via the `window.Scalar` global. The bundle is code-split, so the heavy interactive parts load after the page has painted and less JavaScript blocks the first render.
 
-If you pass a custom `cdn`, point it at an ESM build (for example `.../@scalar/api-reference/esm.js`). Under a strict `script-src` Content Security Policy the bundle now loads its chunks through the module loader, so add `'strict-dynamic'` (or allow-list the CDN host).
+Passing a `cdn` keeps working exactly as before: a UMD or version-pinned URL still loads through `<script src>` and `window.Scalar`. Point `cdn` at an ESM entry (`.../esm.js`, or any `.mjs`/`*.esm.js` URL) to opt into the module build. Under a strict `script-src` Content Security Policy the module build loads its chunks through the module loader, so add `'strict-dynamic'` (or allow-list the CDN host).

--- a/.changeset/client-side-rendering-esm-cdn.md
+++ b/.changeset/client-side-rendering-esm-cdn.md
@@ -10,4 +10,4 @@ The generated HTML now loads the code-split ESM build (`.../@scalar/api-referenc
 
 To keep the classic UMD bundle (loaded via `<script src>` and the `window.Scalar` global), set `cdn` to a UMD URL — for example to pin a version — or pass `bundle: false`. You can also pass `bundle: 'https://.../esm.js'` to load a specific ESM build.
 
-Under a strict `script-src` Content Security Policy the ESM build loads its chunks through the module loader, so add `'strict-dynamic'` (or allow-list the CDN host).
+When a `nonce` is set (a strict, nonce-based CSP) the UMD bundle is used automatically, because the ESM build's `import`-loaded chunks cannot be nonced. Pass `bundle: true` to force the ESM build if your CSP uses `'strict-dynamic'`.

--- a/.changeset/client-side-rendering-esm-cdn.md
+++ b/.changeset/client-side-rendering-esm-cdn.md
@@ -1,0 +1,9 @@
+---
+'@scalar/client-side-rendering': minor
+---
+
+Load the API Reference from the ESM CDN build by default
+
+The generated HTML now loads `@scalar/api-reference` from the short ESM entry (`/esm.js`, added in #9871) as a `<script type="module">` and calls `createApiReference` directly, instead of the monolithic UMD bundle via the `window.Scalar` global. The browser only downloads the lazy chunks the page actually needs, so the initial JavaScript drops from about 1.04 MB to about 665 KB gzip.
+
+If you pass a custom `cdn`, point it at an ESM build (for example `.../@scalar/api-reference/esm.js`). Under a strict `script-src` Content Security Policy the bundle now loads its chunks through the module loader, so add `'strict-dynamic'` (or allow-list the CDN host).

--- a/packages/client-side-rendering/README.md
+++ b/packages/client-side-rendering/README.md
@@ -33,8 +33,6 @@ import { renderApiReference } from '@scalar/client-side-rendering'
 
 const html = renderApiReference({
   pageTitle: 'My API Reference',
-  // Load the modern, code-split ESM build (recommended)
-  bundle: true,
   config: {
     url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=json',
   },
@@ -43,13 +41,16 @@ const html = renderApiReference({
 
 ### Choosing the bundle
 
-By default the generated HTML loads the classic UMD bundle via a `<script src>` tag. Set `bundle: true`
-to load the modern ESM build (`.../@scalar/api-reference/esm.js`) as a `<script type="module">`
-instead. Because it is code-split, less JavaScript blocks the first render.
+By default the generated HTML loads the modern, code-split ESM build
+(`.../@scalar/api-reference/esm.js`) as a `<script type="module">`. Because it is code-split, less
+JavaScript blocks the first render.
 
-- `bundle: true` — load the default ESM entry.
-- `bundle: 'https://.../esm.js'` — load a specific ESM build.
-- `cdn: 'https://.../@scalar/api-reference'` — pin a specific UMD build (unchanged, still supported).
+To use the classic UMD bundle instead (loaded via `<script src>` and the `window.Scalar` global):
+
+- `cdn: 'https://.../@scalar/api-reference'` — pin a specific UMD build.
+- `bundle: false` — use the default UMD build.
+
+You can also pass `bundle: 'https://.../esm.js'` to load a specific ESM build.
 
 Under a strict `script-src` Content Security Policy the ESM build loads its chunks through the module
 loader, so add `'strict-dynamic'` (or allow-list the CDN host).

--- a/packages/client-side-rendering/README.md
+++ b/packages/client-side-rendering/README.md
@@ -33,11 +33,26 @@ import { renderApiReference } from '@scalar/client-side-rendering'
 
 const html = renderApiReference({
   pageTitle: 'My API Reference',
+  // Load the modern, code-split ESM build (recommended)
+  bundle: true,
   config: {
     url: 'https://registry.scalar.com/@scalar/apis/galaxy?format=json',
   },
 })
 ```
+
+### Choosing the bundle
+
+By default the generated HTML loads the classic UMD bundle via a `<script src>` tag. Set `bundle: true`
+to load the modern ESM build (`.../@scalar/api-reference/esm.js`) as a `<script type="module">`
+instead. Because it is code-split, less JavaScript blocks the first render.
+
+- `bundle: true` — load the default ESM entry.
+- `bundle: 'https://.../esm.js'` — load a specific ESM build.
+- `cdn: 'https://.../@scalar/api-reference'` — pin a specific UMD build (unchanged, still supported).
+
+Under a strict `script-src` Content Security Policy the ESM build loads its chunks through the module
+loader, so add `'strict-dynamic'` (or allow-list the CDN host).
 
 ## Community
 

--- a/packages/client-side-rendering/README.md
+++ b/packages/client-side-rendering/README.md
@@ -52,8 +52,13 @@ To use the classic UMD bundle instead (loaded via `<script src>` and the `window
 
 You can also pass `bundle: 'https://.../esm.js'` to load a specific ESM build.
 
-Under a strict `script-src` Content Security Policy the ESM build loads its chunks through the module
-loader, so add `'strict-dynamic'` (or allow-list the CDN host).
+#### Content Security Policy
+
+Passing a `nonce` implies a strict, nonce-based CSP. The ESM build loads its chunks with native
+`import`, which cannot carry a nonce, so those requests would be blocked unless your policy also has
+`'strict-dynamic'`. For that reason, **the UMD bundle is used automatically whenever a `nonce` is
+set** — it is a single nonced `<script>` with no follow-up requests. If your CSP uses
+`'strict-dynamic'` (or allow-lists the CDN host), pass `bundle: true` to opt back into the ESM build.
 
 ## Community
 

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -15,9 +15,12 @@ describe('html-rendering', () => {
       expect(html).toContain('<!doctype html>')
       expect(html).toContain('<title>Scalar API Reference</title>')
       expect(html).toContain('body { color: red }')
-      expect(html).toContain('https://cdn.jsdelivr.net/npm/@scalar/api-reference')
+      expect(html).toContain('<script type="module">')
+      expect(html).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
+      )
       expect(html).toContain('<div id="app"></div>')
-      expect(html).toContain("Scalar.createApiReference('#app'")
+      expect(html).toContain("createApiReference('#app'")
     })
 
     it('handles custom page title correctly', () => {
@@ -109,14 +112,13 @@ describe('html-rendering', () => {
       expect(html).toContain('https://example.com/scalar.js')
     })
 
-    it('applies the nonce to the inline script, style and CDN script tags', () => {
+    it('applies the nonce to the module script and style tags', () => {
       const html = renderApiReference({ config: { customCss: 'body { color: red }' }, nonce: 'r4nd0m' })
-      // CDN script
+      // Module script that loads the bundle and initializes it
+      expect(html).toContain('<script type="module" nonce="r4nd0m">')
       expect(html).toContain(
-        '<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" nonce="r4nd0m"></script>',
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
       )
-      // Inline init script
-      expect(html).toContain('<script type="text/javascript" nonce="r4nd0m">')
       // Inline style
       expect(html).toContain('<style type="text/css" nonce="r4nd0m">')
     })
@@ -131,7 +133,7 @@ describe('html-rendering', () => {
       expect(html).not.toContain('nonce=')
       expect(html).not.toContain('csp-nonce')
       expect(html).toContain('<style type="text/css">')
-      expect(html).toContain('<script type="text/javascript">')
+      expect(html).toContain('<script type="module">')
     })
 
     it('escapes the nonce to prevent attribute injection', () => {
@@ -142,14 +144,13 @@ describe('html-rendering', () => {
   })
 
   describe('getScriptTags', () => {
-    it('returns script tags with default CDN', () => {
-      const tags = getScriptTags(
-        apiReferenceConfigurationWithSourceSchema({}),
-        'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+    it('returns a module script with the default ESM CDN', () => {
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}))
+      expect(tags).toContain('<script type="module">')
+      expect(tags).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
       )
-      expect(tags).toContain('<!-- Load the Script -->')
-      expect(tags).toContain('<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>')
-      expect(tags).toContain("Scalar.createApiReference('#app'")
+      expect(tags).toContain("createApiReference('#app'")
     })
 
     it('uses custom CDN when provided', () => {
@@ -157,14 +158,14 @@ describe('html-rendering', () => {
       expect(tags).toContain('https://example.com/script.js')
     })
 
-    it('applies the nonce to both script tags when provided', () => {
+    it('applies the nonce to the module script when provided', () => {
       const tags = getScriptTags(
         apiReferenceConfigurationWithSourceSchema({}),
         'https://example.com/script.js',
         'abc123',
       )
-      expect(tags).toContain('<script src="https://example.com/script.js" nonce="abc123"></script>')
-      expect(tags).toContain('<script type="text/javascript" nonce="abc123">')
+      expect(tags).toContain('<script type="module" nonce="abc123">')
+      expect(tags).toContain("import { createApiReference } from 'https://example.com/script.js'")
     })
 
     it('preserves function properties in configuration', () => {
@@ -245,7 +246,7 @@ describe('html-rendering', () => {
 
       // Check that body contains required elements
       expect(html).toContain('<div id="app"></div>')
-      expect(html).toContain('<script src="https://example.com/script.js"></script>')
+      expect(html).toContain("import { createApiReference } from 'https://example.com/script.js'")
 
       // Check that configuration is properly embedded
       expect(html).toContain('"theme": "kepler"')

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -153,19 +153,43 @@ describe('html-rendering', () => {
       expect(tags).toContain("createApiReference('#app'")
     })
 
-    it('uses custom CDN when provided', () => {
+    it('keeps a non-ESM cdn on the classic UMD script tag for backwards compatibility', () => {
       const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), 'https://example.com/script.js')
-      expect(tags).toContain('https://example.com/script.js')
+      expect(tags).toContain('<script src="https://example.com/script.js"></script>')
+      expect(tags).toContain("Scalar.createApiReference('#app'")
     })
 
-    it('applies the nonce to the module script when provided', () => {
+    it('uses a module script when the cdn points at an ESM entry', () => {
+      const tags = getScriptTags(
+        apiReferenceConfigurationWithSourceSchema({}),
+        'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js',
+      )
+      expect(tags).toContain('<script type="module">')
+      expect(tags).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
+      )
+    })
+
+    it('applies the nonce to the classic script tags for a UMD cdn', () => {
       const tags = getScriptTags(
         apiReferenceConfigurationWithSourceSchema({}),
         'https://example.com/script.js',
         'abc123',
       )
+      expect(tags).toContain('<script src="https://example.com/script.js" nonce="abc123"></script>')
+      expect(tags).toContain('<script type="text/javascript" nonce="abc123">')
+    })
+
+    it('applies the nonce to the module script for an ESM cdn', () => {
+      const tags = getScriptTags(
+        apiReferenceConfigurationWithSourceSchema({}),
+        'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js',
+        'abc123',
+      )
       expect(tags).toContain('<script type="module" nonce="abc123">')
-      expect(tags).toContain("import { createApiReference } from 'https://example.com/script.js'")
+      expect(tags).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
+      )
     })
 
     it('preserves function properties in configuration', () => {
@@ -246,7 +270,7 @@ describe('html-rendering', () => {
 
       // Check that body contains required elements
       expect(html).toContain('<div id="app"></div>')
-      expect(html).toContain("import { createApiReference } from 'https://example.com/script.js'")
+      expect(html).toContain('<script src="https://example.com/script.js"></script>')
 
       // Check that configuration is properly embedded
       expect(html).toContain('"theme": "kepler"')

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -16,14 +16,17 @@ import {
 
 describe('html-rendering', () => {
   describe('renderApiReference', () => {
-    it('returns HTML document with default CDN and custom theme', () => {
+    it('returns HTML document with the default ESM build and custom theme', () => {
       const html = renderApiReference({ config: { customCss: 'body { color: red }' } })
       expect(html).toContain('<!doctype html>')
       expect(html).toContain('<title>Scalar API Reference</title>')
       expect(html).toContain('body { color: red }')
-      expect(html).toContain('https://cdn.jsdelivr.net/npm/@scalar/api-reference')
+      expect(html).toContain('<script type="module">')
+      expect(html).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
+      )
       expect(html).toContain('<div id="app"></div>')
-      expect(html).toContain("Scalar.createApiReference('#app'")
+      expect(html).toContain("createApiReference('#app'")
     })
 
     it('handles custom page title correctly', () => {
@@ -110,9 +113,16 @@ describe('html-rendering', () => {
       expect(html).not.toContain('"content"')
     })
 
-    it('uses custom cdn when provided', () => {
+    it('uses the classic UMD bundle when a cdn is provided', () => {
       const html = renderApiReference({ config: {}, cdn: 'https://example.com/scalar.js' })
-      expect(html).toContain('https://example.com/scalar.js')
+      expect(html).toContain('<script src="https://example.com/scalar.js"></script>')
+      expect(html).toContain("Scalar.createApiReference('#app'")
+    })
+
+    it('falls back to the classic UMD bundle when bundle is false', () => {
+      const html = renderApiReference({ config: {}, bundle: false })
+      expect(html).toContain('<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>')
+      expect(html).toContain("Scalar.createApiReference('#app'")
     })
 
     it('loads the ESM module build when bundle is true', () => {
@@ -139,14 +149,13 @@ describe('html-rendering', () => {
       expect(html).not.toContain('"bundle"')
     })
 
-    it('applies the nonce to the inline script, style and CDN script tags', () => {
+    it('applies the nonce to the module script and style tags', () => {
       const html = renderApiReference({ config: { customCss: 'body { color: red }' }, nonce: 'r4nd0m' })
-      // CDN script
+      // Module script that loads the bundle and initializes it
+      expect(html).toContain('<script type="module" nonce="r4nd0m">')
       expect(html).toContain(
-        '<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" nonce="r4nd0m"></script>',
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
       )
-      // Inline init script
-      expect(html).toContain('<script type="text/javascript" nonce="r4nd0m">')
       // Inline style
       expect(html).toContain('<style type="text/css" nonce="r4nd0m">')
     })
@@ -161,7 +170,7 @@ describe('html-rendering', () => {
       expect(html).not.toContain('nonce=')
       expect(html).not.toContain('csp-nonce')
       expect(html).toContain('<style type="text/css">')
-      expect(html).toContain('<script type="text/javascript">')
+      expect(html).toContain('<script type="module">')
     })
 
     it('escapes the nonce to prevent attribute injection', () => {
@@ -172,12 +181,27 @@ describe('html-rendering', () => {
   })
 
   describe('getScriptTags', () => {
-    it('returns script tags with default CDN', () => {
+    it('defaults to the ESM module build when neither cdn nor bundle is set', () => {
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}))
+      expect(tags).toContain('<script type="module">')
+      expect(tags).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
+      )
+      expect(tags).toContain("createApiReference('#app'")
+    })
+
+    it('uses the classic UMD bundle when a cdn is provided', () => {
       const tags = getScriptTags(
         apiReferenceConfigurationWithSourceSchema({}),
         'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
       )
       expect(tags).toContain('<!-- Load the Script -->')
+      expect(tags).toContain('<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>')
+      expect(tags).toContain("Scalar.createApiReference('#app'")
+    })
+
+    it('falls back to the classic UMD bundle when bundle is false', () => {
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), undefined, undefined, false)
       expect(tags).toContain('<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>')
       expect(tags).toContain("Scalar.createApiReference('#app'")
     })

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -149,15 +149,23 @@ describe('html-rendering', () => {
       expect(html).not.toContain('"bundle"')
     })
 
-    it('applies the nonce to the module script and style tags', () => {
+    it('defaults to the classic UMD bundle when a nonce is set, and applies the nonce', () => {
+      // A nonce implies a strict CSP, where the ESM build's import-loaded chunks cannot be nonced,
+      // so the single-file UMD bundle is the safe default.
       const html = renderApiReference({ config: { customCss: 'body { color: red }' }, nonce: 'r4nd0m' })
-      // Module script that loads the bundle and initializes it
+      expect(html).toContain(
+        '<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" nonce="r4nd0m"></script>',
+      )
+      expect(html).toContain('<script type="text/javascript" nonce="r4nd0m">')
+      expect(html).toContain('<style type="text/css" nonce="r4nd0m">')
+    })
+
+    it('still uses the ESM build with a nonce when bundle is explicitly enabled', () => {
+      const html = renderApiReference({ config: {}, nonce: 'r4nd0m', bundle: true })
       expect(html).toContain('<script type="module" nonce="r4nd0m">')
       expect(html).toContain(
         "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
       )
-      // Inline style
-      expect(html).toContain('<style type="text/css" nonce="r4nd0m">')
     })
 
     it('emits a csp-nonce meta tag so the bundle can nonce its injected styles', () => {
@@ -204,6 +212,12 @@ describe('html-rendering', () => {
       const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), undefined, undefined, false)
       expect(tags).toContain('<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>')
       expect(tags).toContain("Scalar.createApiReference('#app'")
+    })
+
+    it('falls back to the classic UMD bundle when a nonce is set', () => {
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), undefined, 'abc123')
+      expect(tags).toContain('<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" nonce="abc123">')
+      expect(tags).toContain('<script type="text/javascript" nonce="abc123">')
     })
 
     it('uses custom CDN when provided', () => {

--- a/packages/client-side-rendering/src/html-rendering.test.ts
+++ b/packages/client-side-rendering/src/html-rendering.test.ts
@@ -6,7 +6,13 @@ import type { ApiReferenceConfigurationWithSource } from '@scalar/types/api-refe
 import { coerce } from '@scalar/validation'
 import { describe, expect, it } from 'vitest'
 
-import { getConfiguration, getScriptTags, renderApiReference, serializeConfigToJs } from './html-rendering'
+import {
+  type AnyApiReferenceConfiguration,
+  getConfiguration,
+  getScriptTags,
+  renderApiReference,
+  serializeConfigToJs,
+} from './html-rendering'
 
 describe('html-rendering', () => {
   describe('renderApiReference', () => {
@@ -15,12 +21,9 @@ describe('html-rendering', () => {
       expect(html).toContain('<!doctype html>')
       expect(html).toContain('<title>Scalar API Reference</title>')
       expect(html).toContain('body { color: red }')
-      expect(html).toContain('<script type="module">')
-      expect(html).toContain(
-        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
-      )
+      expect(html).toContain('https://cdn.jsdelivr.net/npm/@scalar/api-reference')
       expect(html).toContain('<div id="app"></div>')
-      expect(html).toContain("createApiReference('#app'")
+      expect(html).toContain("Scalar.createApiReference('#app'")
     })
 
     it('handles custom page title correctly', () => {
@@ -112,13 +115,38 @@ describe('html-rendering', () => {
       expect(html).toContain('https://example.com/scalar.js')
     })
 
-    it('applies the nonce to the module script and style tags', () => {
-      const html = renderApiReference({ config: { customCss: 'body { color: red }' }, nonce: 'r4nd0m' })
-      // Module script that loads the bundle and initializes it
-      expect(html).toContain('<script type="module" nonce="r4nd0m">')
+    it('loads the ESM module build when bundle is true', () => {
+      const html = renderApiReference({ config: {}, bundle: true })
+      expect(html).toContain('<script type="module">')
       expect(html).toContain(
         "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
       )
+      expect(html).toContain("createApiReference('#app'")
+      // Not the classic UMD path
+      expect(html).not.toContain('Scalar.createApiReference')
+    })
+
+    it('loads a custom ESM bundle URL when bundle is a string', () => {
+      const html = renderApiReference({ config: {}, bundle: 'https://example.com/esm.js' })
+      expect(html).toContain("import { createApiReference } from 'https://example.com/esm.js'")
+    })
+
+    it('reads bundle from inside the config object, the way integrations pass it', () => {
+      // Integrations spread unknown render options into `config`, so `bundle` arrives there. It must
+      // still switch to the module build and must not leak into the serialized client config.
+      const html = renderApiReference({ config: { bundle: true } as unknown as AnyApiReferenceConfiguration })
+      expect(html).toContain('<script type="module">')
+      expect(html).not.toContain('"bundle"')
+    })
+
+    it('applies the nonce to the inline script, style and CDN script tags', () => {
+      const html = renderApiReference({ config: { customCss: 'body { color: red }' }, nonce: 'r4nd0m' })
+      // CDN script
+      expect(html).toContain(
+        '<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference" nonce="r4nd0m"></script>',
+      )
+      // Inline init script
+      expect(html).toContain('<script type="text/javascript" nonce="r4nd0m">')
       // Inline style
       expect(html).toContain('<style type="text/css" nonce="r4nd0m">')
     })
@@ -133,7 +161,7 @@ describe('html-rendering', () => {
       expect(html).not.toContain('nonce=')
       expect(html).not.toContain('csp-nonce')
       expect(html).toContain('<style type="text/css">')
-      expect(html).toContain('<script type="module">')
+      expect(html).toContain('<script type="text/javascript">')
     })
 
     it('escapes the nonce to prevent attribute injection', () => {
@@ -144,8 +172,23 @@ describe('html-rendering', () => {
   })
 
   describe('getScriptTags', () => {
-    it('returns a module script with the default ESM CDN', () => {
-      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}))
+    it('returns script tags with default CDN', () => {
+      const tags = getScriptTags(
+        apiReferenceConfigurationWithSourceSchema({}),
+        'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+      )
+      expect(tags).toContain('<!-- Load the Script -->')
+      expect(tags).toContain('<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>')
+      expect(tags).toContain("Scalar.createApiReference('#app'")
+    })
+
+    it('uses custom CDN when provided', () => {
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), 'https://example.com/script.js')
+      expect(tags).toContain('https://example.com/script.js')
+    })
+
+    it('loads the default ESM module build when bundle is true', () => {
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), undefined, undefined, true)
       expect(tags).toContain('<script type="module">')
       expect(tags).toContain(
         "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
@@ -153,24 +196,33 @@ describe('html-rendering', () => {
       expect(tags).toContain("createApiReference('#app'")
     })
 
-    it('keeps a non-ESM cdn on the classic UMD script tag for backwards compatibility', () => {
-      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), 'https://example.com/script.js')
-      expect(tags).toContain('<script src="https://example.com/script.js"></script>')
-      expect(tags).toContain("Scalar.createApiReference('#app'")
-    })
-
-    it('uses a module script when the cdn points at an ESM entry', () => {
+    it('loads a custom ESM bundle URL when bundle is a string', () => {
       const tags = getScriptTags(
         apiReferenceConfigurationWithSourceSchema({}),
-        'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js',
+        undefined,
+        undefined,
+        'https://example.com/esm.js',
       )
-      expect(tags).toContain('<script type="module">')
-      expect(tags).toContain(
-        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
-      )
+      expect(tags).toContain("import { createApiReference } from 'https://example.com/esm.js'")
     })
 
-    it('applies the nonce to the classic script tags for a UMD cdn', () => {
+    it('lets bundle take precedence over cdn', () => {
+      const tags = getScriptTags(
+        apiReferenceConfigurationWithSourceSchema({}),
+        'https://example.com/umd.js',
+        undefined,
+        true,
+      )
+      expect(tags).toContain('<script type="module">')
+      expect(tags).not.toContain('<script src="https://example.com/umd.js">')
+    })
+
+    it('applies the nonce to the module script in bundle mode', () => {
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), undefined, 'abc123', true)
+      expect(tags).toContain('<script type="module" nonce="abc123">')
+    })
+
+    it('applies the nonce to both script tags when provided', () => {
       const tags = getScriptTags(
         apiReferenceConfigurationWithSourceSchema({}),
         'https://example.com/script.js',
@@ -178,18 +230,6 @@ describe('html-rendering', () => {
       )
       expect(tags).toContain('<script src="https://example.com/script.js" nonce="abc123"></script>')
       expect(tags).toContain('<script type="text/javascript" nonce="abc123">')
-    })
-
-    it('applies the nonce to the module script for an ESM cdn', () => {
-      const tags = getScriptTags(
-        apiReferenceConfigurationWithSourceSchema({}),
-        'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js',
-        'abc123',
-      )
-      expect(tags).toContain('<script type="module" nonce="abc123">')
-      expect(tags).toContain(
-        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
-      )
     })
 
     it('preserves function properties in configuration', () => {

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -6,15 +6,15 @@ export type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration }
  * Default CDN URL for the @scalar/api-reference UMD standalone bundle.
  *
  * This is the classic build that registers a global `window.Scalar` and is loaded through a plain
- * `<script src="...">` tag. It stays the default so existing setups keep working unchanged.
+ * `<script src="...">` tag. It is used when the UMD bundle is selected via `cdn` or `bundle: false`.
  */
 export const DEFAULT_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
 
 /**
  * Default CDN URL for the @scalar/api-reference ESM standalone build (added in #9871).
  *
- * Used when `bundle` is enabled. It is loaded as a `<script type="module">`, so the browser only
- * downloads the lazy chunks the rendered page needs instead of the whole monolithic UMD bundle.
+ * This is the default: it is loaded as a `<script type="module">`, so the browser only downloads the
+ * lazy chunks the rendered page needs instead of the whole monolithic UMD bundle.
  */
 export const DEFAULT_ESM_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'
 
@@ -113,10 +113,10 @@ export function renderApiReference(
      */
     nonce?: string
     /**
-     * Load the modern ESM build instead of the classic UMD bundle.
+     * Which build to load. The modern, code-split ESM build is the default.
      *
-     * Pass `true` to load the default ESM entry (`DEFAULT_ESM_CDN`) as a `<script type="module">`, or
-     * a URL string to point at a specific ESM build. When set, `bundle` takes precedence over `cdn`.
+     * Pass a URL string to load a specific ESM build, or `false` to fall back to the classic UMD
+     * bundle (equivalent to setting `cdn`). When set, `bundle` takes precedence over `cdn`.
      */
     bundle?: string | boolean
   },
@@ -210,17 +210,17 @@ export function serializeConfigToJs(configuration: Record<string, unknown>): str
 /**
  * The script tag(s) to load the @scalar/api-reference package from the CDN and initialize it.
  *
- * By default this loads the classic UMD bundle via `<script src>` (from `cdn`, defaulting to
- * `DEFAULT_CDN`) and calls `Scalar.createApiReference`, which is unchanged from previous versions.
+ * By default this loads the modern, code-split ESM build as a `<script type="module">` that imports
+ * `createApiReference` directly (from `DEFAULT_ESM_CDN`), so the browser only downloads the lazy
+ * chunks the page needs rather than the whole monolithic UMD bundle before it can paint.
  *
- * Set `bundle` to opt into the modern ESM build instead: it is loaded as a `<script type="module">`
- * that imports `createApiReference` directly, so the browser only downloads the lazy chunks the page
- * needs rather than the whole monolithic UMD bundle. Pass `bundle: true` for the default ESM entry
- * (`DEFAULT_ESM_CDN`), or a URL string to point at a specific ESM build. `bundle` wins over `cdn`.
+ * Opt into the classic UMD bundle — loaded via `<script src>` and `Scalar.createApiReference`, exactly
+ * as before — by setting `cdn` (for example to pin a version) or `bundle: false`. Set `bundle` to a
+ * URL string to load a specific ESM build. `bundle` takes precedence over `cdn`.
  *
  * When a `nonce` is provided it is applied to the script tag(s) so they are allowed under a strict
- * `script-src` Content Security Policy. In `bundle` mode the ESM build then loads its chunks through
- * the module loader, so a strict policy also needs `'strict-dynamic'` (or the CDN host allow-listed).
+ * `script-src` Content Security Policy. For the ESM build the bundle then loads its chunks through the
+ * module loader, so a strict policy also needs `'strict-dynamic'` (or the CDN host allow-listed).
  */
 export function getScriptTags(
   configuration: Record<string, unknown>,
@@ -232,7 +232,11 @@ export function getScriptTags(
 
   const nonceAttr = nonceAttribute(nonce)
 
-  if (bundle) {
+  // The ESM build is the default. Fall back to the classic UMD bundle only when it is explicitly
+  // requested: `bundle: false`, or a `cdn` URL with no `bundle` set.
+  const useUmd = bundle === false || (bundle === undefined && cdn !== undefined)
+
+  if (!useUmd) {
     const esmUrl = typeof bundle === 'string' ? bundle : DEFAULT_ESM_CDN
 
     return `

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -116,7 +116,11 @@ export function renderApiReference(
      * Which build to load. The modern, code-split ESM build is the default.
      *
      * Pass a URL string to load a specific ESM build, or `false` to fall back to the classic UMD
-     * bundle (equivalent to setting `cdn`). When set, `bundle` takes precedence over `cdn`.
+     * bundle. When set, `bundle` takes precedence over both `cdn` and the `nonce` fallback.
+     *
+     * When a `nonce` is set (a strict, nonce-based CSP) the UMD bundle is used by default, because the
+     * ESM build's `import`-loaded chunks cannot be nonced. Pass `bundle: true` to force the ESM build
+     * if your CSP uses `'strict-dynamic'`.
      */
     bundle?: string | boolean
   },
@@ -214,13 +218,16 @@ export function serializeConfigToJs(configuration: Record<string, unknown>): str
  * `createApiReference` directly (from `DEFAULT_ESM_CDN`), so the browser only downloads the lazy
  * chunks the page needs rather than the whole monolithic UMD bundle before it can paint.
  *
- * Opt into the classic UMD bundle — loaded via `<script src>` and `Scalar.createApiReference`, exactly
- * as before — by setting `cdn` (for example to pin a version) or `bundle: false`. Set `bundle` to a
- * URL string to load a specific ESM build. `bundle` takes precedence over `cdn`.
+ * The classic UMD bundle — loaded via `<script src>` and `Scalar.createApiReference`, exactly as
+ * before — is used instead when it is the safer choice or is explicitly requested: when a `nonce` is
+ * set (see below), when a `cdn` URL is given (for example to pin a version), or when `bundle: false`.
+ * Set `bundle` to `true` or a URL string to force the ESM build in those cases; `bundle` takes
+ * precedence over both `cdn` and the `nonce` fallback.
  *
- * When a `nonce` is provided it is applied to the script tag(s) so they are allowed under a strict
- * `script-src` Content Security Policy. For the ESM build the bundle then loads its chunks through the
- * module loader, so a strict policy also needs `'strict-dynamic'` (or the CDN host allow-listed).
+ * A `nonce` signals a strict, nonce-based `script-src` CSP. The ESM build pulls its chunks with native
+ * `import`, which cannot carry a nonce, so those requests are blocked under such a policy unless it
+ * also has `'strict-dynamic'` (or allow-lists the CDN host). The single-file UMD bundle has no such
+ * follow-up requests, so it is the safe default when a `nonce` is present.
  */
 export function getScriptTags(
   configuration: Record<string, unknown>,
@@ -232,9 +239,10 @@ export function getScriptTags(
 
   const nonceAttr = nonceAttribute(nonce)
 
-  // The ESM build is the default. Fall back to the classic UMD bundle only when it is explicitly
-  // requested: `bundle: false`, or a `cdn` URL with no `bundle` set.
-  const useUmd = bundle === false || (bundle === undefined && cdn !== undefined)
+  // The ESM build is the default, but fall back to the single-file UMD bundle when it is the safe or
+  // requested choice: a `nonce` (strict nonce-based CSP, where the ESM build's `import`-loaded chunks
+  // cannot be nonced), a `cdn` URL, or `bundle: false`. An explicit `bundle` (true/URL) always wins.
+  const useUmd = bundle === false || (bundle === undefined && (cdn !== undefined || Boolean(nonce)))
 
   if (!useUmd) {
     const esmUrl = typeof bundle === 'string' ? bundle : DEFAULT_ESM_CDN

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -5,16 +5,16 @@ export type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration }
 /**
  * Default CDN URL for the @scalar/api-reference UMD standalone bundle.
  *
- * This is the classic build that registers a global `window.Scalar`. It is meant for consumers that
- * load the reference through a plain `<script src="...">` tag (for example the Astro client loader).
+ * This is the classic build that registers a global `window.Scalar` and is loaded through a plain
+ * `<script src="...">` tag. It stays the default so existing setups keep working unchanged.
  */
 export const DEFAULT_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
 
 /**
  * Default CDN URL for the @scalar/api-reference ESM standalone build (added in #9871).
  *
- * Loading this entry as a module lets the browser download a small entry plus only the lazy chunks
- * the rendered page actually needs, instead of the whole monolithic UMD bundle up front.
+ * Used when `bundle` is enabled. It is loaded as a `<script type="module">`, so the browser only
+ * downloads the lazy chunks the rendered page needs instead of the whole monolithic UMD bundle.
  */
 export const DEFAULT_ESM_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'
 
@@ -112,6 +112,13 @@ export function renderApiReference(
      * `style="..."` attributes that a CSP nonce cannot authorize.
      */
     nonce?: string
+    /**
+     * Load the modern ESM build instead of the classic UMD bundle.
+     *
+     * Pass `true` to load the default ESM entry (`DEFAULT_ESM_CDN`) as a `<script type="module">`, or
+     * a URL string to point at a specific ESM build. When set, `bundle` takes precedence over `cdn`.
+     */
+    bundle?: string | boolean
   },
   customTheme = '',
 ): string {
@@ -119,7 +126,10 @@ export function renderApiReference(
   const title = escapeHtml(pageTitle ?? 'Scalar API Reference')
 
   const unwrapped = Array.isArray(givenConfig) ? givenConfig[0] : givenConfig
-  const { customCss, theme, ...rest } = (unwrapped ?? {}) as Record<string, unknown>
+  // `bundle` may also arrive inside the config object (integrations spread unknown options into it),
+  // so read it from there too and keep it out of the config that gets serialized to the client.
+  const { customCss, theme, bundle: configBundle, ...rest } = (unwrapped ?? {}) as Record<string, unknown>
+  const bundle = (options.bundle ?? configBundle) as string | boolean | undefined
 
   const configuration = getConfiguration({
     ...rest,
@@ -141,7 +151,7 @@ export function renderApiReference(
       content="width=device-width, initial-scale=1" />${cspNonceMeta}${getStyles(configuration as Record<string, unknown>, customTheme, nonce)}
   </head>
   <body>
-    <div id="app"></div>${getScriptTags(configuration, cdn, nonce)}
+    <div id="app"></div>${getScriptTags(configuration, cdn, nonce, bundle)}
   </body>
 </html>`
 }
@@ -198,46 +208,37 @@ export function serializeConfigToJs(configuration: Record<string, unknown>): str
 }
 
 /**
- * Whether a CDN URL points at the ESM build (loaded as a `<script type="module">`) rather than the
- * classic UMD bundle (loaded via `<script src>` and read off the `window.Scalar` global).
- *
- * The jsDelivr short entry is `.../esm.js`; self-hosted ESM builds are conventionally `*.mjs` or
- * `*.esm.js`. Everything else is treated as the classic UMD bundle, so any `cdn` URL that already
- * worked keeps working exactly as before.
- */
-const isEsmUrl = (cdn: string): boolean => {
-  const path = cdn.replace(/[?#].*$/, '')
-  return path.endsWith('.mjs') || path.endsWith('esm.js')
-}
-
-/**
  * The script tag(s) to load the @scalar/api-reference package from the CDN and initialize it.
  *
- * By default (no `cdn`) it loads the ESM standalone build as a module and calls `createApiReference`
- * directly, so the browser only downloads the lazy chunks the rendered page needs (see
- * `DEFAULT_ESM_CDN`) instead of the whole monolithic UMD bundle before it can paint.
+ * By default this loads the classic UMD bundle via `<script src>` (from `cdn`, defaulting to
+ * `DEFAULT_CDN`) and calls `Scalar.createApiReference`, which is unchanged from previous versions.
  *
- * A provided `cdn` keeps its historic meaning — a classic UMD bundle loaded via `<script src>` that
- * registers `window.Scalar` — so existing URLs (including pinned versions) keep working. Point `cdn`
- * at an ESM entry (`.../esm.js` or an `.mjs`/`*.esm.js` URL) to opt into the module build instead.
+ * Set `bundle` to opt into the modern ESM build instead: it is loaded as a `<script type="module">`
+ * that imports `createApiReference` directly, so the browser only downloads the lazy chunks the page
+ * needs rather than the whole monolithic UMD bundle. Pass `bundle: true` for the default ESM entry
+ * (`DEFAULT_ESM_CDN`), or a URL string to point at a specific ESM build. `bundle` wins over `cdn`.
  *
  * When a `nonce` is provided it is applied to the script tag(s) so they are allowed under a strict
- * `script-src` Content Security Policy. For the module build the bundle then loads its lazy chunks
- * through the module loader, so a strict policy needs `'strict-dynamic'` (or the CDN host
- * allow-listed) for those follow-up requests.
+ * `script-src` Content Security Policy. In `bundle` mode the ESM build then loads its chunks through
+ * the module loader, so a strict policy also needs `'strict-dynamic'` (or the CDN host allow-listed).
  */
-export function getScriptTags(configuration: Record<string, unknown>, cdn?: string, nonce?: string): string {
+export function getScriptTags(
+  configuration: Record<string, unknown>,
+  cdn?: string,
+  nonce?: string,
+  bundle?: string | boolean,
+): string {
   const configString = serializeConfigToJs(configuration)
 
   const nonceAttr = nonceAttribute(nonce)
 
-  // No `cdn` opts into the ESM default; a provided `cdn` stays on the classic UMD path unless it
-  // explicitly points at an ESM entry. This keeps every previously-working `cdn` URL working.
-  if (cdn === undefined || isEsmUrl(cdn)) {
+  if (bundle) {
+    const esmUrl = typeof bundle === 'string' ? bundle : DEFAULT_ESM_CDN
+
     return `
     <!-- Load the Scalar API Reference -->
     <script type="module"${nonceAttr}>
-      import { createApiReference } from '${cdn ?? DEFAULT_ESM_CDN}'
+      import { createApiReference } from '${esmUrl}'
 
       createApiReference('#app', ${configString})
     </script>`
@@ -245,7 +246,7 @@ export function getScriptTags(configuration: Record<string, unknown>, cdn?: stri
 
   return `
     <!-- Load the Script -->
-    <script src="${cdn}"${nonceAttr}></script>
+    <script src="${cdn ?? DEFAULT_CDN}"${nonceAttr}></script>
 
     <!-- Initialize the Scalar API Reference -->
     <script type="text/javascript"${nonceAttr}>

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -198,28 +198,58 @@ export function serializeConfigToJs(configuration: Record<string, unknown>): str
 }
 
 /**
- * The script tag to load the @scalar/api-reference package from the CDN and initialize it.
+ * Whether a CDN URL points at the ESM build (loaded as a `<script type="module">`) rather than the
+ * classic UMD bundle (loaded via `<script src>` and read off the `window.Scalar` global).
  *
- * Loads the ESM standalone build as a module and calls `createApiReference` directly, so the browser
- * only downloads the lazy chunks the rendered page needs (see `DEFAULT_ESM_CDN`) instead of the whole
- * monolithic UMD bundle. Pass a `cdn` that points at an ESM entry to override the default.
+ * The jsDelivr short entry is `.../esm.js`; self-hosted ESM builds are conventionally `*.mjs` or
+ * `*.esm.js`. Everything else is treated as the classic UMD bundle, so any `cdn` URL that already
+ * worked keeps working exactly as before.
+ */
+const isEsmUrl = (cdn: string): boolean => {
+  const path = cdn.replace(/[?#].*$/, '')
+  return path.endsWith('.mjs') || path.endsWith('esm.js')
+}
+
+/**
+ * The script tag(s) to load the @scalar/api-reference package from the CDN and initialize it.
  *
- * When a `nonce` is provided it is applied to the module script so it is allowed under a strict
- * `script-src` Content Security Policy. The bundle then loads its lazy chunks through the module
- * loader, so a strict policy needs `'strict-dynamic'` (or the CDN host allow-listed) for those
- * follow-up requests.
+ * By default (no `cdn`) it loads the ESM standalone build as a module and calls `createApiReference`
+ * directly, so the browser only downloads the lazy chunks the rendered page needs (see
+ * `DEFAULT_ESM_CDN`) instead of the whole monolithic UMD bundle before it can paint.
+ *
+ * A provided `cdn` keeps its historic meaning — a classic UMD bundle loaded via `<script src>` that
+ * registers `window.Scalar` — so existing URLs (including pinned versions) keep working. Point `cdn`
+ * at an ESM entry (`.../esm.js` or an `.mjs`/`*.esm.js` URL) to opt into the module build instead.
+ *
+ * When a `nonce` is provided it is applied to the script tag(s) so they are allowed under a strict
+ * `script-src` Content Security Policy. For the module build the bundle then loads its lazy chunks
+ * through the module loader, so a strict policy needs `'strict-dynamic'` (or the CDN host
+ * allow-listed) for those follow-up requests.
  */
 export function getScriptTags(configuration: Record<string, unknown>, cdn?: string, nonce?: string): string {
   const configString = serializeConfigToJs(configuration)
 
   const nonceAttr = nonceAttribute(nonce)
 
-  return `
+  // No `cdn` opts into the ESM default; a provided `cdn` stays on the classic UMD path unless it
+  // explicitly points at an ESM entry. This keeps every previously-working `cdn` URL working.
+  if (cdn === undefined || isEsmUrl(cdn)) {
+    return `
     <!-- Load the Scalar API Reference -->
     <script type="module"${nonceAttr}>
       import { createApiReference } from '${cdn ?? DEFAULT_ESM_CDN}'
 
       createApiReference('#app', ${configString})
+    </script>`
+  }
+
+  return `
+    <!-- Load the Script -->
+    <script src="${cdn}"${nonceAttr}></script>
+
+    <!-- Initialize the Scalar API Reference -->
+    <script type="text/javascript"${nonceAttr}>
+      Scalar.createApiReference('#app', ${configString})
     </script>`
 }
 

--- a/packages/client-side-rendering/src/html-rendering.ts
+++ b/packages/client-side-rendering/src/html-rendering.ts
@@ -2,8 +2,21 @@ import type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration } from '@
 
 export type { AnyApiReferenceConfiguration, HtmlRenderingConfiguration }
 
-/** Default CDN URL for the @scalar/api-reference standalone bundle. */
+/**
+ * Default CDN URL for the @scalar/api-reference UMD standalone bundle.
+ *
+ * This is the classic build that registers a global `window.Scalar`. It is meant for consumers that
+ * load the reference through a plain `<script src="...">` tag (for example the Astro client loader).
+ */
 export const DEFAULT_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference'
+
+/**
+ * Default CDN URL for the @scalar/api-reference ESM standalone build (added in #9871).
+ *
+ * Loading this entry as a module lets the browser download a small entry plus only the lazy chunks
+ * the rendered page actually needs, instead of the whole monolithic UMD bundle up front.
+ */
+export const DEFAULT_ESM_CDN = 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'
 
 /**
  * Escape HTML special characters in user-provided strings.
@@ -185,10 +198,16 @@ export function serializeConfigToJs(configuration: Record<string, unknown>): str
 }
 
 /**
- * The script tags to load the @scalar/api-reference package from the CDN.
+ * The script tag to load the @scalar/api-reference package from the CDN and initialize it.
  *
- * When a `nonce` is provided it is applied to both script tags so they are allowed under a strict
- * `script-src` Content Security Policy.
+ * Loads the ESM standalone build as a module and calls `createApiReference` directly, so the browser
+ * only downloads the lazy chunks the rendered page needs (see `DEFAULT_ESM_CDN`) instead of the whole
+ * monolithic UMD bundle. Pass a `cdn` that points at an ESM entry to override the default.
+ *
+ * When a `nonce` is provided it is applied to the module script so it is allowed under a strict
+ * `script-src` Content Security Policy. The bundle then loads its lazy chunks through the module
+ * loader, so a strict policy needs `'strict-dynamic'` (or the CDN host allow-listed) for those
+ * follow-up requests.
  */
 export function getScriptTags(configuration: Record<string, unknown>, cdn?: string, nonce?: string): string {
   const configString = serializeConfigToJs(configuration)
@@ -196,12 +215,11 @@ export function getScriptTags(configuration: Record<string, unknown>, cdn?: stri
   const nonceAttr = nonceAttribute(nonce)
 
   return `
-    <!-- Load the Script -->
-    <script src="${cdn ?? DEFAULT_CDN}"${nonceAttr}></script>
+    <!-- Load the Scalar API Reference -->
+    <script type="module"${nonceAttr}>
+      import { createApiReference } from '${cdn ?? DEFAULT_ESM_CDN}'
 
-    <!-- Initialize the Scalar API Reference -->
-    <script type="text/javascript"${nonceAttr}>
-      Scalar.createApiReference('#app', ${configString})
+      createApiReference('#app', ${configString})
     </script>`
 }
 

--- a/packages/client-side-rendering/src/index.ts
+++ b/packages/client-side-rendering/src/index.ts
@@ -1,6 +1,7 @@
 export {
   type AnyApiReferenceConfiguration,
   DEFAULT_CDN,
+  DEFAULT_ESM_CDN,
   type HtmlRenderingConfiguration,
   getConfiguration,
   getScriptTags,

--- a/packages/core/src/libs/html-rendering/html-rendering.test.ts
+++ b/packages/core/src/libs/html-rendering/html-rendering.test.ts
@@ -15,9 +15,12 @@ describe('html-rendering', () => {
       expect(html).toContain('<!doctype html>')
       expect(html).toContain('<title>Scalar API Reference</title>')
       expect(html).toContain('body { color: red }')
-      expect(html).toContain('https://cdn.jsdelivr.net/npm/@scalar/api-reference')
+      expect(html).toContain('<script type="module">')
+      expect(html).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
+      )
       expect(html).toContain('<div id="app"></div>')
-      expect(html).toContain("Scalar.createApiReference('#app'")
+      expect(html).toContain("createApiReference('#app'")
     })
 
     it('handles custom page title correctly', () => {
@@ -98,14 +101,13 @@ describe('html-rendering', () => {
   })
 
   describe('getScriptTags', () => {
-    it('returns script tags with default CDN', () => {
-      const tags = getScriptTags(
-        apiReferenceConfigurationWithSourceSchema({}),
-        'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
+    it('returns a module script with the default ESM CDN', () => {
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}))
+      expect(tags).toContain('<script type="module">')
+      expect(tags).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
       )
-      expect(tags).toContain('<!-- Load the Script -->')
-      expect(tags).toContain('<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>')
-      expect(tags).toContain("Scalar.createApiReference('#app'")
+      expect(tags).toContain("createApiReference('#app'")
     })
 
     it('uses custom CDN when provided', () => {
@@ -191,7 +193,7 @@ describe('html-rendering', () => {
 
       // Check that body contains required elements
       expect(html).toContain('<div id="app"></div>')
-      expect(html).toContain('<script src="https://example.com/script.js"></script>')
+      expect(html).toContain("import { createApiReference } from 'https://example.com/script.js'")
 
       // Check that configuration is properly embedded
       expect(html).toContain('"theme": "kepler"')

--- a/packages/core/src/libs/html-rendering/html-rendering.test.ts
+++ b/packages/core/src/libs/html-rendering/html-rendering.test.ts
@@ -10,14 +10,17 @@ import { getConfiguration, getHtmlDocument, getScriptTags } from './html-renderi
 
 describe('html-rendering', () => {
   describe('getHtmlDocument', () => {
-    it('returns HTML document with default CDN and custom theme', () => {
+    it('returns HTML document with the default ESM build and custom theme', () => {
       const html = getHtmlDocument({ customCss: 'body { color: red }' })
       expect(html).toContain('<!doctype html>')
       expect(html).toContain('<title>Scalar API Reference</title>')
       expect(html).toContain('body { color: red }')
-      expect(html).toContain('https://cdn.jsdelivr.net/npm/@scalar/api-reference')
+      expect(html).toContain('<script type="module">')
+      expect(html).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
+      )
       expect(html).toContain('<div id="app"></div>')
-      expect(html).toContain("Scalar.createApiReference('#app'")
+      expect(html).toContain("createApiReference('#app'")
     })
 
     it('handles custom page title correctly', () => {

--- a/packages/core/src/libs/html-rendering/html-rendering.test.ts
+++ b/packages/core/src/libs/html-rendering/html-rendering.test.ts
@@ -110,9 +110,21 @@ describe('html-rendering', () => {
       expect(tags).toContain("createApiReference('#app'")
     })
 
-    it('uses custom CDN when provided', () => {
+    it('keeps a non-ESM cdn on the classic UMD script tag for backwards compatibility', () => {
       const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), 'https://example.com/script.js')
-      expect(tags).toContain('https://example.com/script.js')
+      expect(tags).toContain('<script src="https://example.com/script.js"></script>')
+      expect(tags).toContain("Scalar.createApiReference('#app'")
+    })
+
+    it('uses a module script when the cdn points at an ESM entry', () => {
+      const tags = getScriptTags(
+        apiReferenceConfigurationWithSourceSchema({}),
+        'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js',
+      )
+      expect(tags).toContain('<script type="module">')
+      expect(tags).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
+      )
     })
 
     it('preserves function properties in configuration', () => {
@@ -193,7 +205,7 @@ describe('html-rendering', () => {
 
       // Check that body contains required elements
       expect(html).toContain('<div id="app"></div>')
-      expect(html).toContain("import { createApiReference } from 'https://example.com/script.js'")
+      expect(html).toContain('<script src="https://example.com/script.js"></script>')
 
       // Check that configuration is properly embedded
       expect(html).toContain('"theme": "kepler"')

--- a/packages/core/src/libs/html-rendering/html-rendering.test.ts
+++ b/packages/core/src/libs/html-rendering/html-rendering.test.ts
@@ -15,12 +15,9 @@ describe('html-rendering', () => {
       expect(html).toContain('<!doctype html>')
       expect(html).toContain('<title>Scalar API Reference</title>')
       expect(html).toContain('body { color: red }')
-      expect(html).toContain('<script type="module">')
-      expect(html).toContain(
-        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
-      )
+      expect(html).toContain('https://cdn.jsdelivr.net/npm/@scalar/api-reference')
       expect(html).toContain('<div id="app"></div>')
-      expect(html).toContain("createApiReference('#app'")
+      expect(html).toContain("Scalar.createApiReference('#app'")
     })
 
     it('handles custom page title correctly', () => {
@@ -98,33 +95,31 @@ describe('html-rendering', () => {
       expect(html).toContain('"url": "https://api.example.com/spec"')
       expect(html).not.toContain('"content"')
     })
+
+    it('loads the ESM module build when bundle is enabled', () => {
+      const html = getHtmlDocument({ bundle: true })
+      expect(html).toContain('<script type="module">')
+      expect(html).toContain(
+        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
+      )
+      expect(html).not.toContain('Scalar.createApiReference')
+    })
   })
 
   describe('getScriptTags', () => {
-    it('returns a module script with the default ESM CDN', () => {
-      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}))
-      expect(tags).toContain('<script type="module">')
-      expect(tags).toContain(
-        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
+    it('returns script tags with default CDN', () => {
+      const tags = getScriptTags(
+        apiReferenceConfigurationWithSourceSchema({}),
+        'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
       )
-      expect(tags).toContain("createApiReference('#app'")
-    })
-
-    it('keeps a non-ESM cdn on the classic UMD script tag for backwards compatibility', () => {
-      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), 'https://example.com/script.js')
-      expect(tags).toContain('<script src="https://example.com/script.js"></script>')
+      expect(tags).toContain('<!-- Load the Script -->')
+      expect(tags).toContain('<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>')
       expect(tags).toContain("Scalar.createApiReference('#app'")
     })
 
-    it('uses a module script when the cdn points at an ESM entry', () => {
-      const tags = getScriptTags(
-        apiReferenceConfigurationWithSourceSchema({}),
-        'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js',
-      )
-      expect(tags).toContain('<script type="module">')
-      expect(tags).toContain(
-        "import { createApiReference } from 'https://cdn.jsdelivr.net/npm/@scalar/api-reference/esm.js'",
-      )
+    it('uses custom CDN when provided', () => {
+      const tags = getScriptTags(apiReferenceConfigurationWithSourceSchema({}), 'https://example.com/script.js')
+      expect(tags).toContain('https://example.com/script.js')
     })
 
     it('preserves function properties in configuration', () => {

--- a/packages/schemas/src/api-reference/html-rendering-configuration.ts
+++ b/packages/schemas/src/api-reference/html-rendering-configuration.ts
@@ -18,8 +18,12 @@ export const htmlRenderingConfigurationSchema = object({
   /**
    * Which build to load. The modern, code-split ESM build is the default.
    *
-   * Pass a URL string to load a specific ESM build, or `false` to fall back to the classic UMD bundle
-   * (equivalent to setting `cdn`). When set, `bundle` takes precedence over `cdn`.
+   * Pass a URL string to load a specific ESM build, or `false` to fall back to the classic UMD bundle.
+   * When set, `bundle` takes precedence over both `cdn` and the `nonce` fallback.
+   *
+   * When a `nonce` is set (a strict, nonce-based CSP) the UMD bundle is used by default, because the
+   * ESM build's `import`-loaded chunks cannot be nonced. Pass `bundle: true` to force the ESM build if
+   * your CSP uses `'strict-dynamic'`.
    */
   bundle: optional(union([string(), boolean()])),
   pageTitle: string({

--- a/packages/schemas/src/api-reference/html-rendering-configuration.ts
+++ b/packages/schemas/src/api-reference/html-rendering-configuration.ts
@@ -1,8 +1,9 @@
-import { object, optional, string } from '@scalar/validation'
+import { boolean, object, optional, string, union } from '@scalar/validation'
 
 export const htmlRenderingConfigurationSchema = object({
   /**
-   * The URL to the Scalar API Reference JS CDN.
+   * The URL to the Scalar API Reference UMD bundle (the classic build that registers `window.Scalar`
+   * and is loaded via `<script src>`).
    *
    * Use this to pin a specific version of the Scalar API Reference.
    *
@@ -13,6 +14,14 @@ export const htmlRenderingConfigurationSchema = object({
   cdn: string({
     default: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
   }),
+  /**
+   * Load the modern, code-split ESM build instead of the classic UMD bundle.
+   *
+   * Pass `true` to load the default ESM entry (`.../@scalar/api-reference/esm.js`) as a
+   * `<script type="module">`, or a URL string to point at a specific ESM build. When set, `bundle`
+   * takes precedence over `cdn`.
+   */
+  bundle: optional(union([string(), boolean()])),
   pageTitle: string({
     default: 'Scalar API Reference',
   }),

--- a/packages/schemas/src/api-reference/html-rendering-configuration.ts
+++ b/packages/schemas/src/api-reference/html-rendering-configuration.ts
@@ -5,7 +5,8 @@ export const htmlRenderingConfigurationSchema = object({
    * The URL to the Scalar API Reference UMD bundle (the classic build that registers `window.Scalar`
    * and is loaded via `<script src>`).
    *
-   * Use this to pin a specific version of the Scalar API Reference.
+   * Setting it selects the UMD build instead of the default ESM build — use it to pin a specific
+   * version of the classic bundle.
    *
    * @default https://cdn.jsdelivr.net/npm/@scalar/api-reference
    *
@@ -15,11 +16,10 @@ export const htmlRenderingConfigurationSchema = object({
     default: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference',
   }),
   /**
-   * Load the modern, code-split ESM build instead of the classic UMD bundle.
+   * Which build to load. The modern, code-split ESM build is the default.
    *
-   * Pass `true` to load the default ESM entry (`.../@scalar/api-reference/esm.js`) as a
-   * `<script type="module">`, or a URL string to point at a specific ESM build. When set, `bundle`
-   * takes precedence over `cdn`.
+   * Pass a URL string to load a specific ESM build, or `false` to fall back to the classic UMD bundle
+   * (equivalent to setting `cdn`). When set, `bundle` takes precedence over `cdn`.
    */
   bundle: optional(union([string(), boolean()])),
   pageTitle: string({

--- a/packages/types/src/api-reference/html-rendering-configuration.ts
+++ b/packages/types/src/api-reference/html-rendering-configuration.ts
@@ -19,8 +19,12 @@ export type HtmlRenderingConfiguration = Partial<ApiReferenceConfigurationWithMu
    * Which build to load. The modern, code-split ESM build is the default, because it lets less
    * JavaScript block the first render.
    *
-   * Pass a URL string to load a specific ESM build, or `false` to fall back to the classic UMD bundle
-   * (equivalent to setting `cdn`). When set, `bundle` takes precedence over `cdn`.
+   * Pass a URL string to load a specific ESM build, or `false` to fall back to the classic UMD bundle.
+   * When set, `bundle` takes precedence over both `cdn` and the `nonce` fallback.
+   *
+   * When a `nonce` is set (a strict, nonce-based CSP) the UMD bundle is used by default, because the
+   * ESM build's `import`-loaded chunks cannot be nonced. Pass `bundle: true` to force the ESM build if
+   * your CSP uses `'strict-dynamic'`.
    */
   bundle?: string | boolean
   /**

--- a/packages/types/src/api-reference/html-rendering-configuration.ts
+++ b/packages/types/src/api-reference/html-rendering-configuration.ts
@@ -3,11 +3,26 @@ import type { ApiReferenceConfigurationWithMultipleSources } from './types'
 /**
  * The configuration for the static HTML rendering using the CDN.
  *
- * It's the ApiReferenceConfiguration, but extended with the `pageTitle` and `cdn` options.
+ * It's the ApiReferenceConfiguration, but extended with the `pageTitle`, `cdn` and `bundle` options.
  */
 export type HtmlRenderingConfiguration = Partial<ApiReferenceConfigurationWithMultipleSources> & {
   pageTitle: string
+  /**
+   * The URL to the Scalar API Reference UMD bundle (the classic build that registers `window.Scalar`
+   * and is loaded via `<script src>`). Use this to pin a specific version.
+   *
+   * @default https://cdn.jsdelivr.net/npm/@scalar/api-reference
+   */
   cdn: string
+  /**
+   * Load the modern, code-split ESM build instead of the classic UMD bundle.
+   *
+   * Pass `true` to load the default ESM entry (`.../@scalar/api-reference/esm.js`) as a
+   * `<script type="module">`, or a URL string to point at a specific ESM build. Because the ESM build
+   * is code-split, less JavaScript blocks the first render. When set, `bundle` takes precedence over
+   * `cdn`.
+   */
+  bundle?: string | boolean
   /**
    * A Content Security Policy (CSP) nonce to apply to the generated inline `<script>` and `<style>`
    * tags (and the CDN `<script>` tag).

--- a/packages/types/src/api-reference/html-rendering-configuration.ts
+++ b/packages/types/src/api-reference/html-rendering-configuration.ts
@@ -9,18 +9,18 @@ export type HtmlRenderingConfiguration = Partial<ApiReferenceConfigurationWithMu
   pageTitle: string
   /**
    * The URL to the Scalar API Reference UMD bundle (the classic build that registers `window.Scalar`
-   * and is loaded via `<script src>`). Use this to pin a specific version.
+   * and is loaded via `<script src>`). Setting it selects the UMD build instead of the default ESM
+   * build — use it to pin a specific version of the classic bundle.
    *
    * @default https://cdn.jsdelivr.net/npm/@scalar/api-reference
    */
   cdn: string
   /**
-   * Load the modern, code-split ESM build instead of the classic UMD bundle.
+   * Which build to load. The modern, code-split ESM build is the default, because it lets less
+   * JavaScript block the first render.
    *
-   * Pass `true` to load the default ESM entry (`.../@scalar/api-reference/esm.js`) as a
-   * `<script type="module">`, or a URL string to point at a specific ESM build. Because the ESM build
-   * is code-split, less JavaScript blocks the first render. When set, `bundle` takes precedence over
-   * `cdn`.
+   * Pass a URL string to load a specific ESM build, or `false` to fall back to the classic UMD bundle
+   * (equivalent to setting `cdn`). When set, `bundle` takes precedence over `cdn`.
    */
   bundle?: string | boolean
   /**


### PR DESCRIPTION
Makes the modern, code-split ESM build the default for the generated API Reference HTML, and keeps the classic UMD bundle available as an opt-out.

- **Default (new):** loads the ESM build (`/esm.js`, added in #9871) as a `<script type="module">`.
- **`cdn: '…/@scalar/api-reference'`:** classic UMD bundle (e.g. to pin a version) — unchanged.
- **`bundle: false`:** classic UMD bundle without picking a URL.
- **`bundle: '…/esm.js'`:** a specific ESM build.

Works everywhere `renderApiReference` is used (Express, Hono, Fastify, Next.js, etc.) — the option flows through the shared config.

### CSP handled automatically

We can't read the CSP header during HTML generation, but a `nonce` is a reliable signal of a strict, nonce-based CSP. The ESM build loads its chunks with native `import`, which can't carry a nonce, so under that policy those requests would be blocked. So **when a `nonce` is set, the UMD bundle is used automatically** — a single nonced `<script>` with no follow-up requests. Set `bundle: true` to force ESM if your CSP uses `'strict-dynamic'`.

### Size

Total download is ~unchanged — the win is that less JavaScript blocks the first paint.

| | UMD | ESM (default) |
| --- | --- | --- |
| JS before first paint | ~1,071 kB | **~700 kB** |
| Total JS | ~1,071 kB | ~1,090 kB |

(Scalar Galaxy doc, live CDN, real browser.) The UMD build is one big file that must finish before rendering; the ESM build defers the heavy interactive parts (API client modal + AI chat, ≈ 370 kB) until after first paint. Renders identically.
