### PR TITLE
fix(api-client): keep the composition selection when reopening the same operation

### DIFF
--- a/.changeset/fix-10023-modal-composition-selection.md
+++ b/.changeset/fix-10023-modal-composition-selection.md
@@ -2,4 +2,4 @@
 '@scalar/api-client': patch
 ---
 
-Fix "Test Request" discarding an edited request body when the operation it opens is already the one shown in the client. Opening the modal on the entry that is already selected does not route anywhere, so the request body kept its edited value while the composition selection was replaced with whatever the reference page had selected. The request body read that as a manual `oneOf`/`anyOf` branch switch and regenerated itself from the schema. The selection is now only applied when the modal actually moves to a different entry.
+Fix "Test Request" discarding an edited request body when the operation it opens is already the one on screen. Reopening the entry the modal already shows does not route anywhere, so the request body kept its edited value while the composition selection was replaced with whatever the reference page had selected. The request body read that as a manual `oneOf`/`anyOf` branch switch and regenerated itself from the schema. An open modal now keeps the selection it is already showing, while opening a different entry still re-establishes it.

--- a/.changeset/fix-10023-modal-composition-selection.md
+++ b/.changeset/fix-10023-modal-composition-selection.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix "Test Request" discarding an edited request body when the operation it opens is already the one shown in the client. Opening the modal on the entry that is already selected does not route anywhere, so the request body kept its edited value while the composition selection was replaced with whatever the reference page had selected. The request body read that as a manual `oneOf`/`anyOf` branch switch and regenerated itself from the schema. The selection is now only applied when the modal actually moves to a different entry.

--- a/packages/api-client/src/v2/features/modal/modal-events.test.ts
+++ b/packages/api-client/src/v2/features/modal/modal-events.test.ts
@@ -8,6 +8,8 @@ import { computed, nextTick, ref } from 'vue'
 
 import 'fake-indexeddb/auto'
 
+import { createMockEventBus } from '@/v2/helpers/test-utils'
+
 import { useModalSidebar } from './hooks/use-modal-sidebar'
 import { initializeModalEvents } from './modal-events'
 
@@ -23,10 +25,18 @@ const getDocument = (overrides: Partial<OpenApiDocument> = {}): OpenApiDocument 
 })
 
 /**
- * Wires up the modal events against a real sidebar and returns the pieces the tests assert on.
+ * Helper to wait for async operations and Vue updates.
+ */
+const waitForUpdates = async () => {
+  await nextTick()
+  await flushPromises()
+}
+
+/**
+ * Wires the modal events up to a real sidebar and returns the pieces the tests assert on.
  *
- * The event bus is a stub that records the registered handlers, so a test can call them the same
- * way the workspace event bus would when `ui:open:client-modal` is emitted.
+ * The mock event bus records the handlers that are registered, so a test can call them the same way
+ * the workspace event bus would when the event is emitted.
  */
 const createTestSetup = async () => {
   const store = createWorkspaceStore()
@@ -38,6 +48,9 @@ const createTestSetup = async () => {
         '/pets': { post: { operationId: 'createPet' } },
         '/users': { post: { operationId: 'createUser' } },
       },
+      webhooks: {
+        newPet: { post: { operationId: 'newPetWebhook' } },
+      },
     }),
   })
 
