### PR TITLE
docs(guides): document new site config and CLI options

### DIFF
--- a/documentation/guides/cli/commands.md
+++ b/documentation/guides/cli/commands.md
@@ -341,6 +341,9 @@ Commands:
   preview [options] [config]  Preview scalar guides
   publish [options]           Publish new build for a github sync project that
                               is not linked.
+  rollback [options]          Roll the live deployment back to a previously
+                              deployed build.
+  deployments                 Inspect a project deployment history.
   upgrade [config]            Upgrade scalar project
   help [command]              display help for command
 ```
@@ -420,6 +423,45 @@ Options:
   -p, --preview          Publish in preview mode
   -g, --github           Publish from your linked remote GitHub repository
   -h, --help             display help for command
+```
+
+### rollback
+```
+Usage: scalar project rollback [options]
+
+Roll the live deployment back to a previously deployed build.
+
+Options:
+  -s, --slug [slug]       Project slug found in Scalar Dashboard
+  -t, --to <publishUid>   Roll back to a specific build id (defaults to the next
+                          older deployed build)
+  -y, --yes               Skip the confirmation prompt
+  -h, --help              display help for command
+```
+
+### deployments
+```
+Usage: scalar project deployments [options] [command]
+
+Inspect a project deployment history.
+
+Options:
+  -h, --help      display help for command
+
+Commands:
+  list [options]  List the production deployment history for a project.
+  help [command]  display help for command
+```
+
+#### deployments list
+```
+Usage: scalar project deployments list [options]
+
+List the production deployment history for a project.
+
+Options:
+  -s, --slug [slug]  Project slug found in Scalar Dashboard
+  -h, --help         display help for command
 ```
 
 ### upgrade
@@ -732,6 +774,7 @@ Options:
   --namespace <namespace>  Scalar team namespace
   --version <version>      API version (e.g. 0.1.0)
   --private                Make API private (default: false)
+  --force                  Force override an existing version (default: false)
   --bundle                 Bundle all external references before uploading
   --treeShake              Remove unused components from the bundled document
   --urlMap                 Generate a map of resolved URLs when bundling the

