### PR TITLE
feat(mock-server): return structured errors from an onError handler

### DIFF
--- a/.agents/skills/mock-server/SKILL.md
+++ b/.agents/skills/mock-server/SKILL.md
@@ -126,3 +126,4 @@ Useful routes:
 - If seeded data is missing, check `x-seed` exists on schema keys and the collection was empty on startup.
 - If auth-protected routes return unauthorized responses, verify matching `securitySchemes` and request credentials.
 - If custom logic fails, inspect `x-handler` runtime errors (mock server returns `500` with handler error details).
+- For an unhandled `500` (one whose `error` is `Internal Server Error`), read its `operation` object — it names the method and OpenAPI path that failed, plus the `operationId` when the document declares one.

--- a/.changeset/mock-server-structured-errors.md
+++ b/.changeset/mock-server-structured-errors.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': minor
+---
+
+Answer unhandled errors with a structured JSON `500` naming the operation that failed, instead of the previous plain-text `Internal Server Error`. The body reports the error `message` along with the matched operation's `method`, OpenAPI `path`, and `operationId` (when the document declares one), and the error is still logged to the console. Errors that already carry their own response keep the status and body they chose.

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -295,6 +295,30 @@ Each violation reports its `location` (`path`, `query`, `header`, `cookie`, or `
 
 > This validates path, query, header, and cookie parameters (across every OpenAPI serialization style, including array and object values), plus JSON request bodies. Response validation, non-JSON bodies, and proxy mode are planned follow-ups.
 
+### Error Responses
+
+When mocking a request fails in a way nothing else handles — a declared response header name that is not a valid HTTP header name, an example that cannot be serialized — the server responds with `500 Internal Server Error` and a JSON body naming the operation that failed:
+
+```json
+{
+  "error": "Internal Server Error",
+  "message": "Headers.set: \"X Invalid Name\" is an invalid header name.",
+  "operation": {
+    "method": "GET",
+    "path": "/pets/{petId}",
+    "operationId": "getPet"
+  }
+}
+```
+
+`operation` reports the HTTP method and the OpenAPI path key of the matched operation, plus its `operationId` when the document declares one. It is left out when the request did not match a mocked operation, for example on a route you added to the returned app yourself. Either way, the error is also logged to the console, so the stack trace stays available.
+
+Failures that are already handled elsewhere never reach this handler, so they keep their own shape and carry no `operation` key:
+
+- **`x-handler` errors** — an extension that throws responds with `{ "error": "Handler execution failed", "message": … }`.
+- **Operations with no response** — an operation whose `responses` are empty responds with `{ "error": "No response defined for this operation." }`.
+- **Errors that carry a response** — an error such as Hono's `HTTPException` keeps the status and body it chose, and is not logged.
+
 ### Custom Request Handlers
 
 Use the `x-handler` extension to write custom JavaScript code for handling requests. This gives you access to a `store` helper for data persistence, `faker` for generating realistic data, and full access to request/response objects.

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -1,8 +1,73 @@
-import { describe, expect, it } from 'vitest'
+import { HTTPException } from 'hono/http-exception'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createMockServer } from './create-mock-server'
 
+/**
+ * A document with a single operation. Pass an `operationId` to have the document declare one; leave
+ * it off to cover the case where it does not.
+ */
+const documentWithOnePet = (operationId?: string): Record<string, unknown> => ({
+  openapi: '3.1.0',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  paths: {
+    '/pets/{petId}': {
+      get: {
+        ...(operationId ? { operationId } : {}),
+        responses: {
+          '200': {
+            description: 'OK',
+          },
+        },
+      },
+    },
+  },
+})
+
+/**
+ * A response header name that is not a valid HTTP token. Building the response throws while the
+ * mock handler runs, which is how a valid-looking document realistically produces a `500`: nothing
+ * validates the header name up front, so the failure only surfaces on the request.
+ */
+const documentWithBrokenResponseHeader: Record<string, unknown> = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Hello World',
+    version: '1.0.0',
+  },
+  paths: {
+    '/pets/{petId}': {
+      get: {
+        operationId: 'getPet',
+        responses: {
+          '200': {
+            description: 'OK',
+            headers: {
+              'X Invalid Name': {
+                schema: {
+                  type: 'string',
+                  example: 'nope',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
 describe('createMockServer', () => {
+  // The error-handling tests below silence the log the server writes. Restoring through a hook
+  // rather than inline keeps a failing assertion from leaving `console.error` mocked for the rest
+  // of the file.
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('supports deprecated specification key', async () => {
     const specification = {
       openapi: '3.1.0',
@@ -1001,5 +1066,133 @@ describe('createMockServer', () => {
 
     expect(response.status).toBe(301)
     expect(response.headers.get('Location')).toBe('/new-location')
+  })
+
+  it('returns a structured JSON 500 naming the operation that failed', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const server = await createMockServer({
+      document: documentWithOnePet('getPet'),
+      onRequest: () => {
+        throw new Error('Boom')
+      },
+    })
+
+    const response = await server.request('/pets/1')
+
+    expect(response.status).toBe(500)
+    expect(response.headers.get('Content-Type')).toBe('application/json')
+    expect(await response.json()).toStrictEqual({
+      error: 'Internal Server Error',
+      message: 'Boom',
+      operation: {
+        method: 'GET',
+        path: '/pets/{petId}',
+        operationId: 'getPet',
+      },
+    })
+  })
+
+  it('omits the operationId when the operation does not declare one', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const server = await createMockServer({
+      document: documentWithOnePet(),
+      onRequest: () => {
+        throw new Error('Boom')
+      },
+    })
+
+    const response = await server.request('/pets/1')
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toStrictEqual({
+      error: 'Internal Server Error',
+      message: 'Boom',
+      operation: {
+        method: 'GET',
+        path: '/pets/{petId}',
+      },
+    })
+  })
+
+  it('logs the operation alongside the error', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const server = await createMockServer({
+      document: documentWithOnePet('getPet'),
+      onRequest: () => {
+        throw new Error('Boom')
+      },
+    })
+
+    await server.request('/pets/1')
+
+    expect(consoleErrorSpy.mock.calls[0]?.[0]).toBe('Error while mocking GET /pets/{petId}:')
+    expect(consoleErrorSpy.mock.calls[0]?.[1]).toStrictEqual(new Error('Boom'))
+  })
+
+  it('names the operation when building the mock response fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const server = await createMockServer({ document: documentWithBrokenResponseHeader })
+
+    const response = await server.request('/pets/1')
+    // The runtime words this failure, so it is the one field matched loosely, on the header name.
+    const { message, ...body } = (await response.json()) as { message: string }
+
+    expect(response.status).toBe(500)
+    expect(body).toStrictEqual({
+      error: 'Internal Server Error',
+      operation: {
+        method: 'GET',
+        path: '/pets/{petId}',
+        operationId: 'getPet',
+      },
+    })
+    expect(message).toContain('X Invalid Name')
+  })
+
+  it('omits the operation when the failing route is not a mocked operation', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const server = await createMockServer({
+      document: {
+        openapi: '3.1.0',
+        info: {
+          title: 'Hello World',
+          version: '1.0.0',
+        },
+        paths: {},
+      },
+    })
+
+    // Routes added to the returned app mock no operation, so there is nothing to name.
+    server.get('/custom', () => {
+      throw new Error('Boom')
+    })
+
+    const response = await server.request('/custom')
+
+    expect(response.status).toBe(500)
+    expect(await response.json()).toStrictEqual({
+      error: 'Internal Server Error',
+      message: 'Boom',
+    })
+    expect(consoleErrorSpy.mock.calls[0]?.[0]).toBe('Error handling GET /custom:')
+  })
+
+  it('keeps the status and body of an error that carries its own response', async () => {
+    const server = await createMockServer({
+      document: documentWithOnePet(),
+      onRequest: () => {
+        throw new HTTPException(418, { message: 'I am a teapot' })
+      },
+    })
+
+    const response = await server.request('/pets/1')
+
+    expect(response.status).toBe(418)
+    expect(await response.text()).toBe('I am a teapot')
   })
 })

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -1,6 +1,6 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { getResolvedRef, mergeSiblingReferences } from '@scalar/workspace-store/helpers/get-resolved-ref'
-import { Hono } from 'hono'
+import { type Context, Hono } from 'hono'
 import { cors } from 'hono/cors'
 
 import type { HttpMethod, MockServerOptions } from '@/types'
@@ -20,11 +20,84 @@ import { mockAnyResponse } from './routes/mock-any-response'
 import { mockHandlerResponse } from './routes/mock-handler-response'
 import { respondWithOpenApiDocument } from './routes/respond-with-openapi-document'
 
+/** The operation a route mocks, used to name what failed in an error response */
+type MockedOperation = {
+  /** Uppercased HTTP method, for example `GET` */
+  method: Uppercase<HttpMethod>
+  /** The OpenAPI path key, for example `/pets/{petId}` (not the Hono route it is registered as) */
+  path: string
+  /** The `operationId` of the operation, when the document declares one */
+  operationId?: string
+}
+
+/**
+ * Context variables the mock server sets on a request, so the error handler can read back which
+ * operation was being mocked when something threw.
+ *
+ * The app itself stays a plain `Hono` because that type is part of this package's public API, so
+ * the variable is reached through a narrowed view of the context instead.
+ */
+type MockServerContext = Context<{ Variables: { mockedOperation: MockedOperation } }>
+
+/** Record which operation a request matched, so an error escaping it can be named */
+const setMockedOperation = (c: Context, operation: MockedOperation): void => {
+  ;(c as MockServerContext).set('mockedOperation', operation)
+}
+
+/** Read back the operation a request matched, or `undefined` when it reached no mocked route */
+const getMockedOperation = (c: Context): MockedOperation | undefined => (c as MockServerContext).get('mockedOperation')
+
+/**
+ * Whether an error carries its own response, the way Hono's `HTTPException` does.
+ *
+ * Checked structurally rather than with `instanceof`, exactly like Hono's own default handler, so an
+ * `HTTPException` thrown from a second copy of Hono is still recognized.
+ */
+const carriesResponse = (error: Error): error is Error & { getResponse: () => Response } =>
+  'getResponse' in error && typeof error.getResponse === 'function'
+
 /**
  * Create a mock server instance
  */
 export async function createMockServer(configuration: MockServerOptions): Promise<Hono> {
   const app = new Hono()
+
+  // Unhandled errors would otherwise reach Hono's default handler, which answers with a plain-text
+  // `Internal Server Error` that says nothing about what broke. A mock server fails for mundane,
+  // document-shaped reasons — a response header name the runtime rejects, an example that cannot be
+  // serialized — so answer with JSON that names the failing operation and repeats the message,
+  // which makes the failure readable in the response instead of something to go reproduce.
+  app.onError((error, c) => {
+    // The status and body such an error chose are deliberate, not an internal failure, so answer
+    // with them. Rebuilt through the context exactly as Hono's default handler does, so headers
+    // already staged on the response — those from the CORS middleware, most of all — still apply.
+    if (carriesResponse(error)) {
+      const response = error.getResponse()
+      return c.newResponse(response.body, response)
+    }
+
+    const operation = getMockedOperation(c)
+
+    // Keep logging the error, as Hono's default handler does, so the stack trace is not lost. Routes
+    // added to the returned app are not mocked operations, so name the concrete request instead —
+    // the log always points somewhere.
+    console.error(
+      operation
+        ? `Error while mocking ${operation.method} ${operation.path}:`
+        : `Error handling ${c.req.method} ${c.req.path}:`,
+      error,
+    )
+
+    return c.json(
+      {
+        error: 'Internal Server Error',
+        message: error.message,
+        // Left out entirely rather than sent as `null`, so a client can test for the key.
+        ...(operation ? { operation } : {}),
+      },
+      500,
+    )
+  })
 
   /** Dereferenced OpenAPI document */
   const schema = await processOpenApiDocument(configuration?.document ?? configuration?.specification)
@@ -79,6 +152,23 @@ export async function createMockServer(configuration: MockServerOptions): Promis
     methods.forEach((method) => {
       const route = honoRouteFromPath(path)
       const operation = pathItem?.[method] as OpenAPIV3_1.OperationObject
+
+      // Remember which operation this route mocks, so the error handler can name it when something
+      // fails downstream. Recorded on the context rather than mapped back from the request path,
+      // which would not survive the app being mounted under a base path. Registered before the rest
+      // of the route so a failure in request validation is named too. The OpenAPI path key is kept
+      // (rather than the Hono route) because that is what the document author reads.
+      const mockedOperation: MockedOperation = {
+        // `toUpperCase` widens to `string`, so restate the narrower type the method union guarantees.
+        method: method.toUpperCase() as Uppercase<HttpMethod>,
+        path,
+        ...(operation?.operationId ? { operationId: operation.operationId } : {}),
+      }
+
+      app[method](route, async (c, next) => {
+        setMockedOperation(c, mockedOperation)
+        await next()
+      })
 
       // Operation-level security overrides the global requirement, so fall back to the
       // document-wide `security` when the operation does not define its own.

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -69,8 +69,9 @@ export async function createMockServer(configuration: MockServerOptions): Promis
   // which makes the failure readable in the response instead of something to go reproduce.
   app.onError((error, c) => {
     // The status and body such an error chose are deliberate, not an internal failure, so answer
-    // with them. Rebuilt through the context exactly as Hono's default handler does, so headers
-    // already staged on the response — those from the CORS middleware, most of all — still apply.
+    // with them. Unlike Hono's default handler, which returns the response directly, it is rebuilt
+    // through the context so headers already staged on the response — those from the CORS
+    // middleware, most of all — still apply.
     if (carriesResponse(error)) {
       const response = error.getResponse()
       return c.newResponse(response.body, response)


### PR DESCRIPTION
## Problem

When something goes wrong while the mock server builds a response, the error reaches Hono's default handler, which answers with a plain-text `Internal Server Error` and nothing else. The response does not say which operation failed, or why.

That is a genuinely bad debugging experience for a tool whose whole job is to be driven by a document you are still authoring. A document can take a request down for mundane reasons — a declared response header name that is not a valid HTTP header name, an example that cannot be serialized — and none of them are validated up front, so the failure only surfaces on the request. Working out which of a few hundred operations produced an empty-bodied 500 currently means reproducing the request and bisecting the document.

## Solution

Register an `app.onError` handler that responds with JSON naming the operation that failed:

```json
{
  "error": "Internal Server Error",
  "message": "Headers.set: \"X Invalid Name\" is an invalid header name.",
  "operation": {
    "method": "GET",
    "path": "/pets/{petId}",
    "operationId": "getPet"
  }
}
```

- `operation` reports the HTTP method and the OpenAPI path key, plus the `operationId` when the document declares one. It is left out when the request matched no mocked operation, for example on a route added to the returned app by a consumer.
- The operation is recorded on the Hono context by a per-route middleware, registered before the rest of the route so a failure in request validation is named too.
- Errors that already carry their own response, such as `HTTPException`, keep the status and body they chose. Rebuilt through the context exactly as Hono's default handler does, so the CORS headers still apply.
- The error is still logged to the console, so the stack trace is not lost.

Failures that are already handled elsewhere (`x-handler` errors, operations with no response defined) never reach this handler and keep their own shape — documented alongside the new behavior.

### Alternative considered

The first cut mapped a request back to its operation through `c.req.routePath`. It was dropped: it reports `HEAD` for a request Hono re-dispatches as `GET`, silently loses the operation when a consumer mounts the app under a base path, can name the *wrong* operation when two OpenAPI path keys collapse onto one Hono route, and leans on a getter Hono marks deprecated. Recording on the context has none of those failure modes.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation.

## Notes

Tests: six new cases in `create-mock-server.test.ts`, driven by a genuinely document-shaped failure. Five of them fail with the implementation reverted; the sixth guards the pass-through branch. On the current head `packages/mock-server` is green (445 passed, 1 skipped), `tsgo --noEmit` is clean, and Biome and Prettier pass on the changed files.

`main` was merged in after the SSE framing and string-body changes landed. Both added a subsection at the same point in the mock-server guide, so the conflict was resolved by keeping both: **Server-Sent Events** from `main`, then **Error Responses** from this branch.

No UI surface is affected, so there are no visual artifacts.