@@ -46,11 +59,13 @@ const createTestSetup = async () => {
   const path = ref<string | undefined>(undefined)
   const method = ref<HttpMethod | undefined>(undefined)
   const exampleName = ref<string | undefined>(undefined)
+  const isWebhook = ref(false)
 
-  const route = vi.fn((payload: { path?: string; method?: HttpMethod; example?: string }) => {
+  const route = vi.fn((payload: { path?: string; method?: HttpMethod; example?: string; isWebhook?: boolean }) => {
     path.value = payload.path
     method.value = payload.method
     exampleName.value = payload.example
+    isWebhook.value = payload.isWebhook ?? false
   })
 
   const sidebarState = useModalSidebar({
@@ -59,77 +74,98 @@ const createTestSetup = async () => {
     path: computed(() => path.value),
     method: computed(() => method.value),
     exampleName: computed(() => exampleName.value),
+    isWebhook: computed(() => isWebhook.value),
     route,
   })
 
-  const handlers: Record<string, (payload?: any) => void> = {}
-  const eventBus = {
-    on: vi.fn((event: string, handler: (payload?: any) => void) => {
-      handlers[event] = handler
-      return vi.fn()
-    }),
-    once: vi.fn(() => vi.fn()),
-    off: vi.fn(),
-    onAny: vi.fn(() => vi.fn()),
-    offAny: vi.fn(),
-    emit: vi.fn(() => null),
-    flushDebouncedEmits: vi.fn(),
-  } as any
+  const handlers: Record<string, (payload?: unknown) => void> = {}
+  const eventBus = createMockEventBus()
+  vi.mocked(eventBus.on).mockImplementation((event, handler) => {
+    handlers[event] = handler as (payload?: unknown) => void
+    return vi.fn()
+  })
 
   const requestBodyCompositionSelection = ref<Record<string, number>>({})
+  const modalState = useModal()
 
   initializeModalEvents({
     eventBus,
     isSidebarOpen: ref(false),
     requestBodyCompositionSelection,
     sidebarState,
-    modalState: useModal(),
+    modalState,
     store,
   })
 
-  const getOperationId = (operationPath: string) =>
-    sidebarState.getEntryByLocation({ document: 'test-doc', path: operationPath, method: 'post' })?.id ?? ''
+  const getEntryId = (location: { path?: string; method?: HttpMethod; isWebhook?: boolean }) =>
+    sidebarState.getEntryByLocation({ document: 'test-doc', method: 'post', ...location })?.id ?? ''
 
   const openClientModal = async (payload: Record<string, unknown>) => {
     handlers['ui:open:client-modal']?.(payload)
-    await nextTick()
-    await flushPromises()
+    await waitForUpdates()
   }
 
-  return { getOperationId, openClientModal, requestBodyCompositionSelection, route }
+  return { getEntryId, modalState, openClientModal, requestBodyCompositionSelection, route }
 }
 
 describe('modal-events', () => {
   it('keeps the request body composition selection when the operation is already open', async () => {
-    const { getOperationId, openClientModal, requestBodyCompositionSelection, route } = await createTestSetup()
-    const petsId = getOperationId('/pets')
+    const { getEntryId, openClientModal, requestBodyCompositionSelection, route } = await createTestSetup()
+    const id = getEntryId({ path: '/pets' })
 
-    await openClientModal({ id: petsId, requestBodyCompositionSelection: { 'requestBody.oneOf': 0 } })
+    await openClientModal({ id, requestBodyCompositionSelection: { 'requestBody.oneOf': 0 } })
 
     expect(route).toHaveBeenCalledTimes(1)
     expect(requestBodyCompositionSelection.value).toEqual({ 'requestBody.oneOf': 0 })
 
-    await openClientModal({ id: petsId, requestBodyCompositionSelection: { 'requestBody.oneOf': 1 } })
+    await openClientModal({ id, requestBodyCompositionSelection: { 'requestBody.oneOf': 1 } })
 
     /**
      * Nothing was routed, so the operation still shows the body the user was working on and the
-     * selection that produced it must survive the second open.
+     * selection that produced it has to survive the second open.
      */
     expect(route).toHaveBeenCalledTimes(1)
     expect(requestBodyCompositionSelection.value).toEqual({ 'requestBody.oneOf': 0 })
   })
 
+  it('keeps the request body composition selection when the webhook is already open', async () => {
+    const { getEntryId, openClientModal, requestBodyCompositionSelection } = await createTestSetup()
+    const id = getEntryId({ path: 'newPet', isWebhook: true })
+
+    await openClientModal({ id, requestBodyCompositionSelection: { 'requestBody.oneOf': 0 } })
+    await openClientModal({ id, requestBodyCompositionSelection: { 'requestBody.oneOf': 1 } })
+
+    /**
+     * Webhooks re-route with the same path, method and example instead of bailing out early, so the
+     * body on screen does not change either.
+     */
+    expect(requestBodyCompositionSelection.value).toEqual({ 'requestBody.oneOf': 0 })
+  })
+
   it('applies the request body composition selection when another operation is opened', async () => {
-    const { getOperationId, openClientModal, requestBodyCompositionSelection } = await createTestSetup()
+    const { getEntryId, openClientModal, requestBodyCompositionSelection } = await createTestSetup()
 
     await openClientModal({
-      id: getOperationId('/pets'),
+      id: getEntryId({ path: '/pets' }),
       requestBodyCompositionSelection: { 'requestBody.oneOf': 0 },
     })
     await openClientModal({
-      id: getOperationId('/users'),
+      id: getEntryId({ path: '/users' }),
       requestBodyCompositionSelection: { 'requestBody.oneOf': 1 },
     })
+
+    expect(requestBodyCompositionSelection.value).toEqual({ 'requestBody.oneOf': 1 })
+  })
+
+  it('applies the request body composition selection when the modal is closed in between', async () => {
+    const { getEntryId, modalState, openClientModal, requestBodyCompositionSelection } = await createTestSetup()
+    const id = getEntryId({ path: '/pets' })
+
+    await openClientModal({ id, requestBodyCompositionSelection: { 'requestBody.oneOf': 0 } })
+
+    modalState.hide()
+
+    await openClientModal({ id, requestBodyCompositionSelection: { 'requestBody.oneOf': 1 } })
 
     expect(requestBodyCompositionSelection.value).toEqual({ 'requestBody.oneOf': 1 })
   })

--- a/packages/api-client/src/v2/features/modal/modal-events.test.ts
+++ b/packages/api-client/src/v2/features/modal/modal-events.test.ts
@@ -1,0 +1,136 @@
+import { useModal } from '@scalar/components/modal'
+import type { HttpMethod } from '@scalar/helpers/http/http-methods'
+import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import type { OpenApiDocument } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, ref } from 'vue'
+
+import 'fake-indexeddb/auto'
+
+import { useModalSidebar } from './hooks/use-modal-sidebar'
+import { initializeModalEvents } from './modal-events'
+
+/**
+ * Creates a test document with sensible defaults.
+ */
+const getDocument = (overrides: Partial<OpenApiDocument> = {}): OpenApiDocument => ({
+  openapi: '3.0.0',
+  info: { title: 'Test API', version: '1.0.0' },
+  paths: {},
+  'x-scalar-original-document-hash': 'test-hash',
+  ...overrides,
+})
+
+/**
+ * Wires up the modal events against a real sidebar and returns the pieces the tests assert on.
+ *
+ * The event bus is a stub that records the registered handlers, so a test can call them the same
+ * way the workspace event bus would when `ui:open:client-modal` is emitted.
+ */
+const createTestSetup = async () => {
+  const store = createWorkspaceStore()
+
+  await store.addDocument({
+    name: 'test-doc',
+    document: getDocument({
+      paths: {
+        '/pets': { post: { operationId: 'createPet' } },
+        '/users': { post: { operationId: 'createUser' } },
+      },
+    }),
+  })
+
+  store.update('x-scalar-active-document', 'test-doc')
+
+  const path = ref<string | undefined>(undefined)
+  const method = ref<HttpMethod | undefined>(undefined)
+  const exampleName = ref<string | undefined>(undefined)
+
+  const route = vi.fn((payload: { path?: string; method?: HttpMethod; example?: string }) => {
+    path.value = payload.path
+    method.value = payload.method
+    exampleName.value = payload.example
+  })
+
+  const sidebarState = useModalSidebar({
+    workspaceStore: store,
+    documentSlug: computed(() => 'test-doc'),
+    path: computed(() => path.value),
+    method: computed(() => method.value),
+    exampleName: computed(() => exampleName.value),
+    route,
+  })
+
+  const handlers: Record<string, (payload?: any) => void> = {}
+  const eventBus = {
+    on: vi.fn((event: string, handler: (payload?: any) => void) => {
+      handlers[event] = handler
+      return vi.fn()
+    }),
+    once: vi.fn(() => vi.fn()),
+    off: vi.fn(),
+    onAny: vi.fn(() => vi.fn()),
+    offAny: vi.fn(),
+    emit: vi.fn(() => null),
+    flushDebouncedEmits: vi.fn(),
+  } as any
+
+  const requestBodyCompositionSelection = ref<Record<string, number>>({})
+
+  initializeModalEvents({
+    eventBus,
+    isSidebarOpen: ref(false),
+    requestBodyCompositionSelection,
+    sidebarState,
+    modalState: useModal(),
+    store,
+  })
+
+  const getOperationId = (operationPath: string) =>
+    sidebarState.getEntryByLocation({ document: 'test-doc', path: operationPath, method: 'post' })?.id ?? ''
+
+  const openClientModal = async (payload: Record<string, unknown>) => {
+    handlers['ui:open:client-modal']?.(payload)
+    await nextTick()
+    await flushPromises()
+  }
+
+  return { getOperationId, openClientModal, requestBodyCompositionSelection, route }
+}
+
+describe('modal-events', () => {
+  it('keeps the request body composition selection when the operation is already open', async () => {
+    const { getOperationId, openClientModal, requestBodyCompositionSelection, route } = await createTestSetup()
+    const petsId = getOperationId('/pets')
+
+    await openClientModal({ id: petsId, requestBodyCompositionSelection: { 'requestBody.oneOf': 0 } })
+
+    expect(route).toHaveBeenCalledTimes(1)
+    expect(requestBodyCompositionSelection.value).toEqual({ 'requestBody.oneOf': 0 })
+
+    await openClientModal({ id: petsId, requestBodyCompositionSelection: { 'requestBody.oneOf': 1 } })
+
+    /**
+     * Nothing was routed, so the operation still shows the body the user was working on and the
+     * selection that produced it must survive the second open.
+     */
+    expect(route).toHaveBeenCalledTimes(1)
+    expect(requestBodyCompositionSelection.value).toEqual({ 'requestBody.oneOf': 0 })
+  })
+
+  it('applies the request body composition selection when another operation is opened', async () => {
+    const { getOperationId, openClientModal, requestBodyCompositionSelection } = await createTestSetup()
+
+    await openClientModal({
+      id: getOperationId('/pets'),
+      requestBodyCompositionSelection: { 'requestBody.oneOf': 0 },
+    })
+    await openClientModal({
+      id: getOperationId('/users'),
+      requestBodyCompositionSelection: { 'requestBody.oneOf': 1 },
+    })
+
+    expect(requestBodyCompositionSelection.value).toEqual({ 'requestBody.oneOf': 1 })
+  })
+})

--- a/packages/api-client/src/v2/features/modal/modal-events.ts
+++ b/packages/api-client/src/v2/features/modal/modal-events.ts
@@ -45,8 +45,8 @@ export function initializeModalEvents({
   eventBus.on('ui:toggle:sidebar', () => (isSidebarOpen.value = !isSidebarOpen.value))
   eventBus.on('ui:close:client-modal', () => modalState.hide())
   eventBus.on('ui:open:client-modal', (payload) => {
-    // Every open re-establishes the selection (falling back to empty), so the modal no longer needs
-    // to reset it on close. Keep this assignment unconditional to preserve that invariant.
+    // Every open that lands on a different entry re-establishes the selection (falling back to
+    // empty), so the modal no longer needs to reset it on close.
     const nextRequestBodyCompositionSelection = (
       payload && 'requestBodyCompositionSelection' in payload && payload.requestBodyCompositionSelection
         ? payload.requestBodyCompositionSelection
@@ -59,6 +59,8 @@ export function initializeModalEvents({
       modalState.show()
       return
     }
+
+    const previouslySelectedId = sidebarState.state.selectedItem.value
 
     // We route to the exact ID
     if ('id' in payload && payload.id) {
@@ -96,7 +98,11 @@ export function initializeModalEvents({
 
     // Apply the selection after routing so the request body compares it with the selection used
     // for this operation, rather than briefly resetting the operation that was previously open.
-    requestBodyCompositionSelection.value = nextRequestBodyCompositionSelection
+    // Reopening the entry that is already shown routes nowhere, so the request body would read the
+    // new selection as a manual branch switch and throw away whatever the user typed into it.
+    if (sidebarState.state.selectedItem.value !== previouslySelectedId) {
+      requestBodyCompositionSelection.value = nextRequestBodyCompositionSelection
+    }
 
     modalState.show()
   })

--- a/packages/api-client/src/v2/features/modal/modal-events.ts
+++ b/packages/api-client/src/v2/features/modal/modal-events.ts
@@ -45,8 +45,8 @@ export function initializeModalEvents({
   eventBus.on('ui:toggle:sidebar', () => (isSidebarOpen.value = !isSidebarOpen.value))
   eventBus.on('ui:close:client-modal', () => modalState.hide())
   eventBus.on('ui:open:client-modal', (payload) => {
-    // Every open that lands on a different entry re-establishes the selection (falling back to
-    // empty), so the modal no longer needs to reset it on close.
+    // Every open re-establishes the selection (falling back to empty), so the modal no longer needs
+    // to reset it on close.
     const nextRequestBodyCompositionSelection = (
       payload && 'requestBodyCompositionSelection' in payload && payload.requestBodyCompositionSelection
         ? payload.requestBodyCompositionSelection
@@ -60,7 +60,7 @@ export function initializeModalEvents({
       return
     }
 
-    const previouslySelectedId = sidebarState.state.selectedItem.value
+    const previousSelectedId = sidebarState.state.selectedItem.value
 
     // We route to the exact ID
     if ('id' in payload && payload.id) {
@@ -98,9 +98,11 @@ export function initializeModalEvents({
 
     // Apply the selection after routing so the request body compares it with the selection used
     // for this operation, rather than briefly resetting the operation that was previously open.
-    // Reopening the entry that is already shown routes nowhere, so the request body would read the
-    // new selection as a manual branch switch and throw away whatever the user typed into it.
-    if (sidebarState.state.selectedItem.value !== previouslySelectedId) {
+    // Reopening the entry already on screen routes nowhere, so a new selection would read as a
+    // manual branch switch and discard the edited body.
+    const isReopeningVisibleEntry = modalState.open && sidebarState.state.selectedItem.value === previousSelectedId
+
+    if (!isReopeningVisibleEntry) {
       requestBodyCompositionSelection.value = nextRequestBodyCompositionSelection
     }
 


### PR DESCRIPTION
## Problem

Clicking "Test Request" for an operation that is already open in the client throws away an edited request body. The modal handler applies the reference page's `requestBodyCompositionSelection` after routing, but `handleSelectItem` returns early without routing when the target entry is already selected. The body stays as the user typed it while the selection jumps to whichever `oneOf`/`anyOf` branch the reference page happened to show, and `RequestBody.vue` can only read that as a manual branch switch, so it regenerates the body from the schema.

Webhooks hit the same thing from the other side: they re-route with an identical path, method and example, so nothing the request body watches changes there either.

## Solution

Remember which sidebar entry was selected before routing, and skip the new selection when an open modal is already showing that entry. Opening a different operation or example still re-establishes the selection, and so does opening the modal again after it was closed, so the reference page keeps driving the branch in every case except the one where it would destroy an edit.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Closes #10023
