### PR TITLE
feat(galaxy): add OpenAPI 3.2 features to the example document

### DIFF
--- a/.changeset/galaxy-openapi-3-2-features.md
+++ b/.changeset/galaxy-openapi-3-2-features.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': minor
+---
+
+Flesh out the OpenAPI 3.2 example document with the features new to 3.2: `$self`, named servers, hierarchical tags (`parent`/`kind`/`summary`), the `query` HTTP method, `additionalOperations`, the `querystring` parameter location, sequential/streaming media types via `itemSchema`, positional multipart encoding (`prefixEncoding`/`itemEncoding`), the OAuth 2.0 device authorization flow, `oauth2MetadataUrl`, a deprecated security scheme, and XML `nodeType`.

--- a/.changeset/galaxy-openapi-3-2-features.md
+++ b/.changeset/galaxy-openapi-3-2-features.md
@@ -2,4 +2,4 @@
 '@scalar/galaxy': minor
 ---
 
-Flesh out the OpenAPI 3.2 example document with the features new to 3.2: `$self`, named servers, hierarchical tags (`parent`/`kind`/`summary`), the `query` HTTP method, `additionalOperations`, the `querystring` parameter location, sequential/streaming media types via `itemSchema`, positional multipart encoding (`prefixEncoding`/`itemEncoding`), the OAuth 2.0 device authorization flow, `oauth2MetadataUrl`, a deprecated security scheme, and XML `nodeType`.
+Flesh out the OpenAPI 3.2 example document with the features new to 3.2: named servers, hierarchical tags (`parent`/`kind`/`summary`), the `query` HTTP method, `additionalOperations`, the `querystring` parameter location, sequential/streaming media types via `itemSchema`, positional multipart encoding (`prefixEncoding`/`itemEncoding`), the OAuth 2.0 device authorization flow, `oauth2MetadataUrl`, a deprecated security scheme, and XML `nodeType`.

--- a/packages/galaxy/galaxy.ruleset.yaml
+++ b/packages/galaxy/galaxy.ruleset.yaml
@@ -10,10 +10,10 @@
 # Only the 3.1 document is linted. Spectral's spectral:oas ruleset does not
 # understand OpenAPI 3.2 yet, so linting src/documents/3.2.yaml validates it
 # against the 3.0 schema and reports false positives (for example, it rejects
-# schema-level "examples"). The 3.2 document is a version-only copy of 3.1
-# (enforced by tests/yaml.test.ts) and is checked structurally by
-# `pnpm --filter @scalar/galaxy validate`, so its content is already covered.
-# Revisit once Spectral gains OpenAPI 3.2 support.
+# schema-level "examples", the QUERY method, `additionalOperations` and other
+# 3.2-only constructs). The 3.2 document showcases the OpenAPI 3.2 feature set
+# and its structure is asserted by tests/yaml.test.ts, so its content is already
+# covered. Revisit once Spectral gains OpenAPI 3.2 support.
 extends: spectral:oas
 rules:
   # Every operation should carry a human-readable description, not just a summary.

--- a/packages/galaxy/src/documents/3.2.yaml
+++ b/packages/galaxy/src/documents/3.2.yaml
@@ -1,4 +1,7 @@
 openapi: 3.2.0
+# `$self` (new in OpenAPI 3.2) declares this document's own base URI. It anchors
+# reference resolution when a description is split across multiple documents.
+$self: https://galaxy.scalar.com/openapi/3.2.yaml
 info:
   title: Scalar Galaxy
   description: |
@@ -60,8 +63,12 @@ externalDocs:
   description: Documentation
   url: https://github.com/scalar/scalar
 servers:
+  # `name` (new in OpenAPI 3.2) gives each server a short, unique handle that
+  # tooling can use to refer to a specific host.
   - url: https://galaxy.scalar.com
+    name: production
   - url: '{protocol}://void.scalar.com/{path}'
+    name: mirror
     description: Responds with your request data
     variables:
       protocol:
@@ -88,14 +95,36 @@ x-speakeasy-webhooks:
     signatureTextEncoding: base64
     algorithm: hmac-sha256
 tags:
