### PR TITLE
docs(guides): document automatic llms.txt

### DIFF
--- a/documentation/guides/docs/configuration/llms-txt.md
+++ b/documentation/guides/docs/configuration/llms-txt.md
@@ -1,0 +1,37 @@
+# llms.txt
+
+Every published Scalar Docs site automatically serves `/llms.txt` and `/llms-full.txt` so AI agents and LLMs can read your documentation. These files follow the [llms.txt convention](https://llmstxt.org) and are generated for you. You do not configure or author them.
+
+## llms.txt
+
+`llms.txt` is a structured index of your site. It starts with an H1 for your site title and a short summary as a blockquote, followed by `##` sections that mirror your navigation groups. Each section is a bullet list of links to the pages, pointing at their `.md` URLs, with the page description where one is available.
+
+```markdown
+# Your Documentation
+
+> A short summary of your site
+
+## Guides
+
+- [Home](https://your-domain/index.md): The landing page
+- [Getting Started](https://your-domain/getting-started/index.md)
+
+## Reference
+
+- [Scalar Galaxy](https://your-domain/api-reference/openapi.json): Explore the Galaxy API
+```
+
+The order is stable and follows your navigation, so identical content produces an identical file on every build.
+
+## llms-full.txt
+
+`llms-full.txt` is the full-text companion. It contains the complete Markdown of your pages, concatenated in the same navigation order as `llms.txt`. Use it when an agent needs the entire content of your docs in a single file rather than an index to fetch from.
+
+## Discovery
+
+Both files live at the root of your site:
+
+```
+https://your-domain/llms.txt
+https://your-domain/llms-full.txt
+```

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -1820,6 +1820,30 @@
                           ]
                         }
                       },
+                      "llms-txt": {
+                        "title": "llms.txt",
+                        "type": "page",
+                        "filepath": "documentation/guides/docs/configuration/llms-txt.md",
+                        "description": "Every published Scalar Docs site automatically serves llms.txt and llms-full.txt so AI agents and LLMs can read your documentation.",
+                        "head": {
+                          "links": [
+                            {
+                              "rel": "canonical",
+                              "href": "https://scalar.com/products/docs/configuration/llms-txt"
+                            }
+                          ],
+                          "meta": [
+                            {
+                              "name": "description",
+                              "content": "Every published Scalar Docs site automatically serves llms.txt and llms-full.txt so AI agents and LLMs can read your documentation."
+                            },
+                            {
+                              "name": "robots",
+                              "content": "index, follow"
+                            }
+                          ]
+                        }
+                      },
                       "private-docs": {
                         "title": "Private Docs",
                         "filepath": "documentation/guides/docs/configuration/private-docs.md",


### PR DESCRIPTION
Adds a short page explaining that every published Scalar Docs site automatically serves `/llms.txt` (a structured index) and `/llms-full.txt` (the full text), so AI agents can read your docs. You do not configure or author them.