### PR TITLE
fix(mock-server): JSON-encode primitive string response bodies

### DIFF
--- a/.changeset/mock-server-json-string-body.md
+++ b/.changeset/mock-server-json-string-body.md
@@ -1,0 +1,9 @@
+---
+'@scalar/mock-server': patch
+---
+
+Fix JSON responses for primitive string bodies. A response declaring `application/json` with a `type: string` schema (or a plain string example) was written to the wire verbatim, so clients received the bare characters `string` instead of `"string"` and could not parse the payload.
+
+A string body is now JSON-encoded whenever the negotiated media type carries a single JSON document, which includes suffixed types such as `application/problem+json` and parameterized ones such as `application/json; charset=utf-8`. Two things keep their raw string: every other media type, where the characters are already the payload (`text/plain`, `text/event-stream`, XML, and the line-delimited JSON types), and a body that is already the value the schema describes — anything that parses when the schema declares a non-string type, or a JSON object or array when the schema says nothing, both of which are documents the author serialized by hand.
+
+XML is now matched on the parsed media type subtype rather than by substring, so only a genuine XML type is serialized as an XML document. A media type that merely contains `xml` somewhere, such as one carrying it in a parameter, no longer is.

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -330,6 +330,259 @@ describe('createMockServer', () => {
     expect(await response.text()).toContain('<foo>bar</foo>')
   })
 
