### PR TITLE
feat(mock-server): frame text/event-stream responses as SSE

### DIFF
--- a/.changeset/mock-server-sse-framing.md
+++ b/.changeset/mock-server-sse-framing.md
@@ -1,0 +1,10 @@
+---
+'@scalar/mock-server': minor
+---
+
+Frame `text/event-stream` responses as Server-Sent Events instead of returning a single JSON body with an SSE content type. Each event is written as a `data:` line terminated by a blank line, then the stream closes.
+
+- Named `examples` are read as the sequence of events the endpoint emits, in declaration order (`Prefer: example=<name>` still pins the stream to one event).
+- An array example or array schema is read as the event sequence too.
+- An example that already spells out SSE framing (`data: {"type":"edit"}`) is written verbatim instead of being wrapped in a second `data:` line.
+- With no example, the schema-generated payload is emitted three times so the stream has more than one event to iterate.

--- a/.changeset/mock-server-sse-framing.md
+++ b/.changeset/mock-server-sse-framing.md
@@ -6,5 +6,5 @@ Frame `text/event-stream` responses as Server-Sent Events instead of returning a
 
 - Named `examples` are read as the sequence of events the endpoint emits, in declaration order (`Prefer: example=<name>` still pins the stream to that one example).
 - An array example is read as the event sequence too, one event per item.
-- An example that already spells out SSE framing (`data: {"type":"edit"}`) is written as its own framing, with only its terminating blank line normalized, instead of being wrapped in a second `data:` line.
+- An example that already spells out SSE framing (`data:` and `event:` lines, or a `:` comment heartbeat) is written as its own framing, with only its terminating blank line normalized, instead of being wrapped in a second `data:` line. Such examples describe a whole stream, so a map of them is read as alternatives and the first one is served.
 - With no example, the schema-generated payload is emitted three times so the stream has more than one event to iterate — unless the schema already generates a sequence (a multi-item array, or a string that spells the wire format out), which is sent once, not repeated.

--- a/.changeset/mock-server-sse-framing.md
+++ b/.changeset/mock-server-sse-framing.md
@@ -7,4 +7,4 @@ Frame `text/event-stream` responses as Server-Sent Events instead of returning a
 - Named `examples` are read as the sequence of events the endpoint emits, in declaration order (`Prefer: example=<name>` still pins the stream to that one example).
 - An array example is read as the event sequence too, one event per item.
 - An example that already spells out SSE framing (`data: {"type":"edit"}`) is written as its own framing, with only its terminating blank line normalized, instead of being wrapped in a second `data:` line.
-- With no example, the schema-generated payload is emitted three times so the stream has more than one event to iterate.
+- With no example, the schema-generated payload is emitted three times so the stream has more than one event to iterate — unless the schema already generates a sequence (a multi-item array, or a string that spells the wire format out), which is sent once, as it stands.

--- a/.changeset/mock-server-sse-framing.md
+++ b/.changeset/mock-server-sse-framing.md
@@ -7,4 +7,4 @@ Frame `text/event-stream` responses as Server-Sent Events instead of returning a
 - Named `examples` are read as the sequence of events the endpoint emits, in declaration order (`Prefer: example=<name>` still pins the stream to that one example).
 - An array example is read as the event sequence too, one event per item.
 - An example that already spells out SSE framing (`data: {"type":"edit"}`) is written as its own framing, with only its terminating blank line normalized, instead of being wrapped in a second `data:` line.
-- With no example, the schema-generated payload is emitted three times so the stream has more than one event to iterate — unless the schema already generates a sequence (a multi-item array, or a string that spells the wire format out), which is sent once, as it stands.
+- With no example, the schema-generated payload is emitted three times so the stream has more than one event to iterate — unless the schema already generates a sequence (a multi-item array, or a string that spells the wire format out), which is sent once, not repeated.

--- a/.changeset/mock-server-sse-framing.md
+++ b/.changeset/mock-server-sse-framing.md
@@ -4,7 +4,7 @@
 
 Frame `text/event-stream` responses as Server-Sent Events instead of returning a single JSON body with an SSE content type. Each event is written as a `data:` line terminated by a blank line, then the stream closes.
 
-- Named `examples` are read as the sequence of events the endpoint emits, in declaration order (`Prefer: example=<name>` still pins the stream to one event).
-- An array example or array schema is read as the event sequence too.
+- Named `examples` are read as the sequence of events the endpoint emits, in declaration order (`Prefer: example=<name>` still pins the stream to that one example).
+- An array example is read as the event sequence too, one event per item.
 - An example that already spells out SSE framing (`data: {"type":"edit"}`) is written verbatim instead of being wrapped in a second `data:` line.
 - With no example, the schema-generated payload is emitted three times so the stream has more than one event to iterate.

--- a/.changeset/mock-server-sse-framing.md
+++ b/.changeset/mock-server-sse-framing.md
@@ -6,5 +6,5 @@ Frame `text/event-stream` responses as Server-Sent Events instead of returning a
 
 - Named `examples` are read as the sequence of events the endpoint emits, in declaration order (`Prefer: example=<name>` still pins the stream to that one example).
 - An array example is read as the event sequence too, one event per item.
-- An example that already spells out SSE framing (`data: {"type":"edit"}`) is written verbatim instead of being wrapped in a second `data:` line.
+- An example that already spells out SSE framing (`data: {"type":"edit"}`) is written as its own framing, with only its terminating blank line normalized, instead of being wrapped in a second `data:` line.
 - With no example, the schema-generated payload is emitted three times so the stream has more than one event to iterate.

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -15,6 +15,7 @@ A powerful Node.js mock server that automatically generates realistic API respon
 - Handles authentication and responds with defined HTTP headers
 - Supports Swagger 2.0 and OpenAPI 3.x documents
 - Mocks event-driven APIs from AsyncAPI 3.1 documents over WebSocket and SSE
+- Streams `text/event-stream` responses as real Server-Sent Events
 - Write custom JavaScript handlers for dynamic responses
 - Automatically seed initial data on server startup
 - Validates incoming requests against your OpenAPI contract
@@ -294,6 +295,41 @@ Content-Type: application/problem+json
 Each violation reports its `location` (`path`, `query`, `header`, `cookie`, or `body`), a `path` pointing at the offending value, and a human-readable `message`. All violations are returned at once, not just the first.
 
 > This validates path, query, header, and cookie parameters (across every OpenAPI serialization style, including array and object values), plus JSON request bodies. Response validation, non-JSON bodies, and proxy mode are planned follow-ups.
+
+### Server-Sent Events
+
+A response with a `text/event-stream` content type is streamed as real Server-Sent Events: every event goes out as a `data:` line terminated by a blank line, and the stream closes when the last event is written.
+
+```yaml
+paths:
+  /events:
+    get:
+      responses:
+        '200':
+          description: Server-sent events stream. Emits a summary event, then one row event.
+          content:
+            text/event-stream:
+              examples:
+                summary:
+                  value: { total_rows: 2 }
+                row:
+                  value: { count: 42 }
+```
+
+```bash
+curl http://localhost:3000/events -H 'Accept: text/event-stream'
+
+data: {"total_rows":2}
+
+data: {"count":42}
+```
+
+How the events are picked:
+
+- Named `examples` are read as the sequence of events the endpoint emits, in declaration order. `Prefer: example=<name>` still works and pins the stream to that single event.
+- An array (in an `example` or generated from an `array` schema) is read as the event sequence too, one event per item.
+- An example that already spells out the wire format (`data: {"type":"edit"}`) is written verbatim, so it is not wrapped in a second `data:` line.
+- When the response only has a schema, the generated payload is sent three times, so a client's read loop sees more than one event before the stream ends.
 
 ### Custom Request Handlers
 

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -318,7 +318,9 @@ paths:
 
 ```bash
 curl http://localhost:3000/events -H 'Accept: text/event-stream'
+```
 
