### PR TITLE
fix(themes): stop autofilled input text rendering hollow

### DIFF
--- a/.changeset/fix-autofill-text-fill-color.md
+++ b/.changeset/fix-autofill-text-fill-color.md
@@ -1,0 +1,5 @@
+---
+'@scalar/themes': patch
+---
+
+Fix autofilled input text rendering hollow and near-illegible in dark mode. The reset clipped WebKit's autofill background to the glyphs without re-asserting `-webkit-text-fill-color`, so the glyph interiors showed that clipped background instead of the theme colour.

--- a/packages/themes/src/base/reset.css
+++ b/packages/themes/src/base/reset.css
@@ -120,6 +120,7 @@
   /** Remove yellow/blue autofill indicator */
   input:-webkit-autofill {
     background-clip: text !important;
+    -webkit-text-fill-color: var(--scalar-color-1);
   }
 
   /** Add outline for focus visible */


### PR DESCRIPTION
Autofilled inputs render hollow and near-invisible in dark mode — the value is there, just outlined at very low contrast. Showed up on the dashboard login filling with 1Password on iOS.

* `background-clip: text` clips WebKit's autofill background to the glyphs, but WebKit also forces `-webkit-text-fill-color` on autofilled fields — without re-asserting it the glyph interiors show that clipped background instead of the theme colour
* `currentColor` doesn't work here (WebKit resolves it against its own forced colour), so it's pinned to `--scalar-color-1`
* Dropping the rule instead just brings the yellow/blue autofill box back, so it's half-written rather than obsolete

No test — autofill state isn't something Playwright can drive.

Before / After

<img width="49%" alt="IMG_2716" src="https://github.com/user-attachments/assets/2a83d737-b301-44d8-ada0-a29c981bda70" />
<img width="49%" alt="IMG_2715" src="https://github.com/user-attachments/assets/e064cb9d-96e7-4c6b-be1a-2ccceb2f50db" />


## Checklist
- [x] I explained why the change is needed.
- [x] I added a changeset.
- [ ] I added tests.
- [ ] I updated the documentation