### PR TITLE
feat(api-reference): resolve heading levels from the page outline

### DIFF
--- a/.changeset/document-outline.md
+++ b/.changeset/document-outline.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-reference': minor
+---
+
+Resolve heading levels from a block's place in the page outline instead of hardcoding them, so a block rendered on its own starts at `h1`.
+
+A block now assumes it is the top of the page: rendered alone, an operation's title is the `h1` and everything it contains follows beneath it. A component that renders several blocks alongside each other owns the relationship between them and anchors the outline — `Content` renders the info block above the tags and operations, so it declares `document` and the rest resolve against it. Composed into a full reference, every heading renders at the level it always has.
+
+Also fixes two headings that never went through the heading components: the classic-layout operation title was a raw `h3`, and the classic-layout Models section label passed a `level` prop to a component that does not accept one, so it rendered no heading element at all.

--- a/packages/api-reference/src/blocks/scalar-info-block/components/IntroductionLayout.vue
+++ b/packages/api-reference/src/blocks/scalar-info-block/components/IntroductionLayout.vue
@@ -16,6 +16,7 @@ import {
   SectionHeader,
   SectionHeaderTag,
 } from '@/components/Section'
+import { useDocumentOutline } from '@/features/document-outline'
 import { useLocalization } from '@/features/localization'
 import { SpecificationExtension } from '@/features/specification-extension'
 
@@ -38,6 +39,8 @@ defineProps<{
 }>()
 
 const { translate } = useLocalization()
+
+const { level: headingLevel } = useDocumentOutline('document')
 </script>
 
 <template>
@@ -64,7 +67,7 @@ const { translate } = useLocalization()
               :version="specificationVersion" />
           </div>
           <SectionHeader tight>
-            <SectionHeaderTag :level="1">
+            <SectionHeaderTag :level="headingLevel">
               {{ info?.title }}
             </SectionHeaderTag>
             <template #links>

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.test.ts
@@ -40,6 +40,9 @@ function createDocumentWithChannel(channel: Record<string, unknown>): AsyncApiDo
 }
 
 describe('Channel', () => {
+  // These mount a Channel on its own, so it is the top of its page and its
+  // heading is an h1. Inside a full reference it resolves to h2 — see
+  // features/document-outline.
   it('renders the channel address as the heading and the description below', () => {
     const wrapper = mount(Channel, {
       props: {
@@ -51,7 +54,7 @@ describe('Channel', () => {
       },
     })
 
-    const heading = wrapper.find('h2')
+    const heading = wrapper.find('h1')
     expect(heading.text()).toContain('user/signedup')
     expect(wrapper.text()).toContain('Fired whenever a user signs up.')
   })
@@ -67,7 +70,7 @@ describe('Channel', () => {
       },
     })
 
-    const heading = wrapper.find('h2')
+    const heading = wrapper.find('h1')
     expect(heading.text()).toContain('user/signedup')
   })
 
@@ -85,8 +88,8 @@ describe('Channel', () => {
       },
     })
 
