### PR TITLE
feat(fastapi): add add_scalar_reference helper and fix small bugs

### DIFF
--- a/.changeset/fastapi-helper-and-fixes.md
+++ b/.changeset/fastapi-helper-and-fixes.md
@@ -1,0 +1,9 @@
+---
+'scalar-fastapi': minor
+---
+
+feat(fastapi): add one-line `add_scalar_reference(app)` setup and fix small bugs
+
+`add_scalar_reference(app)` registers the reference route for you and reads `title` and `openapi_url` straight from the FastAPI app, so the common case is a single line. Any `get_scalar_api_reference` option (theme, custom `route`, etc.) can still be passed through.
+
+Also fixes a few papercuts in `get_scalar_api_reference`: the page title is now HTML-escaped, a document containing `</script>` can no longer break out of the inline script, the `dark_mode` type hint matches its `None` default, and the mutable default arguments were replaced with `None`.

--- a/integrations/fastapi/playground/main.py
+++ b/integrations/fastapi/playground/main.py
@@ -6,20 +6,18 @@ import os
 # Use the local scalar_fastapi package
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from scalar_fastapi import get_scalar_api_reference, Theme
+from scalar_fastapi import add_scalar_reference, Theme
 
 app = FastAPI()
+
+# One line to serve the API reference at /scalar. Any get_scalar_api_reference
+# option can be passed through, like the theme below.
+add_scalar_reference(app, theme=Theme.KEPLER)
+
 
 @app.get("/")
 def read_root():
     return {"Hello": "World"}
-
-@app.get("/scalar", include_in_schema=False)
-async def scalar_html():
-    return get_scalar_api_reference(
-        openapi_url=app.openapi_url,
-        theme=Theme.KEPLER,
-    )
 
 
 @app.get("/items/{item_id}")