+  # OpenAPI 3.2 enriches the Tag Object with `summary`, `parent` (to build a
+  # navigation hierarchy) and `kind` (from the Tag Kinds registry, e.g. `nav`,
+  # `badge`, `audience`).
   - name: Authentication
+    summary: Accounts and tokens
+    kind: nav
     description: Some endpoints are public, but some require authentication. We
       provide all the required endpoints to create an account and authorize
       yourself.
-  - name: Planets
-    description: Everything about planets
   - name: Celestial Bodies
+    summary: Everything in the void
+    kind: nav
     description: Celestial bodies are the planets and satellites in the Scalar Galaxy.
+  - name: Planets
+    summary: Worlds big and small
+    kind: nav
+    parent: Celestial Bodies
+    description: Everything about planets
+  - name: Streaming
+    summary: Real-time galaxy feeds
+    kind: nav
+    description: Server-sent events and sequential JSON streams of galaxy activity.
+  - name: Beta
+    summary: Experimental endpoints
+    kind: badge
+    description: Endpoints that are still experimental and may change without notice.
+  - name: Partners
+    summary: Partner-only operations
+    kind: audience
+    description: Operations intended for integration partners rather than the public API.
 paths:
   /planets:
     get:
@@ -255,6 +284,88 @@ paths:
           pm.expect(jsonData).to.have.property("id");
           pm.expect(jsonData).to.have.property("name");
         });
+    query:
+      tags:
+        - Planets
+      summary: Query planets
+      description:
+        Search the planet catalog by sending a query payload with the HTTP QUERY
+        method (new in OpenAPI 3.2). QUERY is safe and idempotent like GET, but
+        accepts a request body so you can express richer filters than a URL query
+        string allows.
+      operationId: queryPlanets
+      security: []
+      requestBody:
+        description: The query to run against the planet catalog
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlanetQuery'
+      responses:
+        '200':
+          description: Matching planets
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $id: 'https://galaxy.scalar.com/schemas/QueriedPlanets'
+                $defs:
+                  itemType:
+                    $dynamicAnchor: itemType
+                    $ref: '#/components/schemas/Planet'
+                $ref: '#/components/schemas/PaginatedResource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+      x-post-response: |
+        pm.test("Status code is 200", () => {
+          pm.response.to.have.status(200);
+        });
+
+        pm.test("Response has data array and meta", () => {
+          const jsonData = pm.response.json();
+          pm.expect(jsonData).to.have.property("data");
+          pm.expect(jsonData.data).to.be.an("array");
+          pm.expect(jsonData).to.have.property("meta");
+        });
+  /planets/search:
+    get:
+      tags:
+        - Planets
+      summary: Search planets with a structured query string
+      description:
+        Filter planets using a single, structured query string. The `filter`
+        parameter sets `in` to `querystring` (new in OpenAPI 3.2), which describes
+        the entire query string as one value via a media type instead of listing
+        each query parameter individually.
+      operationId: searchPlanets
+      security: []
+      parameters:
+        - name: filter
+          in: querystring
+          description: The complete query string, encoded as JSON, describing the filter to apply.
+          required: false
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanetQuery'
+      responses:
+        '200':
+          description: Matching planets
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $id: 'https://galaxy.scalar.com/schemas/SearchedPlanets'
+                $defs:
+                  itemType:
+                    $dynamicAnchor: itemType
+                    $ref: '#/components/schemas/Planet'
+                $ref: '#/components/schemas/PaginatedResource'
   /planets/{planetId}:
     get:
       tags:
@@ -370,6 +481,42 @@ paths:
         pm.test("Status code is 204", () => {
           pm.response.to.have.status(204);
         });
+    additionalOperations:
+      # `additionalOperations` (new in OpenAPI 3.2) documents HTTP methods beyond
+      # the fixed set of get, put, post, delete, options, head, patch, trace and
+      # query. The map key is the exact method name sent on the wire.
+      COPY:
+        tags:
+          - Planets
+          - Partners
+        summary: Copy a planet
+        description:
+          Duplicate an existing planet using the WebDAV-style COPY method. This
+          demonstrates how OpenAPI 3.2 describes custom HTTP methods.
+        operationId: copyPlanet
+        parameters:
+          - $ref: '#/components/parameters/planetId'
+          - name: Destination
+            in: header
+            required: true
+            description: The location where the copied planet should be created
+            schema:
+              type: string
+              format: uri-reference
+              examples:
+                - /planets/999
+        responses:
+          '201':
+            description: Planet copied
+            headers:
+              Location:
+                $ref: '#/components/headers/Location'
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Planet'
+          '404':
+            $ref: '#/components/responses/NotFound'
   /planets/{planetId}/image:
     post:
       tags:
@@ -416,6 +563,91 @@ paths:
           pm.expect(jsonData).to.have.property("message");
           pm.expect(jsonData).to.have.property("imageUrl");
         });
+  /planets/events:
+    get:
+      tags:
+        - Streaming
+        - Beta
+      summary: Stream planet events
+      description:
+        Subscribe to a live feed of planet changes. The response is an open stream
+        rather than a single document, so each media type uses `itemSchema` (new in
+        OpenAPI 3.2) to describe one event at a time. Server-Sent Events
+        (`text/event-stream`), JSON Lines (`application/jsonl`) and JSON Text
+        Sequences (`application/json-seq`) are all offered.
+      operationId: streamPlanetEvents
+      security: []
+      responses:
+        '200':
+          description: An open stream of planet events
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            text/event-stream:
+              itemSchema:
+                $ref: '#/components/schemas/PlanetEvent'
+            application/jsonl:
+              itemSchema:
+                $ref: '#/components/schemas/PlanetEvent'
+            application/json-seq:
+              itemSchema:
+                $ref: '#/components/schemas/PlanetEvent'
+  /planets/{planetId}/observations:
+    post:
+      tags:
+        - Planets
+        - Beta
+      summary: Upload a batch of observations
+      description:
+        Send a mixed multipart stream — a single metadata part followed by any
+        number of image parts. This shows the OpenAPI 3.2 positional multipart
+        encoding fields — `prefixEncoding` describes the leading, fixed parts and
+        `itemEncoding` applies to every repeated item that follows.
+      operationId: uploadObservations
+      parameters:
+        - $ref: '#/components/parameters/planetId'
+      requestBody:
+        required: true
+        content:
+          multipart/mixed:
+            schema:
+              type: array
+              prefixItems:
+                - $ref: '#/components/schemas/ObservationBatchMeta'
+              items:
+                type: string
+                format: binary
+                description: A captured image, one per remaining part
+            prefixEncoding:
+              - contentType: application/json
+            itemEncoding:
+              contentType: image/jpeg
+      responses:
+        '202':
+          description: Observations accepted for processing
+          headers:
+            X-Request-ID:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accepted:
+                    type: integer
+                    description: Number of observation parts accepted
+                    examples:
+                      - 12
+                  batchId:
+                    type: string
+                    format: uuid
+                    examples:
+                      - 8f47c132-9d1f-4f83-b5a4-91db5ee757ab
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /celestial-bodies:
     post:
       tags:
@@ -700,6 +932,9 @@ components:
       in: query
       name: api_key
       description: API key query parameter
+      # `deprecated` on a Security Scheme is new in OpenAPI 3.2. Passing API keys
+      # in the URL query string is discouraged, so this scheme is marked deprecated.
+      deprecated: true
     apiKeyCookie:
       type: apiKey
       in: cookie
@@ -708,6 +943,9 @@ components:
     oAuth2:
       type: oauth2
       description: OAuth 2.0 authentication
+      # `oauth2MetadataUrl` (new in OpenAPI 3.2) points to the OAuth 2.0
+      # Authorization Server Metadata document for automatic discovery.
+      oauth2MetadataUrl: https://galaxy.scalar.com/.well-known/oauth-authorization-server
       flows:
         authorizationCode:
           authorizationUrl: https://galaxy.scalar.com/oauth/authorize
@@ -717,6 +955,15 @@ components:
             write:planets: modify planets in your account
             read:planets: read your planets
         clientCredentials:
+          tokenUrl: https://galaxy.scalar.com/oauth/token
+          scopes:
+            read:account: read your account information
+            write:planets: modify planets in your account
+            read:planets: read your planets
+        # New in OpenAPI 3.2: the OAuth 2.0 Device Authorization flow, for
+        # input-constrained devices such as CLIs, smart TVs and IoT hardware.
+        deviceAuthorization:
+          deviceAuthorizationUrl: https://galaxy.scalar.com/oauth/device
           tokenUrl: https://galaxy.scalar.com/oauth/token
           scopes:
             read:account: read your account information