+  it('GET /foobar -> JSON-encodes a string schema body', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('"string"')
+  })
+
+  it('GET /foobar -> JSON-encodes a string enum body', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                      enum: ['available', 'pending', 'sold'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('"available"')
+  })
+
+  it('GET /foobar -> JSON-encodes a formatted string body', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                      format: 'date-time',
+                      example: '2024-01-01T00:00:00Z',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('"2024-01-01T00:00:00Z"')
+  })
+
+  it('GET /foobar -> JSON-encodes a string body for a suffixed JSON media type', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '400': {
+                description: 'Bad Request',
+                content: {
+                  'application/problem+json': {
+                    example: 'something went wrong',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get('Content-Type')).toBe('application/problem+json')
+    expect(await response.text()).toBe('"something went wrong"')
+  })
+
+  it('GET /foobar -> keeps a pre-serialized JSON example raw', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        foo: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                    example: '{"foo":"bar"}',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toStrictEqual({ foo: 'bar' })
+  })
+
+  it('GET /foobar -> keeps a line-delimited JSON string body raw', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/x-ndjson': {
+                    example: '{"foo":"bar"}\n{"foo":"baz"}',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('application/x-ndjson')
+    expect(await response.text()).toBe('{"foo":"bar"}\n{"foo":"baz"}')
+  })
+
+  it('GET /foobar -> keeps a plain text string body raw', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/foobar': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'text/plain': {
+                    schema: {
+                      type: 'string',
+                      example: 'foobar',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/foobar')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('foobar')
+  })
+
   it('uses http verbs only to register routes', async () => {
     const document = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -1,4 +1,3 @@
-import { json2xml } from '@scalar/helpers/file/json2xml'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
@@ -11,6 +10,7 @@ import { findPreferredResponseKey } from '@/utils/find-preferred-response-key'
 import { normalizeResponseBody } from '@/utils/normalize-response-body'
 import { parsePreferHeader } from '@/utils/parse-prefer-header'
 import { selectResponseExample } from '@/utils/select-response-example'
+import { serializeResponseBody } from '@/utils/serialize-response-body'
 
 /**
  * Mock any response
@@ -103,20 +103,12 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
 
   c.status(statusCode)
 
-  return c.body(
-    // `null` is `typeof 'object'` too, but it is not a valid XML/JSON object
-    // root — serialize it (and any non-string primitive) with `JSON.stringify`
-    // so a `null` example does not get fed into `json2xml`.
-    body !== null && typeof body === 'object'
-      ? // XML
-        acceptedContentType?.includes('xml')
-        ? json2xml(body as Record<string, unknown>)
-        : // JSON
-          JSON.stringify(body)
-      : typeof body === 'string'
-        ? // String
-          body
-        : // null / number / boolean
-          JSON.stringify(body),
-  )
+  const serializedBody = serializeResponseBody(body, acceptedContentType, responseSchema)
+
+  // `JSON.stringify` returns `undefined` for an `undefined` body, which is an empty response.
+  if (serializedBody === undefined) {
+    return c.body(null)
+  }
+
+  return c.body(serializedBody)
 }

--- a/packages/mock-server/src/utils/serialize-response-body.test.ts
+++ b/packages/mock-server/src/utils/serialize-response-body.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+
+import { serializeResponseBody } from './serialize-response-body'
+
+describe('serializeResponseBody', () => {
+  it('encodes a string body under a JSON media type', () => {
+    expect(serializeResponseBody('string', 'application/json', { type: 'string' })).toBe('"string"')
+  })
+
+  it('encodes a string body under a suffixed JSON media type', () => {
+    expect(serializeResponseBody('nope', 'application/problem+json')).toBe('"nope"')
+  })
+
+  it('encodes a string body under a parameterized JSON media type', () => {
+    expect(serializeResponseBody('string', 'application/json; charset=utf-8', { type: 'string' })).toBe('"string"')
+  })
+
+  it('encodes a string body under an uppercase JSON media type', () => {
+    expect(serializeResponseBody('string', 'APPLICATION/JSON', { type: 'string' })).toBe('"string"')
+  })
+
+  it('encodes a string body a nullable string schema declares', () => {
+    expect(serializeResponseBody('string', 'application/json', { type: ['string', 'null'] })).toBe('"string"')
+  })
+
+  it('encodes a numeric string a string schema declares', () => {
+    expect(serializeResponseBody('123', 'application/json', { type: 'string' })).toBe('"123"')
+  })
+
+  it('encodes a scalar-looking string no schema declares', () => {
+    expect(serializeResponseBody('123', 'application/json')).toBe('"123"')
+    expect(serializeResponseBody('true', 'application/json')).toBe('"true"')
+    expect(serializeResponseBody('"quoted"', 'application/json')).toBe('"\\"quoted\\""')
+  })
+
+  it('keeps a scalar a non-string schema declares', () => {
+    expect(serializeResponseBody('123', 'application/json', { type: 'integer' })).toBe('123')
+    expect(serializeResponseBody('true', 'application/json', { type: 'boolean' })).toBe('true')
+  })
+
+  it('encodes a body a non-string schema declares that does not parse', () => {
+    expect(serializeResponseBody('N/A', 'application/json', { type: 'integer' })).toBe('"N/A"')
+  })
+
+  it('encodes a body a composite schema describes', () => {
+    expect(serializeResponseBody('available', 'application/json', { enum: ['available', 'sold'] })).toBe('"available"')
+    expect(serializeResponseBody('string', 'application/json', { allOf: [{ type: 'string' }] })).toBe('"string"')
+  })
+
+  it('encodes an empty string body', () => {
+    expect(serializeResponseBody('', 'application/json', { type: 'string' })).toBe('""')
+    expect(serializeResponseBody('', 'application/json')).toBe('""')
+  })
+
+  it('keeps a hand-serialized JSON document raw', () => {
+    expect(serializeResponseBody('{"foo":"bar"}', 'application/json', { type: 'object' })).toBe('{"foo":"bar"}')
+    // Whitespace around the document is part of the author's example, so the body is written as it is.
+    expect(serializeResponseBody('  [1,2]  ', 'application/json')).toBe('  [1,2]  ')
+  })
+
+  it('keeps a hand-serialized JSON document raw when the schema omits a type', () => {
+    expect(
+      serializeResponseBody('{"foo":"bar"}', 'application/json', { properties: { foo: { type: 'string' } } }),
+    ).toBe('{"foo":"bar"}')
+  })
+
+  it('encodes a serialized document a string schema declares', () => {
+    expect(serializeResponseBody('{"foo":"bar"}', 'application/json', { type: 'string' })).toBe(
+      '"{\\"foo\\":\\"bar\\"}"',
+    )
+  })
+
+  it('encodes a string that only looks like a JSON document', () => {
+    expect(serializeResponseBody('{not json', 'application/json')).toBe('"{not json"')
+  })
+
+  it.each([
+    [{ foo: 'bar' }, '{"foo":"bar"}'],
+    [[1, 2], '[1,2]'],
+    [null, 'null'],
+    [1, '1'],
+    [true, 'true'],
+  ])('serializes %j as JSON', (body, expected) => {
+    expect(serializeResponseBody(body, 'application/json')).toBe(expected)
+  })
+
+  it('serializes an undefined body to nothing', () => {
+    expect(serializeResponseBody(undefined, 'application/json')).toBeUndefined()
+  })
+
+  it('keeps a line-delimited JSON body raw', () => {
+    expect(serializeResponseBody('{"foo":1}\n{"foo":2}', 'application/x-ndjson')).toBe('{"foo":1}\n{"foo":2}')
+    expect(serializeResponseBody('{"foo":1}\n{"foo":2}', 'application/jsonl')).toBe('{"foo":1}\n{"foo":2}')
+    expect(serializeResponseBody('{"foo":1}\n{"foo":2}', 'application/json-seq')).toBe('{"foo":1}\n{"foo":2}')
+    expect(serializeResponseBody('{"foo":1}\n{"foo":2}', 'application/x-json-stream')).toBe('{"foo":1}\n{"foo":2}')
+  })
+
+  it('keeps a server-sent event body raw', () => {
+    expect(serializeResponseBody('data: hello\n\n', 'text/event-stream')).toBe('data: hello\n\n')
+  })
+
+  it('keeps a plain text body raw', () => {
+    expect(serializeResponseBody('hello', 'text/plain')).toBe('hello')
+    expect(serializeResponseBody('hello', 'text/html')).toBe('hello')
+  })
+
+  it('keeps a body raw for a media type that only mentions JSON in a parameter', () => {
+    expect(serializeResponseBody('hello', 'text/plain; format=json')).toBe('hello')
+    expect(serializeResponseBody('hello', 'multipart/form-data; boundary=jsonBoundary')).toBe('hello')
+  })
+
+  it('keeps a string body raw when no media type was negotiated', () => {
+    expect(serializeResponseBody('hello', undefined)).toBe('hello')
+  })
+
+  it('serializes an object as JSON when no media type was negotiated', () => {
+    expect(serializeResponseBody({ foo: 'bar' }, undefined)).toBe('{"foo":"bar"}')
+  })
+
+  it('turns an object into XML', () => {
+    expect(serializeResponseBody({ foo: 'bar' }, 'application/xml')).toContain('<foo>bar</foo>')
+    expect(serializeResponseBody({ foo: 'bar' }, 'text/xml')).toContain('<foo>bar</foo>')
+    expect(serializeResponseBody({ foo: 'bar' }, 'application/xhtml+xml')).toContain('<foo>bar</foo>')
+  })
+
+  it('serializes an object as JSON for a media type that only mentions XML in a parameter', () => {
+    expect(serializeResponseBody({ foo: 'bar' }, 'text/plain; boundary=xmlBoundary')).toBe('{"foo":"bar"}')
+  })
+
+  it('keeps an XML string body raw', () => {
+    expect(serializeResponseBody('<foo>bar</foo>', 'application/xml')).toBe('<foo>bar</foo>')
+  })
+
+  it('serializes a null XML body rather than building a document from it', () => {
+    expect(serializeResponseBody(null, 'application/xml')).toBe('null')
+  })
+})

--- a/packages/mock-server/src/utils/serialize-response-body.ts
+++ b/packages/mock-server/src/utils/serialize-response-body.ts
@@ -1,0 +1,113 @@
+import { json2xml } from '@scalar/helpers/file/json2xml'
+import { parseMimeType } from '@scalar/helpers/http/mime-type'
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+
+type Schema = NonNullable<OpenAPIV3_1.ComponentsObject['schemas']>[string]
+
+/**
+ * Whether a media type carries a single JSON document.
+ *
+ * Matched on the parsed subtype, so suffixed types (`application/problem+json`) and parameterized ones
+ * (`application/json; charset=utf-8`) count, while a type that merely mentions JSON in a parameter does
+ * not. Line-delimited relatives (`application/jsonl`, `application/x-ndjson`) are deliberately excluded:
+ * their payload is a sequence of documents, so a string body already carries the framing. A missing
+ * media type parses as `text/plain`, which is the safe answer here: the body is written as it is.
+ */
+const isJsonDocumentContentType = (contentType: string | undefined): boolean => {
+  const { subtype } = parseMimeType(contentType)
+
+  return subtype === 'json' || subtype.endsWith('+json')
+}
+
+/** Whether a media type carries XML, including suffixed types such as `application/xhtml+xml`. */
+const isXmlContentType = (contentType: string | undefined): boolean => {
+  const { subtype } = parseMimeType(contentType)
+
+  return subtype === 'xml' || subtype.endsWith('+xml')
+}
+
+/**
+ * How the resolved response schema describes the body: as a string, as something else, or not at all.
+ *
+ * Composite schemas (`allOf`, an `enum` without a type) land on `unknown`, which is the honest answer:
+ * they say nothing this decision can act on.
+ */
+const declaredBodyKind = (schema: Schema | undefined): 'string' | 'other' | 'unknown' => {
+  if (!schema || typeof schema !== 'object' || !('type' in schema) || schema.type === undefined) {
+    return 'unknown'
+  }
+
+  const { type } = schema
+
+  if (Array.isArray(type)) {
+    if (type.length === 0) {
+      return 'unknown'
+    }
+
+    return type.includes('string') ? 'string' : 'other'
+  }
+
+  return type === 'string' ? 'string' : 'other'
+}
+
+/** Whether a string holds serialized JSON of any shape, a bare scalar included. */
+const isSerializedJson = (value: string): boolean => {
+  try {
+    JSON.parse(value)
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Whether a string holds a serialized JSON object or array. */
+const isSerializedJsonDocument = (value: string): boolean => {
+  const trimmed = value.trim()
+
+  return (trimmed.startsWith('{') || trimmed.startsWith('[')) && isSerializedJson(trimmed)
+}
+
+/**
+ * Serializes a mocked response body for the negotiated media type.
+ *
+ * Returns `undefined` for an `undefined` body, mirroring `JSON.stringify`, so the caller can send an
+ * empty body rather than the characters `undefined`.
+ */
+export const serializeResponseBody = (
+  body: unknown,
+  contentType: string | undefined,
+  schema?: Schema,
+): string | undefined => {
+  // XML: only an object tree can be turned into a document. `null` is `typeof 'object'` too, but it is
+  // not a valid XML root, so it falls through to `JSON.stringify` below rather than into `json2xml`.
+  if (body !== null && typeof body === 'object' && isXmlContentType(contentType)) {
+    return json2xml(body as Record<string, unknown>)
+  }
+
+  if (typeof body === 'string') {
+    // Anywhere but a single JSON document, the characters are the payload: `text/plain`, `text/html`,
+    // XML, `text/event-stream`, line-delimited JSON, and anything else the mock does not recognize.
+    if (!isJsonDocumentContentType(contentType)) {
+      return body
+    }
+
+    // Under a JSON media type a string has to be encoded, or a `type: string` response arrives as the
+    // bare characters `string`, which no JSON client can parse. What survives unencoded is text that is
+    // already the body the document describes: whatever parses when the schema declares a non-string
+    // type, and an object or array when the schema says nothing, both of which are documents the author
+    // serialized by hand. A quoted scalar without a schema behind it stays a string, since the author
+    // quoting `'123'` is the only signal available about what they meant.
+    const kind = declaredBodyKind(schema)
+
+    if (kind === 'other' && isSerializedJson(body)) {
+      return body
+    }
+
+    if (kind === 'unknown' && isSerializedJsonDocument(body)) {
+      return body
+    }
+  }
+
+  return JSON.stringify(body)
+}


### PR DESCRIPTION
## Problem

A response declaring a JSON media type with a `type: string` schema (or a plain string example) was written to the wire verbatim, so the client received the bare characters `string` rather than `"string"`. That is not parseable JSON, so any typed client hitting the mock for such an operation fails to decode the response — with `Content-Type: application/json` promising otherwise.

The final `c.body(...)` in `mock-any-response.ts` ended in `typeof body === 'string' ? body : JSON.stringify(body)`. That branch is right for `text/*` and XML, where the characters are the payload, but wrong for JSON.

Consumers driving generated SDKs against a mock built from a real document hit this on every string-returning operation and have to patch the response on the way out.

## Solution

Serialization moved into `serializeResponseBody` (`src/utils/serialize-response-body.ts`), so the media type rules are unit-testable directly instead of through a full HTTP fixture per case. A string body under a JSON media type is now encoded, with one exception: text that is already the value the schema describes is written through unchanged.

The rule, for a string body when the media type carries a single JSON document:

| schema | body | result |
|---|---|---|
| declares a string | anything | JSON-encoded — the contract is explicit |
| declares a non-string type | parses as JSON | written through, it is already that value |
| declares a non-string type | does not parse | JSON-encoded, the only valid JSON available |
| says nothing usable | a JSON object or array | written through, a hand-serialized document |
| says nothing usable | anything else | JSON-encoded |

Every other media type is untouched: `text/plain`, `text/html`, `text/event-stream`, XML, the line-delimited JSON types (`application/jsonl`, `application/x-ndjson`, `application/json-seq`), and anything unrecognized all keep their raw string.

Media types are matched on the parsed subtype via `parseMimeType`, not by substring, so `application/problem+json` and `application/json; charset=utf-8` count while `application/x-ndjson` and `multipart/form-data; boundary=jsonBoundary` do not. XML moved to the same subtype test in the same breath — matching `+json` strictly next to an `includes('xml')` substring test would have classified one media type two different ways inside a single function.

Alternatives considered and rejected: keying only on the media type (double-encodes hand-serialized documents that used to work); keying only on whether the body already parses (breaks a `type: string` example of `"123"`, which would reach the client as a number); a purely schema-based guard (leaks on schemas with `properties` and no explicit `type`).

Net effect: under a JSON media type every response is now valid JSON, and every body that was already valid JSON is byte-identical to before, except a bare scalar example with no schema behind it — `example: '123'` is a string in OpenAPI and now serializes as one.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation. <!-- The mock server guide documents response selection and validation, not body serialization; nothing there described the old behavior. -->

## Tests

`serialize-response-body.test.ts` covers the rule table and the media-type edges (suffixed, parameterized, uppercase, jsonl/ndjson/json-seq, SSE, XML, parameter-only mentions, empty and undefined bodies). End-to-end cases in `create-mock-server.test.ts` pin the wire bytes for a string schema, an enum, a `format: date-time` example, a suffixed JSON type, and the raw-string paths. The JSON cases fail against `main`; the raw-string ones are regression guards.

`pnpm vitest --run` in `packages/mock-server`: 402 passed, 1 skipped. `types:check`, Biome and `knip` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T547Yzz7n2vtwpyqdMSLsk)_