--- a/integrations/fastapi/scalar_fastapi/__init__.py
+++ b/integrations/fastapi/scalar_fastapi/__init__.py
@@ -1,4 +1,5 @@
 from .scalar_fastapi import (
+    add_scalar_reference,
     DocumentDownloadType,
     get_scalar_api_reference,
     Layout,
@@ -9,6 +10,7 @@ from .scalar_fastapi import (
 )
 
 __all__ = [
+    "add_scalar_reference",
     "DocumentDownloadType",
     "get_scalar_api_reference",
     "Layout",

--- a/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import json
 from enum import Enum
+from html import escape as escape_html
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from typing_extensions import Annotated, Doc, Literal
 from fastapi.responses import HTMLResponse
-from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
 
 
 class Layout(Enum):
@@ -349,7 +353,7 @@ def get_scalar_api_reference(
         ),
     ] = False,
     dark_mode: Annotated[
-        bool,
+        bool | None,
         Doc(
             """
             Whether dark mode is on or off initially (light mode).
@@ -385,7 +389,7 @@ def get_scalar_api_reference(
         ),
     ] = SearchHotKey.K,
     hidden_clients: Annotated[
-        bool | dict[str, bool | list[str]] | list[str],
+        bool | dict[str, bool | list[str]] | list[str] | None,
         Doc(
             """
             A dictionary with the keys being the target names and the values being a boolean to hide all clients of the target or a list clients.
@@ -394,7 +398,7 @@ def get_scalar_api_reference(
             Default is [] which means no clients are hidden.
             """
         ),
-    ] = [],
+    ] = None,
     base_server_url: Annotated[
         str,
         Doc(
@@ -405,7 +409,7 @@ def get_scalar_api_reference(
         ),
     ] = "",
     servers: Annotated[
-        list[dict[str, Any]],
+        list[dict[str, Any]] | None,
         Doc(
             """
             List of OpenAPI Server Objects. Each item must have a required 'url' (string) and may have
@@ -414,9 +418,9 @@ def get_scalar_api_reference(
             Default is [] which means no servers are provided.
             """
         ),
-    ] = [],
+    ] = None,
     plugin_urls: Annotated[
-        list[str],
+        list[str] | None,
         Doc(
             """
             URLs of ESM modules that provide additional API Reference plugins.
@@ -425,7 +429,7 @@ def get_scalar_api_reference(
             Default is [] which means no plugin URLs are provided.
             """
         ),
-    ] = [],
+    ] = None,
     default_open_all_tags: Annotated[
         bool,
         Doc(
@@ -473,14 +477,14 @@ def get_scalar_api_reference(
         ),
     ] = "alpha",
     authentication: Annotated[
-        dict,
+        dict | None,
         Doc(
             """
             A dictionary of additional authentication information.
             Default is {} which means no authentication information is provided.
             """
         ),
-    ] = {},
+    ] = None,
     hide_client_button: Annotated[
         bool,
         Doc(
@@ -568,14 +572,14 @@ def get_scalar_api_reference(
         ),
     ] = None,
     overrides: Annotated[
-        Dict[str, Any],
+        Dict[str, Any] | None,
         Doc(
             """
             A dictionary of additional configuration overrides to pass to Scalar.
             Default is {} which means no overrides are provided.
             """
         ),
-    ] = {},
+    ] = None,
 ) -> HTMLResponse:
     # Build configuration object with only non-default values
     config = {}
@@ -695,11 +699,17 @@ def get_scalar_api_reference(
     if overrides:  # Default is {}
         config.update(overrides)
 
+    # Escape the title so it cannot inject markup, and escape "</" in the
+    # serialized config so a document that contains "</script>" cannot break
+    # out of the inline <script> block below.
+    page_title = escape_html(title) if title else "Scalar"
+    config_json = json.dumps(config).replace("</", "<\\/")
+
     html = f"""
 <!doctype html>
 <html>
     <head>
-        {f"<title>{title if title else 'Scalar'}</title>"}
+        <title>{page_title}</title>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="shortcut icon" href="{scalar_favicon_url}">
@@ -720,9 +730,44 @@ def get_scalar_api_reference(
 
         <!-- Initialize the Scalar API Reference -->
         <script>
-            Scalar.createApiReference("#app", {json.dumps(config)})
+            Scalar.createApiReference("#app", {config_json})
         </script>
     </body>
     </html>
     """
     return HTMLResponse(html)
+
+
+def add_scalar_reference(
+    app: FastAPI,
+    *,
+    route: str = "/scalar",
+    include_in_schema: bool = False,
+    **kwargs: Any,
+) -> FastAPI:
+    """
+    Register a Scalar API Reference route on a FastAPI application.
+
+    This is the one-line way to add Scalar to a FastAPI app. It wires up the
+    route and fills in ``openapi_url`` and ``title`` from the app, so the common
+    case is simply::
+
+        from fastapi import FastAPI
+        from scalar_fastapi import add_scalar_reference
+
+        app = FastAPI()
+        add_scalar_reference(app)
+
+    Any keyword argument accepted by :func:`get_scalar_api_reference` can be
+    passed through, for example ``add_scalar_reference(app, theme=Theme.KEPLER)``
+    or a custom ``route="/docs/scalar"``.
+    """
+    # Fall back to the app's own values, but let callers override either one.
+    kwargs.setdefault("openapi_url", app.openapi_url)
+    kwargs.setdefault("title", app.title)
+
+    @app.get(route, include_in_schema=include_in_schema)
+    async def scalar_html() -> HTMLResponse:
+        return get_scalar_api_reference(**kwargs)
+
+    return app

--- a/integrations/fastapi/tests/test_imports.py
+++ b/integrations/fastapi/tests/test_imports.py
@@ -13,6 +13,10 @@ def test_scalar_fastapi_imports():
     from scalar_fastapi import get_scalar_api_reference
     assert callable(get_scalar_api_reference)
 
+    # Test the one-line helper import
+    from scalar_fastapi import add_scalar_reference
+    assert callable(add_scalar_reference)
+
     # Test enum imports
     from scalar_fastapi import Layout, SearchHotKey, Theme
     assert Layout.MODERN.value == "modern"

--- a/integrations/fastapi/tests/test_scalar_fastapi.py
+++ b/integrations/fastapi/tests/test_scalar_fastapi.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from fastapi.responses import HTMLResponse
 
 from scalar_fastapi import (
+    add_scalar_reference,
     get_scalar_api_reference,
     Layout,
     OpenAPISource,
@@ -478,8 +479,8 @@ class TestEdgeCases:
         assert '"url": ""' in html_content
         assert "<title>Scalar</title>" in html_content
 
-    def test_special_characters_in_title(self):
-        """Test with special characters in title"""
+    def test_special_characters_in_title_are_escaped(self):
+        """Special characters in the title are HTML-escaped to prevent injection"""
         title_with_special_chars = "API & Documentation <script>alert('xss')</script>"
         response = get_scalar_api_reference(
             openapi_url="/openapi.json",
@@ -487,8 +488,23 @@ class TestEdgeCases:
         )
 
         html_content = response.body.decode()
-        # The title should be properly escaped in the HTML
-        assert title_with_special_chars in html_content
+        # The raw script payload must not survive into the output ...
+        assert "<script>alert('xss')</script>" not in html_content
+        # ... it should be escaped instead.
+        assert "API &amp; Documentation" in html_content
+        assert "&lt;script&gt;" in html_content
+
+    def test_content_with_closing_script_tag_cannot_break_out(self):
+        """A document containing </script> must not break out of the inline script"""
+        response = get_scalar_api_reference(
+            content='{"openapi": "3.1.0", "info": {"title": "</script><script>alert(1)</script>"}}',
+        )
+
+        html_content = response.body.decode()
+        # The closing tag is neutralized as <\/script> inside the config ...
+        assert "<\\/script>" in html_content
+        # ... so the raw breakout sequence never appears.
+        assert "</script><script>alert(1)</script>" not in html_content
 
     def test_complex_json_in_configuration(self):
         """Test with complex JSON structures in configuration"""
@@ -518,3 +534,52 @@ class TestEdgeCases:
         # The complex JSON should be properly serialized
         assert "oauth2" in html_content
         assert "authorizationCode" in html_content
+
+
+class TestAddScalarReference:
+    """Test the one-line add_scalar_reference helper"""
+
+    def test_registers_route_and_serves_html(self):
+        """The helper mounts /scalar and fills in title and openapi_url from the app"""
+        app = FastAPI(title="My API")
+        add_scalar_reference(app)
+
+        client = TestClient(app)
+        response = client.get("/scalar")
+
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+
+        html_content = response.text
+        assert "<title>My API</title>" in html_content
+        assert '"url": "/openapi.json"' in html_content
+
+    def test_custom_route_and_passthrough_kwargs(self):
+        """A custom route works and extra kwargs reach get_scalar_api_reference"""
+        app = FastAPI(title="My API")
+        add_scalar_reference(app, route="/docs/scalar", theme=Theme.KEPLER, title="Docs")
+
+        client = TestClient(app)
+
+        # The default route is not registered when a custom one is used.
+        assert client.get("/scalar").status_code == 404
+
+        response = client.get("/docs/scalar")
+        assert response.status_code == 200
+        assert '"theme": "kepler"' in response.text
+        assert "<title>Docs</title>" in response.text
+
+    def test_route_is_hidden_from_schema_by_default(self):
+        """The reference route does not clutter the OpenAPI schema"""
+        app = FastAPI()
+        add_scalar_reference(app)
+
+        client = TestClient(app)
+        schema = client.get("/openapi.json").json()
+
+        assert "/scalar" not in schema["paths"]
+
+    def test_returns_the_app_for_chaining(self):
+        """The helper returns the app so calls can be chained"""
+        app = FastAPI()
+        assert add_scalar_reference(app) is app


### PR DESCRIPTION
Adds a one-line setup and fixes a few small bugs.

- `add_scalar_reference(app)` mounts the reference at `/scalar` and reads the title and OpenAPI URL from your app. You can still pass any option through, e.g. `add_scalar_reference(app, theme=Theme.KEPLER)` or a custom `route`.
- Escapes the page title so it can't inject markup.
- Stops a document that contains `</script>` from breaking the page.
- Fixes the `dark_mode` type hint and replaces the mutable default arguments with `None`.

Backward compatible,`get_scalar_api_reference` still works as before.