@@ -1006,6 +1253,10 @@ components:
           type: integer
           format: int64
           readOnly: true
+          # Serialize the id as an XML attribute (<planet id="1">) using the new
+          # 3.2 `nodeType` field instead of the deprecated `attribute: true`.
+          xml:
+            nodeType: attribute
           examples:
             - 1
           x-variable: planetId
@@ -1019,6 +1270,9 @@ components:
           type:
             - string
             - 'null'
+          # `nodeType: cdata` wraps free-form text in a CDATA section.
+          xml:
+            nodeType: cdata
           examples:
             - The red planet
             - A gas giant with a great red spot
@@ -1144,14 +1398,25 @@ components:
             - https://cdn.scalar.com/photos/mars.jpg
         satellites:
           type: array
+          # `nodeType: none` keeps the array unwrapped: each <satellite> appears
+          # directly, with no surrounding <satellites> element (the array default).
+          xml:
+            nodeType: none
           items:
             $ref: '#/components/schemas/Satellite'
         creator:
           $ref: '#/components/schemas/User'
         tags:
           type: array
+          # `nodeType: element` wraps the items in a <tags> element, replacing the
+          # deprecated `wrapped: true`.
+          xml:
+            nodeType: element
+            name: tags
           items:
             type: string
+            xml:
+              name: tag
           examples:
             - - solar-system
               - rocky
@@ -1237,6 +1502,133 @@ components:
               description: Average distance from the planet in kilometers
               examples:
                 - 9376
+    PlanetQuery:
+      description:
+        A structured query for the planet catalog, sent either as the body of a
+        QUERY request or as a `querystring` parameter.
+      type: object
+      properties:
+        name:
+          type: string
+          description: Match planets whose name contains this text
+          examples:
+            - Mars
+        type:
+          type: array
+          description: Restrict results to these planet types
+          items:
+            type: string
+            enum:
+              - terrestrial
+              - gas_giant
+              - ice_giant
+              - dwarf
+              - super_earth
+          examples:
+            - - terrestrial
+              - super_earth
+        minHabitabilityIndex:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          description: Only return planets at or above this habitability score
+          examples:
+            - 0.5
+        sort:
+          type: string
+          enum:
+            - name
+            - -name
+            - habitabilityIndex
+            - -habitabilityIndex
+          description: Sort field; prefix with `-` for descending order
+          examples:
+            - -habitabilityIndex
+    PlanetEvent:
+      description: A single event emitted on the planet stream. Each item in a
+        `text/event-stream`, `application/jsonl` or `application/json-seq` response
+        validates against this schema.
+      type: object
+      xml:
+        name: event
+      required:
+        - event
+        - planet
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the event
+          xml:
+            nodeType: attribute
+          examples:
+            - 123e4567-e89b-12d3-a456-426614174000
+        event:
+          type: string
+          enum:
+            - created
+            - updated
+            - deleted
+            - exploded
+          description: The kind of change that occurred
+          xml:
+            nodeType: attribute
+          examples:
+            - created
+        planet:
+          $ref: '#/components/schemas/Planet'
+        note:
+          $ref: '#/components/schemas/GalaxyMessage'
+        occurredAt:
+          type: string
+          format: date-time
+          examples:
+            - 2024-01-15T14:30:00Z
+    GalaxyMessage:
+      description:
+        A short, localized message. Demonstrates the OpenAPI 3.2 XML `nodeType`
+        values `attribute` and `text`, which serialize as
+        `<message lang="en">A new planet has appeared</message>`.
+      type: object
+      xml:
+        name: message
+      properties:
+        lang:
+          type: string
+          description: BCP 47 language tag
+          xml:
+            nodeType: attribute
+          examples:
+            - en
+        value:
+          type: string
+          description: The message text, serialized as the element's text content
+          xml:
+            nodeType: text
+          examples:
+            - A new planet has appeared
+    ObservationBatchMeta:
+      description: Metadata describing a batch of uploaded observations
+      type: object
+      required:
+        - observer
+      properties:
+        observer:
+          type: string
+          description: Who captured the observations
+          examples:
+            - Galileo Observatory
+        observedAt:
+          type: string
+          format: date-time
+          examples:
+            - 2024-01-15T14:30:00Z
+        count:
+          type: integer
+          description: Number of image parts that follow this metadata part
+          examples:
+            - 12
     PaginatedResource:
       description:
         A generic paginated resource. Specializing schemas bind the item type by declaring a