+```text
 data: {"total_rows":2}
 
 data: {"count":42}
@@ -326,10 +328,10 @@ data: {"count":42}
 
 How the events are picked:
 
-- Named `examples` are read as the sequence of events the endpoint emits, in declaration order. `Prefer: example=<name>` still works and pins the stream to that single event.
-- An array (in an `example` or generated from an `array` schema) is read as the event sequence too, one event per item.
+- Named `examples` are read as the sequence of events the endpoint emits, in declaration order. `Prefer: example=<name>` still works and pins the stream to that one example.
+- An array example is read as the event sequence too, one event per item.
 - An example that already spells out the wire format (`data: {"type":"edit"}`) is written verbatim, so it is not wrapped in a second `data:` line.
-- When the response only has a schema, the generated payload is sent three times, so a client's read loop sees more than one event before the stream ends.
+- When the response only has a schema, the generated payload is sent three times, so a client's read loop sees more than one event before the stream ends. A schema that generates several events (an `array` schema with more than one item) is sent once, as its own sequence.
 
 ### Custom Request Handlers
 

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -348,7 +348,7 @@ How the events are picked:
 - Named `examples` are read as the sequence of events the endpoint emits, in declaration order. `Prefer: example=<name>` still works and pins the stream to that one example.
 - An array example is read as the event sequence too, one event per item.
 - An example that already spells out the wire format (`data: {"type":"edit"}`) is written as its own framing, with only its terminating blank line normalized, instead of being wrapped in a second `data:` line.
-- When the response only has a schema, the generated payload is sent three times, so a client's read loop sees more than one event before the stream ends. A schema that already generates a sequence — an `array` with more than one item, or a string that spells the wire format out — is sent once, as it stands.
+- When the response only has a schema, the generated payload is sent three times, so a client's read loop sees more than one event before the stream ends. A schema that already generates a sequence — an `array` with more than one item, or a string that spells the wire format out — is sent once, not repeated.
 
 ### Custom Request Handlers
 

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -347,7 +347,7 @@ How the events are picked:
 
 - Named `examples` are read as the sequence of events the endpoint emits, in declaration order. `Prefer: example=<name>` still works and pins the stream to that one example.
 - An array example is read as the event sequence too, one event per item.
-- An example that already spells out the wire format (`data: {"type":"edit"}`) is written as its own framing, with only its terminating blank line normalized, instead of being wrapped in a second `data:` line.
+- An example that already spells out the wire format — `data:` and `event:` lines, or a `:` comment heartbeat — is written as its own framing, with only its terminating blank line normalized, instead of being wrapped in a second `data:` line. Examples like that describe a whole stream, so a map of them lists alternatives: the first one is served, and `Prefer: example=<name>` picks another.
 - When the response only has a schema, the generated payload is sent three times, so a client's read loop sees more than one event before the stream ends. A schema that already generates a sequence — an `array` with more than one item, or a string that spells the wire format out — is sent once, not repeated.
 
 ### Custom Request Handlers

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -298,22 +298,39 @@ Each violation reports its `location` (`path`, `query`, `header`, `cookie`, or `
 
 ### Server-Sent Events
 
-A response with a `text/event-stream` content type is streamed as real Server-Sent Events: every event goes out as a `data:` line terminated by a blank line, and the stream closes when the last event is written.
+When `text/event-stream` is the negotiated response media type, the response is streamed as real Server-Sent Events: every event goes out as a `data:` line terminated by a blank line, and the stream closes when the last event is written.
 
