### PR TITLE
chore(renovate): limit open PRs to a maximum of 5

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":dependencyDashboardApproval", "helpers:pinGitHubActionDigests"],
-  "prConcurrentLimit": 0,
+  "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
   "labels": ["dependencies"],
   "semanticCommits": "enabled",


### PR DESCRIPTION
Limits the number of open Renovate PRs to a maximum of 5 by setting `prConcurrentLimit` to `5` (was `0`, meaning unlimited).

`prHourlyLimit` is left at `0` — that only caps how many PRs are created per hour, not how many stay open at once.