### PR TITLE
ci: pin the Netlify CLI to 27.1.2

### DIFF
--- a/.github/workflows/deploy-previews.yml
+++ b/.github/workflows/deploy-previews.yml
@@ -44,6 +44,13 @@ on:
 permissions:
   contents: read
 
+env:
+  # The Netlify CLI is pinned because netlify@27.3.0 and newer pull in
+  # @netlify/dev@5.0.4, which depends on an @netlify/ai version that was never
+  # published — every install fails to resolve. Drop the pin once upstream
+  # publishes a working release.
+  NETLIFY_CLI_VERSION: '27.1.2'
+
 jobs:
   deploy-examples:
     runs-on: blacksmith-2vcpu-ubuntu-2204
@@ -72,7 +79,7 @@ jobs:
         run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV"
 
       - name: Install Netlify CLI
-        run: pnpm install -g netlify
+        run: pnpm install -g netlify@${{ env.NETLIFY_CLI_VERSION }}
 
       - name: Deploy to Netlify
         run: |
@@ -147,7 +154,7 @@ jobs:
         run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV"
 
       - name: Install Netlify CLI
-        run: pnpm install -g netlify
+        run: pnpm install -g netlify@${{ env.NETLIFY_CLI_VERSION }}
 
       - name: Build storybook
         run: pnpm --filter components build:storybook

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,11 @@ concurrency:
 
 env:
   TURBO_FLAGS: '--concurrency=100% --filter "!./integrations/{java,rust,dotnet,docker,fastapi,django-ninja}/**" --filter "!./projects/proxy-scalar-com/**"'
+  # The Netlify CLI is pinned because netlify@27.3.0 and newer pull in
+  # @netlify/dev@5.0.4, which depends on an @netlify/ai version that was never
+  # published — every install fails to resolve. Drop the pin once upstream
+  # publishes a working release.
+  NETLIFY_CLI_VERSION: '27.1.2'
 
 jobs:
   build:
@@ -393,7 +398,7 @@ jobs:
       - name: Generate DEPLOY_ID
         run: echo "DEPLOY_ID=$(pnpx uuid)" >> "$GITHUB_ENV"
       - name: Install Netlify CLI
-        run: pnpm install -g netlify
+        run: pnpm install -g netlify@${{ env.NETLIFY_CLI_VERSION }}
       - name: Build storybook
         run: pnpm --filter components build:storybook
       - name: Deploy Storybook to Netlify (Production)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,11 @@ concurrency:
 env:
   # Exclude these packages from turbo as they are handled by dedicated jobs
   TURBO_FLAGS: '--concurrency=100% --filter "!./integrations/{java,rust,dotnet,docker,fastapi,django-ninja}/**" --filter "!./projects/proxy-scalar-com/**"'
+  # The Netlify CLI is pinned because netlify@27.3.0 and newer pull in
+  # @netlify/dev@5.0.4, which depends on an @netlify/ai version that was never
+  # published — every install fails to resolve. Drop the pin once upstream
+  # publishes a working release.
+  NETLIFY_CLI_VERSION: '27.1.2'
 
 jobs:
   # Initial build.
@@ -335,7 +340,7 @@ jobs:
       - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Deploy Playwright Report to Netlify
         run: |
-          pnpx netlify deploy --dir "./packages/api-reference/playwright-report" \
+          pnpx netlify@${{ env.NETLIFY_CLI_VERSION }} deploy --dir "./packages/api-reference/playwright-report" \
             --message "Deployed from GitHub (${{ env.DEPLOY_ID }})" \
             --site ${{ vars.NETLIFY_SITE_ID_COMPONENTS_SNAPSHOTS }} \
             --auth ${{ secrets.NETLIFY_AUTH_TOKEN }} \
@@ -383,7 +388,7 @@ jobs:
       - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Deploy Playwright Report to Netlify
         run: |
-          pnpx netlify deploy --dir "./projects/scalar-app/playwright-report" \
+          pnpx netlify@${{ env.NETLIFY_CLI_VERSION }} deploy --dir "./projects/scalar-app/playwright-report" \
             --message "Deployed from GitHub (${{ env.DEPLOY_ID }})" \
             --site ${{ vars.NETLIFY_SITE_ID_COMPONENTS_SNAPSHOTS }} \
             --auth ${{ secrets.NETLIFY_AUTH_TOKEN }} \
@@ -430,7 +435,7 @@ jobs:
       - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Deploy Playwright Report to Netlify
         run: |
-          pnpx netlify deploy --dir "./packages/components/playwright-report" \
+          pnpx netlify@${{ env.NETLIFY_CLI_VERSION }} deploy --dir "./packages/components/playwright-report" \
             --message "Deployed from GitHub (${{ env.DEPLOY_ID }})" \
             --site ${{ vars.NETLIFY_SITE_ID_COMPONENTS_SNAPSHOTS }} \
             --auth ${{ secrets.NETLIFY_AUTH_TOKEN }} \
@@ -476,7 +481,7 @@ jobs:
       - if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.actor, '[bot]') }}
         name: Deploy Playwright Report to Netlify
         run: |
-          pnpx netlify deploy --dir "./packages/api-reference/playwright-report-cdn" \
+          pnpx netlify@${{ env.NETLIFY_CLI_VERSION }} deploy --dir "./packages/api-reference/playwright-report-cdn" \
             --message "Deployed from GitHub (${{ env.DEPLOY_ID }})" \
             --site ${{ vars.NETLIFY_SITE_ID_COMPONENTS_SNAPSHOTS }} \
             --auth ${{ secrets.NETLIFY_AUTH_TOKEN }} \


### PR DESCRIPTION
## Problem

Every job that reaches for the Netlify CLI is failing at the install step, on every branch.

`netlify@27.3.0` and newer pull in `@netlify/dev@5.0.4`, which depends on an `@netlify/ai` version that was never published to npm. There is nothing to resolve, so `pnpm install -g netlify` and `pnpx netlify` both fail outright — and because none of the invocations were pinned, the breakage arrived on its own the moment upstream published, without a commit here.

The fix currently rides along inside https://github.com/scalar/scalar/pull/10033, which is a `@scalar/highlight` feature PR. It is repo-wide and unrelated to that change, so it should not have to wait for a feature review to land.

## Solution

Pins the CLI through a `NETLIFY_CLI_VERSION` workflow-level env var, set to the last working release, in each of the three workflows that use it:

- `pr.yml` — the four `pnpx netlify deploy` calls that upload Playwright reports
- `main.yml` — the global install in the Storybook production deploy
- `deploy-previews.yml` — the global installs in the examples and Storybook preview deploys

One variable per workflow rather than seven inline versions, so unpinning later is a single-line change per file. The comment on each says why the pin exists and what has to happen upstream before it can go.

Extracted verbatim from https://github.com/scalar/scalar/pull/10033 — the workflow diff here is identical, so whichever lands first, the other is a no-op merge.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Workflow-only change; no package is published from it. -->
- [ ] I added tests. <!-- CI config; the workflow runs are the test. -->
- [x] I updated the documentation. <!-- The pin is commented inline in each workflow. -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoGPa2xNPk9QLEunosA91Q)_