### PR TITLE
fix(openapi-parser): stop leaking @scalar/types into published types

### DIFF
--- a/.changeset/openapi-parser-types-dep-leak.md
+++ b/.changeset/openapi-parser-types-dep-leak.md
@@ -1,0 +1,8 @@
+---
+'@scalar/openapi-parser': patch
+'@scalar/types': patch
+---
+
+Fix `@scalar/types` leaking into the published type declarations. `@scalar/openapi-parser` referenced `@scalar/types` from its `.d.ts` files while only depending on it as a `devDependency`, so consumers hit `TS2307` (cannot find module). `@scalar/types` is now a regular dependency, and the package uses the shared `UnknownObject` and `AnyObject` utility types from `@scalar/types/utils` directly instead of defining its own local copies (`AnyObject` was added to `@scalar/types/utils` alongside the existing `UnknownObject`).
+
+The generic `AnyObject` and `UnknownObject` types are no longer re-exported from `@scalar/openapi-parser`. Import them from `@scalar/types/utils` instead.

--- a/packages/openapi-parser/src/index.ts
+++ b/packages/openapi-parser/src/index.ts
@@ -11,7 +11,7 @@ export {
   upgradeFromThreeToThreeOne,
 } from '@scalar/openapi-upgrader/3.0-to-3.1'
 
-export type { AnyObject, ErrorObject, Filesystem, LoadResult, UnknownObject } from './types'
+export type { ErrorObject, Filesystem, LoadResult } from './types'
 export { type DereferenceOptions, dereference } from './utils/dereference'
 export { filter } from './utils/filter'
 export { isJson } from './utils/is-json'

--- a/packages/openapi-parser/src/types/index.ts
+++ b/packages/openapi-parser/src/types/index.ts
@@ -2,6 +2,7 @@ import type { Document as OpenApiDocumentV2 } from '@scalar/openapi-types/2.0'
 import type { Document as OpenApiDocumentV3 } from '@scalar/openapi-types/3.0'
 import type { Document as OpenApiDocumentV3_1 } from '@scalar/openapi-types/3.1'
 import type { Document as OpenApiDocumentV3_2 } from '@scalar/openapi-types/3.2'
+import type { UnknownObject } from '@scalar/types/utils'
 
 import type { ERRORS, OpenApiVersion } from '@/configuration'
 
@@ -10,10 +11,6 @@ import type { ERRORS, OpenApiVersion } from '@/configuration'
  * Merge types with each other
  */
 type Merge<A, B> = A & Omit<B, keyof A>
