### PR TITLE
feat(fastapi): accept plain strings for enum options

### DIFF
--- a/.changeset/fastapi-accept-strings.md
+++ b/.changeset/fastapi-accept-strings.md
@@ -1,0 +1,7 @@
+---
+'scalar-fastapi': minor
+---
+
+feat(fastapi): accept plain strings for enum options
+
+`layout`, `theme`, `search_hot_key`, and `document_download_type` now accept a plain string (for example `theme="moon"`) in addition to their enum members, so every option can be configured the same way. The enums are still exported and keep working unchanged. `force_dark_mode_state` is also tightened from `str` to `Literal["dark", "light"]`.

--- a/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
@@ -286,10 +286,11 @@ def get_scalar_api_reference(
         ),
     ] = "https://fastapi.tiangolo.com/img/favicon.png",
     layout: Annotated[
-        Layout,
+        Layout | str,
         Doc(
             """
             The layout to use for Scalar.
+            Accepts a Layout member or its plain string value (e.g. "classic").
             Default is "modern".
             """
         ),
@@ -314,10 +315,11 @@ def get_scalar_api_reference(
         ),
     ] = False,
     document_download_type: Annotated[
-        DocumentDownloadType,
+        DocumentDownloadType | str,
         Doc(
             """
             Sets the file type of the document to download, set to 'none' to hide the download button.
+            Accepts a DocumentDownloadType member or its plain string value (e.g. "json").
             Default is 'both'.
             """
         ),
@@ -359,7 +361,7 @@ def get_scalar_api_reference(
         ),
     ] = None,
     force_dark_mode_state: Annotated[
-        str | None,
+        Literal["dark", "light"] | None,
         Doc(
             """
             Force dark mode state to always be this state no matter what.
@@ -377,10 +379,11 @@ def get_scalar_api_reference(
         ),
     ] = False,
     search_hot_key: Annotated[
-        SearchHotKey,
+        SearchHotKey | str,
         Doc(
             """
             The hotkey to use for search.
+            Accepts a SearchHotKey member or a plain single-letter string (e.g. "s").
             Default is "k" (e.g. CMD+k).
             """
         ),
@@ -528,10 +531,11 @@ def get_scalar_api_reference(
         ),
     ] = "fastapi",
     theme: Annotated[
-        Theme,
+        Theme | str,
         Doc(
             """
             The theme to use for Scalar.
+            Accepts a Theme member or its plain string value (e.g. "moon").
             Default is "default".
             """
         ),
@@ -578,6 +582,17 @@ def get_scalar_api_reference(
         ),
     ] = None,
 ) -> HTMLResponse:
+    # Accept either the enum members or their plain string values, so callers
+    # can pass, for example, theme="moon" instead of theme=Theme.MOON.
+    layout = layout.value if isinstance(layout, Enum) else layout
+    theme = theme.value if isinstance(theme, Enum) else theme
+    search_hot_key = search_hot_key.value if isinstance(search_hot_key, Enum) else search_hot_key
+    document_download_type = (
+        document_download_type.value
+        if isinstance(document_download_type, Enum)
+        else document_download_type
+    )
+
     # Build configuration object with only non-default values
     config = {}
 
@@ -604,8 +619,8 @@ def get_scalar_api_reference(
     if agent is not None:
         config["agent"] = agent.model_dump(exclude_none=True)
 
-    if layout != Layout.MODERN:
-        config["layout"] = layout.value
+    if layout != Layout.MODERN.value:
+        config["layout"] = layout
 
     if not show_sidebar:  # Default is True
         config["showSidebar"] = show_sidebar
@@ -615,8 +630,8 @@ def get_scalar_api_reference(
         hide_download_button
     ):  # Deprecated, but still supported for backwards compatibility
         config["hideDownloadButton"] = hide_download_button
-    elif document_download_type != DocumentDownloadType.BOTH:  # Default is BOTH
-        config["documentDownloadType"] = document_download_type.value
+    elif document_download_type != DocumentDownloadType.BOTH.value:  # Default is BOTH
+        config["documentDownloadType"] = document_download_type
 
     if hide_test_request_button:  # Default is False
         config["hideTestRequestButton"] = hide_test_request_button
@@ -636,8 +651,8 @@ def get_scalar_api_reference(
     if hide_dark_mode_toggle:  # Default is False
         config["hideDarkModeToggle"] = hide_dark_mode_toggle
 
-    if search_hot_key != SearchHotKey.K:  # Default is K
-        config["searchHotKey"] = search_hot_key.value
+    if search_hot_key != SearchHotKey.K.value:  # Default is K
+        config["searchHotKey"] = search_hot_key
 
     if hidden_clients:  # Default is []
         config["hiddenClients"] = hidden_clients
@@ -684,8 +699,8 @@ def get_scalar_api_reference(
     if integration:
         config["_integration"] = integration
 
-    if theme != Theme.DEFAULT:  # Default is DEFAULT
-        config["theme"] = theme.value
+    if theme != Theme.DEFAULT.value:  # Default is DEFAULT
+        config["theme"] = theme
 
     if show_developer_tools != "localhost":  # Default is 'localhost'
         config["showDeveloperTools"] = show_developer_tools
@@ -716,7 +731,7 @@ def get_scalar_api_reference(
                 padding: 0;
             }}
 
-            {scalar_theme if theme.value == Theme.DEFAULT.value else ""}
+            {scalar_theme if theme == Theme.DEFAULT.value else ""}
         </style>
     </head>
     <body>

--- a/integrations/fastapi/tests/test_scalar_fastapi.py
+++ b/integrations/fastapi/tests/test_scalar_fastapi.py
@@ -583,3 +583,66 @@ class TestAddScalarReference:
         """The helper returns the app so calls can be chained"""
         app = FastAPI()
         assert add_scalar_reference(app) is app
+
+
+class TestPlainStringValues:
+    """Plain strings work anywhere an enum is accepted"""
+
+    def test_string_values_are_accepted(self):
+        """Passing string values behaves the same as passing enum members"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            layout="classic",
+            theme="moon",
+            search_hot_key="s",
+            document_download_type="json",
+        )
+
+        html_content = response.body.decode()
+        assert '"layout": "classic"' in html_content
+        assert '"theme": "moon"' in html_content
+        assert '"searchHotKey": "s"' in html_content
+        assert '"documentDownloadType": "json"' in html_content
+
+    def test_default_string_values_are_omitted(self):
+        """Default values passed as strings are still left out of the config"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            layout="modern",
+            theme="default",
+            search_hot_key="k",
+        )
+
+        html_content = response.body.decode()
+        config_start = html_content.find('Scalar.createApiReference("#app", {')
+        config_end = html_content.find('})', config_start)
+        config_section = html_content[config_start:config_end]
+
+        assert 'layout' not in config_section
+        assert 'theme' not in config_section
+        assert 'searchHotKey' not in config_section
+
+    def test_default_theme_string_still_injects_styles(self):
+        """The default theme styles are injected whether the value is an enum or a string"""
+        response = get_scalar_api_reference(
+            openapi_url="/openapi.json",
+            title="Test API",
+            theme="default",
+        )
+
+        html_content = response.body.decode()
+        # The bundled default theme CSS is present.
+        assert "--scalar-color-accent" in html_content
+
+    def test_string_and_enum_produce_identical_output(self):
+        """A string and its matching enum member yield the same HTML"""
+        from_string = get_scalar_api_reference(
+            openapi_url="/openapi.json", title="Test API", theme="kepler"
+        ).body.decode()
+        from_enum = get_scalar_api_reference(
+            openapi_url="/openapi.json", title="Test API", theme=Theme.KEPLER
+        ).body.decode()
+
+        assert from_string == from_enum


### PR DESCRIPTION
Makes every option configurable the same way, you can now pass a plain string instead of an enum member.

- `theme="moon"`, `layout="classic"`, `search_hot_key="s"`, `document_download_type="json"` all work (the enums still work too).
- Tightens `force_dark_mode_state` from `str` to `Literal["dark", "light"]`.

Backward compatible.