--- a/documentation/guides/docs/configuration/ask-ai.md
+++ b/documentation/guides/docs/configuration/ask-ai.md
@@ -54,6 +54,8 @@ https://<your-domain>/mcp
 
 You can configure Ask AI in the [Scalar Dashboard](https://dashboard.scalar.com). Navigate to your Docs project and open the settings to enable or disable the feature, or to adjust its behavior.
 
+Appearance options — the button, its sidebar placement, the floating widget position, and suggested questions — can also be set via `siteConfig.agent` in `scalar.config.json`. See [site config](site-config.md#ask-ai) for the full list of properties.
+
 ## Usage tracking
 
 Track how users interact with Ask AI in the [Scalar Dashboard](https://dashboard.scalar.com). The dashboard shows the number of conversations, common questions, and usage trends over time.

--- a/documentation/guides/docs/configuration/site-config.md
+++ b/documentation/guides/docs/configuration/site-config.md
@@ -175,6 +175,35 @@ Respect the user's system preference while allowing them to override it:
 }
 ```
 
+## Ask AI
+
+The `agent` property controls the appearance of [Ask AI](ask-ai.md) on your documentation site: the Ask AI button, its placement in the sidebar, the position of the floating chat widget, and the suggested questions shown in the chat.
+
+```json
+// scalar.config.json
+{
+  "$schema": "https://registry.scalar.com/@scalar/schemas/config",
+  "scalar": "2.0.0",
+  "siteConfig": {
+    "agent": {
+      "position": "right",
+      "suggestions": ["How do I authenticate?", "What are the rate limits?"]
+    }
+  }
+}
+```
+
+### Properties
+
+| Property          | Type                          | Default    | Description                                                                                                    |
+| ----------------- | ----------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------- |
+| `enabled`         | `boolean`                     | —          | Whether the Ask AI button is shown on the site                                                                 |
+| `buttonText`      | `string`                      | `"Ask AI"` | Label shown on the Ask AI button                                                                               |
+| `sidebarPosition` | `"below-search" \| "default"` | —          | Placement of the Ask AI button in the sidebar. `"default"` renders it next to the search bar; `"below-search"` renders it on its own row beneath the search bar |
+| `position`        | `"center" \| "right"`         | `"center"` | Where the floating chat widget anchors at the bottom of the viewport                                           |
+| `suggestions`     | `string[]`                    | —          | Suggested questions shown as pills above the chat input when it is focused. Two or three short questions work best |
+| `mcp`             | `object`                      | —          | References an MCP server and installation by slug (`serverSlug`, `installationSlug`), resolved on publish      |
+
 ## Layout
 
 The `layout` property controls global layout options that apply to all pages unless overridden by a page's own [layout options](navigation.md#layout-options).
@@ -337,39 +366,60 @@ Meta tags can be provided as an array of objects or as a key-value object:
 
 ### Styles
 
-Include custom CSS files in your documentation:
+Include custom CSS files in your documentation. Each entry loads from either a local `path` or a remote `url`:
 
 ```json
 "styles": [
   {
     "path": "assets/custom-styles.css",
     "tagPosition": "head"
+  },
+  {
+    "url": "https://example.com/theme.css"
   }
 ]
 ```
 
-| Property      | Type                                  | Required | Description                   |
-| ------------- | ------------------------------------- | -------- | ----------------------------- |
-| `path`        | `string`                              | Yes      | Relative path to the CSS file |
-| `tagPosition` | `"head" \| "bodyOpen"` \| "bodyClose" | No       | Where to inject the style tag |
+| Property      | Type                                    | Required | Description                                  |
+| ------------- | --------------------------------------- | -------- | -------------------------------------------- |
+| `path`        | `string`                                | Yes\*    | Relative path to the CSS file                |
+| `url`         | `string`                                | Yes\*    | Remote URL to the CSS file                   |
+| `tagPosition` | `"head" \| "bodyOpen" \| "bodyClose"`   | No       | Where to inject the style tag                |
+
+\* Provide either `path` or `url`.
 
 ### Scripts
 
-Include custom JavaScript files:
+Include custom JavaScript files. Each entry loads from either a local `path` or a remote `url`:
 
 ```json
 "scripts": [
   {
     "path": "assets/analytics.js",
-    "tagPosition": "bodyEnd"
+    "tagPosition": "bodyClose"
   }
 ]
 ```
 
-| Property      | Type                                  | Required | Description                          |
-| ------------- | ------------------------------------- | -------- | ------------------------------------ |
-| `path`        | `string`                              | Yes      | Relative path to the JavaScript file |
-| `tagPosition` | `"head" \| "bodyOpen"` \| "bodyClose" | No       | Where to inject the style tag        |
+| Property      | Type                                    | Required | Description                                                                       |
+| ------------- | --------------------------------------- | -------- | --------------------------------------------------------------------------------- |
+| `path`        | `string`                                | Yes\*    | Relative path to the JavaScript file                                              |
+| `url`         | `string`                                | Yes\*    | Remote URL to the JavaScript file                                                 |
+| `tagPosition` | `"head" \| "bodyOpen" \| "bodyClose"`   | No       | Where to inject the script tag                                                    |
+| `async`       | `boolean`                               | No       | Load the script without blocking the parser, running it as soon as it arrives     |
+| `defer`       | `boolean`                               | No       | Load the script without blocking the parser, running it after parsing in document order |
+| `type`        | `string`                                | No       | The script type attribute, for example `"module"`                                 |
+
+\* Provide either `path` or `url`.
+
+By default a configured script loads synchronously in the `<head>` and blocks first render until it has downloaded and run. Set `async` or `defer` so non-critical scripts (analytics, consent banners, chat widgets) load without blocking:
+
+```json
+"scripts": [
+  { "path": "assets/analytics.js" },
+  { "url": "https://example.com/widget.js", "defer": true }
+]
+```
 
 ### Links
 

--- a/documentation/guides/docs/deployment/cli.md
+++ b/documentation/guides/docs/deployment/cli.md
@@ -121,3 +121,15 @@ scalar project publish --github
 Use `project publish` for ad-hoc or local-first workflows. Use `project publish --github` when the project is connected to GitHub and you want the deployment to reflect the remote repository.
 
 Your documentation will be available at `https://your-subdomain.apidocumentation.com`.
+
+## Rollback
+
+If a deployment introduced a problem, you can roll the live deployment back to a previously deployed build. List recent production deployments to find the build you want, then roll back to the previous build (or pass `--to <build-id>` to target a specific one).
+
+```bash
+# See recent production deployments
+scalar project deployments list --slug your-docs
+
+# Roll back to the previous build (or pass --to <build-id>)
+scalar project rollback --slug your-docs
+```


### PR DESCRIPTION
Docs for a few things that shipped but were not written down yet:

- **Head scripts/styles** — you can now add `async`, `defer`, and `type` to scripts, and load styles/scripts from a remote `url` (not just a local `path`). Also fixed a wrong `bodyEnd` value in the example (the real option is `bodyClose`).
- **Ask AI** — new `siteConfig.agent` options: button, sidebar placement, floating widget `position`, and `suggestions`.
- **CLI** — added the `--force` flag to `scalar schema publish`, and documented `scalar project rollback` and `scalar project deployments list`.