### PR TITLE
docs: document the RSS pages feed mode

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -323,7 +323,7 @@ For `scripts` and `styles`: path relative to config root. For `links` (favicon):
 
 ### rss
 
-Publishes an RSS feed for your changelog so readers can subscribe. Written to `<path>/rss.xml` — a changelog at `/changelog` publishes its feed at `/changelog/rss.xml`.
+Publishes an RSS feed for your changelog or blog so readers can subscribe. Written to `<path>/rss.xml` — a changelog at `/changelog` publishes its feed at `/changelog/rss.xml`.
 
 ```json
 "rss": {
@@ -338,8 +338,11 @@ Publishes an RSS feed for your changelog so readers can subscribe. Written to `<
 | `path`        | `string` | Yes      | Changelog route, e.g. `/changelog`. No `..` segments     |
 | `title`       | `string` | No       | Feed title. Defaults to your site title plus `Changelog` |
 | `description` | `string` | No       | Feed description                                         |
+| `entries`     | `string` | No       | `headings` (default) or `pages` — see below              |
 
 Entries come from dated headings (`## 1.2.0 (2026-07-24)`) on the page at `path` or any page beneath it, merged newest-first. Only the top-most dated heading level starts entries; deeper headings (dated or not) fold into the release above them. Hidden pages are skipped. Every page advertises the feed with a `<link rel="alternate" type="application/rss+xml">` tag, and pages under `path` show a subscribe button in the page header.
+
+Set `entries` to `pages` for a blog instead: every page under `path` with a `date` in its frontmatter (`date: 2026-07-24`) becomes one item, titled by the page. Pages without a `date` (an index, a draft) are skipped. Use the default `headings` for a changelog.
 
 ### routing
 

--- a/documentation/guides/docs/configuration/site-config.md
+++ b/documentation/guides/docs/configuration/site-config.md
@@ -446,6 +446,7 @@ Point `path` at the route your changelog lives on. The feed is written to `rss.x
 | `path`        | `string` | Yes      | Route of your changelog, for example `/changelog`. Must be a plain site route with no `..` segments |
 | `title`       | `string` | No       | Title of the feed, shown in feed readers. Defaults to your site title plus `Changelog` |
 | `description` | `string` | No       | Description of the feed, shown in feed readers                                      |
+| `entries`     | `string` | No       | How items are found. `headings` (default) turns each dated heading into an item; `pages` turns each page under `path` with a `date` in its frontmatter into an item |
 
 ### Writing Entries
 
@@ -478,6 +479,39 @@ A changelog split across several pages works too. Every page at `path` or beneat
 An index page with no dated headings contributes nothing of its own, which is what you want when it only links to the products.
 
 Hidden pages are skipped. A page kept out of the sidebar and the sitemap stays out of the feed as well.
+
+### One Item per Page
+
+For a blog, where each post is its own page rather than a heading on a shared page, set `entries` to `pages`:
+
+```json
+// scalar.config.json
+{
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
+  "scalar": "2.0.0",
+  "siteConfig": {
+    "rss": {
+      "path": "/blog",
+      "title": "Scalar Blog",
+      "entries": "pages"
+    }
+  }
+}
+```
+
+Now every page under `path` that carries a `date` in its frontmatter becomes one feed item, newest first:
+
+```markdown
+---
+date: 2026-07-24
+---
+
+# Our new dark mode
+
+A short introduction to the post.
+```
+
+The page title becomes the item title, its description becomes the item description, and the frontmatter `date` sets the publish date. Pages without a `date` — an index page, a draft — are left out, so nothing is syndicated by accident.
 
 ### Discovery
 


### PR DESCRIPTION
Documents the new `entries: "pages"` RSS mode — each page under a feed's path with a `date` in frontmatter becomes one feed item (the blog shape).

Updates both the site-config guide and the `scalar-docs` skill.