-```yaml
-paths:
-  /events:
-    get:
-      responses:
-        '200':
-          description: Server-sent events stream. Emits a summary event, then one row event.
-          content:
-            text/event-stream:
-              examples:
-                summary:
-                  value: { total_rows: 2 }
-                row:
-                  value: { count: 42 }
+```typescript
+const document = {
+  openapi: '3.1.1',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  paths: {
+    '/events': {
+      get: {
+        responses: {
+          '200': {
+            description: 'Server-Sent Events stream. Emits a summary event, then one row event.',
+            content: {
+              'text/event-stream': {
+                examples: {
+                  summary: {
+                    value: { total_rows: 2 },
+                  },
+                  row: {
+                    value: { count: 42 },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
 ```
 
 ```bash
@@ -330,7 +347,7 @@ How the events are picked:
 
 - Named `examples` are read as the sequence of events the endpoint emits, in declaration order. `Prefer: example=<name>` still works and pins the stream to that one example.
 - An array example is read as the event sequence too, one event per item.
-- An example that already spells out the wire format (`data: {"type":"edit"}`) is written verbatim, so it is not wrapped in a second `data:` line.
+- An example that already spells out the wire format (`data: {"type":"edit"}`) is written as its own framing, with only its terminating blank line normalized, instead of being wrapped in a second `data:` line.
 - When the response only has a schema, the generated payload is sent three times, so a client's read loop sees more than one event before the stream ends. A schema that generates several events (an `array` schema with more than one item) is sent once, as its own sequence.
 
 ### Custom Request Handlers

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -348,7 +348,7 @@ How the events are picked:
 - Named `examples` are read as the sequence of events the endpoint emits, in declaration order. `Prefer: example=<name>` still works and pins the stream to that one example.
 - An array example is read as the event sequence too, one event per item.
 - An example that already spells out the wire format (`data: {"type":"edit"}`) is written as its own framing, with only its terminating blank line normalized, instead of being wrapped in a second `data:` line.
-- When the response only has a schema, the generated payload is sent three times, so a client's read loop sees more than one event before the stream ends. A schema that generates several events (an `array` schema with more than one item) is sent once, as its own sequence.
+- When the response only has a schema, the generated payload is sent three times, so a client's read loop sees more than one event before the stream ends. A schema that already generates a sequence — an `array` with more than one item, or a string that spells the wire format out — is sent once, as it stands.
 
 ### Custom Request Handlers
 

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -155,6 +155,196 @@ describe('createMockServer', () => {
     expect(await response.text()).toBe('{"foo":"bar"}')
   })
 
+  it('GET /events -> frames a schema-generated text/event-stream response', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/events': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'text/event-stream': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        type: {
+                          type: 'string',
+                          example: 'edit',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/events')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(await response.text()).toBe('data: {"type":"edit"}\n\ndata: {"type":"edit"}\n\ndata: {"type":"edit"}\n\n')
+  })
+
+  it('GET /events -> emits one event per named example', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/events': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'text/event-stream': {
+                    examples: {
+                      summary: { value: { total_rows: 2 } },
+                      row: { value: { count: 42 } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/events')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('data: {"total_rows":2}\n\ndata: {"count":42}\n\n')
+  })
+
+  it('GET /events -> picks a single event with Prefer: example', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/events': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'text/event-stream': {
+                    examples: {
+                      summary: { value: { total_rows: 2 } },
+                      row: { value: { count: 42 } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/events', {
+      headers: { Prefer: 'example=row' },
+    })
+
+    expect(await response.text()).toBe('data: {"count":42}\n\n')
+  })
+
+  it('GET /events -> writes an already framed example verbatim', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/events': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'text/event-stream': {
+                    schema: {
+                      type: 'object',
+                      properties: { type: { type: 'string' } },
+                    },
+                    example: 'data: {"type":"edit"}\n\n',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/events')
+
+    expect(await response.text()).toBe('data: {"type":"edit"}\n\n')
+  })
+
+  it('GET /events -> keeps returning a buffered body for the JSON variant', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/events': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    example: { type: 'edit' },
+                  },
+                  'text/event-stream': {
+                    example: { type: 'edit' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const json = await server.request('/events', { headers: { Accept: 'application/json' } })
+    expect(json.headers.get('Content-Type')).toBe('application/json')
+    expect(await json.text()).toBe('{"type":"edit"}')
+
+    const stream = await server.request('/events', { headers: { Accept: 'text/event-stream' } })
+    expect(stream.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(await stream.text()).toBe('data: {"type":"edit"}\n\n')
+  })
+
   it('GET /foobar -> omits writeOnly properties in responses', async () => {
     const document = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -345,6 +345,36 @@ describe('createMockServer', () => {
     expect(await response.text()).toBe('data: {"type":"edit"}\n\ndata: {"type":"delete"}\n\n')
   })
 
+  it('GET /events -> splits a multi-line payload across data lines', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/events': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'text/event-stream': { example: 'user created\nid: 42' },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/events')
+
+    expect(await response.text()).toBe('data: user created\ndata: id: 42\n\n')
+  })
+
   it('GET /events -> keeps the status code and declared headers of the streamed response', async () => {
     const document = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -197,6 +197,42 @@ describe('createMockServer', () => {
     expect(await response.text()).toBe('data: {"type":"edit"}\n\ndata: {"type":"edit"}\n\ndata: {"type":"edit"}\n\n')
   })
 
+  it('GET /events -> emits one event per named example', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/events': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'text/event-stream': {
+                    examples: {
+                      summary: { value: { total_rows: 2 } },
+                      row: { value: { count: 42 } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/events')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('data: {"total_rows":2}\n\ndata: {"count":42}\n\n')
+  })
+
   it('GET /events -> picks a single event with Prefer: example', async () => {
     const document = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -306,6 +306,97 @@ describe('createMockServer', () => {
     expect(await response.text()).toBe('data: {"type":"edit"}\n\n')
   })
 
+  it('GET /events -> frames an array schema as events', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/events': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'text/event-stream': {
+                    schema: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          type: {
+                            type: 'string',
+                            example: 'edit',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/events')
+
+    expect(await response.text()).toBe('data: {"type":"edit"}\n\ndata: {"type":"edit"}\n\ndata: {"type":"edit"}\n\n')
+  })
+
+  it('GET /events -> keeps the status code and declared headers of the streamed response', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: {
+        '/events': {
+          get: {
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'text/event-stream': { example: { from: '200' } },
+                },
+              },
+              '201': {
+                description: 'Created',
+                headers: {
+                  'X-Stream-Id': {
+                    schema: {
+                      type: 'string',
+                      example: 'stream-1',
+                    },
+                  },
+                },
+                content: {
+                  'text/event-stream': { example: { from: '201' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/events', {
+      headers: { Prefer: 'code=201' },
+    })
+
+    expect(response.status).toBe(201)
+    expect(response.headers.get('X-Stream-Id')).toBe('stream-1')
+    expect(await response.text()).toBe('data: {"from":"201"}\n\n')
+  })
+
   it('GET /events -> keeps returning a buffered body for the JSON variant', async () => {
     const document = {
       openapi: '3.1.0',

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -197,42 +197,6 @@ describe('createMockServer', () => {
     expect(await response.text()).toBe('data: {"type":"edit"}\n\ndata: {"type":"edit"}\n\ndata: {"type":"edit"}\n\n')
   })
 
-  it('GET /events -> emits one event per named example', async () => {
-    const document = {
-      openapi: '3.1.0',
-      info: {
-        title: 'Hello World',
-        version: '1.0.0',
-      },
-      paths: {
-        '/events': {
-          get: {
-            responses: {
-              '200': {
-                description: 'OK',
-                content: {
-                  'text/event-stream': {
-                    examples: {
-                      summary: { value: { total_rows: 2 } },
-                      row: { value: { count: 42 } },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    }
-
-    const server = await createMockServer({ document })
-
-    const response = await server.request('/events')
-
-    expect(response.status).toBe(200)
-    expect(await response.text()).toBe('data: {"total_rows":2}\n\ndata: {"count":42}\n\n')
-  })
-
   it('GET /events -> picks a single event with Prefer: example', async () => {
     const document = {
       openapi: '3.1.0',
@@ -306,7 +270,7 @@ describe('createMockServer', () => {
     expect(await response.text()).toBe('data: {"type":"edit"}\n\n')
   })
 
-  it('GET /events -> frames an array schema as events', async () => {
+  it('GET /events -> frames a multi-item array schema as its own sequence', async () => {
     const document = {
       openapi: '3.1.0',
       info: {
@@ -323,14 +287,10 @@ describe('createMockServer', () => {
                   'text/event-stream': {
                     schema: {
                       type: 'array',
+                      example: [{ type: 'edit' }, { type: 'delete' }],
                       items: {
                         type: 'object',
-                        properties: {
-                          type: {
-                            type: 'string',
-                            example: 'edit',
-                          },
-                        },
+                        properties: { type: { type: 'string' } },
                       },
                     },
                   },
@@ -346,7 +306,7 @@ describe('createMockServer', () => {
 
     const response = await server.request('/events')
 
-    expect(await response.text()).toBe('data: {"type":"edit"}\n\ndata: {"type":"edit"}\n\ndata: {"type":"edit"}\n\n')
+    expect(await response.text()).toBe('data: {"type":"edit"}\n\ndata: {"type":"delete"}\n\n')
   })
 
   it('GET /events -> keeps the status code and declared headers of the streamed response', async () => {

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -5,8 +5,10 @@ import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved
 import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 import type { Context } from 'hono'
 import { accepts } from 'hono/accepts'
+import { streamSSE } from 'hono/streaming'
 import type { StatusCode } from 'hono/utils/http-status'
 
+import { collectSseEvents, isEventStreamContentType } from '@/utils/collect-sse-events'
 import { findPreferredResponseKey } from '@/utils/find-preferred-response-key'
 import { normalizeResponseBody } from '@/utils/normalize-response-body'
 import { parsePreferHeader } from '@/utils/parse-prefer-header'
@@ -83,22 +85,48 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
 
   const acceptedResponse = selectedResponse?.content?.[acceptedContentType]
 
+  const responseSchema = acceptedResponse?.schema ? getResolvedRefDeep(acceptedResponse.schema) : undefined
+
+  /** The response body generated from the schema, or `undefined` when the response declares none. */
+  const generateFromSchema = (): unknown =>
+    responseSchema
+      ? getExampleFromSchema(responseSchema, {
+          emptyString: 'string',
+          variables: c.req.param(),
+          mode: 'read',
+        })
+      : undefined
+
+  // Server-Sent Events are a framed, multi-event wire format, so they cannot go out as one buffered
+  // body: a client reading the stream expects `data:` lines terminated by a blank line. Everything
+  // else (JSON, XML, text) keeps taking the single-body path below.
+  if (isEventStreamContentType(acceptedContentType)) {
+    const events = collectSseEvents(acceptedResponse, {
+      exampleName: prefer.example,
+      generate: generateFromSchema,
+    })
+
+    c.status(statusCode)
+
+    return streamSSE(c, async (stream) => {
+      for (const event of events) {
+        if (event.framed) {
+          await stream.write(event.text)
+        } else {
+          await stream.writeSSE({ data: event.text })
+        }
+      }
+    })
+  }
+
   // Body: a named/singular/first example if one is defined, otherwise generate
   // a value from the schema. `Prefer: example=<name>` picks a named example.
   const selectedExample = selectResponseExample(acceptedResponse, prefer.example)
-  const responseSchema = acceptedResponse?.schema ? getResolvedRefDeep(acceptedResponse.schema) : undefined
 
   const body = selectedExample
     ? normalizeResponseBody(selectedExample.value, responseSchema)
     : responseSchema
-      ? normalizeResponseBody(
-          getExampleFromSchema(responseSchema, {
-            emptyString: 'string',
-            variables: c.req.param(),
-            mode: 'read',
-          }),
-          responseSchema,
-        )
+      ? normalizeResponseBody(generateFromSchema(), responseSchema)
       : null
 
   c.status(statusCode)

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -108,6 +108,9 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
 
     c.status(statusCode)
 
+    // `streamSSE` sets the transport headers itself (`Content-Type`, `Cache-Control`, `Connection`,
+    // `Transfer-Encoding`), so those win over a value the document declared for the same header —
+    // they are what makes the stream readable. Every other declared header set above survives.
     return streamSSE(c, async (stream) => {
       for (const event of events) {
         if (event.framed) {

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -87,7 +87,7 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
 
   const responseSchema = acceptedResponse?.schema ? getResolvedRefDeep(acceptedResponse.schema) : undefined
 
-  /** The response body generated from the schema, or `undefined` when the response declares none. */
+  /** Generates the response body from the schema, or returns `undefined` when there is no schema. */
   const generateFromSchema = (): unknown =>
     responseSchema
       ? getExampleFromSchema(responseSchema, {

--- a/packages/mock-server/src/utils/collect-sse-events.test.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.test.ts
@@ -212,7 +212,7 @@ describe('collect-sse-events', () => {
   })
 
   describe('isEventStreamContentType', () => {
-    it('matches text/event-stream with and without parameters', () => {
+    it('matches text/event-stream regardless of parameters or casing', () => {
       expect(isEventStreamContentType('text/event-stream')).toBe(true)
       expect(isEventStreamContentType('text/event-stream; charset=utf-8')).toBe(true)
       expect(isEventStreamContentType('TEXT/EVENT-STREAM')).toBe(true)

--- a/packages/mock-server/src/utils/collect-sse-events.test.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.test.ts
@@ -27,6 +27,18 @@ describe('collect-sse-events', () => {
       expect(generate).not.toHaveBeenCalled()
     })
 
+    it('prefers the singular example over the examples map', () => {
+      const events = collectSseEvents(
+        {
+          example: { from: 'example' },
+          examples: { first: { value: { from: 'examples' } } },
+        },
+        { generate: () => undefined },
+      )
+
+      expect(events).toStrictEqual([{ text: '{"from":"example"}', framed: false }])
+    })
+
     it('emits one event per named example, in declaration order', () => {
       const events = collectSseEvents(
         {
@@ -44,7 +56,34 @@ describe('collect-sse-events', () => {
       ])
     })
 
-    it('pins the stream to a single event for Prefer: example=<name>', () => {
+    it('skips examples that carry no value', () => {
+      const events = collectSseEvents(
+        {
+          examples: {
+            external: { externalValue: 'https://example.com/events.txt' },
+            row: { value: { count: 42 } },
+          },
+        },
+        { generate: () => undefined },
+      )
+
+      expect(events).toStrictEqual([{ text: '{"count":42}', framed: false }])
+    })
+
+    it('generates from the schema when every example carries no value', () => {
+      const events = collectSseEvents(
+        { examples: { external: { externalValue: 'https://example.com/events.txt' } } },
+        { generate: () => ({ generated: true }) },
+      )
+
+      expect(events).toStrictEqual([
+        { text: '{"generated":true}', framed: false },
+        { text: '{"generated":true}', framed: false },
+        { text: '{"generated":true}', framed: false },
+      ])
+    })
+
+    it('picks the example requested by name', () => {
       const events = collectSseEvents(
         {
           examples: {
@@ -67,6 +106,19 @@ describe('collect-sse-events', () => {
       expect(events).toStrictEqual([{ text: '{"count":42}', framed: false }])
     })
 
+    it('falls back to the schema when the requested example carries no value', () => {
+      const events = collectSseEvents(
+        { examples: { external: { externalValue: 'https://example.com/events.txt' } } },
+        { exampleName: 'external', generate: () => ({ generated: true }) },
+      )
+
+      expect(events).toStrictEqual([
+        { text: '{"generated":true}', framed: false },
+        { text: '{"generated":true}', framed: false },
+        { text: '{"generated":true}', framed: false },
+      ])
+    })
+
     it('reads an array payload as the sequence of events', () => {
       const events = collectSseEvents({ example: [{ id: 1 }, { id: 2 }] }, { generate: () => undefined })
 
@@ -76,12 +128,22 @@ describe('collect-sse-events', () => {
       ])
     })
 
-    it('reads a schema-generated array as the sequence of events instead of repeating it', () => {
+    it('reads a schema-generated array of several items as the sequence of events', () => {
       const events = collectSseEvents({}, { generate: () => [{ id: 1 }, { id: 2 }] })
 
       expect(events).toStrictEqual([
         { text: '{"id":1}', framed: false },
         { text: '{"id":2}', framed: false },
+      ])
+    })
+
+    it('repeats a schema-generated array that holds a single item', () => {
+      const events = collectSseEvents({}, { generate: () => [{ id: 1 }] })
+
+      expect(events).toStrictEqual([
+        { text: '{"id":1}', framed: false },
+        { text: '{"id":1}', framed: false },
+        { text: '{"id":1}', framed: false },
       ])
     })
 
@@ -91,10 +153,36 @@ describe('collect-sse-events', () => {
       expect(events).toStrictEqual([{ text: 'data: {"type":"edit"}\n\n', framed: true }])
     })
 
-    it('terminates framed text that is missing its blank line', () => {
-      const events = collectSseEvents({ example: 'event: ping\ndata: 1' }, { generate: () => undefined })
+    it('terminates framed text with exactly one blank line', () => {
+      expect(collectSseEvents({ example: 'event: ping\ndata: 1' }, { generate: () => undefined })).toStrictEqual([
+        { text: 'event: ping\ndata: 1\n\n', framed: true },
+      ])
+      expect(collectSseEvents({ example: 'data: 1\n' }, { generate: () => undefined })).toStrictEqual([
+        { text: 'data: 1\n\n', framed: true },
+      ])
+      expect(collectSseEvents({ example: 'data: 1\r\n\r\n' }, { generate: () => undefined })).toStrictEqual([
+        { text: 'data: 1\r\n\r\n', framed: true },
+      ])
+    })
 
-      expect(events).toStrictEqual([{ text: 'event: ping\ndata: 1\n\n', framed: true }])
+    it('does not repeat a schema-generated payload that is already framed', () => {
+      const events = collectSseEvents({}, { generate: () => 'data: {"a":1}\n\ndata: [DONE]\n\n' })
+
+      expect(events).toStrictEqual([{ text: 'data: {"a":1}\n\ndata: [DONE]\n\n', framed: true }])
+    })
+
+    it('treats prose that merely looks like a field as a data payload', () => {
+      // A compliant client ignores a line without a colon, so passing this through verbatim would
+      // dispatch nothing at all.
+      const events = collectSseEvents({ example: 'user created\nid: 42' }, { generate: () => undefined })
+
+      expect(events).toStrictEqual([{ text: 'user created\nid: 42', framed: false }])
+    })
+
+    it('treats framing without a data line as a data payload', () => {
+      const events = collectSseEvents({ example: 'id: 42' }, { generate: () => undefined })
+
+      expect(events).toStrictEqual([{ text: 'id: 42', framed: false }])
     })
 
     it('keeps a plain string example as the data payload', () => {
@@ -103,13 +191,9 @@ describe('collect-sse-events', () => {
       expect(events).toStrictEqual([{ text: 'hello', framed: false }])
     })
 
-    it('serializes primitive payloads as JSON', () => {
+    it('serializes a null example as JSON', () => {
       expect(collectSseEvents({ example: null }, { generate: () => undefined })).toStrictEqual([
         { text: 'null', framed: false },
-      ])
-      expect(collectSseEvents({ example: [1, true] }, { generate: () => undefined })).toStrictEqual([
-        { text: '1', framed: false },
-        { text: 'true', framed: false },
       ])
     })
 
@@ -129,7 +213,6 @@ describe('collect-sse-events', () => {
       expect(isEventStreamContentType('application/json')).toBe(false)
       expect(isEventStreamContentType('text/plain')).toBe(false)
       expect(isEventStreamContentType(undefined)).toBe(false)
-      expect(isEventStreamContentType(null)).toBe(false)
     })
   })
 })

--- a/packages/mock-server/src/utils/collect-sse-events.test.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { collectSseEvents, isEventStreamContentType } from './collect-sse-events'
+
+describe('collect-sse-events', () => {
+  describe('collectSseEvents', () => {
+    it('repeats a schema-generated payload so the stream has more than one event', () => {
+      const events = collectSseEvents({}, { generate: () => ({ type: 'edit' }) })
+
+      expect(events).toStrictEqual([
+        { text: '{"type":"edit"}', framed: false },
+        { text: '{"type":"edit"}', framed: false },
+        { text: '{"type":"edit"}', framed: false },
+      ])
+    })
+
+    it('returns no events when neither an example nor a schema is defined', () => {
+      expect(collectSseEvents({}, { generate: () => undefined })).toStrictEqual([])
+    })
+
+    it('does not generate from the schema when an example is defined', () => {
+      const generate = vi.fn(() => ({ generated: true }))
+
+      const events = collectSseEvents({ example: { from: 'example' } }, { generate })
+
+      expect(events).toStrictEqual([{ text: '{"from":"example"}', framed: false }])
+      expect(generate).not.toHaveBeenCalled()
+    })
+
+    it('emits one event per named example, in declaration order', () => {
+      const events = collectSseEvents(
+        {
+          examples: {
+            summary: { value: { total_rows: 2 } },
+            row: { value: { count: 42 } },
+          },
+        },
+        { generate: () => undefined },
+      )
+
+      expect(events).toStrictEqual([
+        { text: '{"total_rows":2}', framed: false },
+        { text: '{"count":42}', framed: false },
+      ])
+    })
+
+    it('pins the stream to a single event for Prefer: example=<name>', () => {
+      const events = collectSseEvents(
+        {
+          examples: {
+            summary: { value: { total_rows: 2 } },
+            row: { value: { count: 42 } },
+          },
+        },
+        { exampleName: 'row', generate: () => undefined },
+      )
+
+      expect(events).toStrictEqual([{ text: '{"count":42}', framed: false }])
+    })
+
+    it('falls back to every example when the requested example name is unknown', () => {
+      const events = collectSseEvents(
+        { examples: { row: { value: { count: 42 } } } },
+        { exampleName: 'nope', generate: () => undefined },
+      )
+
+      expect(events).toStrictEqual([{ text: '{"count":42}', framed: false }])
+    })
+
+    it('reads an array payload as the sequence of events', () => {
+      const events = collectSseEvents({ example: [{ id: 1 }, { id: 2 }] }, { generate: () => undefined })
+
+      expect(events).toStrictEqual([
+        { text: '{"id":1}', framed: false },
+        { text: '{"id":2}', framed: false },
+      ])
+    })
+
+    it('reads a schema-generated array as the sequence of events instead of repeating it', () => {
+      const events = collectSseEvents({}, { generate: () => [{ id: 1 }, { id: 2 }] })
+
+      expect(events).toStrictEqual([
+        { text: '{"id":1}', framed: false },
+        { text: '{"id":2}', framed: false },
+      ])
+    })
+
+    it('passes an example that is already SSE framing through untouched', () => {
+      const events = collectSseEvents({ example: 'data: {"type":"edit"}\n\n' }, { generate: () => undefined })
+
+      expect(events).toStrictEqual([{ text: 'data: {"type":"edit"}\n\n', framed: true }])
+    })
+
+    it('terminates framed text that is missing its blank line', () => {
+      const events = collectSseEvents({ example: 'event: ping\ndata: 1' }, { generate: () => undefined })
+
+      expect(events).toStrictEqual([{ text: 'event: ping\ndata: 1\n\n', framed: true }])
+    })
+
+    it('keeps a plain string example as the data payload', () => {
+      const events = collectSseEvents({ example: 'hello' }, { generate: () => undefined })
+
+      expect(events).toStrictEqual([{ text: 'hello', framed: false }])
+    })
+
+    it('serializes primitive payloads as JSON', () => {
+      expect(collectSseEvents({ example: null }, { generate: () => undefined })).toStrictEqual([
+        { text: 'null', framed: false },
+      ])
+      expect(collectSseEvents({ example: [1, true] }, { generate: () => undefined })).toStrictEqual([
+        { text: '1', framed: false },
+        { text: 'true', framed: false },
+      ])
+    })
+
+    it('handles a missing media type object', () => {
+      expect(collectSseEvents(undefined, { generate: () => undefined })).toStrictEqual([])
+    })
+  })
+
+  describe('isEventStreamContentType', () => {
+    it('matches text/event-stream with and without parameters', () => {
+      expect(isEventStreamContentType('text/event-stream')).toBe(true)
+      expect(isEventStreamContentType('text/event-stream; charset=utf-8')).toBe(true)
+      expect(isEventStreamContentType('TEXT/EVENT-STREAM')).toBe(true)
+    })
+
+    it('does not match other content types', () => {
+      expect(isEventStreamContentType('application/json')).toBe(false)
+      expect(isEventStreamContentType('text/plain')).toBe(false)
+      expect(isEventStreamContentType(undefined)).toBe(false)
+      expect(isEventStreamContentType(null)).toBe(false)
+    })
+  })
+})

--- a/packages/mock-server/src/utils/collect-sse-events.test.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.test.ts
@@ -56,6 +56,34 @@ describe('collect-sse-events', () => {
       ])
     })
 
+    it('serves the first example when the examples map lists alternative framed streams', () => {
+      const events = collectSseEvents(
+        {
+          examples: {
+            text: { value: 'data: 1\n\ndata: [DONE]\n\n' },
+            toolCall: { value: 'data: 2\n\ndata: [DONE]\n\n' },
+          },
+        },
+        { generate: () => undefined },
+      )
+
+      expect(events).toStrictEqual([{ text: 'data: 1\n\ndata: [DONE]\n\n', framed: true }])
+    })
+
+    it('picks another framed stream by name', () => {
+      const events = collectSseEvents(
+        {
+          examples: {
+            text: { value: 'data: 1\n\ndata: [DONE]\n\n' },
+            toolCall: { value: 'data: 2\n\ndata: [DONE]\n\n' },
+          },
+        },
+        { exampleName: 'toolCall', generate: () => undefined },
+      )
+
+      expect(events).toStrictEqual([{ text: 'data: 2\n\ndata: [DONE]\n\n', framed: true }])
+    })
+
     it('skips examples that carry no value', () => {
       const events = collectSseEvents(
         {
@@ -175,9 +203,20 @@ describe('collect-sse-events', () => {
       expect(collectSseEvents({ example: ': ping\n\ndata: 1\n\n' }, { generate: () => undefined })).toStrictEqual([
         { text: ': ping\n\ndata: 1\n\n', framed: true },
       ])
+    })
+
+    it('passes a comment-only keep-alive through as framing', () => {
       expect(collectSseEvents({ example: ': keep-alive\n\n' }, { generate: () => undefined })).toStrictEqual([
         { text: ': keep-alive\n\n', framed: true },
       ])
+    })
+
+    it('treats a comment followed by a payload as a data payload', () => {
+      // Only the comment looks like SSE here, so passing it through would leave a compliant client
+      // with nothing to dispatch.
+      const events = collectSseEvents({ example: ': one event per row\n{"count":42}' }, { generate: () => undefined })
+
+      expect(events).toStrictEqual([{ text: ': one event per row\n{"count":42}', framed: false }])
     })
 
     it('treats prose that merely looks like a field as a data payload', () => {

--- a/packages/mock-server/src/utils/collect-sse-events.test.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.test.ts
@@ -171,6 +171,15 @@ describe('collect-sse-events', () => {
       expect(events).toStrictEqual([{ text: 'data: {"a":1}\n\ndata: [DONE]\n\n', framed: true }])
     })
 
+    it('passes framing that opens with a comment line through as framing', () => {
+      expect(collectSseEvents({ example: ': ping\n\ndata: 1\n\n' }, { generate: () => undefined })).toStrictEqual([
+        { text: ': ping\n\ndata: 1\n\n', framed: true },
+      ])
+      expect(collectSseEvents({ example: ': keep-alive\n\n' }, { generate: () => undefined })).toStrictEqual([
+        { text: ': keep-alive\n\n', framed: true },
+      ])
+    })
+
     it('treats prose that merely looks like a field as a data payload', () => {
       // A compliant client ignores a line without a colon, so passing this through verbatim would
       // dispatch nothing at all.

--- a/packages/mock-server/src/utils/collect-sse-events.test.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.test.ts
@@ -70,6 +70,23 @@ describe('collect-sse-events', () => {
       expect(events).toStrictEqual([{ text: 'data: 1\n\ndata: [DONE]\n\n', framed: true }])
     })
 
+    it('keeps a map that mixes payloads and framing as one sequence', () => {
+      const events = collectSseEvents(
+        {
+          examples: {
+            row: { value: { count: 42 } },
+            done: { value: 'data: [DONE]\n\n' },
+          },
+        },
+        { generate: () => undefined },
+      )
+
+      expect(events).toStrictEqual([
+        { text: '{"count":42}', framed: false },
+        { text: 'data: [DONE]\n\n', framed: true },
+      ])
+    })
+
     it('picks another framed stream by name', () => {
       const events = collectSseEvents(
         {
@@ -190,6 +207,12 @@ describe('collect-sse-events', () => {
       ])
       expect(collectSseEvents({ example: 'data: 1\r\n\r\n' }, { generate: () => undefined })).toStrictEqual([
         { text: 'data: 1\r\n\r\n', framed: true },
+      ])
+      expect(collectSseEvents({ example: 'data: 1\n\n   ' }, { generate: () => undefined })).toStrictEqual([
+        { text: 'data: 1\n\n', framed: true },
+      ])
+      expect(collectSseEvents({ example: 'data: keep me   ' }, { generate: () => undefined })).toStrictEqual([
+        { text: 'data: keep me   \n\n', framed: true },
       ])
     })
 

--- a/packages/mock-server/src/utils/collect-sse-events.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.ts
@@ -36,7 +36,17 @@ const isFramed = (text: string): boolean => {
   const lines = text.split(/\r\n|\r|\n/)
   const firstLine = lines.find((line) => line.trim() !== '')
 
-  return firstLine !== undefined && SSE_FIELD.test(firstLine) && lines.some((line) => line.startsWith('data:'))
+  if (firstLine === undefined) {
+    return false
+  }
+
+  // A line opening with `:` is an SSE comment — the keep-alive form nothing but a stream writes — so
+  // it is framing on its own, even when the rest of the example carries no event.
+  if (firstLine.startsWith(':')) {
+    return true
+  }
+
+  return SSE_FIELD.test(firstLine) && lines.some((line) => line.startsWith('data:'))
 }
 
 /**

--- a/packages/mock-server/src/utils/collect-sse-events.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.ts
@@ -28,9 +28,10 @@ type SseEvent = {
  * describing a single event payload. Wrapping that in another `data:` line would hand the client the
  * framing as its payload, so it is written as is, with only its terminating blank line normalized.
  *
- * The test is deliberately narrow: real framing starts with a field on its first line and carries at
- * least one `data:` line. Prose that merely happens to contain a colon (`user created\nid: 42`) is
- * not framing — passing it through would make a compliant client dispatch nothing at all.
+ * The test is deliberately narrow: real framing opens with an SSE field or a comment on its first
+ * line and, unless it opens with a comment, carries at least one `data:` line. Prose that merely
+ * happens to contain a colon (`user created\nid: 42`) is not framing — passing it through would make
+ * a compliant client dispatch nothing at all.
  */
 const isFramed = (text: string): boolean => {
   const lines = text.split(/\r\n|\r|\n/)

--- a/packages/mock-server/src/utils/collect-sse-events.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.ts
@@ -1,0 +1,103 @@
+import type { OpenAPIV3_1 } from '@scalar/openapi-types'
+import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
+
+/**
+ * How many events a schema-generated `text/event-stream` response emits.
+ *
+ * A single event barely exercises a client's read loop, and an endless stream would never let a
+ * request finish, so the mock sends a short, finite burst and closes.
+ */
+const GENERATED_EVENT_COUNT = 3
+
+/**
+ * Matches text that is already Server-Sent Events framing, so it is written to the wire as is.
+ *
+ * Some documents spell the wire format out in their example (`data: {"type":"edit"}\n\n`) instead of
+ * describing a single event payload. Wrapping that in another `data:` line would hand the client the
+ * framing as its payload, so it is passed through untouched.
+ */
+const SSE_FRAMING = /^(?:data|event|id|retry):/m
+
+/** One event of a mocked Server-Sent Events response. */
+type SseEvent = {
+  /** Already-framed event text when `framed` is true, otherwise the `data` payload of one event. */
+  text: string
+  /** Whether `text` is complete SSE framing that has to be written verbatim. */
+  framed: boolean
+}
+
+/** Closes framed text with the blank line that ends an SSE event, if the document left it out. */
+const terminate = (text: string): string => (text.endsWith('\n\n') ? text : `${text}\n\n`)
+
+/** Turns one payload into an event, serializing anything that is not already text. */
+const toEvent = (payload: unknown): SseEvent => {
+  if (typeof payload !== 'string') {
+    // `undefined` has no JSON representation, so fall back to `null` rather than an empty event.
+    return { text: JSON.stringify(payload) ?? 'null', framed: false }
+  }
+
+  return SSE_FRAMING.test(payload) ? { text: terminate(payload), framed: true } : { text: payload, framed: false }
+}
+
+/**
+ * Expands one payload into the events it stands for. An array is read as the sequence of events the
+ * endpoint emits, not as a single event carrying a JSON array — that is the shape a stream describes.
+ */
+const expand = (payload: unknown): SseEvent[] => (Array.isArray(payload) ? payload.map(toEvent) : [toEvent(payload)])
+
+/**
+ * The events a `text/event-stream` response emits, in order.
+ *
+ * Examples win over the schema, mirroring `selectResponseExample`, but a stream reads them as a
+ * sequence rather than a single body:
+ * 1. A named example requested via `Prefer: example=<name>` pins the stream to that one event.
+ * 2. The singular `example` keyword.
+ * 3. Every entry of the `examples` map, in declaration order — an event stream that documents a
+ *    `summary` and a `row` example is documenting the two events it sends.
+ * 4. Nothing declared: a schema-generated payload, repeated so the stream has more than one event.
+ *
+ * `generate` is a callback so the schema is only turned into an example when no example is declared.
+ */
+export const collectSseEvents = (
+  mediaType: OpenAPIV3_1.MediaTypeObject | undefined,
+  { exampleName, generate }: { exampleName?: string; generate: () => unknown },
+): SseEvent[] => {
+  const { example, examples } = mediaType ?? {}
+
+  if (exampleName && examples && exampleName in examples) {
+    const value = getResolvedRef(examples[exampleName])?.value
+
+    if (value !== undefined) {
+      return expand(value)
+    }
+  }
+
+  if (example !== undefined) {
+    return expand(example)
+  }
+
+  if (examples) {
+    const values = Object.values(examples)
+      .map((entry) => getResolvedRef(entry)?.value)
+      .filter((value) => value !== undefined)
+
+    if (values.length > 0) {
+      return values.flatMap(expand)
+    }
+  }
+
+  const generated = generate()
+
+  // Without a schema there is nothing to send, so the stream opens and closes without an event.
+  if (generated === undefined) {
+    return []
+  }
+
+  return Array.isArray(generated)
+    ? generated.map(toEvent)
+    : Array.from({ length: GENERATED_EVENT_COUNT }, () => toEvent(generated))
+}
+
+/** Whether a media type is Server-Sent Events, ignoring parameters such as `; charset=utf-8`. */
+export const isEventStreamContentType = (contentType: string | undefined | null): boolean =>
+  contentType?.split(';')[0]?.trim().toLowerCase() === 'text/event-stream'

--- a/packages/mock-server/src/utils/collect-sse-events.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.ts
@@ -59,8 +59,11 @@ const isFramed = (text: string): boolean => {
  */
 const terminate = (text: string): string => {
   const lineEnding = text.includes('\r\n') ? '\r\n' : '\n'
+  // Trailing blank lines go, indentation a block scalar left behind with them. Every run stripped
+  // contains a line break, so spaces inside the last field's value survive.
+  const trimmed = text.replace(/(?:[ \t]*(?:\r\n|\r|\n))+[ \t]*$/, '')
 
-  return `${text.replace(/[\r\n]+$/, '')}${lineEnding}${lineEnding}`
+  return `${trimmed}${lineEnding}${lineEnding}`
 }
 
 /** Turns one payload into an event, serializing anything that is not already text. */
@@ -87,8 +90,8 @@ const expand = (payload: unknown): SseEvent[] => (Array.isArray(payload) ? paylo
  * 1. A named example requested via `Prefer: example=<name>`.
  * 2. The singular `example` keyword.
  * 3. Every entry of the `examples` map, in declaration order — an event stream that documents a
- *    `summary` and a `row` example is documenting the two events it sends. Entries that are complete
- *    framing are the exception: those are alternative streams, so only the first is served.
+ *    `summary` and a `row` example is documenting the two events it sends. A map of nothing but
+ *    complete framing is the exception: those are alternative streams, so only the first is served.
  * 4. Nothing declared: a schema-generated payload, repeated so the stream has more than one event.
  *
  * `generate` is a callback so the schema is only turned into an example when no example is declared.
@@ -123,11 +126,12 @@ export const collectSseEvents = (
     if (values.length > 0) {
       const events = values.flatMap(expand)
 
-      // An example that is framing already describes a whole stream, so a map of them lists
-      // alternative streams rather than consecutive events. Sending them back to back would replay a
-      // terminal event such as `[DONE]`, so only the first is served — `Prefer: example=<name>`
-      // picks another one.
-      return events.some((event) => event.framed) ? expand(firstValue) : events
+      // An example that is framing already describes a whole stream, so a map of nothing but those
+      // lists alternative streams rather than consecutive events. Sending them back to back would
+      // replay a terminal event such as `[DONE]`, so only the first is served —
+      // `Prefer: example=<name>` picks another one. A map that mixes framing with payloads is still
+      // one sequence: there the framing is a single chunk of it, such as a documented `[DONE]`.
+      return events.every((event) => event.framed) ? expand(firstValue) : events
     }
   }
 

--- a/packages/mock-server/src/utils/collect-sse-events.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.ts
@@ -1,3 +1,4 @@
+import { parseMimeType } from '@scalar/helpers/http/mime-type'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 
@@ -9,14 +10,8 @@ import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref
  */
 const GENERATED_EVENT_COUNT = 3
 
-/**
- * Matches text that is already Server-Sent Events framing, so it is written to the wire as is.
- *
- * Some documents spell the wire format out in their example (`data: {"type":"edit"}\n\n`) instead of
- * describing a single event payload. Wrapping that in another `data:` line would hand the client the
- * framing as its payload, so it is passed through untouched.
- */
-const SSE_FRAMING = /^(?:data|event|id|retry):/m
+/** The field prefixes an SSE line may start with (`data`, `event`, `id`, `retry`). */
+const SSE_FIELD = /^(?:data|event|id|retry):/
 
 /** One event of a mocked Server-Sent Events response. */
 type SseEvent = {
@@ -26,8 +21,36 @@ type SseEvent = {
   framed: boolean
 }
 
-/** Closes framed text with the blank line that ends an SSE event, if the document left it out. */
-const terminate = (text: string): string => (text.endsWith('\n\n') ? text : `${text}\n\n`)
+/**
+ * Whether text is already Server-Sent Events framing, so it goes to the wire as is.
+ *
+ * Some documents spell the wire format out in their example (`data: {"type":"edit"}`) instead of
+ * describing a single event payload. Wrapping that in another `data:` line would hand the client the
+ * framing as its payload, so it is passed through untouched.
+ *
+ * The test is deliberately narrow: real framing starts with a field on its first line and carries at
+ * least one `data:` line. Prose that merely happens to contain a colon (`user created\nid: 42`) is
+ * not framing — passing it through would make a compliant client dispatch nothing at all.
+ */
+const isFramed = (text: string): boolean => {
+  const lines = text.split(/\r\n|\r|\n/)
+  const firstLine = lines.find((line) => line.trim() !== '')
+
+  return firstLine !== undefined && SSE_FIELD.test(firstLine) && lines.some((line) => line.startsWith('data:'))
+}
+
+/**
+ * Closes framed text with the blank line that ends an SSE event.
+ *
+ * Documents terminate their framing inconsistently — a YAML block scalar drops all but one newline,
+ * and a Windows-authored document uses CRLF — so the tail is normalized to exactly one blank line in
+ * the document's own line ending instead of being appended to blindly.
+ */
+const terminate = (text: string): string => {
+  const lineEnding = text.includes('\r\n') ? '\r\n' : '\n'
+
+  return `${text.replace(/[\r\n]+$/, '')}${lineEnding}${lineEnding}`
+}
 
 /** Turns one payload into an event, serializing anything that is not already text. */
 const toEvent = (payload: unknown): SseEvent => {
@@ -36,7 +59,7 @@ const toEvent = (payload: unknown): SseEvent => {
     return { text: JSON.stringify(payload) ?? 'null', framed: false }
   }
 
-  return SSE_FRAMING.test(payload) ? { text: terminate(payload), framed: true } : { text: payload, framed: false }
+  return isFramed(payload) ? { text: terminate(payload), framed: true } : { text: payload, framed: false }
 }
 
 /**
@@ -50,7 +73,7 @@ const expand = (payload: unknown): SseEvent[] => (Array.isArray(payload) ? paylo
  *
  * Examples win over the schema, mirroring `selectResponseExample`, but a stream reads them as a
  * sequence rather than a single body:
- * 1. A named example requested via `Prefer: example=<name>` pins the stream to that one event.
+ * 1. A named example requested via `Prefer: example=<name>`.
  * 2. The singular `example` keyword.
  * 3. Every entry of the `examples` map, in declaration order — an event stream that documents a
  *    `summary` and a `row` example is documenting the two events it sends.
@@ -77,6 +100,8 @@ export const collectSseEvents = (
   }
 
   if (examples) {
+    // An Example Object that only carries an `externalValue` has no value to send, so it is skipped
+    // rather than turned into a `data: null` event.
     const values = Object.values(examples)
       .map((entry) => getResolvedRef(entry)?.value)
       .filter((value) => value !== undefined)
@@ -93,11 +118,17 @@ export const collectSseEvents = (
     return []
   }
 
-  return Array.isArray(generated)
-    ? generated.map(toEvent)
-    : Array.from({ length: GENERATED_EVENT_COUNT }, () => toEvent(generated))
+  const events = expand(generated)
+  const [firstEvent] = events
+
+  // Only a lone generated payload is repeated. Framing generated from the schema already spells the
+  // whole stream out (repeating it would replay a terminal event such as `[DONE]`), and a generated
+  // sequence of several events is a sequence already.
+  return events.length === 1 && firstEvent && !firstEvent.framed
+    ? Array.from({ length: GENERATED_EVENT_COUNT }, () => firstEvent)
+    : events
 }
 
 /** Whether a media type is Server-Sent Events, ignoring parameters such as `; charset=utf-8`. */
-export const isEventStreamContentType = (contentType: string | undefined | null): boolean =>
-  contentType?.split(';')[0]?.trim().toLowerCase() === 'text/event-stream'
+export const isEventStreamContentType = (contentType: string | undefined): boolean =>
+  parseMimeType(contentType).essence === 'text/event-stream'

--- a/packages/mock-server/src/utils/collect-sse-events.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.ts
@@ -17,16 +17,16 @@ const SSE_FIELD = /^(?:data|event|id|retry):/
 type SseEvent = {
   /** Already-framed event text when `framed` is true, otherwise the `data` payload of one event. */
   text: string
-  /** Whether `text` is complete SSE framing that has to be written verbatim. */
+  /** Whether `text` is SSE framing of its own, to be written as is rather than wrapped in a `data:` line. */
   framed: boolean
 }
 
 /**
- * Whether text is already Server-Sent Events framing, so it goes to the wire as is.
+ * Whether text is already Server-Sent Events framing, so it goes to the wire as its own framing.
  *
  * Some documents spell the wire format out in their example (`data: {"type":"edit"}`) instead of
  * describing a single event payload. Wrapping that in another `data:` line would hand the client the
- * framing as its payload, so it is passed through untouched.
+ * framing as its payload, so it is written as is, with only its terminating blank line normalized.
  *
  * The test is deliberately narrow: real framing starts with a field on its first line and carries at
  * least one `data:` line. Prose that merely happens to contain a colon (`user created\nid: 42`) is

--- a/packages/mock-server/src/utils/collect-sse-events.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.ts
@@ -28,26 +28,26 @@ type SseEvent = {
  * describing a single event payload. Wrapping that in another `data:` line would hand the client the
  * framing as its payload, so it is written as is, with only its terminating blank line normalized.
  *
- * The test is deliberately narrow: real framing opens with an SSE field or a comment on its first
- * line and, unless it opens with a comment, carries at least one `data:` line. Prose that merely
- * happens to contain a colon (`user created\nid: 42`) is not framing — passing it through would make
- * a compliant client dispatch nothing at all.
+ * The test is deliberately narrow: real framing opens with an SSE field or a `:` comment on its first
+ * line and carries at least one `data:` line. Prose that merely happens to contain a colon
+ * (`user created\nid: 42`) is not framing — passing it through would make a compliant client dispatch
+ * nothing at all.
  */
 const isFramed = (text: string): boolean => {
-  const lines = text.split(/\r\n|\r|\n/)
-  const firstLine = lines.find((line) => line.trim() !== '')
+  const lines = text.split(/\r\n|\r|\n/).filter((line) => line.trim() !== '')
+  const [firstLine] = lines
 
   if (firstLine === undefined) {
     return false
   }
 
-  // A line opening with `:` is an SSE comment — the keep-alive form nothing but a stream writes — so
-  // it is framing on its own, even when the rest of the example carries no event.
-  if (firstLine.startsWith(':')) {
+  // Text made only of `:` comments is the keep-alive form nothing but a stream writes, so it is
+  // framing even though it carries no event of its own.
+  if (lines.every((line) => line.startsWith(':'))) {
     return true
   }
 
-  return SSE_FIELD.test(firstLine) && lines.some((line) => line.startsWith('data:'))
+  return (firstLine.startsWith(':') || SSE_FIELD.test(firstLine)) && lines.some((line) => line.startsWith('data:'))
 }
 
 /**
@@ -87,7 +87,8 @@ const expand = (payload: unknown): SseEvent[] => (Array.isArray(payload) ? paylo
  * 1. A named example requested via `Prefer: example=<name>`.
  * 2. The singular `example` keyword.
  * 3. Every entry of the `examples` map, in declaration order — an event stream that documents a
- *    `summary` and a `row` example is documenting the two events it sends.
+ *    `summary` and a `row` example is documenting the two events it sends. Entries that are complete
+ *    framing are the exception: those are alternative streams, so only the first is served.
  * 4. Nothing declared: a schema-generated payload, repeated so the stream has more than one event.
  *
  * `generate` is a callback so the schema is only turned into an example when no example is declared.
@@ -117,8 +118,16 @@ export const collectSseEvents = (
       .map((entry) => getResolvedRef(entry)?.value)
       .filter((value) => value !== undefined)
 
+    const [firstValue] = values
+
     if (values.length > 0) {
-      return values.flatMap(expand)
+      const events = values.flatMap(expand)
+
+      // An example that is framing already describes a whole stream, so a map of them lists
+      // alternative streams rather than consecutive events. Sending them back to back would replay a
+      // terminal event such as `[DONE]`, so only the first is served — `Prefer: example=<name>`
+      // picks another one.
+      return events.some((event) => event.framed) ? expand(firstValue) : events
     }
   }
 

--- a/packages/mock-server/src/utils/collect-sse-events.ts
+++ b/packages/mock-server/src/utils/collect-sse-events.ts
@@ -59,11 +59,28 @@ const isFramed = (text: string): boolean => {
  */
 const terminate = (text: string): string => {
   const lineEnding = text.includes('\r\n') ? '\r\n' : '\n'
-  // Trailing blank lines go, indentation a block scalar left behind with them. Every run stripped
-  // contains a line break, so spaces inside the last field's value survive.
-  const trimmed = text.replace(/(?:[ \t]*(?:\r\n|\r|\n))+[ \t]*$/, '')
 
-  return `${trimmed}${lineEnding}${lineEnding}`
+  // Walk back over the trailing blank lines, taking the indentation a block scalar left on them.
+  // Spaces are only dropped once a line break is found past them, so spaces inside the last field's
+  // value survive. A scan rather than a regex: the pattern for this needs nested quantifiers, which
+  // backtrack quadratically on a long run of spaces.
+  let cursor = text.length
+  let end = text.length
+
+  while (cursor > 0) {
+    const character = text[cursor - 1]
+
+    if (character === '\n' || character === '\r') {
+      cursor -= 1
+      end = cursor
+    } else if (character === ' ' || character === '\t') {
+      cursor -= 1
+    } else {
+      break
+    }
+  }
+
+  return `${text.slice(0, end)}${lineEnding}${lineEnding}`
 }
 
 /** Turns one payload into an event, serializing anything that is not already text. */


### PR DESCRIPTION
## Problem

A response with a `text/event-stream` content type came back as a single buffered body with an SSE content type on it — one JSON object, no framing. Nothing on the wire told a client where an event began or ended, so an SSE reader (`EventSource`, or a generated SDK iterating `data:` chunks) either got one malformed event or nothing it could dispatch.

That makes every streaming endpoint unmockable. In our own fixture corpus that is 18 operations across 5 API descriptions — anything that documents a `text/event-stream` response cannot be exercised against the mock at all, even though it routes and answers 200.

## Solution

When `text/event-stream` is the negotiated response media type, stream it as real Server-Sent Events with Hono's `streamSSE`: one `data:` line per event, terminated by a blank line, then close. Every other content type keeps the existing buffered path untouched.

Which events to send is decided in a new pure helper, `packages/mock-server/src/utils/collect-sse-events.ts`:

- **Named `examples` are the sequence**, in declaration order — a response documenting a `summary` and a `row` example is documenting the two events it sends. `Prefer: example=<name>` still pins the stream to one of them.
- **An array example is a sequence too**, one event per item.
- **An example that already spells out the wire format** — `data:`/`event:` lines, or a `:` comment heartbeat — is written as its own framing (only the terminating blank line is normalized) rather than being wrapped in a second `data:` line. A map of nothing but those describes alternative streams, so the first one is served. The detection is deliberately narrow: framing has to open with a field or comment line and carry a `data:` line, so prose that merely contains a colon (`user created\nid: 42`) is still sent as a payload.
- **With only a schema**, the generated payload goes out three times so a client's read loop sees more than one event. A schema that already generates a sequence — a multi-item array, or a string spelling the wire format out — is sent once, so a documented `[DONE]` terminator is never replayed.

Alternatives considered: emitting a single event (too weak to exercise a read loop), and deriving an `event:` name from the example key (rejected — example names are arbitrary identifiers, and a wrong event name makes a client dispatching on it silently drop the event).

Checked against real API descriptions: profound streams its documented `summary` then `row` events, wikipedia-stream's pre-framed example passes through unchanged, and dedalus/petstore stream framed generated events. Status codes, `Prefer: code=`, declared response headers, CORS, authentication, and request validation all behave the same on the streamed path as on the buffered one.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrkRDG7vVwjLeSAQoB3Aah)_