### PR TITLE
docs(asyncapi-upgrader): add getting started guide

### DIFF
--- a/documentation/guides/asyncapi-upgrader/getting-started.md
+++ b/documentation/guides/asyncapi-upgrader/getting-started.md
@@ -1,0 +1,101 @@
+# Scalar AsyncAPI Upgrader
+
+<div class="flex gap-2">
+  <a href="https://www.npmjs.com/@scalar/asyncapi-upgrader">
+    <img src="https://img.shields.io/npm/v/@scalar/asyncapi-upgrader" alt="Version">
+  </a>
+  <a href="https://www.npmjs.com/@scalar/asyncapi-upgrader">
+    <img src="https://img.shields.io/npm/dm/@scalar/asyncapi-upgrader" alt="Downloads">
+  </a>
+  <a href="https://www.npmjs.com/package/@scalar/asyncapi-upgrader">
+    <img src="https://img.shields.io/npm/l/@scalar/asyncapi-upgrader" alt="License">
+  </a>
+  <a href="https://discord.gg/scalar">
+    <img src="https://img.shields.io/discord/1135330207960678410?style=flat&color=5865F2" alt="Discord">
+  </a>
+</div>
+
+Upgrade all your AsyncAPI documents to the latest and greatest version.
+
+## TypeScript Package
+
+You can use the package in your Node.js/JavaScript/TypeScript projects:
+
+```bash
+npm add @scalar/asyncapi-upgrader
+```
+
+### Usage
+
+The `upgrade` function migrates any AsyncAPI 1.x, 2.x, or 3.0 document all the way to the latest version (3.1.0) in a single call.
+
+```typescript
+import { upgrade } from '@scalar/asyncapi-upgrader'
+
+const document = upgrade({
+  asyncapi: '2.6.0',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  channels: {},
+})
+
+console.log(document.asyncapi)
+// Output: 3.1.0
+```
+
+Documents without an `asyncapi` field are returned untouched, so it is safe to run `upgrade` on documents that might already be up to date.
+
+### From AsyncAPI 1.x to 2.6
+
+```typescript
+import { upgradeFromOneToTwo } from '@scalar/asyncapi-upgrader/1.2-to-2.6'
+
+const document = upgradeFromOneToTwo({
+  asyncapi: '1.2.0',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+})
+
+console.log(document.asyncapi)
+// Output: 2.6.0
+```
+
+### From AsyncAPI 2.6 to 3.0
+
+```typescript
+import { upgradeFromTwoToThree } from '@scalar/asyncapi-upgrader/2.6-to-3.0'
+
+const document = upgradeFromTwoToThree({
+  asyncapi: '2.6.0',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  channels: {},
+})
+
+console.log(document.asyncapi)
+// Output: 3.0.0
+```
+
+### From AsyncAPI 3.0 to 3.1
+
+```typescript
+import { upgradeFromThreeToThreeOne } from '@scalar/asyncapi-upgrader/3.0-to-3.1'
+
+const document = upgradeFromThreeToThreeOne({
+  asyncapi: '3.0.0',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  channels: {},
+})
+
+console.log(document.asyncapi)
+// Output: 3.1.0
+```

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -3920,6 +3920,53 @@
                   }
                 }
               },
+              "../../tools/asyncapi-upgrader": {
+                "title": "AsyncAPI Upgrader",
+                "description": "Automatically upgrade your AsyncAPI documents from 1.x and 2.x to the latest 3.x version with zero manual work.",
+                "type": "group",
+                "mode": "nested",
+                "icon": "phosphor/regular/arrow-up-right",
+                "children": {
+                  "getting-started": {
+                    "title": "Getting Started",
+                    "filepath": "documentation/guides/asyncapi-upgrader/getting-started.md",
+                    "type": "page",
+                    "description": "Migrate legacy AsyncAPI 1.x and 2.x documents to the modern 3.x format automatically with our free conversion tool.",
+                    "head": {
+                      "links": [
+                        {
+                          "rel": "canonical",
+                          "href": "https://scalar.com/tools/asyncapi-upgrader/getting-started"
+                        }
+                      ],
+                      "meta": [
+                        {
+                          "name": "description",
+                          "content": "Migrate legacy AsyncAPI 1.x and 2.x documents to the modern 3.x format automatically with our free conversion tool."
+                        },
+                        {
+                          "property": "og:title",
+                          "content": "Getting Started with AsyncAPI Upgrader - Upgrade to AsyncAPI 3.x"
+                        },
+                        {
+                          "property": "og:description",
+                          "content": "Migrate legacy AsyncAPI 1.x and 2.x documents to the modern 3.x format automatically with our free conversion tool."
+                        },
+                        {
+                          "name": "robots",
+                          "content": "index, follow"
+                        }
+                      ]
+                    }
+                  },
+                  "changelog": {
+                    "title": "Changelog",
+                    "description": "Changelog for @scalar/asyncapi-upgrader releases.",
+                    "filepath": "packages/asyncapi-upgrader/CHANGELOG.md",
+                    "type": "page"
+                  }
+                }
+              },
               "../../tools/api": {
                 "type": "openapi",
                 "namespace": "scalar",


### PR DESCRIPTION
Adds a Getting Started guide for `@scalar/asyncapi-upgrader`, mirroring the existing OpenAPI Upgrader guide, and wires it into the docs sidebar via `scalar.config.json`.

- New page: `documentation/guides/asyncapi-upgrader/getting-started.md` — install + `upgrade()`, plus the per-step exports (`1.2-to-2.6`, `2.6-to-3.0`, `3.0-to-3.1`).
- New nav group `tools/asyncapi-upgrader` in `scalar.config.json` (Getting Started + Changelog).

Note: unlike the OpenAPI Upgrader, this package has no `@scalar/cli` command yet, so the guide is TypeScript-only.
