### PR TITLE
fix(fastapi): stop the default theme from hiding an introduction card

### DIFF
--- a/.changeset/fastapi-theme-card-hack.md
+++ b/.changeset/fastapi-theme-card-hack.md
@@ -1,0 +1,7 @@
+---
+'scalar-fastapi': patch
+---
+
+fix(fastapi): stop the default theme from hiding an introduction card
+
+The bundled default theme included `.scalar-card:nth-of-type(3) { display: none }`, which hid whichever introduction card (server, authentication, client, …) happened to render third. Because that depends on the document and the Scalar version, it hid content unpredictably. The rule has been removed so all cards render.

--- a/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
+++ b/integrations/fastapi/scalar_fastapi/scalar_fastapi.py
@@ -212,9 +212,6 @@ scalar_theme = """
   --scalar-radius: 3px;
   --scalar-radius-lg: 6px;
   --scalar-radius-xl: 8px;
-}
-.scalar-card:nth-of-type(3) {
-  display: none;
 }"""
 
 


### PR DESCRIPTION
The bundled default theme had a brittle rule, `.scalar-card:nth-of-type(3) { display: none }`, that hid whichever introduction card (server, auth, client, …) happened to render third. What lands third depends on the document and the Scalar version, so it hid content unpredictably. Removed it — all cards now render.

Note: this is a visual change (a previously-hidden card reappears), worth a quick look at the default theme before merging.