--- a/packages/galaxy/src/documents/3.2.yaml
+++ b/packages/galaxy/src/documents/3.2.yaml
@@ -1,7 +1,4 @@
 openapi: 3.2.0
-# `$self` (new in OpenAPI 3.2) declares this document's own base URI. It anchors
-# reference resolution when a description is split across multiple documents.
-$self: https://galaxy.scalar.com/openapi/3.2.yaml
 info:
   title: Scalar Galaxy
   description: |
@@ -63,8 +60,6 @@ externalDocs:
   description: Documentation
   url: https://github.com/scalar/scalar
 servers:
-  # `name` (new in OpenAPI 3.2) gives each server a short, unique handle that
-  # tooling can use to refer to a specific host.
   - url: https://galaxy.scalar.com
     name: production
   - url: '{protocol}://void.scalar.com/{path}'
@@ -95,9 +90,6 @@ x-speakeasy-webhooks:
     signatureTextEncoding: base64
     algorithm: hmac-sha256
 tags:
-  # OpenAPI 3.2 enriches the Tag Object with `summary`, `parent` (to build a
-  # navigation hierarchy) and `kind` (from the Tag Kinds registry, e.g. `nav`,
-  # `badge`, `audience`).
   - name: Authentication
     summary: Accounts and tokens
     kind: nav
@@ -157,7 +149,6 @@ paths:
             application/json:
               schema:
                 $id: 'https://galaxy.scalar.com/schemas/PaginatedPlanets'
-                # Bind the generic PaginatedResource template's item type to Planet via a $dynamicAnchor.
                 $defs:
                   itemType:
                     $dynamicAnchor: itemType
@@ -482,9 +473,6 @@ paths:
           pm.response.to.have.status(204);
         });
     additionalOperations:
-      # `additionalOperations` (new in OpenAPI 3.2) documents HTTP methods beyond
-      # the fixed set of get, put, post, delete, options, head, patch, trace and
-      # query. The map key is the exact method name sent on the wire.
       COPY:
         tags:
           - Planets
@@ -932,8 +920,6 @@ components:
       in: query
       name: api_key
       description: API key query parameter
-      # `deprecated` on a Security Scheme is new in OpenAPI 3.2. Passing API keys
-      # in the URL query string is discouraged, so this scheme is marked deprecated.
       deprecated: true
     apiKeyCookie:
       type: apiKey
@@ -943,8 +929,6 @@ components:
     oAuth2:
       type: oauth2
       description: OAuth 2.0 authentication
-      # `oauth2MetadataUrl` (new in OpenAPI 3.2) points to the OAuth 2.0
-      # Authorization Server Metadata document for automatic discovery.
       oauth2MetadataUrl: https://galaxy.scalar.com/.well-known/oauth-authorization-server
       flows:
         authorizationCode:
@@ -960,8 +944,6 @@ components:
             read:account: read your account information
             write:planets: modify planets in your account
             read:planets: read your planets
-        # New in OpenAPI 3.2: the OAuth 2.0 Device Authorization flow, for
-        # input-constrained devices such as CLIs, smart TVs and IoT hardware.
         deviceAuthorization:
           deviceAuthorizationUrl: https://galaxy.scalar.com/oauth/device
           tokenUrl: https://galaxy.scalar.com/oauth/token
@@ -969,14 +951,12 @@ components:
             read:account: read your account information
             write:planets: modify planets in your account
             read:planets: read your planets
-        # Legacy
         implicit:
           authorizationUrl: https://galaxy.scalar.com/oauth/authorize
           scopes:
             read:account: read your account information
             write:planets: modify planets in your account
             read:planets: read your planets
-        # Legacy
         password:
           tokenUrl: https://galaxy.scalar.com/oauth/token
           scopes:
@@ -1253,8 +1233,6 @@ components:
           type: integer
           format: int64
           readOnly: true