-
-export type { AnyObject } from '@scalar/types/utils'
-
-export type UnknownObject = Record<string, unknown>
 
 /**
  * JSON, YAML or object representation of an OpenAPI API definition

--- a/packages/openapi-parser/src/utils/dereference.test.ts
+++ b/packages/openapi-parser/src/utils/dereference.test.ts
@@ -3,8 +3,8 @@ import type {
   MediaTypeObject as OpenApiMediaTypeObjectV3_2,
   ResponseObject as OpenApiResponseObjectV3_2,
 } from '@scalar/openapi-types/3.2'
+import type { AnyObject } from '@scalar/types/utils'
 import { describe, expect, it } from 'vitest'
-import type { AnyObject } from '@/types/index'
 
 import { dereference } from './dereference'
 

--- a/packages/openapi-parser/src/utils/filter.ts
+++ b/packages/openapi-parser/src/utils/filter.ts
@@ -1,4 +1,7 @@
-import type { AnyApiDefinitionFormat, UnknownObject, FilterResult } from '@/types/index'
+import type { UnknownObject } from '@scalar/types/utils'
+
+import type { AnyApiDefinitionFormat, FilterResult } from '@/types/index'
+
 import { getEntrypoint } from './get-entrypoint'
 import { makeFilesystem } from './make-filesystem'
 import { traverse } from './traverse'

--- a/packages/openapi-parser/src/utils/get-list-of-references.ts
+++ b/packages/openapi-parser/src/utils/get-list-of-references.ts
@@ -1,4 +1,5 @@
-import type { AnyObject } from '@/types/index'
+import type { AnyObject } from '@scalar/types/utils'
+
 import { traverse } from './traverse'
 
 /**

--- a/packages/openapi-parser/src/utils/join/join.ts
+++ b/packages/openapi-parser/src/utils/join/join.ts
@@ -7,8 +7,8 @@ import type {
   ServerObject,
   TagObject,
 } from '@scalar/openapi-types/3.1'
+import type { UnknownObject } from '@scalar/types/utils'
 
-import type { UnknownObject } from '@/types'
 import { mergeObjects } from '@/utils/join/merge-objects'
 import { upgrade } from '@/utils/upgrade'
 

--- a/packages/openapi-parser/src/utils/make-filesystem.ts
+++ b/packages/openapi-parser/src/utils/make-filesystem.ts
@@ -1,4 +1,7 @@
-import type { Filesystem, FilesystemEntry, UnknownObject } from '@/types/index'
+import type { UnknownObject } from '@scalar/types/utils'
+
+import type { Filesystem, FilesystemEntry } from '@/types/index'
+
 import { getListOfReferences } from './get-list-of-references'
 import { isFilesystem } from './is-filesystem'
 import { normalize } from './normalize'

--- a/packages/openapi-parser/src/utils/openapi/openapi.test.ts
+++ b/packages/openapi-parser/src/utils/openapi/openapi.test.ts
@@ -1,10 +1,10 @@
 import { join } from 'node:path'
 
+import type { AnyObject } from '@scalar/types/utils'
 import { describe, expect, it } from 'vitest'
 import { stringify } from 'yaml'
 
 import { readFiles } from '@/plugins/read-files/read-files'
-import type { AnyObject } from '@/types/index'
 
 import { openapi } from './openapi'
 

--- a/packages/openapi-parser/src/utils/resolve-references.test.ts
+++ b/packages/openapi-parser/src/utils/resolve-references.test.ts
@@ -6,10 +6,10 @@ import path from 'node:path'
 
 import SwaggerParser from '@apidevtools/swagger-parser'
 import type { Document as OpenApiDocumentV3_2, InfoObject as OpenApiInfoObjectV3_2 } from '@scalar/openapi-types/3.2'
+import type { AnyObject } from '@scalar/types/utils'
 import { describe, expect, it } from 'vitest'
 
 import { readFiles } from '@/plugins/read-files/read-files'
-import type { AnyObject } from '@/types/index'
 
 import { load } from './load/load'
 import { resolveReferences } from './resolve-references'

--- a/packages/openapi-parser/src/utils/resolve-references.ts
+++ b/packages/openapi-parser/src/utils/resolve-references.ts
@@ -1,14 +1,8 @@
 import { isObject } from '@scalar/helpers/object/is-object'
+import type { AnyObject, UnknownObject } from '@scalar/types/utils'
 
 import { ERRORS } from '@/configuration'
-import type {
-  AnyObject,
-  ErrorObject,
-  Filesystem,
-  FilesystemEntry,
-  ThrowOnErrorOption,
-  UnknownObject,
-} from '@/types/index'
+import type { ErrorObject, Filesystem, FilesystemEntry, ThrowOnErrorOption } from '@/types/index'
 
 import { getEntrypoint } from './get-entrypoint'
 import { getSegmentsFromPath } from './get-segments-from-path'

--- a/packages/openapi-parser/src/utils/to-json.ts
+++ b/packages/openapi-parser/src/utils/to-json.ts
@@ -1,3 +1,3 @@
-import type { AnyObject } from '@/types/index'
+import type { AnyObject } from '@scalar/types/utils'
 
 export const toJson = (value: AnyObject) => JSON.stringify(value, null, 2)

--- a/packages/openapi-parser/src/utils/to-yaml.ts
+++ b/packages/openapi-parser/src/utils/to-yaml.ts
@@ -1,5 +1,4 @@
+import type { AnyObject } from '@scalar/types/utils'
 import { stringify } from 'yaml'
-
-import type { AnyObject } from '@/types/index'
 
 export const toYaml = (value: AnyObject) => stringify(value)

--- a/packages/openapi-parser/src/utils/transform/sanitize.test.ts
+++ b/packages/openapi-parser/src/utils/transform/sanitize.test.ts
@@ -1,5 +1,5 @@
+import type { AnyObject } from '@scalar/types/utils'
 import { describe, expect, it } from 'vitest'
-import type { AnyObject } from '@/types/index'
 
 import { DEFAULT_OPENAPI_VERSION, DEFAULT_TITLE, sanitize } from './sanitize'
 

--- a/packages/openapi-parser/src/utils/transform/sanitize.ts
+++ b/packages/openapi-parser/src/utils/transform/sanitize.ts
@@ -1,4 +1,4 @@
-import type { AnyObject, UnknownObject } from '@/types/index'
+import type { AnyObject, UnknownObject } from '@scalar/types/utils'
 
 import { addInfoObject } from './utils/addInfoObject'
 import { addLatestOpenApiVersion } from './utils/addLatestOpenApiVersion'

--- a/packages/openapi-parser/src/utils/transform/utils/addInfoObject.ts
+++ b/packages/openapi-parser/src/utils/transform/utils/addInfoObject.ts
@@ -1,4 +1,4 @@
-import type { AnyObject } from '@/types/index'
+import type { AnyObject } from '@scalar/types/utils'
 
 export const DEFAULT_TITLE = 'API'
 const DEFAULT_VERSION = '1.0'

--- a/packages/openapi-parser/src/utils/transform/utils/addLatestOpenApiVersion.ts
+++ b/packages/openapi-parser/src/utils/transform/utils/addLatestOpenApiVersion.ts
@@ -1,4 +1,4 @@
-import type { AnyObject } from '@/types/index'
+import type { AnyObject } from '@scalar/types/utils'
 
 export const DEFAULT_OPENAPI_VERSION = '3.1.1'
 

--- a/packages/openapi-parser/src/utils/transform/utils/addMissingTags.ts
+++ b/packages/openapi-parser/src/utils/transform/utils/addMissingTags.ts
@@ -1,4 +1,4 @@
-import type { AnyObject } from '@/types/index'
+import type { AnyObject } from '@scalar/types/utils'
 
 export const addMissingTags = (definition: AnyObject) => {
   if (!definition.paths) {

--- a/packages/openapi-parser/src/utils/transform/utils/normalizeSecuritySchemes.ts
+++ b/packages/openapi-parser/src/utils/transform/utils/normalizeSecuritySchemes.ts
@@ -1,4 +1,4 @@
-import type { AnyObject } from '@/types/index'
+import type { AnyObject } from '@scalar/types/utils'
 
 export const normalizeSecuritySchemes = (definition: AnyObject) => {
   if (!definition.components?.securitySchemes) {

--- a/packages/openapi-parser/src/utils/transform/utils/rejectSwaggerDocuments.ts
+++ b/packages/openapi-parser/src/utils/transform/utils/rejectSwaggerDocuments.ts
@@ -1,4 +1,4 @@
-import type { AnyObject } from '@/types/index'
+import type { AnyObject } from '@scalar/types/utils'
 
 export const rejectSwaggerDocuments = (defintion: AnyObject) => {
   if ('swagger' in defintion) {

--- a/packages/openapi-parser/src/utils/traverse.ts
+++ b/packages/openapi-parser/src/utils/traverse.ts
@@ -1,5 +1,4 @@
-import type { AnyObject } from '@/types/index'
-import type { UnknownObject } from '@scalar/types/utils'
+import type { AnyObject, UnknownObject } from '@scalar/types/utils'
 
 /**
  * Recursively traverses the content and applies the transform function to each node.

--- a/packages/openapi-parser/src/utils/upgrade.ts
+++ b/packages/openapi-parser/src/utils/upgrade.ts
@@ -1,7 +1,8 @@
 import type { Document as OpenApiDocumentV3_1 } from '@scalar/openapi-types/3.1'
 import { upgrade as originalUpgrade } from '@scalar/openapi-upgrader'
+import type { UnknownObject } from '@scalar/types/utils'
 
-import type { Filesystem, UnknownObject, UpgradeResult } from '@/types/index'
+import type { Filesystem, UpgradeResult } from '@/types/index'
 
 import { getEntrypoint } from './get-entrypoint'
 import { isFilesystem } from './is-filesystem'

--- a/packages/openapi-parser/src/utils/validate.test.ts
+++ b/packages/openapi-parser/src/utils/validate.test.ts
@@ -1,6 +1,5 @@
+import type { AnyObject } from '@scalar/types/utils'
 import { describe, expect, it } from 'vitest'
-
-import type { AnyObject } from '@/types/index'
 
 import { validate } from './validate'
 

--- a/packages/openapi-parser/src/utils/validate.ts
+++ b/packages/openapi-parser/src/utils/validate.ts
@@ -3,13 +3,7 @@ import { validate as validateDocument, validatePathParameters } from '@scalar/op
 import type { UnknownObject } from '@scalar/types/utils'
 
 import { ERRORS, type OpenApiVersion } from '@/configuration'
-import type {
-  ErrorObject,
-  Filesystem,
-  StrictOpenApiDocument,
-  ThrowOnErrorOption,
-  ValidateResult,
-} from '@/types/index'
+import type { ErrorObject, Filesystem, StrictOpenApiDocument, ThrowOnErrorOption, ValidateResult } from '@/types/index'
 
 import { getEntrypoint } from './get-entrypoint'
 import { makeFilesystem } from './make-filesystem'

--- a/packages/openapi-parser/src/utils/validate.ts
+++ b/packages/openapi-parser/src/utils/validate.ts
@@ -1,5 +1,6 @@
 import { isObject } from '@scalar/helpers/object/is-object'
 import { validate as validateDocument, validatePathParameters } from '@scalar/openapi-validator'
+import type { UnknownObject } from '@scalar/types/utils'
 
 import { ERRORS, type OpenApiVersion } from '@/configuration'
 import type {
@@ -7,7 +8,6 @@ import type {
   Filesystem,
   StrictOpenApiDocument,
   ThrowOnErrorOption,
-  UnknownObject,
   ValidateResult,
 } from '@/types/index'
 

--- a/packages/openapi-parser/tests/benchmark/utils/resolveNew.ts
+++ b/packages/openapi-parser/tests/benchmark/utils/resolveNew.ts
@@ -1,4 +1,5 @@
-import type { AnyObject } from '@/types'
+import type { AnyObject } from '@scalar/types/utils'
+
 import { normalize } from '@/utils/normalize'
 import { resolveReferences } from '@/utils/resolve-references'
 

--- a/packages/openapi-parser/tests/benchmark/utils/resolveOld.ts
+++ b/packages/openapi-parser/tests/benchmark/utils/resolveOld.ts
@@ -1,5 +1,5 @@
-import type { AnyObject } from '@/types'
 import SwaggerParser from '@apidevtools/swagger-parser'
+import type { AnyObject } from '@scalar/types/utils'
 
 export async function resolveOld(specification: AnyObject) {
   return await new Promise((resolve, reject) => {

--- a/packages/openapi-parser/tests/diff.test.ts
+++ b/packages/openapi-parser/tests/diff.test.ts
@@ -1,9 +1,9 @@
 import SwaggerParser from '@apidevtools/swagger-parser'
+import type { AnyObject } from '@scalar/types/utils'
 import { diff } from 'just-diff'
 import { expect, test } from 'vitest'
 
 import { load, normalize } from '../src/index'
-import type { AnyObject } from '../src/types'
 import { dereference } from '../src/utils/dereference'
 
 const expectedErrors = {

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/fail/schemaProperties.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/fail/schemaProperties.test.ts
@@ -1,7 +1,7 @@
+import type { AnyObject } from '@scalar/types/utils'
 import { describe, expect, it } from 'vitest'
 
 import { validate } from '../../../../src/index'
-import type { AnyObject } from '../../../../src/types'
 import schemaProperties from './schemaProperties.yaml?raw'
 
 describe('schemaProperties', () => {

--- a/packages/openapi-parser/tests/openapi3-examples/3.0/pass/cyclical.test.ts
+++ b/packages/openapi-parser/tests/openapi3-examples/3.0/pass/cyclical.test.ts
@@ -1,7 +1,8 @@
+import type { AnyObject } from '@scalar/types/utils'
+import { describe, expect, it } from 'vitest'
+
 import { getListOfReferences } from '@/utils/get-list-of-references'
 import { validate } from '@/utils/validate'
-import { describe, expect, it } from 'vitest'
-import type { AnyObject } from '@/types/index'
 
 describe('cyclical', () => {
   it('resolves circular references', async () => {


### PR DESCRIPTION
`@scalar/openapi-parser` used `UnknownObject`/`AnyObject` from `@scalar/types`, but that package was only a dev dependency. So the published `.d.ts` files pointed at a package users do not install, and TypeScript threw `TS2307` for them.

Now `@scalar/types` is a real dependency, and the parser uses the shared `UnknownObject` and `AnyObject` types from `@scalar/types/utils` directly instead of its own local copies. `AnyObject` was added to `@scalar/types/utils` next to the existing `UnknownObject`.

These two generic types are no longer re-exported from `@scalar/openapi-parser` — import them from `@scalar/types/utils` instead.