### PR TITLE
fix(fastify): do not expose broken document endpoints for url sources

### DIFF
--- a/.changeset/fastify-url-source-endpoints.md
+++ b/.changeset/fastify-url-source-endpoints.md
@@ -1,0 +1,5 @@
+---
+'@scalar/fastify-api-reference': patch
+---
+
+Fix the OpenAPI document endpoints for `url` sources. When the specification was provided via `configuration.url`, the plugin still registered `${routePrefix}/openapi.json` and `${routePrefix}/openapi.yaml`, but they returned a broken response (a 500 for JSON, an empty body for YAML) because the URL string was normalized as if it were the document itself. The reference already loads the URL directly in the browser, so these endpoints are no longer registered for `url` sources — matching the existing behavior for `sources`.

--- a/integrations/fastify/src/fastifyApiReference.test.ts
+++ b/integrations/fastify/src/fastifyApiReference.test.ts
@@ -475,7 +475,9 @@ describe('fastifyApiReference', () => {
 
     await fastify.register(fastifyApiReference, {
       configuration: {
-        url: '/openapi.json',
+        // Use a content source so the document endpoints are registered too, and
+        // assert that every route the plugin adds respects `logLevel: 'silent'`.
+        content: exampleDocument(),
       },
       logLevel: 'silent',
     })
@@ -534,5 +536,31 @@ describe('fastifyApiReference', () => {
     expect(response3.status).toBe(404)
     expect(response4.status).toBe(404)
     expect(await response1.text()).toContain('/openapi.json')
+  })
+
+  it('does not expose the document endpoints for a url source', async () => {
+    fastify = Fastify({
+      logger: false,
+    })
+
+    await fastify.register(fastifyApiReference, {
+      routePrefix: '/reference',
+      configuration: {
+        url: '/openapi.json',
+      },
+    })
+
+    const address = await fastify.listen({ port: 0 })
+    const html = await fetch(`${address}/reference/`)
+    const js = await fetch(`${address}/reference/js/scalar.js`)
+    const json = await fetch(`${address}/reference/openapi.json`)
+    const yaml = await fetch(`${address}/reference/openapi.yaml`)
+
+    // The reference loads the user's URL directly, so we do not re-expose it here.
+    expect(html.status).toBe(200)
+    expect(js.status).toBe(200)
+    expect(json.status).toBe(404)
+    expect(yaml.status).toBe(404)
+    expect(await html.text()).toContain('/openapi.json')
   })
 })

--- a/integrations/fastify/src/fastifyApiReference.ts
+++ b/integrations/fastify/src/fastifyApiReference.ts
@@ -132,8 +132,11 @@ const fastifyApiReference = fp<
       return slug(spec?.specification?.info?.title ?? 'spec')
     }
 
-    // Only expose the endpoints if specSource is available
-    if (specSource) {
+    // Only expose the document endpoints when we can serve the document ourselves.
+    // For a `url` source the reference loads the user's URL directly in the browser, so a
+    // local re-exposure is meaningless — and normalizing the URL string here produced a
+    // broken response (a 500 for JSON, an empty body for YAML).
+    if (specSource && specSource.type !== 'url') {
       const openApiSpecUrlJson = `${getRoutePrefix(options.routePrefix)}${getOpenApiDocumentEndpoints(options.openApiDocumentEndpoints).json}`
       fastify.route({
         method: 'GET',

--- a/integrations/fastify/src/types.ts
+++ b/integrations/fastify/src/types.ts
@@ -24,12 +24,11 @@ export type FastifyApiReferenceOptions = {
   /**
    * Set where the OpenAPI specification is exposed under `${routePrefix}`.
    *
-   * The specification is always available on these endpoints, parsed by `@scalar/openapi-parser`.
+   * The specification is available on these endpoints (parsed by `@scalar/openapi-parser`)
+   * when it is provided via `configuration.content` or `@fastify/swagger`.
    *
-   * The specification is sourced from, in order of precedence:
-   * - `configuration.spec.content`
-   * - `configuration.spec.url` – fetched via `@scalar/openapi-parser/plugins/fetch-urls`
-   * - `@fastify/swagger` – if `configuration.spec` is not provided
+   * A `configuration.url` source is loaded directly by the reference in the browser, so it
+   * is not re-exposed on these endpoints.
    *
    * These endpoints can be used to fetch the OpenAPI specification for your own programmatic use.
    *


### PR DESCRIPTION
When the OpenAPI document was provided via `configuration.url`, the plugin still registered `${routePrefix}/openapi.json` and `${routePrefix}/openapi.yaml`, but they were broken and unused:

- `openapi.json` returned **500** (`"undefined" is not valid JSON`) — the URL string was passed to `normalize()` as if it were the document.
- `openapi.yaml` returned **200 with an empty body**.
- The reference itself loads the user's URL directly in the browser, so these endpoints were never consumed anyway.

This stops registering the document endpoints for `url` sources (they now 404, matching the existing behavior for `sources`). `content` and `@fastify/swagger` sources are unaffected — they still expose the document.

Also corrects the `types.ts` JSDoc, which wrongly claimed the `url` was "fetched via `@scalar/openapi-parser/plugins/fetch-urls`" and referenced non-existent `configuration.spec.*` paths.