-          # Serialize the id as an XML attribute (<planet id="1">) using the new
-          # 3.2 `nodeType` field instead of the deprecated `attribute: true`.
           xml:
             nodeType: attribute
           examples:
@@ -1270,7 +1248,6 @@ components:
           type:
             - string
             - 'null'
-          # `nodeType: cdata` wraps free-form text in a CDATA section.
           xml:
             nodeType: cdata
           examples:
@@ -1398,8 +1375,6 @@ components:
             - https://cdn.scalar.com/photos/mars.jpg
         satellites:
           type: array
-          # `nodeType: none` keeps the array unwrapped: each <satellite> appears
-          # directly, with no surrounding <satellites> element (the array default).
           xml:
             nodeType: none
           items:
@@ -1408,8 +1383,6 @@ components:
           $ref: '#/components/schemas/User'
         tags:
           type: array
-          # `nodeType: element` wraps the items in a <tags> element, replacing the
-          # deprecated `wrapped: true`.
           xml:
             nodeType: element
             name: tags

--- a/packages/galaxy/tests/yaml.test.ts
+++ b/packages/galaxy/tests/yaml.test.ts
@@ -52,7 +52,6 @@ type ThreeTwoSecurityScheme = {
 }
 
 type ThreeTwoDocument = {
-  $self?: string
   servers: Array<{ url: string; name?: string }>
   tags: Array<{ name: string; summary?: string; parent?: string; kind?: string }>
   paths: Record<string, ThreeTwoPathItem>
@@ -71,10 +70,6 @@ describe('yaml', () => {
 
   it('ships a 3.2 document on version 3.2.0', () => {
     expect(galaxyThreeTwo).toContain('openapi: 3.2.0')
-  })
-
-  it('declares the document base URI with $self', () => {
-    expect(getThreeTwoDocument().$self).toBeTypeOf('string')
   })
 
   it('gives every server a name', () => {

--- a/packages/galaxy/tests/yaml.test.ts
+++ b/packages/galaxy/tests/yaml.test.ts
@@ -26,6 +26,44 @@ const HTTP_METHODS: HttpMethod[] = ['get', 'post', 'put', 'delete', 'patch', 'op
 
 const getDocument = (): OpenApiDocument => YAML.parse(galaxy) as OpenApiDocument
 
+// A focused view of the 3.2 document, typed only for the OpenAPI 3.2 features
+// exercised below rather than the whole specification surface.
+type ThreeTwoMediaType = {
+  itemSchema?: unknown
+  prefixEncoding?: unknown[]
+  itemEncoding?: unknown
+}
+
+type ThreeTwoOperation = {
+  parameters?: Array<{ in?: string }>
+  requestBody?: { content?: Record<string, ThreeTwoMediaType> }
+  responses?: Record<string, { content?: Record<string, ThreeTwoMediaType> }>
+}
+
+type ThreeTwoPathItem = Partial<Record<HttpMethod, ThreeTwoOperation>> & {
+  query?: ThreeTwoOperation
+  additionalOperations?: Record<string, ThreeTwoOperation>
+}
+
+type ThreeTwoSecurityScheme = {
+  deprecated?: boolean
+  oauth2MetadataUrl?: string
+  flows?: Record<string, { deviceAuthorizationUrl?: string; tokenUrl?: string }>
+}
+
+type ThreeTwoDocument = {
+  $self?: string
+  servers: Array<{ url: string; name?: string }>
+  tags: Array<{ name: string; summary?: string; parent?: string; kind?: string }>
+  paths: Record<string, ThreeTwoPathItem>
+  components: {
+    securitySchemes: Record<string, ThreeTwoSecurityScheme>
+    schemas: Record<string, { properties?: Record<string, { xml?: { nodeType?: string } }> }>
+  }
+}
+
+const getThreeTwoDocument = (): ThreeTwoDocument => YAML.parse(galaxyThreeTwo) as ThreeTwoDocument
+
 describe('yaml', () => {
   it('has OpenAPI version', () => {
     expect(galaxy).toContain('openapi: 3.1.1')
@@ -35,10 +73,65 @@ describe('yaml', () => {
     expect(galaxyThreeTwo).toContain('openapi: 3.2.0')
   })
 
-  it('keeps the 3.2 document identical to 3.1 apart from the OpenAPI version', () => {
-    // For now the 3.2 document is a version-only copy of 3.1. This guard fails the
-    // moment the two drift, so an accidental change to one document does not slip through.
-    expect(galaxyThreeTwo).toBe(galaxy.replace('openapi: 3.1.1', 'openapi: 3.2.0'))
+  it('declares the document base URI with $self', () => {
+    expect(getThreeTwoDocument().$self).toBeTypeOf('string')
+  })
+
+  it('gives every server a name', () => {
+    const { servers } = getThreeTwoDocument()
+    expect(servers.length).toBeGreaterThan(0)
+    expect(servers.every((server) => typeof server.name === 'string')).toBe(true)
+  })
+
+  it('nests tags with parent, kind and summary', () => {
+    const { tags } = getThreeTwoDocument()
+    const planets = tags.find((tag) => tag.name === 'Planets')
+    expect(planets?.parent).toBe('Celestial Bodies')
+    expect(planets?.kind).toBe('nav')
+    expect(planets?.summary).toBeTypeOf('string')
+    expect(tags.some((tag) => tag.kind === 'badge')).toBe(true)
+    expect(tags.some((tag) => tag.kind === 'audience')).toBe(true)
+  })
+
+  it('defines a QUERY operation and a custom COPY operation', () => {
+    const { paths } = getThreeTwoDocument()
+    expect(paths['/planets']?.query).toBeDefined()
+    expect(paths['/planets/{planetId}']?.additionalOperations?.COPY).toBeDefined()
+  })
+
+  it('describes a full query string with the querystring parameter location', () => {
+    const parameters = getThreeTwoDocument().paths['/planets/search']?.get?.parameters ?? []
+    expect(parameters.some((parameter) => parameter.in === 'querystring')).toBe(true)
+  })
+
+  it('streams items with itemSchema across sequential media types', () => {
+    const content = getThreeTwoDocument().paths['/planets/events']?.get?.responses?.['200']?.content ?? {}
+    expect(content['text/event-stream']?.itemSchema).toBeDefined()
+    expect(content['application/jsonl']?.itemSchema).toBeDefined()
+    expect(content['application/json-seq']?.itemSchema).toBeDefined()
+  })
+
+  it('encodes multipart streams with prefixEncoding and itemEncoding', () => {
+    const content = getThreeTwoDocument().paths['/planets/{planetId}/observations']?.post?.requestBody?.content ?? {}
+    const mixed = content['multipart/mixed']
+    expect(mixed?.prefixEncoding).toBeDefined()
+    expect(mixed?.itemEncoding).toBeDefined()
+  })
+
+  it('adds the OAuth 2.0 device authorization flow and metadata url', () => {
+    const oauth = getThreeTwoDocument().components.securitySchemes.oAuth2
+    expect(oauth.flows?.deviceAuthorization?.deviceAuthorizationUrl).toBeTypeOf('string')
+    expect(oauth.oauth2MetadataUrl).toBeTypeOf('string')
+  })
+
+  it('marks a legacy security scheme as deprecated', () => {
+    expect(getThreeTwoDocument().components.securitySchemes.apiKeyQuery.deprecated).toBe(true)
+  })
+
+  it('maps schema properties to XML node types', () => {
+    const { schemas } = getThreeTwoDocument().components
+    expect(schemas.Planet.properties?.id.xml?.nodeType).toBe('attribute')
+    expect(schemas.GalaxyMessage.properties?.value.xml?.nodeType).toBe('text')
   })
 
   it('uses the expected security requirements for all operations', () => {


### PR DESCRIPTION
Adds the new OpenAPI 3.2 features to the Galaxy example doc (`3.2.yaml`) so we can test them.

What's in there now:

- named servers and nested tags (`parent` / `kind` / `summary`)
- the `QUERY` method, custom methods (`additionalOperations`), and the `querystring` parameter
- streaming responses (`itemSchema`) and multipart part encoding
- the OAuth 2.0 device flow, `oauth2MetadataUrl`, and a deprecated auth scheme
- XML `nodeType`

It also adds a few new example endpoints for the above and updates the tests. The 3.1 doc is untouched.