-    expect(wrapper.find('h2').text()).toContain('User signups')
-    expect(wrapper.find('h2').text()).not.toContain('user/signedup')
+    expect(wrapper.find('h1').text()).toContain('User signups')
+    expect(wrapper.find('h1').text()).not.toContain('user/signedup')
   })
 
   it('falls back to the channel key when neither title nor address is set', () => {
@@ -101,7 +104,7 @@ describe('Channel', () => {
       },
     })
 
-    expect(wrapper.find('h2').text()).toContain('userSignedUp')
+    expect(wrapper.find('h1').text()).toContain('userSignedUp')
   })
 
   it('renders an accordion wrapper for the classic layout', () => {

--- a/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Channel.vue
@@ -18,6 +18,7 @@ import {
   SectionHeader,
   SectionHeaderTag,
 } from '@/components/Section'
+import { useDocumentOutline } from '@/features/document-outline'
 import ParameterList from '@/features/Operation/components/ParameterList.vue'
 
 import AsyncApiLabels from './AsyncApiLabels.vue'
@@ -115,6 +116,8 @@ const operations = computed(() =>
     'asyncapi-operation',
   ),
 )
+
+const { level: headingLevel } = useDocumentOutline('channel')
 </script>
 
 <template>
@@ -133,7 +136,7 @@ const operations = computed(() =>
           @copyAnchorUrl="
             () => eventBus?.emit('copy-url:nav-item', { id: channel.id })
           ">
-          <SectionHeaderTag :level="2">
+          <SectionHeaderTag :level="headingLevel">
             {{ headingText }}
           </SectionHeaderTag>
         </Anchor>
@@ -182,7 +185,7 @@ const operations = computed(() =>
           ">
           <SectionHeaderTag
             :id="headerId"
-            :level="2">
+            :level="headingLevel">
             {{ headingText }}
           </SectionHeaderTag>
         </Anchor>

--- a/packages/api-reference/src/components/Content/AsyncApi/Message.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Message.vue
@@ -10,6 +10,7 @@ import { Anchor } from '@/components/Anchor'
 import { Schema } from '@/components/Content/Schema'
 import type { SchemaOptions } from '@/components/Content/Schema/types'
 import { SectionAccordion, SectionHeaderTag } from '@/components/Section'
+import { useDocumentOutline } from '@/features/document-outline'
 import {
   getAsyncApiMessageHeadersSchema,
   getAsyncApiMessagePayloadSchema,
@@ -142,6 +143,8 @@ const onToggle = (open: boolean) => {
   isExpanded.value = open
   eventBus?.emit('toggle:nav-item', { id: message.id, open })
 }
+
+const { level: headingLevel } = useDocumentOutline('message')
 </script>
 
 <template>
@@ -162,7 +165,7 @@ const onToggle = (open: boolean) => {
             <SectionHeaderTag
               :id="headerId"
               class="message-title"
-              :level="4">
+              :level="headingLevel">
               {{ headingText }}
             </SectionHeaderTag>
             <AsyncApiLabels :protocols="protocolLabels" />

--- a/packages/api-reference/src/components/Content/AsyncApi/Operation.vue
+++ b/packages/api-reference/src/components/Content/AsyncApi/Operation.vue
@@ -10,6 +10,7 @@ import { computed, useId, useTemplateRef } from 'vue'
 
 import { Anchor } from '@/components/Anchor'
 import { SectionHeaderTag } from '@/components/Section'
+import { useDocumentOutline } from '@/features/document-outline'
 import OperationScopes from '@/features/Operation/components/OperationScopes.vue'
 import { useIntersection } from '@/hooks/use-intersection'
 
@@ -82,6 +83,8 @@ const messages = computed(() =>
 const requiredSecurity = computed(() =>
   getAsyncApiRequiredSecurity(document, resolvedOperation.value),
 )
+
+const { level: headingLevel } = useDocumentOutline('operation')
 </script>
 
 <template>
@@ -103,7 +106,7 @@ const requiredSecurity = computed(() =>
         <SectionHeaderTag
           :id="headerId"
           class="operation-title"
-          :level="3">
+          :level="headingLevel">
           {{ headingText }}
         </SectionHeaderTag>
       </Anchor>

--- a/packages/api-reference/src/components/Content/Content.vue
+++ b/packages/api-reference/src/components/Content/Content.vue
@@ -48,6 +48,7 @@ import {
 import TraversedEntry from '@/components/Content/Operations/TraversedEntry.vue'
 import { RenderPlugins } from '@/components/RenderPlugins'
 import { SectionFlare } from '@/components/SectionFlare'
+import { provideDocumentOutline } from '@/features/document-outline'
 import { getXKeysFromObject } from '@/features/specification-extension'
 import {
   firstLazyLoadComplete,
@@ -243,6 +244,10 @@ const showAuthSelector = computed(
 onMounted(() => {
   scheduleInitialLoadComplete()
 })
+
+// Content renders the info block above the tags, operations and models, so it
+// owns the relationship between them and anchors the outline at the document.
+provideDocumentOutline('document')
 </script>
 <template>
   <SectionFlare />

--- a/packages/api-reference/src/components/Content/Models/ModelTag.vue
+++ b/packages/api-reference/src/components/Content/Models/ModelTag.vue
@@ -10,6 +10,7 @@ import SectionContainer from '@/components/Section/SectionContainer.vue'
 import SectionContainerAccordion from '@/components/Section/SectionContainerAccordion.vue'
 import SectionHeaderTag from '@/components/Section/SectionHeaderTag.vue'
 import ShowMoreButton from '@/components/ShowMoreButton.vue'
+import { useDocumentOutline } from '@/features/document-outline'
 
 const { modelsSectionLabel = DEFAULT_MODELS_SECTION_LABEL } = defineProps<{
   id: string
@@ -18,6 +19,8 @@ const { modelsSectionLabel = DEFAULT_MODELS_SECTION_LABEL } = defineProps<{
   layout: 'classic' | 'modern'
   modelsSectionLabel?: ModelsSectionLabel
 }>()
+
+const { level: headingLevel } = useDocumentOutline('modelGroup')
 </script>
 <template>
   <!-- Modern Layout Model Container -->
@@ -27,7 +30,7 @@ const { modelsSectionLabel = DEFAULT_MODELS_SECTION_LABEL } = defineProps<{
       :aria-label="modelsSectionLabel"
       @intersecting="() => eventBus?.emit('intersecting:nav-item', { id })">
       <SectionHeader>
-        <SectionHeaderTag :level="2">
+        <SectionHeaderTag :level="headingLevel">
           {{ modelsSectionLabel }}
         </SectionHeaderTag>
       </SectionHeader>
@@ -53,7 +56,11 @@ const { modelsSectionLabel = DEFAULT_MODELS_SECTION_LABEL } = defineProps<{
       () => eventBus?.emit('toggle:nav-item', { id, open: isCollapsed })
     ">
     <template #title>
-      <SectionHeader :level="2">{{ modelsSectionLabel }}</SectionHeader>
+      <SectionHeader>
+        <SectionHeaderTag :level="headingLevel">
+          {{ modelsSectionLabel }}
+        </SectionHeaderTag>
+      </SectionHeader>
     </template>
     <slot />
   </SectionContainerAccordion>

--- a/packages/api-reference/src/components/Content/Models/components/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/components/ClassicLayout.vue
@@ -9,6 +9,7 @@ import type {
 
 import { Anchor } from '@/components/Anchor'
 import { SectionAccordion, SectionHeaderTag } from '@/components/Section'
+import { useDocumentOutline } from '@/features/document-outline'
 
 import { SchemaHeading, SchemaProperty } from '../../Schema'
 
@@ -28,6 +29,8 @@ const { eventBus, id, options, document } = defineProps<{
     | 'hideModels'
   >
 }>()
+
+const { level: headingLevel } = useDocumentOutline('model')
 </script>
 <template>
   <SectionAccordion
@@ -41,7 +44,7 @@ const { eventBus, id, options, document } = defineProps<{
         class="reference-models-anchor"
         :eventBus="eventBus"
         @copyAnchorUrl="() => eventBus?.emit('copy-url:nav-item', { id })">
-        <SectionHeaderTag :level="3">
+        <SectionHeaderTag :level="headingLevel">
           <SchemaHeading
             class="reference-models-label"
             :name="schema.title ?? name"

--- a/packages/api-reference/src/components/Content/Models/components/ModernLayout.vue
+++ b/packages/api-reference/src/components/Content/Models/components/ModernLayout.vue
@@ -7,6 +7,7 @@ import type {
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 
 import { CompactSection, SectionHeaderTag } from '@/components/Section'
+import { useDocumentOutline } from '@/features/document-outline'
 
 import { Schema, SchemaHeading } from '../../Schema'
 
@@ -25,6 +26,8 @@ const { schema, options, document } = defineProps<{
     expandAllSchemaProperties: boolean | undefined
   }
 }>()
+
+const { level: headingLevel } = useDocumentOutline('model')
 </script>
 <template>
   <CompactSection
@@ -37,7 +40,7 @@ const { schema, options, document } = defineProps<{
       (value) => eventBus?.emit('toggle:nav-item', { id, open: value })
     ">
     <template #heading>
-      <SectionHeaderTag :level="3">
+      <SectionHeaderTag :level="headingLevel">
         <SchemaHeading
           :name="schema.title ?? name"
           :value="schema" />

--- a/packages/api-reference/src/components/Content/Tags/components/ClassicLayout.test.ts
+++ b/packages/api-reference/src/components/Content/Tags/components/ClassicLayout.test.ts
@@ -1,6 +1,9 @@
 import type { TraversedTag } from '@scalar/workspace-store/schemas/navigation'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import { provideDocumentOutline } from '@/features/document-outline'
 
 import ClassicLayout from './ClassicLayout.vue'
 
@@ -163,16 +166,36 @@ describe('ClassicLayout', () => {
       expect(wrapper.element.tagName).toBe('SECTION') // Vue test utils wraps in div
     })
 
-    it('renders SectionHeaderTag with level 2', () => {
-      const mockTag = createMockTag()
-
+    it('renders SectionHeaderTag with level 1 when rendered on its own', () => {
+      // A block assumes it is the top of the page unless something composes it.
       const wrapper = mount(ClassicLayout, {
         props: {
           eventBus: null,
-          tag: mockTag,
+          tag: createMockTag(),
           isCollapsed: false,
         },
       })
+
+      const sectionHeaderTag = wrapper.findComponent({ name: 'SectionHeaderTag' })
+      expect(sectionHeaderTag.props('level')).toBe(1)
+    })
+
+    it('renders SectionHeaderTag with level 2 inside a document outline', () => {
+      // What Content does: it renders the info block above the tags, so a tag
+      // resolves one level beneath the document.
+      const wrapper = mount(
+        defineComponent({
+          setup() {
+            provideDocumentOutline('document')
+            return () =>
+              h(ClassicLayout, {
+                eventBus: null,
+                tag: createMockTag(),
+                isCollapsed: false,
+              })
+          },
+        }),
+      )
 
       const sectionHeaderTag = wrapper.findComponent({ name: 'SectionHeaderTag' })
       expect(sectionHeaderTag.props('level')).toBe(2)

--- a/packages/api-reference/src/components/Content/Tags/components/ClassicLayout.vue
+++ b/packages/api-reference/src/components/Content/Tags/components/ClassicLayout.vue
@@ -9,6 +9,7 @@ import {
   SectionHeader,
   SectionHeaderTag,
 } from '@/components/Section'
+import { useDocumentOutline } from '@/features/document-outline'
 
 const { tag, isCollapsed } = defineProps<{
   tag: TraversedTag
@@ -17,6 +18,8 @@ const { tag, isCollapsed } = defineProps<{
   /** Whether this tag sits inside a parent tag's container (drops its own padding). */
   nested?: boolean
 }>()
+
+const { level: headingLevel } = useDocumentOutline('tag')
 </script>
 
 <template>
@@ -36,7 +39,7 @@ const { tag, isCollapsed } = defineProps<{
           @copyAnchorUrl="
             () => eventBus?.emit('copy-url:nav-item', { id: tag.id })
           ">
-          <SectionHeaderTag :level="2">
+          <SectionHeaderTag :level="headingLevel">
             {{ tag.title }}
           </SectionHeaderTag>
         </Anchor>

--- a/packages/api-reference/src/components/Content/Tags/components/ModernLayout.vue
+++ b/packages/api-reference/src/components/Content/Tags/components/ModernLayout.vue
@@ -5,6 +5,7 @@ import { computed, useId } from 'vue'
 
 import { SectionContainer } from '@/components/Section'
 import ShowMoreButton from '@/components/ShowMoreButton.vue'
+import { useDocumentOutline } from '@/features/document-outline'
 import { useLocalization } from '@/features/localization'
 
 import TagSection from './TagSection.vue'
@@ -45,6 +46,8 @@ const showMore = computed(() => sectionCollapsed.value && hasChildren.value)
 
 /** Nested sections remain transparent so only first-level tags establish a surface. */
 const hasCollapsedSurface = computed(() => showMore.value && !nested)
+
+const { level: headingLevel } = useDocumentOutline('tag')
 </script>
 
 <template>
@@ -58,6 +61,7 @@ const hasCollapsedSurface = computed(() => showMore.value && !nested)
     role="region">
     <TagSection
       v-if="moreThanOneDefaultTag"
+      :headingLevel
       :eventBus="eventBus"
       :headerId="headerId"
       :isCollapsed="isCollapsed"

--- a/packages/api-reference/src/components/Content/Tags/components/TagSection.vue
+++ b/packages/api-reference/src/components/Content/Tags/components/TagSection.vue
@@ -19,8 +19,10 @@ import {
 import { useLocalization } from '@/features/localization'
 import { SpecificationExtension } from '@/features/specification-extension'
 
-const { tag, headerId, isCollapsed } = defineProps<{
+const { tag, headerId, isCollapsed, headingLevel } = defineProps<{
   tag: TraversedTag
+  /** Resolved by the parent, which owns this tag and the operations beside it. */
+  headingLevel: number
   headerId?: string
   isCollapsed?: boolean
   eventBus: WorkspaceEventBus | null
@@ -51,7 +53,7 @@ const hasChannels = computed(
         ">
         <SectionHeaderTag
           :id="headerId"
-          :level="2">
+          :level="headingLevel">
           {{ tag.title }}
           <ScreenReader v-if="isCollapsed">
             ({{ translate('navigation.collapsed') }})

--- a/packages/api-reference/src/components/Content/Tags/components/TagSection.vue
+++ b/packages/api-reference/src/components/Content/Tags/components/TagSection.vue
@@ -16,13 +16,22 @@ import {
   SectionHeader,
   SectionHeaderTag,
 } from '@/components/Section'
+import type { HeadingLevel } from '@/features/document-outline'
 import { useLocalization } from '@/features/localization'
 import { SpecificationExtension } from '@/features/specification-extension'
 
-const { tag, headerId, isCollapsed, headingLevel } = defineProps<{
+const {
+  tag,
+  headerId,
+  isCollapsed,
+  headingLevel = 1,
+} = defineProps<{
   tag: TraversedTag
-  /** Resolved by the parent, which owns this tag and the operations beside it. */
-  headingLevel: number
+  /**
+   * Resolved by the parent, which owns this tag and the operations beside it.
+   * Defaults to the top of the page, like any other block rendered on its own.
+   */
+  headingLevel?: HeadingLevel
   headerId?: string
   isCollapsed?: boolean
   eventBus: WorkspaceEventBus | null

--- a/packages/api-reference/src/components/GettingStarted.vue
+++ b/packages/api-reference/src/components/GettingStarted.vue
@@ -2,6 +2,7 @@
 import { ScalarButton } from '@scalar/components/button'
 import { themeLabels, type ThemeId } from '@scalar/themes'
 
+import { useDocumentOutline } from '@/features/document-outline'
 import { useLocalization } from '@/features/localization'
 
 defineProps<{
@@ -36,6 +37,8 @@ async function fetchExampleSpecification() {
 
   emits('updateContent', await response.text())
 }
+
+const { level: headingLevel } = useDocumentOutline('document')
 </script>
 <template>
   <div class="custom-scroll start">
@@ -52,9 +55,11 @@ async function fetchExampleSpecification() {
             fill-rule="evenodd" />
         </svg>
       </div>
-      <h1 class="start-h1">
+      <component
+        :is="`h${headingLevel}`"
+        class="start-h1">
         {{ translate('gettingStarted.swaggerEditor') }}
-      </h1>
+      </component>
       <p class="start-p">
         {{ translate('gettingStarted.description') }}
       </p>

--- a/packages/api-reference/src/components/OperationsList/OperationsListItem.vue
+++ b/packages/api-reference/src/components/OperationsList/OperationsListItem.vue
@@ -11,6 +11,7 @@ import { computed } from 'vue'
 
 import { HttpMethod } from '@/components/HttpMethod'
 import { SectionHeaderTag } from '@/components/Section'
+import { useDocumentOutline } from '@/features/document-outline'
 
 const { operation } = defineProps<{
   operation: TraversedOperation | TraversedWebhook
@@ -29,6 +30,8 @@ const pathOrTitle = computed(() => {
 const isWebhook = (
   _operation: TraversedEntry,
 ): _operation is TraversedWebhook => _operation.type === 'webhook'
+
+const { level: headingLevel } = useDocumentOutline('operation')
 </script>
 
 <template>
@@ -39,7 +42,7 @@ const isWebhook = (
     <SectionHeaderTag
       v-if="isCollapsed"
       class="sr-only"
-      :level="3">
+      :level="headingLevel">
       {{ operation.title }} (Hidden)
     </SectionHeaderTag>
     <a

--- a/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ClassicLayout.vue
@@ -24,6 +24,7 @@ import { HttpMethod } from '@/components/HttpMethod'
 import { LinkList } from '@/components/LinkList'
 import OperationPath from '@/components/OperationPath.vue'
 import { SectionAccordion } from '@/components/Section'
+import { useDocumentOutline } from '@/features/document-outline'
 import { ExampleResponses } from '@/features/example-responses'
 import { ExternalDocs } from '@/features/external-docs'
 import { useLocalization } from '@/features/localization'
@@ -127,6 +128,8 @@ provide(REQUEST_BODY_COMPOSITION_INDEX_SYMBOL, requestBodyCompositionSelection)
 const selectedResponseContentTypes = ref<Record<string, string>>({})
 
 const { copyToClipboard } = useClipboard()
+
+const { level: headingLevel } = useDocumentOutline('operation')
 </script>
 <template>
   <SectionAccordion
@@ -148,7 +151,9 @@ const { copyToClipboard } = useClipboard()
           <Anchor
             class="endpoint-anchor"
             @copyAnchorUrl="() => eventBus?.emit('copy-url:nav-item', { id })">
-            <h3 class="endpoint-label">
+            <component
+              :is="`h${headingLevel}`"
+              class="endpoint-label">
               <div class="endpoint-label-path">
                 <OperationPath
                   :deprecated="isOperationDeprecated(operation)"
@@ -177,7 +182,7 @@ const { copyToClipboard } = useClipboard()
               <XBadges
                 :badges="operation['x-badges']"
                 position="before" />
-            </h3>
+            </component>
           </Anchor>
         </div>
       </div>

--- a/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
+++ b/packages/api-reference/src/features/Operation/layouts/ModernLayout.vue
@@ -18,6 +18,7 @@ import { LinkList } from '@/components/LinkList'
 import OperationPath from '@/components/OperationPath.vue'
 import { Section, SectionContent, SectionHeaderTag } from '@/components/Section'
 import AskAgentButton from '@/features/ask-agent-button/AskAgentButton.vue'
+import { useDocumentOutline } from '@/features/document-outline'
 import { ExampleResponses } from '@/features/example-responses'
 import { ExternalDocs } from '@/features/external-docs'
 import { useLocalization } from '@/features/localization'
@@ -109,6 +110,8 @@ provide(REQUEST_BODY_COMPOSITION_INDEX_SYMBOL, requestBodyCompositionSelection)
  * the selection) and the example response panel (which reads it) so the two stay in sync.
  */
 const selectedResponseContentTypes = ref<Record<string, string>>({})
+
+const { level: headingLevel } = useDocumentOutline('operation')
 </script>
 
 <template>
@@ -163,7 +166,7 @@ const selectedResponseContentTypes = ref<Record<string, string>>({})
             @copyAnchorUrl="() => eventBus?.emit('copy-url:nav-item', { id })">
             <SectionHeaderTag
               :id="labelId"
-              :level="3">
+              :level="headingLevel">
               {{ operationTitle }}
             </SectionHeaderTag>
           </Anchor>

--- a/packages/api-reference/src/features/document-outline/index.ts
+++ b/packages/api-reference/src/features/document-outline/index.ts
@@ -1,0 +1,6 @@
+export {
+  type HeadingLevel,
+  type OutlineRole,
+  provideDocumentOutline,
+  useDocumentOutline,
+} from './use-document-outline'

--- a/packages/api-reference/src/features/document-outline/index.ts
+++ b/packages/api-reference/src/features/document-outline/index.ts
@@ -1,6 +1,5 @@
 export {
   type HeadingLevel,
-  type OutlineRole,
   provideDocumentOutline,
   useDocumentOutline,
 } from './use-document-outline'

--- a/packages/api-reference/src/features/document-outline/use-document-outline.integration.test.ts
+++ b/packages/api-reference/src/features/document-outline/use-document-outline.integration.test.ts
@@ -1,0 +1,83 @@
+import { apiReferenceConfigurationSchema } from '@scalar/schemas/api-reference'
+import { coerce } from '@scalar/validation'
+import { createWorkspaceStore } from '@scalar/workspace-store/client'
+import { createWorkspaceEventBus } from '@scalar/workspace-store/events'
+import { coerceValue } from '@scalar/workspace-store/schemas/typebox-coerce'
+import { OpenAPIDocumentSchema } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import Operation from '@/features/Operation/Operation.vue'
+
+import { provideDocumentOutline } from './use-document-outline'
+
+const eventBus = createWorkspaceEventBus()
+const workspaceStore = createWorkspaceStore()
+
+const document = coerceValue(OpenAPIDocumentSchema, {
+  openapi: '3.1.0',
+  info: { title: 'Test API', version: '1.0.0' },
+  paths: {
+    '/users/{userId}': {
+      get: { operationId: 'getUserById', summary: 'Get user by ID' },
+    },
+  },
+  components: { schemas: {} },
+})
+
+const operationProps = {
+  id: 'test-operation',
+  method: 'get' as const,
+  securitySchemes: {},
+  options: coerce(apiReferenceConfigurationSchema, {
+    layout: 'modern',
+    theme: 'default',
+  }),
+  document,
+  path: '/users/{userId}',
+  pathValue: document.paths?.['/users/{userId}'],
+  server: null,
+  clientOptions: [],
+  isCollapsed: false,
+  authStore: workspaceStore.auth,
+  isWebhook: false,
+  selectedClient: 'c/fetch',
+  selectedExample: '',
+  eventBus,
+}
+
+const mountOperation = (composed: boolean) =>
+  mount(
+    defineComponent({
+      setup() {
+        if (composed) {
+          provideDocumentOutline('document')
+        }
+        return () => h(Operation, operationProps)
+      },
+    }),
+    {
+      global: {
+        stubs: { RouterLink: { name: 'RouterLink', template: '<a><slot /></a>' } },
+      },
+    },
+  )
+
+describe('document outline on a real Operation', () => {
+  it('is the h1 when rendered on its own', () => {
+    // What ssg-docs does for a standalone one-operation page — DOC-6034. No
+    // configuration: the block assumes it is the page.
+    const wrapper = mountOperation(false)
+
+    expect(wrapper.find('h1').text()).toContain('Get user by ID')
+    expect(wrapper.find('h3').exists()).toBe(false)
+  })
+
+  it('is an h3 when composed into a full reference outline', () => {
+    const wrapper = mountOperation(true)
+
+    expect(wrapper.find('h3').text()).toContain('Get user by ID')
+    expect(wrapper.find('h1').exists()).toBe(false)
+  })
+})

--- a/packages/api-reference/src/features/document-outline/use-document-outline.test.ts
+++ b/packages/api-reference/src/features/document-outline/use-document-outline.test.ts
@@ -1,0 +1,139 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import { type OutlineRole, provideDocumentOutline, useDocumentOutline } from './use-document-outline'
+
+/** A block that renders the level it resolves, so a mount can assert on it. */
+const Block = defineComponent({
+  props: { role: { type: String as () => OutlineRole, required: true } },
+  setup(props, { slots }) {
+    const { level } = useDocumentOutline(props.role)
+    return () => h('div', [h(`h${level}`, String(level)), slots.default?.()])
+  },
+})
+
+/** A composer that anchors the outline, the way Content does. */
+const Composer = defineComponent({
+  props: { root: { type: String as () => OutlineRole, required: true } },
+  setup(props, { slots }) {
+    provideDocumentOutline(props.root)
+    return () => h('div', slots.default?.())
+  },
+})
+
+/** Level a block resolves to, optionally inside a composed outline. */
+const levelOf = (role: OutlineRole, root?: OutlineRole) => {
+  const block = h(Block, { role })
+  const wrapper = mount(
+    defineComponent({
+      setup: () => () => (root ? h(Composer, { root }, { default: () => [block] }) : block),
+    }),
+  )
+  return Number(wrapper.find('h1,h2,h3,h4,h5,h6').text())
+}
+
+describe('useDocumentOutline', () => {
+  describe('a block rendered on its own', () => {
+    // The default: a block assumes it is the page, so it is the h1. This is what
+    // makes a standalone operation page work with no configuration at all.
+    it.each(['document', 'tag', 'channel', 'modelGroup', 'operation', 'model', 'message'] as const)(
+      'resolves %s to h1',
+      (role) => {
+        expect(levelOf(role)).toBe(1)
+      },
+    )
+  })
+
+  describe('inside a document outline', () => {
+    // These are the levels the embedded reference renders today, so this is the
+    // regression guard for the full single-page reference.
+    it.each([
+      ['document', 1],
+      ['tag', 2],
+      ['channel', 2],
+      ['modelGroup', 2],
+      ['operation', 3],
+      ['model', 3],
+      ['message', 4],
+    ] as const)('resolves %s to h%i', (role, expected) => {
+      expect(levelOf(role, 'document')).toBe(expected)
+    })
+  })
+
+  it('keeps an untagged operation at the same level as a tagged one', () => {
+    // Level tracks the page hierarchy, not nesting — an operation is an
+    // operation whether or not a tag wraps it.
+    expect(levelOf('operation', 'document')).toBe(3)
+  })
+
+  it('nests beneath a block that anchors its own outline', () => {
+    // A standalone tag page: the tag is the h1 and its operations follow under
+    // it, without the page declaring anything.
+    const wrapper = mount(
+      defineComponent({
+        setup: () => () =>
+          h(
+            Block,
+            { role: 'tag' },
+            {
+              default: () => [h(Block, { role: 'operation' })],
+            },
+          ),
+      }),
+    )
+
+    expect(wrapper.find('h1').exists()).toBe(true)
+    expect(wrapper.find('h2').exists()).toBe(true)
+    expect(wrapper.find('h3').exists()).toBe(false)
+  })
+
+  it('leaves a nested tag at the same level as its parent tag', () => {
+    // Brynn's rule: nested tags stay h2, because level is the page hierarchy.
+    const wrapper = mount(
+      defineComponent({
+        setup: () => () =>
+          h(
+            Composer,
+            { root: 'document' },
+            {
+              default: () => [
+                h(
+                  Block,
+                  { role: 'tag' },
+                  {
+                    default: () => [h(Block, { role: 'tag' })],
+                  },
+                ),
+              ],
+            },
+          ),
+      }),
+    )
+
+    expect(wrapper.findAll('h2')).toHaveLength(2)
+    expect(wrapper.find('h3').exists()).toBe(false)
+  })
+
+  it('clamps rather than resolving below h1', () => {
+    expect(levelOf('document', 'message')).toBe(1)
+  })
+
+  it('reaches a block passed in as slot content', () => {
+    // The real shape — a composer wraps content it does not own.
+    const wrapper = mount(
+      defineComponent({
+        setup: () => () =>
+          h(
+            Composer,
+            { root: 'document' },
+            {
+              default: () => [h('section', [h(Block, { role: 'operation' })])],
+            },
+          ),
+      }),
+    )
+
+    expect(wrapper.find('h3').exists()).toBe(true)
+  })
+})

--- a/packages/api-reference/src/features/document-outline/use-document-outline.ts
+++ b/packages/api-reference/src/features/document-outline/use-document-outline.ts
@@ -1,0 +1,68 @@
+import { type InjectionKey, inject, provide } from 'vue'
+
+/**
+ * What a block is in the reference's page hierarchy.
+ *
+ * This is the *page* hierarchy, not the DOM. An operation is an `operation`
+ * whether or not a tag happens to wrap it, which is why levels cannot be
+ * derived from nesting depth.
+ */
+export type OutlineRole = 'document' | 'tag' | 'channel' | 'modelGroup' | 'operation' | 'model' | 'message'
+
+/** Valid heading levels, matching the tags `h1` through `h6`. */
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6
+
+/**
+ * The outline of a full reference, and the only place levels are written down.
+ *
+ * Each role appears exactly once: a role has one place in the hierarchy, so
+ * roles that sit alongside each other share a level.
+ */
+const OUTLINE: Record<OutlineRole, number> = {
+  document: 1,
+  tag: 2,
+  channel: 2,
+  modelGroup: 2,
+  operation: 3,
+  model: 3,
+  message: 4,
+}
+
+/** The role at the top of the current page. */
+const OUTLINE_ROOT: InjectionKey<OutlineRole> = Symbol('DOCUMENT_OUTLINE_ROOT')
+
+const clamp = (level: number): HeadingLevel => Math.min(6, Math.max(1, level)) as HeadingLevel
+
+/**
+ * Declare the role at the top of this page.
+ *
+ * Called by a component that renders two or more blocks alongside each other
+ * and therefore owns the relationship between them — `Content` renders the
+ * info block above the tags and operations, so it anchors the outline at
+ * `document` and everything below resolves against that.
+ *
+ * A block rendered on its own needs no call: it anchors itself.
+ */
+export const provideDocumentOutline = (role: OutlineRole) => provide(OUTLINE_ROOT, role)
+
+/**
+ * The heading level for a block's own heading.
+ *
+ * A block assumes it is the top of the page — rendered on its own it is the
+ * `h1`, and the blocks it contains follow beneath it. Rendering it inside a
+ * composed outline overrides that, so the same component is an `h3` in a full
+ * reference and an `h1` on a page that shows only that operation.
+ */
+export const useDocumentOutline = (role: OutlineRole) => {
+  const inherited = inject(OUTLINE_ROOT, null)
+
+  // Nothing above declared an outline, so this block is the top of the page and
+  // anchors one for whatever it renders beneath it.
+  if (!inherited) {
+    provide(OUTLINE_ROOT, role)
+  }
+
+  const root = inherited ?? role
+
+  return { level: clamp(OUTLINE[role] - OUTLINE[root] + 1) }
+}


### PR DESCRIPTION
Docs sites render one operation per page, so the title was coming out as an `h3` with no `h1` on the page at all. Blocks now resolve their own level instead of hardcoding one — rendered on its own a block is the `h1`, composed into a full reference nothing moves.

* New `useDocumentOutline` hook — a block declares its role, `Content` anchors the outline, the levels fall out
* Classic layout operation titles were a raw `h3` that skipped the heading components entirely
* Classic layout Models label passed `:level` to a component that doesn't take one, so it rendered no heading at all

No visual change — the themes reset already neutralizes UA heading sizing, so only the tag names move.

## Checklist
- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation