### PR TITLE
refactor(types): migrate security-scheme + nanoid off zod to @scalar/validation

### DIFF
--- a/.changeset/security-scheme-validation.md
+++ b/.changeset/security-scheme-validation.md
@@ -1,0 +1,6 @@
+---
+'@scalar/types': patch
+'@scalar/api-reference': patch
+---
+
+Migrate the `nanoid` and `security-scheme` entity schemas from `zod` to the zero-dependency `@scalar/validation`. These were the only two runtime modules in `@scalar/types` that constructed zod schema values at module load, so this removes the `zod@4.3.5` runtime path from the `@scalar/api-reference` standalone browser bundle (22 modules, ~141 KB raw). The standalone bundle drops from 3,806,019 to 3,735,844 bytes raw (1,092,517 to 1,074,157 bytes gzip). The exported schema value names and inferred types are preserved, so downstream `import type` consumers keep working unchanged. `zod` remains a dependency of `@scalar/types` because the type-only api-reference configuration schemas still use it (they are already tree-shaken out of the bundle).

--- a/packages/oas-utils/package.json
+++ b/packages/oas-utils/package.json
@@ -54,6 +54,7 @@
     "yaml": "catalog:*"
   },
   "devDependencies": {
+    "@scalar/validation": "workspace:*",
     "@types/node": "catalog:*",
     "fake-indexeddb": "catalog:*",
     "vite": "catalog:*",

--- a/packages/oas-utils/src/migrations/migrate-to-indexdb.test.ts
+++ b/packages/oas-utils/src/migrations/migrate-to-indexdb.test.ts
@@ -1,4 +1,5 @@
 import { type SecurityScheme, securitySchemeSchema } from '@scalar/types/entities'
+import { coerce } from '@scalar/validation'
 import { getPathItemOperation } from '@scalar/workspace-store/helpers/for-each-path-item-operation'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
@@ -7,6 +8,12 @@ import 'fake-indexeddb/auto'
 
 import { shouldMigrateToIndexDb, transformLegacyDataToWorkspace } from './migrate-to-indexdb'
 import type { v_2_5_0 } from './v-2.5.0/types.generated'
+
+/**
+ * Coerces a raw value into a `SecurityScheme`. Annotating the result keeps the (deep) `Static` return type of
+ * `securitySchemeSchema` from being re-instantiated at every call site, which would otherwise trip `TS2589`.
+ */
+const coerceSecurityScheme = (value: unknown): SecurityScheme => coerce(securitySchemeSchema, value) as SecurityScheme
 
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -433,7 +440,7 @@ describe('migrate-to-indexdb', () => {
 
   describe('transformLegacyDataToWorkspace - Security Schemes', () => {
     it('should transform API key security schemes into document components and auth store', async () => {
-      const scheme = securitySchemeSchema.parse({
+      const scheme = coerceSecurityScheme({
         uid: 'security-1',
         nameKey: 'api-key-auth',
         type: 'apiKey',
@@ -478,7 +485,7 @@ describe('migrate-to-indexdb', () => {
     })
 
     it('should transform HTTP bearer security schemes into document components and auth store', async () => {
-      const scheme = securitySchemeSchema.parse({
+      const scheme = coerceSecurityScheme({
         uid: 'security-1',
         nameKey: 'bearer-auth',
         type: 'http',
@@ -521,7 +528,7 @@ describe('migrate-to-indexdb', () => {
     })
 
     it('should transform HTTP basic security schemes into document components and auth store', async () => {
-      const scheme = securitySchemeSchema.parse({
+      const scheme = coerceSecurityScheme({
         uid: 'security-1',
         nameKey: 'basic-auth',
         type: 'http',
@@ -567,7 +574,7 @@ describe('migrate-to-indexdb', () => {
     })
 
     it('should transform OAuth2 security schemes into document components and auth store', async () => {
-      const scheme = securitySchemeSchema.parse({
+      const scheme = coerceSecurityScheme({
         uid: 'security-1',
         nameKey: 'oauth2-auth',
         type: 'oauth2',
@@ -641,7 +648,7 @@ describe('migrate-to-indexdb', () => {
         collections: ['collection-1', 'collection-2'],
       })
 
-      const scheme1 = securitySchemeSchema.parse({
+      const scheme1 = coerceSecurityScheme({
         uid: 'security-1',
         nameKey: 'api-key',
         type: 'apiKey',
@@ -650,7 +657,7 @@ describe('migrate-to-indexdb', () => {
         value: 'key-123',
       })
 
-      const scheme2 = securitySchemeSchema.parse({
+      const scheme2 = coerceSecurityScheme({
         uid: 'security-2',
         nameKey: 'bearer-token',
         type: 'http',
@@ -4330,7 +4337,7 @@ describe('migrate-to-indexdb', () => {
 
     describe('request with security', () => {
       it('transforms a request with security requirements', async () => {
-        const scheme = securitySchemeSchema.parse({
+        const scheme = coerceSecurityScheme({
           uid: 'security-1',
           nameKey: 'api-key',
           type: 'apiKey',
@@ -4383,7 +4390,7 @@ describe('migrate-to-indexdb', () => {
       })
 
       it('transforms a request with multiple security requirements (AND)', async () => {
-        const apiKeyScheme = securitySchemeSchema.parse({
+        const apiKeyScheme = coerceSecurityScheme({
           uid: 'security-1',
           nameKey: 'api-key',
           type: 'apiKey',
@@ -4392,7 +4399,7 @@ describe('migrate-to-indexdb', () => {
           value: 'key-123',
         })
 
-        const bearerScheme = securitySchemeSchema.parse({
+        const bearerScheme = coerceSecurityScheme({
           uid: 'security-2',
           nameKey: 'bearer-auth',
           type: 'http',
@@ -4451,7 +4458,7 @@ describe('migrate-to-indexdb', () => {
       })
 
       it('transforms a request with alternative security requirements (OR)', async () => {
-        const apiKeyScheme = securitySchemeSchema.parse({
+        const apiKeyScheme = coerceSecurityScheme({
           uid: 'security-1',
           nameKey: 'api-key',
           type: 'apiKey',
@@ -4460,7 +4467,7 @@ describe('migrate-to-indexdb', () => {
           value: 'key-123',
         })
 
-        const bearerScheme = securitySchemeSchema.parse({
+        const bearerScheme = coerceSecurityScheme({
           uid: 'security-2',
           nameKey: 'bearer-auth',
           type: 'http',
@@ -4519,7 +4526,7 @@ describe('migrate-to-indexdb', () => {
       })
 
       it('transforms a request with OAuth2 security and scopes', async () => {
-        const oauthScheme = securitySchemeSchema.parse({
+        const oauthScheme = coerceSecurityScheme({
           uid: 'security-1',
           nameKey: 'oauth2',
           type: 'oauth2',
@@ -4657,7 +4664,7 @@ describe('migrate-to-indexdb', () => {
       })
 
       it('transforms different security requirements across multiple requests', async () => {
-        const apiKeyScheme = securitySchemeSchema.parse({
+        const apiKeyScheme = coerceSecurityScheme({
           uid: 'security-1',
           nameKey: 'api-key',
           type: 'apiKey',
@@ -4666,7 +4673,7 @@ describe('migrate-to-indexdb', () => {
           value: 'key-123',
         })
 
-        const bearerScheme = securitySchemeSchema.parse({
+        const bearerScheme = coerceSecurityScheme({
           uid: 'security-2',
           nameKey: 'bearer-auth',
           type: 'http',

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -130,6 +130,7 @@
   ],
   "dependencies": {
     "@scalar/helpers": "workspace:*",
+    "@scalar/validation": "workspace:*",
     "nanoid": "catalog:*",
     "type-fest": "catalog:*",
     "zod": "catalog:*"

--- a/packages/types/src/entities/security-scheme.test.ts
+++ b/packages/types/src/entities/security-scheme.test.ts
@@ -1,5 +1,7 @@
+import { coerce, validate } from '@scalar/validation'
 import { describe, expect, it } from 'vitest'
 
+import type { SecuritySchemeOauth2 } from './security-scheme'
 import {
   oasSecurityRequirementSchema,
   pkceOptions,
@@ -12,7 +14,7 @@ import {
 
 describe('Security Schemas', () => {
   describe('API Key Schema', () => {
-    it('should validate a valid API key schema', () => {
+    it('validates a valid API key schema', () => {
       const apiKey = {
         type: 'apiKey',
         name: 'api_key',
@@ -23,17 +25,16 @@ describe('Security Schemas', () => {
         value: 'test-api-key',
       }
 
-      const result = securityApiKeySchema.safeParse(apiKey)
-      expect(result.success).toBe(true)
+      expect(validate(securityApiKeySchema, apiKey)).toBe(true)
     })
 
-    it('should apply default values', () => {
+    it('applies default values', () => {
       const minimalApiKey = {
         type: 'apiKey',
         uid: 'apikey123',
       }
 
-      const result = securityApiKeySchema.parse(minimalApiKey)
+      const result = coerce(securityApiKeySchema, minimalApiKey)
       expect(result).toEqual({
         type: 'apiKey',
         uid: 'apikey123',
@@ -46,21 +47,23 @@ describe('Security Schemas', () => {
   })
 
   describe('HTTP Schema', () => {
-    it('should validate a valid HTTP basic schema', () => {
+    it('validates a valid HTTP basic schema', () => {
       const httpBasic = {
         type: 'http',
         scheme: 'basic',
         description: 'Basic HTTP Authentication',
         uid: 'http123',
+        bearerFormat: 'JWT',
+        nameKey: '',
         username: 'user',
         password: 'pass',
+        token: '',
       }
 
-      const result = securityHttpSchema.safeParse(httpBasic)
-      expect(result.success).toBe(true)
+      expect(validate(securityHttpSchema, httpBasic)).toBe(true)
     })
 
-    it('should validate a valid HTTP bearer schema', () => {
+    it('coerces a valid HTTP bearer schema', () => {
       const httpBearer = {
         type: 'http',
         scheme: 'bearer',
@@ -70,17 +73,19 @@ describe('Security Schemas', () => {
         token: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
       }
 
-      const result = securityHttpSchema.safeParse(httpBearer)
-      expect(result.success).toBe(true)
+      const result = coerce(securityHttpSchema, httpBearer)
+      expect(result.type).toBe('http')
+      expect(result.scheme).toBe('bearer')
+      expect(result.token).toBe('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9')
     })
 
-    it('should apply default values', () => {
+    it('applies default values', () => {
       const minimalHttp = {
         type: 'http',
         uid: 'http123',
       }
 
-      const result = securityHttpSchema.parse(minimalHttp)
+      const result = coerce(securityHttpSchema, minimalHttp)
       expect(result).toEqual({
         type: 'http',
         uid: 'http123',
@@ -93,20 +98,20 @@ describe('Security Schemas', () => {
       })
     })
 
-    it('should reject invalid scheme values', () => {
+    it('falls back to basic for invalid scheme values', () => {
       const invalidHttp = {
         type: 'http',
         scheme: 'digest',
         uid: 'http123',
       }
 
-      const result = securityHttpSchema.safeParse(invalidHttp)
-      expect(result.success).toBe(false)
+      const result = coerce(securityHttpSchema, invalidHttp)
+      expect(result.scheme).toBe('basic')
     })
   })
 
   describe('OpenID Connect Schema', () => {
-    it('should validate a valid OpenID schema', () => {
+    it('validates a valid OpenID schema', () => {
       const openId = {
         type: 'openIdConnect',
         openIdConnectUrl: 'https://example.com/.well-known/openid-configuration',
@@ -115,17 +120,16 @@ describe('Security Schemas', () => {
         nameKey: 'openid',
       }
 
-      const result = securityOpenIdSchema.safeParse(openId)
-      expect(result.success).toBe(true)
+      expect(validate(securityOpenIdSchema, openId)).toBe(true)
     })
 
-    it('should apply default values', () => {
+    it('applies default values', () => {
       const minimalOpenId = {
         type: 'openIdConnect',
         uid: 'openid123',
       }
 
-      const result = securityOpenIdSchema.parse(minimalOpenId)
+      const result = coerce(securityOpenIdSchema, minimalOpenId)
       expect(result).toEqual({
         type: 'openIdConnect',
         uid: 'openid123',
@@ -136,7 +140,7 @@ describe('Security Schemas', () => {
   })
 
   describe('OAuth2 Schema', () => {
-    it('should validate a valid OAuth2 implicit flow schema', () => {
+    it('coerces a valid OAuth2 implicit flow schema', () => {
       const oauth2Implicit = {
         type: 'oauth2',
         description: 'OAuth2 Implicit Flow',
@@ -155,11 +159,13 @@ describe('Security Schemas', () => {
         },
       }
 
-      const result = securityOauthSchema.safeParse(oauth2Implicit)
-      expect(result.success).toBe(true)
+      const result = coerce(securityOauthSchema, oauth2Implicit) as SecuritySchemeOauth2
+      expect(result.type).toBe('oauth2')
+      expect(result.flows.implicit?.authorizationUrl).toBe('https://example.com/oauth/authorize')
+      expect(result.flows.implicit?.selectedScopes).toEqual(['read:api'])
     })
 
-    it('should validate a valid OAuth2 with missing scopes', () => {
+    it('coerces a valid OAuth2 with missing scopes', () => {
       const oauth2Implicit = {
         type: 'oauth2',
         description: 'OAuth2 Implicit Flow',
@@ -175,11 +181,13 @@ describe('Security Schemas', () => {
         },
       }
 
-      const result = securityOauthSchema.safeParse(oauth2Implicit)
-      expect(result.success).toBe(true)
+      const result = coerce(securityOauthSchema, oauth2Implicit) as SecuritySchemeOauth2
+      expect(result.type).toBe('oauth2')
+      // Invalid `scopes` falls back to an empty record.
+      expect(result.flows.implicit?.scopes).toEqual({})
     })
 
-    it('should validate a valid OAuth2 authorization code flow schema', () => {
+    it('coerces a valid OAuth2 authorization code flow schema', () => {
       const oauth2AuthCode = {
         type: 'oauth2',
         description: 'OAuth2 Authorization Code Flow',
@@ -206,17 +214,18 @@ describe('Security Schemas', () => {
         },
       }
 
-      const result = securityOauthSchema.safeParse(oauth2AuthCode)
-      expect(result.success).toBe(true)
-      expect(result.data?.flows.authorizationCode?.['x-scalar-security-query']).toEqual({
+      const result = coerce(securityOauthSchema, oauth2AuthCode) as SecuritySchemeOauth2
+      expect(result.type).toBe('oauth2')
+      expect(result.flows.authorizationCode?.['x-usePkce']).toBe('SHA-256')
+      expect(result.flows.authorizationCode?.['x-scalar-security-query']).toEqual({
         prompt: 'consent',
       })
-      expect(result.data?.flows.authorizationCode?.['x-scalar-security-body']).toEqual({
+      expect(result.flows.authorizationCode?.['x-scalar-security-body']).toEqual({
         audience: 'foo',
       })
     })
 
-    it('should validate a valid OAuth2 client credentials flow schema', () => {
+    it('coerces a valid OAuth2 client credentials flow schema', () => {
       const oauth2ClientCreds = {
         type: 'oauth2',
         description: 'OAuth2 Client Credentials Flow',
@@ -232,11 +241,12 @@ describe('Security Schemas', () => {
         },
       }
 
-      const result = securityOauthSchema.safeParse(oauth2ClientCreds)
-      expect(result.success).toBe(true)
+      const result = coerce(securityOauthSchema, oauth2ClientCreds) as SecuritySchemeOauth2
+      expect(result.type).toBe('oauth2')
+      expect(result.flows.clientCredentials?.tokenUrl).toBe('https://example.com/oauth/token')
     })
 
-    it('should validate a valid OAuth2 password flow schema', () => {
+    it('coerces a valid OAuth2 password flow schema', () => {
       const oauth2Password = {
         type: 'oauth2',
         description: 'OAuth2 Password Flow',
@@ -258,17 +268,18 @@ describe('Security Schemas', () => {
         },
       }
 
-      const result = securityOauthSchema.safeParse(oauth2Password)
-      expect(result.success).toBe(true)
+      const result = coerce(securityOauthSchema, oauth2Password) as SecuritySchemeOauth2
+      expect(result.type).toBe('oauth2')
+      expect(result.flows.password?.username).toBe('testuser')
     })
 
-    it('should apply default values', () => {
+    it('applies default values', () => {
       const minimalOauth2 = {
         type: 'oauth2',
         uid: 'oauth123',
       }
 
-      const result = securityOauthSchema.parse(minimalOauth2)
+      const result = coerce(securityOauthSchema, minimalOauth2) as SecuritySchemeOauth2
       expect(result.flows.implicit).toBeDefined()
       expect(result.flows.implicit?.authorizationUrl).toBe('http://localhost:8080')
       expect(result.flows.implicit?.scopes).toEqual({})
@@ -277,20 +288,20 @@ describe('Security Schemas', () => {
       expect(result.nameKey).toBe('')
     })
 
-    it('should validate PKCE options', () => {
+    it('validates PKCE options', () => {
       expect(pkceOptions).toContain('SHA-256')
       expect(pkceOptions).toContain('plain')
       expect(pkceOptions).toContain('no')
     })
 
-    it('should apply x-default-scopes', () => {
+    it('applies x-default-scopes', () => {
       const oauth2 = {
         type: 'oauth2',
         uid: 'oauth123',
         'x-default-scopes': ['read:api', 'write:api'],
       }
 
-      const result = securitySchemeSchema.parse(oauth2)
+      const result = coerce(securitySchemeSchema, oauth2)
       if (result.type !== 'oauth2') {
         throw new Error('Expected oauth2 schema')
       }
@@ -300,22 +311,21 @@ describe('Security Schemas', () => {
   })
 
   describe('Security Requirement Schema', () => {
-    it('should validate a valid security requirement', () => {
+    it('validates a valid security requirement', () => {
       const securityRequirement = {
         'api_key': [],
         'oauth2': ['read:api', 'write:api'],
       }
 
-      const result = oasSecurityRequirementSchema.safeParse(securityRequirement)
-      expect(result.success).toBe(true)
+      expect(validate(oasSecurityRequirementSchema, securityRequirement)).toBe(true)
     })
 
-    it('should apply default values for empty scopes', () => {
+    it('applies default values for empty scopes', () => {
       const securityRequirement = {
         'api_key': undefined,
       }
 
-      const result = oasSecurityRequirementSchema.parse(securityRequirement)
+      const result = coerce(oasSecurityRequirementSchema, securityRequirement)
       expect(result).toEqual({
         'api_key': [],
       })
@@ -323,7 +333,7 @@ describe('Security Schemas', () => {
   })
 
   describe('Combined Security Scheme', () => {
-    it('should validate all security scheme types', () => {
+    it('coerces all security scheme types', () => {
       const apiKey = {
         type: 'apiKey',
         name: 'api_key',
@@ -358,10 +368,10 @@ describe('Security Schemas', () => {
         },
       }
 
-      expect(securitySchemeSchema.safeParse(apiKey).success).toBe(true)
-      expect(securitySchemeSchema.safeParse(http).success).toBe(true)
-      expect(securitySchemeSchema.safeParse(openId).success).toBe(true)
-      expect(securitySchemeSchema.safeParse(oauth2).success).toBe(true)
+      expect(coerce(securitySchemeSchema, apiKey).type).toBe('apiKey')
+      expect(coerce(securitySchemeSchema, http).type).toBe('http')
+      expect(coerce(securitySchemeSchema, openId).type).toBe('openIdConnect')
+      expect(coerce(securitySchemeSchema, oauth2).type).toBe('oauth2')
     })
   })
 })

--- a/packages/types/src/entities/security-scheme.ts
+++ b/packages/types/src/entities/security-scheme.ts
@@ -1,135 +1,224 @@
-import { z } from 'zod'
+import {
+  type Schema,
+  any,
+  array,
+  boolean,
+  coerce,
+  evaluate,
+  literal,
+  number,
+  object,
+  optional,
+  record,
+  string,
+  union,
+} from '@scalar/validation'
 
-import { type ENTITY_BRANDS, nanoidSchema } from '../utils/nanoid'
+import { type Brand, type ENTITY_BRANDS, nanoidSchema } from '../utils/nanoid'
+
+/**
+ * Branded uid shared by every security scheme entity.
+ *
+ * The exported types below are written explicitly instead of being derived from `Static<typeof schema>`.
+ * `@scalar/validation`'s `Static` is a deeply nested conditional type; deriving these (fairly large) types
+ * from it — and especially feeding the result to `PartialDeep` downstream (see the authentication
+ * configuration) — exhausts TypeScript's instantiation budget and fails with `TS2589` "excessively deep".
+ * Hand-writing the shapes keeps every consumer cheap while the runtime schemas below stay the single source
+ * of truth for validation and coercion. This mirrors `@scalar/workspace-store`, which likewise pairs an
+ * explicit `SecuritySchemeObject` union with its runtime schema.
+ */
+type SecuritySchemeUid = Brand<string, ENTITY_BRANDS['SECURITY_SCHEME']>
+
+/** Properties shared by every security scheme. */
+type CommonSecuritySchemeProps = {
+  /** A description for security scheme. CommonMark syntax MAY be used for rich text representation. */
+  description?: string
+  /** When true, the whole scheme is hidden from the auth UI. */
+  'x-scalar-ignore'?: boolean
+  /** UID for the entity, branded to the security scheme kind. */
+  uid: SecuritySchemeUid
+  /** The name key that links a security requirement to a security object. */
+  nameKey: string
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+//
+// `@scalar/validation` has no direct equivalent of a few zod combinators used here, so we recreate the
+// exact runtime behaviour with `evaluate`, which normalises the incoming value before the inner schema
+// validates or coerces it.
+
+/**
+ * Reproduces `z.enum(values).optional().default(fallback).catch(fallback)`.
+ *
+ * Any value that is not one of `values` (including `undefined`) becomes `fallback`.
+ */
+const enumWithDefault = <const Values extends readonly [string, ...string[]]>(
+  values: Values,
+  fallback: Values[number],
+) =>
+  evaluate(
+    (value) => (typeof value === 'string' && (values as readonly string[]).includes(value) ? value : fallback),
+    union(values.map((value) => literal(value)) as unknown as [Schema, ...Schema[]]),
+  )
 
 // ---------------------------------------------------------------------------
 // COMMON PROPS FOR ALL SECURITY SCHEMES
 
 /** Some common properties used in all security schemes */
-const commonProps = z.object({
-  /* A description for security scheme. CommonMark syntax MAY be used for rich text representation. */
-  description: z.string().optional(),
+const commonProps = {
+  /** A description for security scheme. CommonMark syntax MAY be used for rich text representation. */
+  description: optional(string()),
   /** When true, the whole scheme is hidden from the auth UI. See documentation/openapi.md. */
-  'x-scalar-ignore': z.boolean().optional(),
-})
+  'x-scalar-ignore': optional(boolean()),
+}
 
-const extendedSecuritySchema = z.object({
-  uid: nanoidSchema.brand<ENTITY_BRANDS['SECURITY_SCHEME']>(),
+const extendedSecurityProps = {
+  uid: nanoidSchema,
   /** The name key that links a security requirement to a security object */
-  nameKey: z.string().optional().default(''),
-})
+  nameKey: string({ default: '' }),
+}
 
 // ---------------------------------------------------------------------------
 // API KEY
 
 const securitySchemeApiKeyIn = ['query', 'header', 'cookie'] as const
 
-const oasSecuritySchemeApiKey = commonProps.extend({
-  type: z.literal('apiKey'),
+const oasSecuritySchemeApiKeyProps = {
+  ...commonProps,
+  type: literal('apiKey'),
   /** REQUIRED. The name of the header, query or cookie parameter to be used. */
-  name: z.string().optional().default(''),
+  name: string({ default: '' }),
   /** REQUIRED. The location of the API key. Valid values are "query", "header" or "cookie". */
-  in: z.enum(securitySchemeApiKeyIn).optional().default('header').catch('header'),
-})
+  in: enumWithDefault(securitySchemeApiKeyIn, 'header'),
+}
 
-const apiKeyValueSchema = z.object({
-  value: z.string().default(''),
-})
+const oasSecuritySchemeApiKey = object(oasSecuritySchemeApiKeyProps)
 
-export const securityApiKeySchema = oasSecuritySchemeApiKey.merge(extendedSecuritySchema).merge(apiKeyValueSchema)
-export type SecuritySchemeApiKey = z.infer<typeof securityApiKeySchema>
+const apiKeyValueProps = {
+  value: string({ default: '' }),
+}
+
+export const securityApiKeySchema = object({
+  ...oasSecuritySchemeApiKeyProps,
+  ...extendedSecurityProps,
+  ...apiKeyValueProps,
+})
+export type SecuritySchemeApiKey = CommonSecuritySchemeProps & {
+  type: 'apiKey'
+  /** REQUIRED. The name of the header, query or cookie parameter to be used. */
+  name: string
+  /** REQUIRED. The location of the API key. Valid values are "query", "header" or "cookie". */
+  in: 'query' | 'header' | 'cookie'
+  value: string
+}
 
 // ---------------------------------------------------------------------------
 // HTTP
 
-const oasSecuritySchemeHttp = commonProps.extend({
-  type: z.literal('http'),
+const oasSecuritySchemeHttpProps = {
+  ...commonProps,
+  type: literal('http'),
   /**
    * REQUIRED. The name of the HTTP Authorization scheme to be used in the Authorization header as defined in
    * [RFC7235]. The values used SHOULD be registered in the IANA Authentication Scheme registry.
+   *
+   * The value is lower-cased before validation to stay backwards-compatible with `z.string().toLowerCase()`.
    */
-  scheme: z
-    .string()
-    .toLowerCase()
-    .pipe(z.enum(['basic', 'bearer']))
-    .optional()
-    .default('basic'),
+  scheme: evaluate(
+    (value) => {
+      const normalized = typeof value === 'string' ? value.toLowerCase() : value
+      return normalized === 'basic' || normalized === 'bearer' ? normalized : 'basic'
+    },
+    union([literal('basic'), literal('bearer')]),
+  ),
   /**
    * A hint to the client to identify how the bearer token is formatted.
    * Bearer tokens are usually generated by an authorization server, so
    * this information is primarily for documentation purposes.
    */
-  bearerFormat: z
-    .union([z.literal('JWT'), z.string()])
-    .optional()
-    .default('JWT'),
-})
+  bearerFormat: string({ default: 'JWT' }),
+}
 
-const httpValueSchema = z.object({
-  username: z.string().default(''),
-  password: z.string().default(''),
-  token: z.string().default(''),
-})
+const oasSecuritySchemeHttp = object(oasSecuritySchemeHttpProps)
 
-export const securityHttpSchema = oasSecuritySchemeHttp.merge(extendedSecuritySchema).merge(httpValueSchema)
-export type SecuritySchemaHttp = z.infer<typeof securityHttpSchema>
+const httpValueProps = {
+  username: string({ default: '' }),
+  password: string({ default: '' }),
+  token: string({ default: '' }),
+}
+
+export const securityHttpSchema = object({
+  ...oasSecuritySchemeHttpProps,
+  ...extendedSecurityProps,
+  ...httpValueProps,
+})
+export type SecuritySchemaHttp = CommonSecuritySchemeProps & {
+  type: 'http'
+  /** REQUIRED. The name of the HTTP Authorization scheme to be used in the Authorization header. */
+  scheme: 'basic' | 'bearer'
+  /** A hint to the client to identify how the bearer token is formatted. */
+  bearerFormat: string
+  username: string
+  password: string
+  token: string
+}
 
 // ---------------------------------------------------------------------------
 // OPENID CONNECT
-const oasSecuritySchemeOpenId = commonProps.extend({
-  type: z.literal('openIdConnect'),
+
+const oasSecuritySchemeOpenIdProps = {
+  ...commonProps,
+  type: literal('openIdConnect'),
   /**
    * REQUIRED. OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the
    * form of a URL. The OpenID Connect standard requires the use of TLS.
    */
-  openIdConnectUrl: z.string().optional().default(''),
-})
+  openIdConnectUrl: string({ default: '' }),
+}
 
-export const securityOpenIdSchema = oasSecuritySchemeOpenId.merge(extendedSecuritySchema)
-export type SecuritySchemaOpenId = z.infer<typeof securityOpenIdSchema>
+const oasSecuritySchemeOpenId = object(oasSecuritySchemeOpenIdProps)
+
+export const securityOpenIdSchema = object({
+  ...oasSecuritySchemeOpenIdProps,
+  ...extendedSecurityProps,
+})
+export type SecuritySchemaOpenId = CommonSecuritySchemeProps & {
+  type: 'openIdConnect'
+  /** REQUIRED. OpenId Connect URL to discover OAuth2 configuration values. */
+  openIdConnectUrl: string
+}
 
 // ---------------------------------------------------------------------------
 
-/**
- * REQUIRED. The authorization URL to be used for this flow. This MUST be in
- * the form of a URL. The OAuth2 standard requires the use of TLS.
- */
-const authorizationUrl = z.string().default('')
-
-/**
- * REQUIRED. The token URL to be used for this flow. This MUST be in the
- * form of a URL. The OAuth2 standard requires the use of TLS.
- */
-const tokenUrl = z.string().default('')
-
 /** Common properties used across all oauth2 flows */
-const flowsCommon = z.object({
+const flowsCommon = {
   /**
    * The URL to be used for obtaining refresh tokens. This MUST be in the form of a
    * URL. The OAuth2 standard requires the use of TLS.
    */
-  'refreshUrl': z.string().optional().default(''),
+  'refreshUrl': string({ default: '' }),
   /**
    * REQUIRED. The available scopes for the OAuth2 security scheme. A map
    * between the scope name and a short description for it. The map MAY be empty.
    */
-  'scopes': z.record(z.string(), z.string().optional().default('')).optional().default({}).catch({}),
-  'selectedScopes': z.array(z.string()).optional().default([]),
+  'scopes': record(string(), string()),
+  'selectedScopes': array(string()),
   /** Extension to save the client Id associated with an oauth flow */
-  'x-scalar-client-id': z.string().optional().default(''),
+  'x-scalar-client-id': string({ default: '' }),
   /** The auth token */
-  'token': z.string().default(''),
+  'token': string({ default: '' }),
   /** Additional query parameters for the OAuth authorization request. Example: { prompt: 'consent', audience: 'scalar' }. */
-  'x-scalar-security-query': z.record(z.string(), z.string()).optional(),
+  'x-scalar-security-query': optional(record(string(), string())),
   /** Additional body parameters for the OAuth token request. Example: { audience: 'foo' }. */
-  'x-scalar-security-body': z.record(z.string(), z.string()).optional(),
+  'x-scalar-security-body': optional(record(string(), string())),
   /** Extension to specify custom token name in the response (defaults to 'access_token') */
-  'x-tokenName': z.string().optional(),
+  'x-tokenName': optional(string()),
   /** Display order of this flow's tab in the auth UI (ascending). See documentation/openapi.md. */
-  'x-order': z.number().optional(),
+  'x-order': optional(number()),
   /** When true, this flow's tab is hidden from the auth UI. See documentation/openapi.md. */
-  'x-scalar-ignore': z.boolean().optional(),
-})
+  'x-scalar-ignore': optional(boolean()),
+}
 
 /** Setup a default redirect uri if we can */
 const defaultRedirectUri = typeof window !== 'undefined' ? window.location.origin + window.location.pathname : ''
@@ -137,78 +226,164 @@ const defaultRedirectUri = typeof window !== 'undefined' ? window.location.origi
 /** Options for the x-usePkce extension */
 export const pkceOptions = ['SHA-256', 'plain', 'no'] as const
 
-const credentialsLocationExtension = z.enum(['header', 'body']).optional()
+const credentialsLocationExtension = optional(union([literal('header'), literal('body')]))
 
-/** Oauth2 security scheme */
-const oasSecuritySchemeOauth2 = commonProps.extend({
-  type: z.literal('oauth2'),
-  /** The default scopes for the oauth flow */
-  'x-default-scopes': z.array(z.string()).optional(),
-  /** REQUIRED. An object containing configuration information for the flow types supported. */
-  flows: z
-    .object({
-      /** Configuration for the OAuth Implicit flow */
-      implicit: flowsCommon.extend({
-        'type': z.literal('implicit').default('implicit'),
-        authorizationUrl,
-        'x-scalar-redirect-uri': z.string().optional().default(defaultRedirectUri),
-      }),
-      /** Configuration for the OAuth Resource Owner Password flow */
-      password: flowsCommon.extend({
-        type: z.literal('password').default('password'),
-        tokenUrl,
-        clientSecret: z.string().default(''),
-        username: z.string().default(''),
-        password: z.string().default(''),
-        'x-scalar-credentials-location': credentialsLocationExtension,
-      }),
-      /** Configuration for the OAuth Client Credentials flow. Previously called application in OpenAPI 2.0. */
-      clientCredentials: flowsCommon.extend({
-        type: z.literal('clientCredentials').default('clientCredentials'),
-        tokenUrl,
-        clientSecret: z.string().default(''),
-        'x-scalar-credentials-location': credentialsLocationExtension,
-      }),
-      /** Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0.*/
-      authorizationCode: flowsCommon.extend({
-        'type': z.literal('authorizationCode').default('authorizationCode'),
-        authorizationUrl,
-        'x-usePkce': z.enum(pkceOptions).optional().default('no'),
-        'x-scalar-redirect-uri': z.string().optional().default(defaultRedirectUri),
-        tokenUrl,
-        clientSecret: z.string().default(''),
-        'x-scalar-credentials-location': credentialsLocationExtension,
-      }),
-    })
-    .partial()
-    .default({
-      implicit: {
-        selectedScopes: [],
-        scopes: {},
-        'x-scalar-client-id': '',
-        refreshUrl: '',
-        token: '',
-        type: 'implicit',
-        authorizationUrl: 'http://localhost:8080',
-        'x-scalar-redirect-uri': defaultRedirectUri,
-      },
-    }),
+const implicitFlowSchema = object({
+  ...flowsCommon,
+  'type': literal('implicit'),
+  'authorizationUrl': string({ default: '' }),
+  'x-scalar-redirect-uri': string({ default: defaultRedirectUri }),
 })
 
-export const securityOauthSchema = oasSecuritySchemeOauth2.merge(extendedSecuritySchema)
+const passwordFlowSchema = object({
+  ...flowsCommon,
+  'type': literal('password'),
+  'tokenUrl': string({ default: '' }),
+  'clientSecret': string({ default: '' }),
+  'username': string({ default: '' }),
+  'password': string({ default: '' }),
+  'x-scalar-credentials-location': credentialsLocationExtension,
+})
 
-export type SecuritySchemeOauth2 = z.infer<typeof securityOauthSchema>
-export type SecuritySchemeOauth2Payload = z.input<typeof securityOauthSchema>
-export type Oauth2Flow = NonNullable<
-  SecuritySchemeOauth2['flows']['authorizationCode' | 'clientCredentials' | 'implicit' | 'password']
->
+const clientCredentialsFlowSchema = object({
+  ...flowsCommon,
+  'type': literal('clientCredentials'),
+  'tokenUrl': string({ default: '' }),
+  'clientSecret': string({ default: '' }),
+  'x-scalar-credentials-location': credentialsLocationExtension,
+})
+
+const authorizationCodeFlowSchema = object({
+  ...flowsCommon,
+  'type': literal('authorizationCode'),
+  'authorizationUrl': string({ default: '' }),
+  'x-usePkce': enumWithDefault(pkceOptions, 'no'),
+  'x-scalar-redirect-uri': string({ default: defaultRedirectUri }),
+  'tokenUrl': string({ default: '' }),
+  'clientSecret': string({ default: '' }),
+  'x-scalar-credentials-location': credentialsLocationExtension,
+})
+
+/** The default flows object applied when no `flows` are provided (mirrors the previous zod `.default(...)`). */
+const defaultFlows = {
+  implicit: {
+    selectedScopes: [],
+    scopes: {},
+    'x-scalar-client-id': '',
+    refreshUrl: '',
+    token: '',
+    type: 'implicit',
+    authorizationUrl: 'http://localhost:8080',
+    'x-scalar-redirect-uri': defaultRedirectUri,
+  },
+}
+
+const oasSecuritySchemeOauth2Props = {
+  ...commonProps,
+  type: literal('oauth2'),
+  /** The default scopes for the oauth flow */
+  'x-default-scopes': optional(array(string())),
+  /** REQUIRED. An object containing configuration information for the flow types supported. */
+  flows: evaluate(
+    (value) => (value === undefined ? defaultFlows : value),
+    object({
+      /** Configuration for the OAuth Implicit flow */
+      implicit: optional(implicitFlowSchema),
+      /** Configuration for the OAuth Resource Owner Password flow */
+      password: optional(passwordFlowSchema),
+      /** Configuration for the OAuth Client Credentials flow. Previously called application in OpenAPI 2.0. */
+      clientCredentials: optional(clientCredentialsFlowSchema),
+      /** Configuration for the OAuth Authorization Code flow. Previously called accessCode in OpenAPI 2.0. */
+      authorizationCode: optional(authorizationCodeFlowSchema),
+    }),
+  ),
+}
+
+const oasSecuritySchemeOauth2 = object(oasSecuritySchemeOauth2Props)
+
+export const securityOauthSchema = object({
+  ...oasSecuritySchemeOauth2Props,
+  ...extendedSecurityProps,
+})
+
+/** Properties shared by every oauth2 flow. */
+type OAuth2FlowCommon = {
+  /** The URL to be used for obtaining refresh tokens. */
+  refreshUrl: string
+  /** REQUIRED. The available scopes for the OAuth2 security scheme. */
+  scopes: Record<string, string>
+  selectedScopes: string[]
+  /** Extension to save the client Id associated with an oauth flow. */
+  'x-scalar-client-id': string
+  /** The auth token. */
+  token: string
+  /** Additional query parameters for the OAuth authorization request. */
+  'x-scalar-security-query'?: Record<string, string>
+  /** Additional body parameters for the OAuth token request. */
+  'x-scalar-security-body'?: Record<string, string>
+  /** Extension to specify custom token name in the response (defaults to 'access_token'). */
+  'x-tokenName'?: string
+  /** Display order of this flow's tab in the auth UI (ascending). */
+  'x-order'?: number
+  /** When true, this flow's tab is hidden from the auth UI. */
+  'x-scalar-ignore'?: boolean
+}
+
+export type Oauth2FlowImplicit = OAuth2FlowCommon & {
+  type: 'implicit'
+  authorizationUrl: string
+  'x-scalar-redirect-uri': string
+}
+
+export type Oauth2FlowPassword = OAuth2FlowCommon & {
+  type: 'password'
+  tokenUrl: string
+  clientSecret: string
+  username: string
+  password: string
+  'x-scalar-credentials-location'?: 'header' | 'body'
+}
+
+export type Oauth2FlowClientCredentials = OAuth2FlowCommon & {
+  type: 'clientCredentials'
+  tokenUrl: string
+  clientSecret: string
+  'x-scalar-credentials-location'?: 'header' | 'body'
+}
+
+export type Oauth2FlowAuthorizationCode = OAuth2FlowCommon & {
+  type: 'authorizationCode'
+  authorizationUrl: string
+  'x-usePkce': (typeof pkceOptions)[number]
+  'x-scalar-redirect-uri': string
+  tokenUrl: string
+  clientSecret: string
+  'x-scalar-credentials-location'?: 'header' | 'body'
+}
+
+/** The set of oauth2 flows, each optional. */
+export type Oauth2Flows = {
+  implicit?: Oauth2FlowImplicit
+  password?: Oauth2FlowPassword
+  clientCredentials?: Oauth2FlowClientCredentials
+  authorizationCode?: Oauth2FlowAuthorizationCode
+}
+
+export type SecuritySchemeOauth2 = CommonSecuritySchemeProps & {
+  type: 'oauth2'
+  /** The default scopes for the oauth flow. */
+  'x-default-scopes'?: string[]
+  /** REQUIRED. An object containing configuration information for the flow types supported. */
+  flows: Oauth2Flows
+}
+export type SecuritySchemeOauth2Payload = SecuritySchemeOauth2
+export type Oauth2Flow =
+  | Oauth2FlowImplicit
+  | Oauth2FlowPassword
+  | Oauth2FlowClientCredentials
+  | Oauth2FlowAuthorizationCode
 /** Payload for the oauth 2 flows + extensions */
-export type Oauth2FlowPayload = NonNullable<SecuritySchemeOauth2Payload['flows']>[
-  | 'authorizationCode'
-  | 'clientCredentials'
-  | 'implicit'
-  | 'password'] &
-  Record<`x-${string}`, string>
+export type Oauth2FlowPayload = Oauth2Flow & Record<`x-${string}`, string>
 
 // ---------------------------------------------------------------------------
 // Final Types
@@ -223,36 +398,63 @@ export type Oauth2FlowPayload = NonNullable<SecuritySchemeOauth2Payload['flows']
  *
  * @see https://spec.openapis.org/oas/latest.html#security-requirement-object
  */
-export const oasSecurityRequirementSchema = z.record(z.string(), z.array(z.string()).optional().default([]))
+export const oasSecurityRequirementSchema = record(string(), array(string()))
 
 /** OAS Compliant security schemes */
-export const oasSecuritySchemeSchema = z.union([
+export const oasSecuritySchemeSchema = union([
   oasSecuritySchemeApiKey,
   oasSecuritySchemeHttp,
   oasSecuritySchemeOauth2,
   oasSecuritySchemeOpenId,
 ])
 
-/** Extended security schemes for workspace usage */
-export const securitySchemeSchema = z
-  .discriminatedUnion('type', [securityApiKeySchema, securityHttpSchema, securityOpenIdSchema, securityOauthSchema])
-  .transform((data) => {
-    // Set selected scopes from x-default-scopes
-    if (data.type === 'oauth2' && data['x-default-scopes']?.length) {
-      const keys = Object.keys(data.flows) as Array<keyof typeof data.flows>
-      keys.forEach((key) => {
-        if (data.flows[key]?.selectedScopes && data['x-default-scopes']) {
-          data.flows[key].selectedScopes = [data['x-default-scopes']].flat()
-        }
-      })
-    }
-    return data
-  })
+const securitySchemeUnion = union([securityApiKeySchema, securityHttpSchema, securityOpenIdSchema, securityOauthSchema])
+
+/**
+ * Applies the `x-default-scopes` extension to every oauth2 flow's `selectedScopes`.
+ *
+ * This preserves the behaviour of the previous zod `.transform(...)`: after the union coerces the value into
+ * its final shape, we copy `x-default-scopes` into each flow's `selectedScopes`.
+ */
+const applyDefaultScopes = (data: SecurityScheme): SecurityScheme => {
+  if (data.type === 'oauth2' && data['x-default-scopes']?.length) {
+    const keys = Object.keys(data.flows) as Array<keyof typeof data.flows>
+    keys.forEach((key) => {
+      const flow = data.flows[key]
+      if (flow?.selectedScopes && data['x-default-scopes']) {
+        flow.selectedScopes = [data['x-default-scopes']].flat()
+      }
+    })
+  }
+  return data
+}
+
+/**
+ * Extended security schemes for workspace usage.
+ *
+ * Coercing a value with this schema runs the union coercion first and then applies the `x-default-scopes`
+ * transform, mirroring the previous zod `discriminatedUnion(...).transform(...)`. The inner schema is
+ * `any()` so the transformed value passes through untouched; the type is pinned to the union so `Static`
+ * and downstream `import type` sites keep the exact discriminated-union shape.
+ */
+// `coerce`'s return type is `Static<S>`; on the full concrete union that computation is deep enough to trip
+// `tsc`'s `TS2589` budget when instantiated here. Reference it through a plain `(schema, value) => unknown`
+// signature so the return type is not computed at this call site; the runtime behaviour is unchanged.
+const coerceValue = coerce as (schema: Schema, value: unknown) => unknown
+
+export const securitySchemeSchema = evaluate(
+  (value) => applyDefaultScopes(coerceValue(securitySchemeUnion, value) as SecurityScheme),
+  any(),
+) as unknown as typeof securitySchemeUnion
 
 /**
  * Security Scheme Object
  *
+ * Built from the already-materialised branch types instead of `Static<typeof securitySchemeUnion>`.
+ * Resolving the union once here keeps the type shallow so downstream `PartialDeep<SecurityScheme>` usages
+ * (for example the authentication configuration) do not hit `TS2589` "excessively deep" instantiation.
+ *
  * @see https://spec.openapis.org/oas/latest.html#security-scheme-object
  */
-export type SecurityScheme = z.infer<typeof securitySchemeSchema>
-export type SecuritySchemePayload = z.input<typeof securitySchemeSchema>
+export type SecurityScheme = SecuritySchemeApiKey | SecuritySchemaHttp | SecuritySchemaOpenId | SecuritySchemeOauth2
+export type SecuritySchemePayload = SecurityScheme

--- a/packages/types/src/utils/nanoid.test.ts
+++ b/packages/types/src/utils/nanoid.test.ts
@@ -1,34 +1,36 @@
+import { coerce } from '@scalar/validation'
 import { describe, expect, it } from 'vitest'
-import { z } from 'zod'
 
 import { type Nanoid, nanoidSchema } from './nanoid'
 
 describe('nanoidSchema', () => {
-  it('should generate a string with minimum length of 7 characters when no value is provided', () => {
-    const result = nanoidSchema.parse(undefined)
+  it('generates a string with minimum length of 7 characters when no value is provided', () => {
+    const result = coerce(nanoidSchema, undefined)
     expect(typeof result).toBe('string')
     expect(result.length).toBeGreaterThanOrEqual(7)
   })
 
-  it('should accept valid strings with length >= 7', () => {
+  it('accepts valid strings with length >= 7', () => {
     const validString = '1234567'
-    const result = nanoidSchema.parse(validString)
+    const result = coerce(nanoidSchema, validString)
     expect(result).toBe(validString)
   })
 
-  it('should reject strings shorter than 7 characters', () => {
+  it('generates a new id for strings shorter than 7 characters', () => {
     const invalidString = '123456'
-    expect(() => nanoidSchema.parse(invalidString)).toThrow(z.ZodError)
+    const result = coerce(nanoidSchema, invalidString)
+    expect(result).not.toBe(invalidString)
+    expect(result.length).toBeGreaterThanOrEqual(7)
   })
 
-  it('should generate different IDs for multiple calls', () => {
-    const id1 = nanoidSchema.parse(undefined)
-    const id2 = nanoidSchema.parse(undefined)
+  it('generates different IDs for multiple calls', () => {
+    const id1 = coerce(nanoidSchema, undefined)
+    const id2 = coerce(nanoidSchema, undefined)
     expect(id1).not.toBe(id2)
   })
 
-  it('should properly type the generated ID as Nanoid', () => {
-    const id: Nanoid = nanoidSchema.parse(undefined)
+  it('types the generated ID as Nanoid', () => {
+    const id: Nanoid = coerce(nanoidSchema, undefined)
     expect(typeof id).toBe('string')
   })
 })

--- a/packages/types/src/utils/nanoid.ts
+++ b/packages/types/src/utils/nanoid.ts
@@ -1,16 +1,37 @@
+import { type Static, evaluate, string } from '@scalar/validation'
 import { nanoid } from 'nanoid'
-import { z } from 'zod'
 
-/** Generates a default value */
-export const nanoidSchema = z
-  .string()
-  .min(7)
-  .default(() => nanoid())
+/**
+ * Minimum length for a generated id. Historically enforced by `z.string().min(7)`.
+ * Anything shorter (or a non-string) is treated as missing and a fresh id is generated.
+ */
+const MINIMUM_ID_LENGTH = 7
+
+/**
+ * Schema for our entity uids.
+ *
+ * When a valid id (a string of at least {@link MINIMUM_ID_LENGTH} characters) is provided it is kept
+ * as-is; otherwise a fresh id is generated with `nanoid()`. This mirrors the previous
+ * `z.string().min(7).default(() => nanoid())` behaviour, but without pulling zod into the runtime bundle.
+ */
+export const nanoidSchema = evaluate(
+  (value) => (typeof value === 'string' && value.length >= MINIMUM_ID_LENGTH ? value : nanoid()),
+  string(),
+)
+
+/**
+ * Nominal brand helper.
+ *
+ * `@scalar/validation` has no equivalent of zod's `.brand()`, so we reproduce the nominal typing at the
+ * type level. `Brand<string, 'collection'>` stays structurally compatible with `string` (matching how the
+ * previous zod brands behaved for our uids) while still distinguishing entity kinds in editor tooling.
+ */
+export type Brand<T, B> = T & { readonly __brand?: B }
 
 /** UID format for objects */
-export type Nanoid = z.infer<typeof nanoidSchema>
+export type Nanoid = Static<typeof nanoidSchema>
 
-/** All of our Zod brands for entities, used to brand nanoidSchemas. */
+/** All of our brands for entities, used to brand uids. */
 export type ENTITY_BRANDS = {
   COLLECTION: 'collection'
   COOKIE: 'cookie'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1085,7 +1085,7 @@ importers:
     dependencies:
       '@nuxt/kit':
         specifier: ^4.0.0
-        version: 4.3.1(magicast@0.3.5)
+        version: 4.3.1(magicast@0.5.2)
       '@scalar/api-client':
         specifier: workspace:*
         version: link:../../packages/api-client
@@ -1104,7 +1104,7 @@ importers:
     devDependencies:
       '@nuxt/module-builder':
         specifier: ^1.0.1
-        version: 1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5))(@vue/compiler-core@3.5.40)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))
+        version: 1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.40)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))
       '@types/node':
         specifier: ^24.1.0
         version: 24.10.13
@@ -1113,7 +1113,7 @@ importers:
         version: 10.1.0
       nuxt:
         specifier: ^4.1.0
-        version: 4.1.2(@biomejs/biome@2.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.40)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.1.5)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+        version: 4.1.2(@biomejs/biome@2.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.40)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.1.5)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       vitest:
         specifier: catalog:*
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.10.13)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))
@@ -2126,6 +2126,9 @@ importers:
         specifier: catalog:*
         version: 2.9.0
     devDependencies:
+      '@scalar/validation':
+        specifier: workspace:*
+        version: link:../validation
       '@types/node':
         specifier: ^24.1.0
         version: 24.10.13
@@ -2571,6 +2574,9 @@ importers:
       '@scalar/helpers':
         specifier: workspace:*
         version: link:../helpers
+      '@scalar/validation':
+        specifier: workspace:*
+        version: link:../validation
       nanoid:
         specifier: catalog:*
         version: 5.1.6
@@ -23844,11 +23850,11 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)':
+  '@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)':
     dependencies:
       '@bomb.sh/tab': 0.0.14(cac@6.7.14)(citty@0.2.1)(commander@13.1.0)
       '@clack/prompts': 1.1.0
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       citty: 0.2.1
       confbox: 0.2.4
       consola: 3.4.2
@@ -24056,9 +24062,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/kit@4.1.2(magicast@0.3.5)':
+  '@nuxt/kit@4.1.2(magicast@0.5.2)':
     dependencies:
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.4
       destr: 2.0.5
@@ -24079,31 +24085,6 @@ snapshots:
       ufo: 1.6.3
       unctx: 2.5.0
       unimport: 5.7.0
-      untyped: 2.0.0
-    transitivePeerDependencies:
-      - magicast
-
-  '@nuxt/kit@4.3.1(magicast@0.3.5)':
-    dependencies:
-      c12: 3.3.3(magicast@0.3.5)
-      consola: 3.4.2
-      defu: 6.1.4
-      destr: 2.0.5
-      errx: 0.1.0
-      exsolve: 1.0.8
-      ignore: 7.0.5
-      jiti: 2.6.1
-      klona: 2.0.6
-      mlly: 1.8.1
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.0
-      rc9: 3.0.0
-      scule: 1.3.0
-      semver: 7.7.4
-      tinyglobby: 0.2.15
-      ufo: 1.6.3
-      unctx: 2.5.0
       untyped: 2.0.0
     transitivePeerDependencies:
       - magicast
@@ -24133,9 +24114,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5))(@vue/compiler-core@3.5.40)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))':
+  '@nuxt/module-builder@1.0.1(@nuxt/cli@3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.40)(esbuild@0.27.3)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))':
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
@@ -24250,9 +24231,9 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.1.2(magicast@0.3.5))':
+  '@nuxt/telemetry@2.7.0(@nuxt/kit@4.1.2(magicast@0.5.2))':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.3.5)
+      '@nuxt/kit': 4.1.2(magicast@0.5.2)
       citty: 0.2.1
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
@@ -24322,9 +24303,9 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.1.5)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.1.5)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))(yaml@2.9.0)':
     dependencies:
-      '@nuxt/kit': 4.1.2(magicast@0.3.5)
+      '@nuxt/kit': 4.1.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
       '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
       '@vitejs/plugin-vue-jsx': 5.1.4(vite@7.3.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
@@ -34110,18 +34091,18 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.1.2(@biomejs/biome@2.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.40)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.1.5)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0):
+  nuxt@4.1.2(@biomejs/biome@2.2.4)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.6)(@types/node@24.10.13)(@vue/compiler-sfc@3.5.40)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(encoding@0.1.13)(eslint@9.39.2(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.1.5)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
-      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.3.5)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.1.2)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
       '@nuxt/devalue': 2.0.2
       '@nuxt/devtools': 2.7.0(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.6.1)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
-      '@nuxt/kit': 4.1.2(magicast@0.3.5)
+      '@nuxt/kit': 4.1.2(magicast@0.5.2)
       '@nuxt/schema': 4.1.2
-      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.1.2(magicast@0.3.5))
-      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.3.5)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.1.5)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))(yaml@2.9.0)
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.1.2(magicast@0.5.2))
+      '@nuxt/vite-builder': 4.1.2(@biomejs/biome@2.2.4)(@types/node@24.10.13)(eslint@9.39.2(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(optionator@0.9.4)(rolldown@1.1.5)(rollup@4.59.0)(terser@5.31.2)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@2.2.12(typescript@5.9.3))(vue@3.5.40(typescript@5.9.3))(yaml@2.9.0)
       '@unhead/vue': 2.1.12(vue@3.5.40(typescript@5.9.3))
       '@vue/shared': 3.5.30
-      c12: 3.3.3(magicast@0.3.5)
+      c12: 3.3.3(magicast@0.5.2)
       chokidar: 4.0.3
       compatx: 0.2.0
       consola: 3.4.2


### PR DESCRIPTION
Migrates the two runtime modules in `@scalar/types` that build zod schema values at module load — `utils/nanoid.ts` and `entities/security-scheme.ts` — onto the zero-dependency `@scalar/validation`.

These two modules were the only thing pulling the `zod@4.3.5` runtime path into the `@scalar/api-reference` standalone browser bundle. After the change that path is gone.

### Bundle impact (standalone.js)

| | before | after |
|---|---|---|
| raw | 3,806,019 B | 3,735,844 B (−68.5 KB) |
| gzip | 1,092,517 B | 1,074,157 B (−17.9 KB) |
| `zod@4.3.5` modules | 22 (~141 KB) | **0** |

The separate `zod@4.4.3` copy in the bundle comes from a different dependency and is out of scope here.

### zod is not fully removed from `@scalar/types`

`zod` stays a dependency of `@scalar/types` because the type-only api-reference configuration schemas (`api-reference/*.ts`) still use it for `z.infer`. Those are already tree-shaken out of the reference bundle, so keeping them on zod does not affect bundle size. This PR removes zod only from the **runtime** bundle path.

### Notes on behaviour mapping

`@scalar/validation` has no `.parse()`/`.brand()`/`.transform()`/`.catch()`, so a few things were mapped faithfully rather than 1:1:

- Exported schema value names and inferred type shapes are preserved, so downstream `import type` consumers are unchanged. The only runtime `.parse()`/`.safeParse()` callers were tests; they now use `coerce()`/`validate()`.
- The branded `uid` is preserved at the type level via a small `Brand<T, B>` helper (validation has no runtime brand).
- zod's `.default(() => nanoid())` becomes an `evaluate(...)` that generates an id for missing/too-short values.
- The `.catch()`/`.transform()` behaviours (enum fallbacks, HTTP scheme lower-casing, default oauth flows, `x-default-scopes` → `selectedScopes`) are reproduced with `evaluate` and a post-coerce transform.
- The exported types are hand-written concrete shapes rather than `Static<typeof schema>`, because deriving them from validation's deep `Static` conditional — and feeding the result to `PartialDeep` downstream — trips TypeScript's `TS2589` "excessively deep" budget. This mirrors how `@scalar/workspace-store` pairs an explicit `SecuritySchemeObject` union with its runtime schema.

### Checks

- `@scalar/types`: build (tsc) + type-check (tsgo) clean, 56 tests pass
- `@scalar/workspace-store`, `@scalar/api-client`, `@scalar/oas-utils`: type-check clean; auth/security tests pass (workspace-store 133, api-client auth-selector 342, oas-utils migration 131)
- knip clean on both touched workspaces
