### PR TITLE
fix(mock-server): escape path keys and route query-string paths

### DIFF
--- a/.changeset/plenty-pugs-shave.md
+++ b/.changeset/plenty-pugs-shave.md
@@ -8,4 +8,4 @@ Path keys such as `/v1/messages?beta=true` used to be registered verbatim as rou
 
 Characters that would otherwise be read as routing syntax (`:`, `*`, `|`, and braces outside a path parameter) are escaped, so a path key can no longer act as a pattern. Note that this also applies to `*`: a path key ending in `*` is now served as a literal path instead of matching everything below it.
 
-One limitation is worth knowing: Hono allows a single parameter per path segment, so a segment that mixes a path parameter with escaped literal text (`/v1/jobs/{jobId}:cancel`) routes to the right operation but does not bind `jobId` by name. Request validation reads it as missing, so such an operation needs `validateRequest: false` for now.
+One limitation is worth knowing: Hono allows a single parameter per path segment, so a segment that mixes a path parameter with escaped literal text (`/v1/jobs/{jobId}:cancel`) routes to the right operation but does not bind `jobId` by name. Request validation reads it as missing, so a document describing such a path needs the server-wide `validateRequest: false` for now.

--- a/.changeset/plenty-pugs-shave.md
+++ b/.changeset/plenty-pugs-shave.md
@@ -6,4 +6,6 @@ fix: escape spec-derived path keys and route path keys that carry a query string
 
 Path keys such as `/v1/messages?beta=true` used to be registered verbatim as routes, where the query string was read as routing syntax. On a parameterized path that made the router compile an invalid regular expression and every single request failed with an empty `500`. The query is now peeled off and matched against the incoming request, so `/v1/messages?beta=true` answers only requests that send `beta=true` and `/v1/messages` keeps answering the rest.
 
-Characters that would otherwise be read as routing syntax (`:`, `*`, `?`, `|`, `{`, `}`) are escaped, so a path key can no longer act as a pattern. Note that this also applies to `*`: a path key ending in `*` is now served as a literal path instead of matching everything below it.
+Characters that would otherwise be read as routing syntax (`:`, `*`, `|`, and braces outside a path parameter) are escaped, so a path key can no longer act as a pattern. Note that this also applies to `*`: a path key ending in `*` is now served as a literal path instead of matching everything below it.
+
+One limitation is worth knowing: Hono allows a single parameter per path segment, so a segment that mixes a path parameter with escaped literal text (`/v1/jobs/{jobId}:cancel`) routes to the right operation but does not bind `jobId` by name. Request validation reads it as missing, so such an operation needs `validateRequest: false` for now.

--- a/.changeset/plenty-pugs-shave.md
+++ b/.changeset/plenty-pugs-shave.md
@@ -1,0 +1,7 @@
+---
+'@scalar/mock-server': patch
+---
+
+fix: escape spec-derived path keys and route path keys that carry a query string
+
+Path keys such as `/v1/messages?beta=true` used to be registered verbatim as routes, where the query string was read as routing syntax. On a parameterized path that made the router compile an invalid regular expression and every single request failed with an empty `500`. The query is now peeled off and matched against the incoming request, so `/v1/messages?beta=true` answers only requests that send `beta=true` and `/v1/messages` keeps answering the rest. Characters that would otherwise be read as routing syntax (`:`, `*`, `?`, `|`, `{`, `}`) are escaped, so a path key can no longer act as a pattern.

--- a/.changeset/plenty-pugs-shave.md
+++ b/.changeset/plenty-pugs-shave.md
@@ -4,4 +4,6 @@
 
 fix: escape spec-derived path keys and route path keys that carry a query string
 
-Path keys such as `/v1/messages?beta=true` used to be registered verbatim as routes, where the query string was read as routing syntax. On a parameterized path that made the router compile an invalid regular expression and every single request failed with an empty `500`. The query is now peeled off and matched against the incoming request, so `/v1/messages?beta=true` answers only requests that send `beta=true` and `/v1/messages` keeps answering the rest. Characters that would otherwise be read as routing syntax (`:`, `*`, `?`, `|`, `{`, `}`) are escaped, so a path key can no longer act as a pattern.
+Path keys such as `/v1/messages?beta=true` used to be registered verbatim as routes, where the query string was read as routing syntax. On a parameterized path that made the router compile an invalid regular expression and every single request failed with an empty `500`. The query is now peeled off and matched against the incoming request, so `/v1/messages?beta=true` answers only requests that send `beta=true` and `/v1/messages` keeps answering the rest.
+
+Characters that would otherwise be read as routing syntax (`:`, `*`, `?`, `|`, `{`, `}`) are escaped, so a path key can no longer act as a pattern. Note that this also applies to `*`: a path key ending in `*` is now served as a literal path instead of matching everything below it.

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -203,7 +203,7 @@ Both keys are routed. The variant answers only requests that actually send every
 
 Everything else in a path key is matched literally, so a path such as `/users:batchGet` or `/reports*` is served as written.
 
-A segment that mixes a path parameter with literal text of that kind (`/v1/jobs/{jobId}:cancel`) routes to the right operation, but `jobId` is not bound by name — a single path segment can only carry one parameter. Request validation reads it as missing, so give such an operation `validateRequest: false`.
+A segment that mixes a path parameter with literal text of that kind (`/v1/jobs/{jobId}:cancel`) routes to the right operation, but `jobId` is not bound by name — a single path segment can only carry one parameter. Request validation reads it as missing, so a document that describes such a path has to run the mock server with `validateRequest: false`, which turns validation off for every operation in it.
 
 ### Selecting responses
 

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -203,6 +203,8 @@ Both keys are routed. The variant answers only requests that actually send every
 
 Everything else in a path key is matched literally, so a path such as `/users:batchGet` or `/reports*` is served as written.
 
+A segment that mixes a path parameter with literal text of that kind (`/v1/jobs/{jobId}:cancel`) routes to the right operation, but `jobId` is not bound by name — a single path segment can only carry one parameter. Request validation reads it as missing, so give such an operation `validateRequest: false`.
+
 ### Selecting responses
 
 By default the mock server picks a response (and its status code) for you and returns the first example it can find. You can override both with the standard [`Prefer` header](https://www.rfc-editor.org/rfc/rfc7240), just like [Stoplight Prism](https://github.com/stoplightio/prism).

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -189,6 +189,20 @@ The given OpenAPI document is automatically exposed:
 
 - `/openapi.json` and `/openapi.yaml`
 
+### Path keys with a query string
+
+Some documents describe a variant of an operation by putting a query string in the path key:
+
+```yaml
+paths:
+  /v1/messages: …
+  /v1/messages?beta=true: …
+```
+
+Both keys are routed. The variant answers only requests that actually send every query parameter it pins (`?beta=true` here), and the plain key answers everything else. A key that pins a name without a value (`?beta`) matches any value.
+
+Everything else in a path key is matched literally, so a path such as `/users:batchGet` or `/reports*` is served as written.
+
 ### Selecting responses
 
 By default the mock server picks a response (and its status code) for you and returns the first example it can find. You can override both with the standard [`Prefer` header](https://www.rfc-editor.org/rfc/rfc7240), just like [Stoplight Prism](https://github.com/stoplightio/prism).

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -1756,6 +1756,33 @@ describe('createMockServer', () => {
     expect(await response.text()).toBe('I am a teapot')
   })
 
+  it('routes a path key whose segment mixes a parameter with literal text', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: { title: 'Hello World', version: '1.0.0' },
+      paths: {
+        '/v1/jobs/{jobId}:cancel': {
+          post: {
+            responses: { '200': { description: 'OK', content: { 'application/json': { example: { ok: true } } } } },
+          },
+        },
+        '/v1/jobs/{jobId}': {
+          get: {
+            responses: { '200': { description: 'OK', content: { 'application/json': { example: { ok: false } } } } },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    expect(await (await server.request('/v1/jobs/42:cancel', { method: 'POST' })).json()).toStrictEqual({ ok: true })
+
+    // Before the literal text was escaped this route was a plain parameter, so it answered any
+    // single segment — including one without the `:cancel` the operation is named for.
+    expect((await server.request('/v1/jobs/42', { method: 'POST' })).status).toBe(404)
+  })
+
   describe('path keys with a query string', () => {
     /** Build a document with a plain path key and a variant that pins `beta=true`. */
     const documentWithBetaVariant = (paths: string[]) => ({

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -1755,4 +1755,129 @@ describe('createMockServer', () => {
     expect(response.status).toBe(418)
     expect(await response.text()).toBe('I am a teapot')
   })
+
+  describe('path keys with a query string', () => {
+    /** Build a document with a plain path key and a variant that pins `beta=true`. */
+    const documentWithBetaVariant = (paths: string[]) => ({
+      openapi: '3.1.0',
+      info: {
+        title: 'Hello World',
+        version: '1.0.0',
+      },
+      paths: Object.fromEntries(
+        paths.map((path) => [
+          path,
+          {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: { 'application/json': { example: { path } } },
+                },
+              },
+            },
+          },
+        ]),
+      ),
+    })
+
+    it('routes the variant and the plain sibling independently', async () => {
+      const server = await createMockServer({
+        document: documentWithBetaVariant(['/v1/messages?beta=true', '/v1/messages']),
+      })
+
+      expect(await (await server.request('/v1/messages?beta=true')).json()).toStrictEqual({
+        path: '/v1/messages?beta=true',
+      })
+      expect(await (await server.request('/v1/messages')).json()).toStrictEqual({ path: '/v1/messages' })
+    })
+
+    it('routes the variant even when the plain sibling comes first in the document', async () => {
+      const server = await createMockServer({
+        document: documentWithBetaVariant(['/v1/messages', '/v1/messages?beta=true']),
+      })
+
+      expect(await (await server.request('/v1/messages?beta=true')).json()).toStrictEqual({
+        path: '/v1/messages?beta=true',
+      })
+    })
+
+    it('ignores a request that does not carry the pinned value', async () => {
+      const server = await createMockServer({ document: documentWithBetaVariant(['/v1/messages?beta=true']) })
+
+      expect((await server.request('/v1/messages?beta=false')).status).toBe(404)
+      expect((await server.request('/v1/messages')).status).toBe(404)
+      expect((await server.request('/v1/messages?beta=true')).status).toBe(200)
+    })
+
+    it('keeps the path parameters of a variant', async () => {
+      const document = {
+        openapi: '3.1.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        paths: {
+          '/v1/models/{model_id}?beta=true': {
+            get: {
+              parameters: [{ name: 'model_id', in: 'path', required: true, schema: { type: 'string' } }],
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: { 'application/json': { example: { beta: true } } },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      expect((await server.request('/v1/models/claude?beta=true')).status).toBe(200)
+    })
+
+    it('still runs authentication and validation for a variant', async () => {
+      const document = {
+        openapi: '3.1.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        components: {
+          securitySchemes: {
+            bearerAuth: { type: 'http', scheme: 'bearer' },
+          },
+        },
+        paths: {
+          '/v1/messages?beta=true': {
+            get: {
+              security: [{ bearerAuth: [] }],
+              parameters: [{ name: 'limit', in: 'query', required: true, schema: { type: 'integer' } }],
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: { 'application/json': { example: { beta: true } } },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      expect((await server.request('/v1/messages?beta=true&limit=1')).status).toBe(401)
+
+      const headers = { Authorization: 'Bearer super-secret-token' }
+
+      expect((await server.request('/v1/messages?beta=true', { headers })).status).toBe(422)
+      expect((await server.request('/v1/messages?beta=true&limit=1', { headers })).status).toBe(200)
+    })
+
+    it('answers requests for a document whose parameterized path keys carry a query string', async () => {
+      // Path keys like these used to make Hono compile an invalid regular expression, so every
+      // single request failed with an empty `500`.
+      const server = await createMockServer({
+        document: documentWithBetaVariant(['/a/{x}/b?q=1', '/a/{x}/b/{y}?q=1']),
+      })
+
+      expect((await server.request('/a/1/b?q=1')).status).toBe(200)
+      expect((await server.request('/a/1/b/2?q=1')).status).toBe(200)
+    })
+  })
 })

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -1834,6 +1834,33 @@ describe('createMockServer', () => {
       expect((await server.request('/v1/models/claude?beta=true')).status).toBe(200)
     })
 
+    it('leaves a literal path ahead of a parameterized one that pins a query', async () => {
+      const document = {
+        openapi: '3.1.0',
+        info: { title: 'Hello World', version: '1.0.0' },
+        paths: {
+          '/v1/messages': {
+            get: {
+              responses: {
+                '200': { description: 'OK', content: { 'application/json': { example: { via: 'literal' } } } },
+              },
+            },
+          },
+          '/v1/{anything}?beta=true': {
+            get: {
+              responses: {
+                '200': { description: 'OK', content: { 'application/json': { example: { via: 'catch-all' } } } },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      expect(await (await server.request('/v1/messages?beta=true')).json()).toStrictEqual({ via: 'literal' })
+    })
+
     it('still runs authentication and validation for a variant', async () => {
       const document = {
         openapi: '3.1.0',

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -1,6 +1,7 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { getResolvedRef, mergeSiblingReferences } from '@scalar/workspace-store/helpers/get-resolved-ref'
-import { type Context, Hono } from 'hono'
+import { type Context, Hono, type MiddlewareHandler } from 'hono'
+import { every } from 'hono/combine'
 import { cors } from 'hono/cors'
 
 import type { HttpMethod, MockServerOptions } from '@/types'
@@ -12,7 +13,9 @@ import { honoRouteFromPath } from '@/utils/hono-route-from-path'
 import { isAuthenticationRequired } from '@/utils/is-authentication-required'
 import { logAuthenticationInstructions } from '@/utils/log-authentication-instructions'
 import { processOpenApiDocument } from '@/utils/process-openapi-document'
+import { requestMatchesPinnedQuery } from '@/utils/request-matches-pinned-query'
 import { setUpAuthenticationRoutes } from '@/utils/set-up-authentication-routes'
+import { splitPathKey } from '@/utils/split-path-key'
 import { validateRequest } from '@/utils/validate-request'
 
 import { store } from './libs/store'
@@ -144,7 +147,16 @@ export async function createMockServer(configuration: MockServerOptions): Promis
   /** Paths specified in the OpenAPI document */
   const paths = schema?.paths ?? {}
 
-  Object.keys(paths).forEach((path) => {
+  // A path key may pin query parameters to describe a variant of an operation, for example
+  // `/v1/messages?beta=true` next to `/v1/messages`. Hono runs every matching route in registration
+  // order, so the variants have to come first — otherwise the plain sibling answers their requests
+  // too. More pinned parameters means a more specific key, and the sort is stable, so path keys that
+  // pin nothing keep their document order.
+  const pathKeys = Object.keys(paths)
+    .map((path) => ({ path, query: splitPathKey(path).query }))
+    .sort((a, b) => b.query.length - a.query.length)
+
+  pathKeys.forEach(({ path, query }) => {
     // A path item may itself be a `$ref`, so resolve it before reading its operations.
     const pathItem = getResolvedRef(paths[path])
     const methods = Object.keys(getOperations(pathItem)) as HttpMethod[]
@@ -166,7 +178,13 @@ export async function createMockServer(configuration: MockServerOptions): Promis
         ...(operation?.operationId ? { operationId: operation.operationId } : {}),
       }
 
-      app[method](route, async (c, next) => {
+      /** Middleware chain answering this operation, in the order it runs */
+      const handlers: MiddlewareHandler[] = []
+
+      // Runs first, so the error handler can name the operation even when validation fails. For a
+      // path key that pins a query it is part of the guarded chain below, so it only fires once the
+      // request actually matches the variant rather than for one that is handed on to the sibling.
+      handlers.push(async (c, next) => {
         setMockedOperation(c, mockedOperation)
         await next()
       })
@@ -177,13 +195,13 @@ export async function createMockServer(configuration: MockServerOptions): Promis
 
       // Check if authentication is required for this operation
       if (isAuthenticationRequired(effectiveSecurity)) {
-        app[method](route, handleAuthentication(schema, operation))
+        handlers.push(handleAuthentication(schema, operation))
       }
 
       // Notify the `onRequest` callback before validation runs, so it fires for every request —
       // including ones the validation middleware rejects with a `422`.
       if (configuration.onRequest) {
-        app[method](route, async (c, next) => {
+        handlers.push(async (c, next) => {
           configuration.onRequest?.({ context: c, operation })
           await next()
         })
@@ -193,7 +211,7 @@ export async function createMockServer(configuration: MockServerOptions): Promis
       // opt out with `validateRequest: false`). Runs after authentication but before the
       // mock handler. Validators are compiled once here, so there is no per-request recompilation.
       if (configuration.validateRequest !== false) {
-        app[method](route, validateRequest(operation, pathItem?.parameters))
+        handlers.push(validateRequest(operation, pathItem?.parameters))
       }
 
       // Check if operation has x-handler extension
@@ -203,10 +221,31 @@ export async function createMockServer(configuration: MockServerOptions): Promis
 
       // Route to appropriate handler
       if (hasHandler) {
-        app[method](route, (c) => mockHandlerResponse(c, operation))
+        handlers.push(async (c) => await mockHandlerResponse(c, operation))
       } else {
-        app[method](route, (c) => mockAnyResponse(c, operation))
+        handlers.push(async (c) => await mockAnyResponse(c, operation))
       }
+
+      if (query.length === 0) {
+        handlers.forEach((handler) => app[method](route, handler))
+
+        return
+      }
+
+      // The pinned query parameters are not part of the route, so they are checked here. A request
+      // that does not carry them is handed on to the next matching route — usually the sibling path
+      // key without the query string.
+      const operationChain = every(...handlers)
+
+      app[method](route, async (c, next) => {
+        if (!requestMatchesPinnedQuery(c, query)) {
+          await next()
+
+          return
+        }
+
+        await operationChain(c, next)
+      })
     })
   })
 

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -166,8 +166,10 @@ export async function createMockServer(configuration: MockServerOptions): Promis
     }
   })
 
-  // Only keys that share a path are reordered against each other. Everything else keeps its document
-  // order, so a literal path still wins over a parameterized one that happens to pin a query.
+  // Keys that share a path are grouped where the first of them appears and the most specific one
+  // leads the group; a key with a path of its own never moves. So a literal path keeps winning over
+  // a parameterized one that happens to pin a query, and the only keys that change places with
+  // anything unrelated are the variants of a path that is described more than once.
   const orderedPathKeys = [...pathKeys].sort(
     (a, b) =>
       (documentOrder.get(a.pathname) ?? 0) - (documentOrder.get(b.pathname) ?? 0) || b.query.length - a.query.length,

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -167,9 +167,11 @@ export async function createMockServer(configuration: MockServerOptions): Promis
   })
 
   // Keys that share a path are grouped where the first of them appears and the most specific one
-  // leads the group; a key with a path of its own never moves. So a literal path keeps winning over
-  // a parameterized one that happens to pin a query, and the only keys that change places with
-  // anything unrelated are the variants of a path that is described more than once.
+  // leads the group; a key with a path of its own never moves. So the only keys that change places
+  // with anything unrelated are the variants of a path that is described more than once. When two
+  // distinct paths overlap — a literal and a parameterized one that pins a query — neither is moved,
+  // so whichever the document declares first is matched first, the same as any pair of overlapping
+  // Hono routes.
   const orderedPathKeys = [...pathKeys].sort(
     (a, b) =>
       (documentOrder.get(a.pathname) ?? 0) - (documentOrder.get(b.pathname) ?? 0) || b.query.length - a.query.length,

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -149,14 +149,31 @@ export async function createMockServer(configuration: MockServerOptions): Promis
 
   // A path key may pin query parameters to describe a variant of an operation, for example
   // `/v1/messages?beta=true` next to `/v1/messages`. Hono runs every matching route in registration
-  // order, so the variants have to come first — otherwise the plain sibling answers their requests
-  // too. More pinned parameters means a more specific key, and the sort is stable, so path keys that
-  // pin nothing keep their document order.
-  const pathKeys = Object.keys(paths)
-    .map((path) => ({ path, query: splitPathKey(path).query }))
-    .sort((a, b) => b.query.length - a.query.length)
+  // order, so a variant has to come before the sibling it shares a path with — otherwise the sibling
+  // answers its requests too, and the more pinned parameters a key has the more specific it is.
+  const pathKeys = Object.keys(paths).map((path) => {
+    const { path: pathname, query } = splitPathKey(path)
 
-  pathKeys.forEach(({ path, query }) => {
+    return { path, pathname, query }
+  })
+
+  /** Where each path first shows up in the document, so its variants stay with it */
+  const documentOrder = new Map<string, number>()
+
+  pathKeys.forEach(({ pathname }, index) => {
+    if (!documentOrder.has(pathname)) {
+      documentOrder.set(pathname, index)
+    }
+  })
+
+  // Only keys that share a path are reordered against each other. Everything else keeps its document
+  // order, so a literal path still wins over a parameterized one that happens to pin a query.
+  const orderedPathKeys = [...pathKeys].sort(
+    (a, b) =>
+      (documentOrder.get(a.pathname) ?? 0) - (documentOrder.get(b.pathname) ?? 0) || b.query.length - a.query.length,
+  )
+
+  orderedPathKeys.forEach(({ path, query }) => {
     // A path item may itself be a `$ref`, so resolve it before reading its operations.
     const pathItem = getResolvedRef(paths[path])
     const methods = Object.keys(getOperations(pathItem)) as HttpMethod[]

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -11,6 +11,7 @@ import { collectSseEvents, isEventStreamContentType } from '@/utils/collect-sse-
 import { findPreferredResponseKey } from '@/utils/find-preferred-response-key'
 import { normalizeResponseBody } from '@/utils/normalize-response-body'
 import { parsePreferHeader } from '@/utils/parse-prefer-header'
+import { pathParameters } from '@/utils/path-parameters'
 import { selectResponseExample } from '@/utils/select-response-example'
 import { serializeResponseBody } from '@/utils/serialize-response-body'
 
@@ -92,7 +93,7 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
     responseSchema
       ? getExampleFromSchema(responseSchema, {
           emptyString: 'string',
-          variables: c.req.param(),
+          variables: pathParameters(c),
           mode: 'read',
         })
       : undefined

--- a/packages/mock-server/src/routes/mock-handler-response.ts
+++ b/packages/mock-server/src/routes/mock-handler-response.ts
@@ -9,6 +9,7 @@ import { buildHandlerContext } from '@/utils/build-handler-context'
 import { executeHandler } from '@/utils/execute-handler'
 import { normalizeResponseBody } from '@/utils/normalize-response-body'
 import { parsePreferHeader } from '@/utils/parse-prefer-header'
+import { pathParameters } from '@/utils/path-parameters'
 import { selectResponseExample } from '@/utils/select-response-example'
 
 /**
@@ -69,7 +70,7 @@ function getExampleFromResponse(
       ? normalizeResponseBody(
           getExampleFromSchema(responseSchema, {
             emptyString: 'string',
-            variables: c.req.param(),
+            variables: pathParameters(c),
             mode: 'read',
           }),
           responseSchema,

--- a/packages/mock-server/src/utils/build-handler-context.ts
+++ b/packages/mock-server/src/utils/build-handler-context.ts
@@ -8,6 +8,7 @@ import { accepts } from 'hono/accepts'
 
 import { store } from '../libs/store'
 import { normalizeResponseBody } from './normalize-response-body'
+import { pathParameters } from './path-parameters'
 import { type StoreOperationTracking, createStoreWrapper } from './store-wrapper'
 
 /**
@@ -83,7 +84,7 @@ function getExampleFromResponse(
       ? normalizeResponseBody(
           getExampleFromSchema(responseSchema, {
             emptyString: 'string',
-            variables: c.req.param(),
+            variables: pathParameters(c),
             mode: 'read',
           }),
           responseSchema,
@@ -138,7 +139,7 @@ export async function buildHandlerContext(
       faker,
       req: {
         body,
-        params: c.req.param(),
+        params: pathParameters(c),
         query: Object.fromEntries(new URL(c.req.url).searchParams.entries()),
         headers: Object.fromEntries(Object.entries(c.req.header()).map(([key, value]) => [key, value ?? ''])),
       },

--- a/packages/mock-server/src/utils/hono-route-from-path.test.ts
+++ b/packages/mock-server/src/utils/hono-route-from-path.test.ts
@@ -1,3 +1,4 @@
+import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 
 import { honoRouteFromPath } from './hono-route-from-path'
@@ -37,5 +38,74 @@ describe('honoRouteFromPath', () => {
 
   it('handles parameters with special naming patterns', () => {
     expect(honoRouteFromPath('/api/{api.version}/{user_id}')).toBe('/api/:api.version/:user_id')
+  })
+
+  it('drops the query string of a path key', () => {
+    expect(honoRouteFromPath('/v1/messages?beta=true')).toBe('/v1/messages')
+  })
+
+  it('drops the query string but keeps the path parameters', () => {
+    expect(honoRouteFromPath('/v1/models/{model_id}?beta=true')).toBe('/v1/models/:model_id')
+  })
+
+  it('leaves characters Hono treats as literal text alone', () => {
+    expect(honoRouteFromPath('/reports/{id}/summary+full')).toBe('/reports/:id/summary+full')
+  })
+
+  describe('escaping', () => {
+    it('matches a colon in a path key literally instead of as a parameter', async () => {
+      const app = new Hono()
+      app.get(honoRouteFromPath('/users:batchGet'), (c) => c.text('matched'))
+
+      expect((await app.request('/users:batchGet')).status).toBe(200)
+      expect((await app.request('/usersBatchGet')).status).toBe(404)
+    })
+
+    it('matches an asterisk in a path key literally instead of as a wildcard', async () => {
+      const app = new Hono()
+      app.get(honoRouteFromPath('/reports*'), (c) => c.text('matched'))
+
+      expect((await app.request('/reports*')).status).toBe(200)
+      expect((await app.request('/reports/2024')).status).toBe(404)
+    })
+
+    it('matches a plus in a path key literally instead of as a quantifier', async () => {
+      const app = new Hono()
+      app.get(honoRouteFromPath('/tags/summary+full'), (c) => c.text('matched'))
+
+      expect((await app.request('/tags/summary+full')).status).toBe(200)
+      expect((await app.request('/tags/summaryyy')).status).toBe(404)
+    })
+
+    it('matches a pipe in a path key literally instead of as an alternation', async () => {
+      const app = new Hono()
+      app.get(honoRouteFromPath('/reports/{id}/a|b'), (c) => c.text('matched'))
+
+      expect((await app.request('/reports/1/a|b')).status).toBe(200)
+      expect((await app.request('/reports/1/a')).status).toBe(404)
+    })
+
+    it('keeps a path parameter next to escaped literal text wildcard-free', async () => {
+      const app = new Hono()
+      app.get(honoRouteFromPath('/reports/{id}:cancel'), (c) => c.text('matched'))
+
+      expect((await app.request('/reports/1:cancel')).status).toBe(200)
+      expect((await app.request('/reports/1/2:cancel')).status).toBe(404)
+    })
+
+    it('routes a path key with a question mark without breaking its sibling', async () => {
+      // Two routes that used to make Hono's `RegExpRouter` compile an invalid regular expression and
+      // throw on the very first request.
+      const app = new Hono()
+      app.get(honoRouteFromPath('/a/{x}/b?q=1'), (c) => c.text('b'))
+      app.get(honoRouteFromPath('/a/{x}/b/{y}?q=1'), (c) => c.text('by'))
+
+      expect((await app.request('/a/1/b')).status).toBe(200)
+      expect((await app.request('/a/1/b/2')).status).toBe(200)
+    })
+
+    it('does not touch a path key Hono can route as written', () => {
+      expect(honoRouteFromPath('/users/{id}/posts')).toBe('/users/:id/posts')
+    })
   })
 })

--- a/packages/mock-server/src/utils/hono-route-from-path.test.ts
+++ b/packages/mock-server/src/utils/hono-route-from-path.test.ts
@@ -88,6 +88,25 @@ describe('honoRouteFromPath', () => {
       expect(performance.now() - start).toBeLessThan(1_000)
     })
 
+    it('routes a path key that ends in a slash behind an escaped segment', async () => {
+      // An empty segment has no literal text to turn into a pattern. Escaping it anyway produced an
+      // empty pattern, which Hono cannot parse — it then threw for every route on the server.
+      const app = new Hono()
+      app.get(honoRouteFromPath('/api/users:search/'), (c) => c.text('matched'))
+      app.get(honoRouteFromPath('/healthz'), (c) => c.text('healthy'))
+
+      expect(await (await app.request('/api/users:search/')).text()).toBe('matched')
+      expect(await (await app.request('/healthz')).text()).toBe('healthy')
+    })
+
+    it('accepts a parameter value that contains the delimiter behind it', async () => {
+      const app = new Hono()
+      app.get(honoRouteFromPath('/v1/{name}:cancel'), (c) => c.text('matched'))
+
+      expect((await app.request('/v1/a:b:cancel')).status).toBe(200)
+      expect((await app.request('/v1/a:b')).status).toBe(404)
+    })
+
     it('matches an asterisk in a path key literally instead of as a wildcard', async () => {
       const app = new Hono()
       app.get(honoRouteFromPath('/reports*'), (c) => c.text('matched'))

--- a/packages/mock-server/src/utils/hono-route-from-path.test.ts
+++ b/packages/mock-server/src/utils/hono-route-from-path.test.ts
@@ -54,11 +54,38 @@ describe('honoRouteFromPath', () => {
 
   describe('escaping', () => {
     it('matches a colon in a path key literally instead of as a parameter', async () => {
+      // The sibling route keeps Hono from serving the key as a static path, which is what used to
+      // hide the colon being read as a parameter.
       const app = new Hono()
-      app.get(honoRouteFromPath('/users:batchGet'), (c) => c.text('matched'))
+      app.get(honoRouteFromPath('/{id}/users:batchGet'), (c) => c.text('matched'))
+      app.get(honoRouteFromPath('/{id}/users'), (c) => c.text('sibling'))
 
-      expect((await app.request('/users:batchGet')).status).toBe(200)
-      expect((await app.request('/usersBatchGet')).status).toBe(404)
+      expect((await app.request('/1/users:batchGet')).status).toBe(200)
+      expect((await app.request('/1/usersBatchGet')).status).toBe(404)
+    })
+
+    it('escapes the segments behind an escaped one', async () => {
+      // Hono splices the segment behind a pattern into a lookahead without escaping it, so an
+      // unbalanced bracket further down the path used to break every request the router handled.
+      const app = new Hono()
+      app.get(honoRouteFromPath('/users:batchGet/x)'), (c) => c.text('matched'))
+      app.get(honoRouteFromPath('/users/{id}'), (c) => c.text('sibling'))
+
+      expect(await (await app.request('/users:batchGet/x)')).text()).toBe('matched')
+      expect(await (await app.request('/users/1')).text()).toBe('sibling')
+      expect((await app.request('/anything')).status).toBe(404)
+    })
+
+    it('matches a request against an escaped segment without backtracking', async () => {
+      // An OpenAPI document is untrusted input: a pattern built from several greedy groups would
+      // backtrack exponentially on a crafted request and block the event loop.
+      const app = new Hono()
+      app.get(honoRouteFromPath('/{a}:{b}:{c}:{d}:{e}:{f}:{g}:{h}:END'), (c) => c.text('matched'))
+
+      const start = performance.now()
+
+      expect((await app.request(`/${Array.from({ length: 60 }, () => 'aa').join(':')}:NOPE`)).status).toBe(404)
+      expect(performance.now() - start).toBeLessThan(1_000)
     })
 
     it('matches an asterisk in a path key literally instead of as a wildcard', async () => {
@@ -69,14 +96,6 @@ describe('honoRouteFromPath', () => {
       expect((await app.request('/reports/2024')).status).toBe(404)
     })
 
-    it('matches a plus in a path key literally instead of as a quantifier', async () => {
-      const app = new Hono()
-      app.get(honoRouteFromPath('/tags/summary+full'), (c) => c.text('matched'))
-
-      expect((await app.request('/tags/summary+full')).status).toBe(200)
-      expect((await app.request('/tags/summaryyy')).status).toBe(404)
-    })
-
     it('matches a pipe in a path key literally instead of as an alternation', async () => {
       const app = new Hono()
       app.get(honoRouteFromPath('/reports/{id}/a|b'), (c) => c.text('matched'))
@@ -85,11 +104,12 @@ describe('honoRouteFromPath', () => {
       expect((await app.request('/reports/1/a')).status).toBe(404)
     })
 
-    it('keeps a path parameter next to escaped literal text wildcard-free', async () => {
+    it('matches a segment that mixes a path parameter with escaped literal text', async () => {
       const app = new Hono()
       app.get(honoRouteFromPath('/reports/{id}:cancel'), (c) => c.text('matched'))
 
       expect((await app.request('/reports/1:cancel')).status).toBe(200)
+      expect((await app.request('/reports/1')).status).toBe(404)
       expect((await app.request('/reports/1/2:cancel')).status).toBe(404)
     })
 
@@ -102,10 +122,6 @@ describe('honoRouteFromPath', () => {
 
       expect((await app.request('/a/1/b')).status).toBe(200)
       expect((await app.request('/a/1/b/2')).status).toBe(200)
-    })
-
-    it('does not touch a path key Hono can route as written', () => {
-      expect(honoRouteFromPath('/users/{id}/posts')).toBe('/users/:id/posts')
     })
   })
 })

--- a/packages/mock-server/src/utils/hono-route-from-path.ts
+++ b/packages/mock-server/src/utils/hono-route-from-path.ts
@@ -1,7 +1,4 @@
-import { splitPathKey } from '@/utils/split-path-key'
-
-/** Matches a `{parameterName}` template inside a path key. */
-const TEMPLATE_PARAMETER = /\{([^{}]+)\}/g
+import { PATH_KEY_TEMPLATE, splitPathKey } from '@/utils/split-path-key'
 
 /**
  * Characters Hono reads as routing syntax instead of as literal path text.
@@ -15,7 +12,7 @@ const TEMPLATE_PARAMETER = /\{([^{}]+)\}/g
 const HONO_ROUTING_CHARACTERS = /[:*?|{}]/
 
 /** Prefix for the parameters we synthesize to match a literal path segment verbatim. */
-const LITERAL_PARAMETER_PREFIX = '__scalar_literal_'
+export const LITERAL_PARAMETER_PREFIX = '__scalar_literal_'
 
 /**
  * Escape a literal for use inside the regular expression of a Hono `:name{pattern}` parameter.
@@ -35,24 +32,48 @@ const escapeRegExpLiteral = (value: string): string =>
 /**
  * Build a regular expression that matches a path segment verbatim.
  *
- * Templates match anything but a slash, everything else is escaped. Splitting on a regular
- * expression with a capturing group interleaves literals and parameter names, so every odd entry is
- * a template.
+ * Literal text is escaped and a template matches anything but a slash. A template also excludes the
+ * character the literal behind it starts with, which keeps the match unambiguous: an OpenAPI
+ * document is untrusted input, and a pattern made of several plain `[^/]+` groups backtracks
+ * exponentially on a crafted request, which would block the event loop of the whole server.
  */
-const patternFromSegment = (segment: string): string =>
-  segment
-    .split(TEMPLATE_PARAMETER)
-    .map((part, index) => (index % 2 === 1 ? '[^/]+' : escapeRegExpLiteral(part)))
-    .join('')
+const patternFromSegment = (segment: string): string => {
+  // Splitting on a regular expression with a capturing group interleaves literals and parameter
+  // names, so every odd entry is a template and the list always begins and ends with a literal.
+  const parts = segment.split(PATH_KEY_TEMPLATE)
+
+  let pattern = ''
+
+  for (let index = 0; index < parts.length; index++) {
+    if (index % 2 === 0) {
+      pattern += escapeRegExpLiteral(parts[index] ?? '')
+      continue
+    }
+
+    const followingLiteral = parts[index + 1] ?? ''
+
+    // Templates with nothing between them cannot be told apart, so they match as a single group.
+    if (followingLiteral === '' && index + 2 < parts.length) {
+      continue
+    }
+
+    pattern += `[^/${escapeRegExpLiteral(followingLiteral.slice(0, 1))}]+`
+  }
+
+  return pattern
+}
 
 /**
  * Convert an OpenAPI path key into a Hono route.
  *
  * Example: `/posts/{id}` → `/posts/:id`
  *
- * A segment whose literal text would be read as routing syntax is registered as a parameter with an
- * explicit pattern instead, because that is the only way to make Hono match it verbatim. Such a
- * segment gives up its parameter names, which is a fair trade for routing the request at all.
+ * A segment whose literal text would be read as routing syntax is registered as a single parameter
+ * with an explicit pattern instead, because Hono allows only one parameter per segment and that is
+ * the only way to make it match such a segment verbatim. The request then routes to the right
+ * operation, but the path parameters of that one segment are no longer bound by name: they surface
+ * as the synthesized parameter, and a required path parameter in it reads as missing to request
+ * validation. Hono cannot express both at once, and matching the wrong operation is worse.
  *
  * A query string in the key (`/v1/messages?beta=true`) is dropped here — it is matched against the
  * incoming request separately, see `splitPathKey`.
@@ -60,20 +81,32 @@ const patternFromSegment = (segment: string): string =>
 export function honoRouteFromPath(path: string): string {
   const { path: pathname } = splitPathKey(path)
 
+  const route: string[] = []
+
   let literalIndex = 0
+  let previousIsPattern: boolean = false
 
-  return pathname
-    .split('/')
-    .map((segment) => {
-      // Check the literal text and the parameter names, but not the braces around them — the `:` we
-      // generate for a template is meant to be routing syntax, a `?` in a parameter name is not.
-      const routeText = segment.replace(TEMPLATE_PARAMETER, '$1')
+  for (const segment of pathname.split('/')) {
+    // Check the literal text and the parameter names, but not the braces around them — the `:` we
+    // generate for a template is meant to be routing syntax, a `?` in a parameter name is not.
+    const routeText = segment.replace(PATH_KEY_TEMPLATE, '$1')
+    const plainSegment = segment.replace(PATH_KEY_TEMPLATE, ':$1')
 
-      if (!HONO_ROUTING_CHARACTERS.test(routeText)) {
-        return segment.replace(TEMPLATE_PARAMETER, ':$1')
-      }
+    // Hono splices the segment that follows a pattern into a lookahead without escaping it, unless
+    // that segment is a parameter itself. So once one segment is a pattern, every segment behind it
+    // has to be one too — otherwise a regular expression metacharacter further down the path makes
+    // the router throw on every request.
+    const needsPattern: boolean =
+      HONO_ROUTING_CHARACTERS.test(routeText) || (previousIsPattern && !plainSegment.startsWith(':'))
 
-      return `:${LITERAL_PARAMETER_PREFIX}${literalIndex++}{${patternFromSegment(segment)}}`
-    })
-    .join('/')
+    if (needsPattern) {
+      route.push(`:${LITERAL_PARAMETER_PREFIX}${literalIndex++}{${patternFromSegment(segment)}}`)
+    } else {
+      route.push(plainSegment)
+    }
+
+    previousIsPattern = needsPattern
+  }
+
+  return route.join('/')
 }

--- a/packages/mock-server/src/utils/hono-route-from-path.ts
+++ b/packages/mock-server/src/utils/hono-route-from-path.ts
@@ -86,7 +86,7 @@ const patternFromSegment = (segment: string): string => {
  * A query string in the key (`/v1/messages?beta=true`) is dropped here — it is matched against the
  * incoming request separately, see `splitPathKey`.
  */
-export function honoRouteFromPath(path: string): string {
+export const honoRouteFromPath = (path: string): string => {
   const { path: pathname } = splitPathKey(path)
 
   const route: string[] = []

--- a/packages/mock-server/src/utils/hono-route-from-path.ts
+++ b/packages/mock-server/src/utils/hono-route-from-path.ts
@@ -32,15 +32,21 @@ const escapeRegExpLiteral = (value: string): string =>
 /**
  * Build a regular expression that matches a path segment verbatim.
  *
- * Literal text is escaped and a template matches anything but a slash. A template also excludes the
- * character the literal behind it starts with, which keeps the match unambiguous: an OpenAPI
- * document is untrusted input, and a pattern made of several plain `[^/]+` groups backtracks
- * exponentially on a crafted request, which would block the event loop of the whole server.
+ * Literal text is escaped and a template matches anything but a slash. Every template except the
+ * last one also excludes the character the literal behind it starts with, so its match has exactly
+ * one possible end and the engine never has to search: an OpenAPI document is untrusted input, and a
+ * segment made of several plain `[^/]+` groups backtracks exponentially on a crafted request, which
+ * would block the event loop of the whole server. The last template stays greedy, so the common
+ * `{name}:cancel` shape still accepts a value that contains the delimiter.
  */
 const patternFromSegment = (segment: string): string => {
   // Splitting on a regular expression with a capturing group interleaves literals and parameter
   // names, so every odd entry is a template and the list always begins and ends with a literal.
   const parts = segment.split(PATH_KEY_TEMPLATE)
+
+  // The split always yields `2n + 1` entries for `n` templates, so the last template sits two
+  // entries from the end — and at `-1` when the segment carries no template at all.
+  const lastTemplate = parts.length - 2
 
   let pattern = ''
 
@@ -53,11 +59,13 @@ const patternFromSegment = (segment: string): string => {
     const followingLiteral = parts[index + 1] ?? ''
 
     // Templates with nothing between them cannot be told apart, so they match as a single group.
-    if (followingLiteral === '' && index + 2 < parts.length) {
+    if (followingLiteral === '' && index !== lastTemplate) {
       continue
     }
 
-    pattern += `[^/${escapeRegExpLiteral(followingLiteral.slice(0, 1))}]+`
+    const delimiter = index === lastTemplate ? '' : escapeRegExpLiteral(followingLiteral.slice(0, 1))
+
+    pattern += `[^/${delimiter}]+`
   }
 
   return pattern
@@ -95,9 +103,11 @@ export function honoRouteFromPath(path: string): string {
     // Hono splices the segment that follows a pattern into a lookahead without escaping it, unless
     // that segment is a parameter itself. So once one segment is a pattern, every segment behind it
     // has to be one too — otherwise a regular expression metacharacter further down the path makes
-    // the router throw on every request.
+    // the router throw on every request. An empty segment (a trailing slash, or `//`) is exempt:
+    // Hono skips the lookahead for it, and it has no literal text to turn into a pattern.
     const needsPattern: boolean =
-      HONO_ROUTING_CHARACTERS.test(routeText) || (previousIsPattern && !plainSegment.startsWith(':'))
+      HONO_ROUTING_CHARACTERS.test(routeText) ||
+      (previousIsPattern && plainSegment !== '' && !plainSegment.startsWith(':'))
 
     if (needsPattern) {
       route.push(`:${LITERAL_PARAMETER_PREFIX}${literalIndex++}{${patternFromSegment(segment)}}`)

--- a/packages/mock-server/src/utils/hono-route-from-path.ts
+++ b/packages/mock-server/src/utils/hono-route-from-path.ts
@@ -1,7 +1,79 @@
+import { splitPathKey } from '@/utils/split-path-key'
+
+/** Matches a `{parameterName}` template inside a path key. */
+const TEMPLATE_PARAMETER = /\{([^{}]+)\}/g
+
 /**
- * Convert path to route
- * Example: /posts/{id} -> /posts/:id
+ * Characters Hono reads as routing syntax instead of as literal path text.
+ *
+ * `:` starts a path parameter and `*` is a wildcard. The remaining ones end up verbatim in the
+ * regular expression that Hono's `RegExpRouter` compiles, where they act as quantifier (`?`),
+ * alternation (`|`) and pattern delimiters (`{`, `}`) — a path key containing them either routes
+ * the wrong requests or makes the router throw. Hono escapes the other regular expression
+ * metacharacters (`.`, `+`, `(`, `[`, …) itself.
  */
-export function honoRouteFromPath(path: string) {
-  return path.replace(/{/g, ':').replace(/}/g, '')
+const HONO_ROUTING_CHARACTERS = /[:*?|{}]/
+
+/** Prefix for the parameters we synthesize to match a literal path segment verbatim. */
+const LITERAL_PARAMETER_PREFIX = '__scalar_literal_'
+
+/**
+ * Escape a literal for use inside the regular expression of a Hono `:name{pattern}` parameter.
+ *
+ * Every non-alphanumeric ASCII character becomes a `\xHH` escape. That keeps regular expression
+ * metacharacters inert and — just as importantly — keeps `{` and `}` out of the pattern, which Hono
+ * uses to delimit it. Non-ASCII characters carry no regular expression meaning and are left alone,
+ * because `\xHH` cannot express them.
+ */
+const escapeRegExpLiteral = (value: string): string =>
+  value.replace(/[^A-Za-z0-9]/g, (character) => {
+    const code = character.charCodeAt(0)
+
+    return code < 128 ? `\\x${code.toString(16).padStart(2, '0')}` : character
+  })
+
+/**
+ * Build a regular expression that matches a path segment verbatim.
+ *
+ * Templates match anything but a slash, everything else is escaped. Splitting on a regular
+ * expression with a capturing group interleaves literals and parameter names, so every odd entry is
+ * a template.
+ */
+const patternFromSegment = (segment: string): string =>
+  segment
+    .split(TEMPLATE_PARAMETER)
+    .map((part, index) => (index % 2 === 1 ? '[^/]+' : escapeRegExpLiteral(part)))
+    .join('')
+
+/**
+ * Convert an OpenAPI path key into a Hono route.
+ *
+ * Example: `/posts/{id}` → `/posts/:id`
+ *
+ * A segment whose literal text would be read as routing syntax is registered as a parameter with an
+ * explicit pattern instead, because that is the only way to make Hono match it verbatim. Such a
+ * segment gives up its parameter names, which is a fair trade for routing the request at all.
+ *
+ * A query string in the key (`/v1/messages?beta=true`) is dropped here — it is matched against the
+ * incoming request separately, see `splitPathKey`.
+ */
+export function honoRouteFromPath(path: string): string {
+  const { path: pathname } = splitPathKey(path)
+
+  let literalIndex = 0
+
+  return pathname
+    .split('/')
+    .map((segment) => {
+      // Check the literal text and the parameter names, but not the braces around them — the `:` we
+      // generate for a template is meant to be routing syntax, a `?` in a parameter name is not.
+      const routeText = segment.replace(TEMPLATE_PARAMETER, '$1')
+
+      if (!HONO_ROUTING_CHARACTERS.test(routeText)) {
+        return segment.replace(TEMPLATE_PARAMETER, ':$1')
+      }
+
+      return `:${LITERAL_PARAMETER_PREFIX}${literalIndex++}{${patternFromSegment(segment)}}`
+    })
+    .join('/')
 }

--- a/packages/mock-server/src/utils/path-parameters.test.ts
+++ b/packages/mock-server/src/utils/path-parameters.test.ts
@@ -1,0 +1,36 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+
+import { honoRouteFromPath } from './hono-route-from-path'
+import { pathParameters } from './path-parameters'
+
+/** Register a path key and report the parameters a request to it exposes. */
+const parametersFor = async (pathKey: string, requestPath: string): Promise<Record<string, string>> => {
+  const app = new Hono()
+  app.get(honoRouteFromPath(pathKey), (c) => c.json(pathParameters(c)))
+
+  return await (await app.request(requestPath)).json()
+}
+
+describe('pathParameters', () => {
+  it('returns the declared path parameters', async () => {
+    expect(await parametersFor('/users/{userId}/posts/{postId}', '/users/1/posts/2')).toStrictEqual({
+      userId: '1',
+      postId: '2',
+    })
+  })
+
+  it('returns nothing for a path without parameters', async () => {
+    expect(await parametersFor('/users', '/users')).toStrictEqual({})
+  })
+
+  it('hides the parameter synthesized for an escaped segment', async () => {
+    expect(await parametersFor('/{id}/users:batchGet', '/1/users:batchGet')).toStrictEqual({ id: '1' })
+  })
+
+  it('keeps a declared parameter that is named like a synthesized one', async () => {
+    expect(await parametersFor('/a/{__scalar_literal_0}', '/a/hello')).toStrictEqual({
+      __scalar_literal_0: 'hello',
+    })
+  })
+})

--- a/packages/mock-server/src/utils/path-parameters.ts
+++ b/packages/mock-server/src/utils/path-parameters.ts
@@ -2,15 +2,21 @@ import type { Context } from 'hono'
 
 import { LITERAL_PARAMETER_PREFIX } from '@/utils/hono-route-from-path'
 
+/** Matches the parameters `honoRouteFromPath` synthesizes, which always carry an explicit pattern. */
+const synthesizedParameter = new RegExp(`:(${LITERAL_PARAMETER_PREFIX}\\d+)\\{`, 'g')
+
 /**
  * Read the path parameters of a request, without the ones synthesized for routing.
  *
  * A path segment Hono cannot match as written is registered as a parameter with a generated name
  * (see `honoRouteFromPath`). That name is an implementation detail, so it has no business showing up
  * in an `x-handler` context or among the variables a mocked response body is generated from.
+ *
+ * The names are read back off the matched route rather than recognized by their prefix, so a
+ * document that happens to declare a parameter of the same name keeps it.
  */
-export function pathParameters(context: Context): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(context.req.param()).filter(([name]) => !name.startsWith(LITERAL_PARAMETER_PREFIX)),
-  )
+export const pathParameters = (context: Context): Record<string, string> => {
+  const synthesized = new Set([...context.req.routePath.matchAll(synthesizedParameter)].map(([, name]) => name))
+
+  return Object.fromEntries(Object.entries(context.req.param()).filter(([name]) => !synthesized.has(name)))
 }

--- a/packages/mock-server/src/utils/path-parameters.ts
+++ b/packages/mock-server/src/utils/path-parameters.ts
@@ -1,0 +1,16 @@
+import type { Context } from 'hono'
+
+import { LITERAL_PARAMETER_PREFIX } from '@/utils/hono-route-from-path'
+
+/**
+ * Read the path parameters of a request, without the ones synthesized for routing.
+ *
+ * A path segment Hono cannot match as written is registered as a parameter with a generated name
+ * (see `honoRouteFromPath`). That name is an implementation detail, so it has no business showing up
+ * in an `x-handler` context or among the variables a mocked response body is generated from.
+ */
+export function pathParameters(context: Context): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(context.req.param()).filter(([name]) => !name.startsWith(LITERAL_PARAMETER_PREFIX)),
+  )
+}

--- a/packages/mock-server/src/utils/request-matches-pinned-query.test.ts
+++ b/packages/mock-server/src/utils/request-matches-pinned-query.test.ts
@@ -1,0 +1,71 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+
+import { requestMatchesPinnedQuery } from './request-matches-pinned-query'
+import type { PinnedQueryParameter } from './split-path-key'
+
+/** Run the predicate against a request, so it sees a real Hono context. */
+const matches = async (url: string, query: PinnedQueryParameter[]): Promise<boolean> => {
+  const app = new Hono()
+
+  let result: boolean | undefined
+  app.get('/*', (c) => {
+    result = requestMatchesPinnedQuery(c, query)
+
+    return c.text('')
+  })
+
+  await app.request(url)
+
+  return result ?? false
+}
+
+describe('requestMatchesPinnedQuery', () => {
+  it('matches when nothing is pinned', async () => {
+    expect(await matches('/v1/messages', [])).toBe(true)
+  })
+
+  it('matches a pinned name and value', async () => {
+    expect(await matches('/v1/messages?beta=true', [{ name: 'beta', value: 'true' }])).toBe(true)
+  })
+
+  it('rejects a different value', async () => {
+    expect(await matches('/v1/messages?beta=false', [{ name: 'beta', value: 'true' }])).toBe(false)
+  })
+
+  it('rejects a missing parameter', async () => {
+    expect(await matches('/v1/messages', [{ name: 'beta', value: 'true' }])).toBe(false)
+  })
+
+  it('matches any value when only the name is pinned', async () => {
+    expect(await matches('/v1/messages?beta=whatever', [{ name: 'beta', value: undefined }])).toBe(true)
+    expect(await matches('/v1/messages?beta', [{ name: 'beta', value: undefined }])).toBe(true)
+  })
+
+  it('matches when one of the repeated values is the pinned one', async () => {
+    expect(await matches('/v1/messages?beta=false&beta=true', [{ name: 'beta', value: 'true' }])).toBe(true)
+  })
+
+  it('requires every pinned parameter', async () => {
+    const query = [
+      { name: 'beta', value: 'true' },
+      { name: 'version', value: '2' },
+    ]
+
+    expect(await matches('/v1/messages?beta=true&version=2', query)).toBe(true)
+    expect(await matches('/v1/messages?beta=true', query)).toBe(false)
+  })
+
+  it('ignores extra query parameters', async () => {
+    expect(await matches('/v1/messages?beta=true&extra=1', [{ name: 'beta', value: 'true' }])).toBe(true)
+  })
+
+  it('compares names and values case-sensitively', async () => {
+    expect(await matches('/v1/messages?Beta=true', [{ name: 'beta', value: 'true' }])).toBe(false)
+    expect(await matches('/v1/messages?beta=TRUE', [{ name: 'beta', value: 'true' }])).toBe(false)
+  })
+
+  it('matches a percent-encoded value', async () => {
+    expect(await matches('/v1/messages?q=hello%20world', [{ name: 'q', value: 'hello world' }])).toBe(true)
+  })
+})

--- a/packages/mock-server/src/utils/request-matches-pinned-query.ts
+++ b/packages/mock-server/src/utils/request-matches-pinned-query.ts
@@ -1,0 +1,21 @@
+import type { Context } from 'hono'
+
+import type { PinnedQueryParameter } from '@/utils/split-path-key'
+
+/**
+ * Check whether a request carries every query parameter a path key pins.
+ *
+ * `/v1/messages?beta=true` describes a variant of `/v1/messages`, so it may only answer requests
+ * that actually send `beta=true`. A parameter pinned without a value (`?beta`) matches any value.
+ */
+export function requestMatchesPinnedQuery(context: Context, query: PinnedQueryParameter[]): boolean {
+  return query.every(({ name, value }) => {
+    const values = context.req.queries(name)
+
+    if (!values?.length) {
+      return false
+    }
+
+    return value === undefined || values.includes(value)
+  })
+}

--- a/packages/mock-server/src/utils/request-matches-pinned-query.ts
+++ b/packages/mock-server/src/utils/request-matches-pinned-query.ts
@@ -8,8 +8,8 @@ import type { PinnedQueryParameter } from '@/utils/split-path-key'
  * `/v1/messages?beta=true` describes a variant of `/v1/messages`, so it may only answer requests
  * that actually send `beta=true`. A parameter pinned without a value (`?beta`) matches any value.
  */
-export function requestMatchesPinnedQuery(context: Context, query: PinnedQueryParameter[]): boolean {
-  return query.every(({ name, value }) => {
+export const requestMatchesPinnedQuery = (context: Context, query: PinnedQueryParameter[]): boolean =>
+  query.every(({ name, value }) => {
     const values = context.req.queries(name)
 
     if (!values?.length) {
@@ -18,4 +18,3 @@ export function requestMatchesPinnedQuery(context: Context, query: PinnedQueryPa
 
     return value === undefined || values.includes(value)
   })
-}

--- a/packages/mock-server/src/utils/split-path-key.test.ts
+++ b/packages/mock-server/src/utils/split-path-key.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { splitPathKey } from './split-path-key'
+
+describe('splitPathKey', () => {
+  it('returns the path unchanged when there is no query string', () => {
+    expect(splitPathKey('/v1/messages')).toEqual({ path: '/v1/messages', query: [] })
+  })
+
+  it('splits a pinned query parameter off the path', () => {
+    expect(splitPathKey('/v1/messages?beta=true')).toEqual({
+      path: '/v1/messages',
+      query: [{ name: 'beta', value: 'true' }],
+    })
+  })
+
+  it('splits multiple pinned query parameters', () => {
+    expect(splitPathKey('/v1/messages?beta=true&version=2')).toEqual({
+      path: '/v1/messages',
+      query: [
+        { name: 'beta', value: 'true' },
+        { name: 'version', value: '2' },
+      ],
+    })
+  })
+
+  it('pins the name only when the key carries no value', () => {
+    expect(splitPathKey('/v1/messages?beta')).toEqual({
+      path: '/v1/messages',
+      query: [{ name: 'beta', value: undefined }],
+    })
+  })
+
+  it('keeps an empty value distinct from a missing one', () => {
+    expect(splitPathKey('/v1/messages?beta=')).toEqual({
+      path: '/v1/messages',
+      query: [{ name: 'beta', value: '' }],
+    })
+  })
+
+  it('keeps path parameters in the path portion', () => {
+    expect(splitPathKey('/v1/models/{model_id}?beta=true')).toEqual({
+      path: '/v1/models/{model_id}',
+      query: [{ name: 'beta', value: 'true' }],
+    })
+  })
+
+  it('ignores a question mark inside a path parameter', () => {
+    expect(splitPathKey('/v1/models/{model?id}')).toEqual({ path: '/v1/models/{model?id}', query: [] })
+  })
+
+  it('splits at the first question mark only', () => {
+    expect(splitPathKey('/search?q=a?b')).toEqual({ path: '/search', query: [{ name: 'q', value: 'a?b' }] })
+  })
+
+  it('decodes percent-encoded names and values', () => {
+    expect(splitPathKey('/search?a%20b=c%20d')).toEqual({ path: '/search', query: [{ name: 'a b', value: 'c d' }] })
+  })
+
+  it('decodes a plus as a space', () => {
+    expect(splitPathKey('/search?q=hello+world')).toEqual({
+      path: '/search',
+      query: [{ name: 'q', value: 'hello world' }],
+    })
+  })
+
+  it('keeps a malformed escape sequence verbatim', () => {
+    expect(splitPathKey('/search?q=100%')).toEqual({ path: '/search', query: [{ name: 'q', value: '100%' }] })
+  })
+
+  it('drops empty pairs', () => {
+    expect(splitPathKey('/search?&beta=true&')).toEqual({ path: '/search', query: [{ name: 'beta', value: 'true' }] })
+  })
+
+  it('returns an empty query for a trailing question mark', () => {
+    expect(splitPathKey('/search?')).toEqual({ path: '/search', query: [] })
+  })
+})

--- a/packages/mock-server/src/utils/split-path-key.test.ts
+++ b/packages/mock-server/src/utils/split-path-key.test.ts
@@ -49,6 +49,13 @@ describe('splitPathKey', () => {
     expect(splitPathKey('/v1/models/{model?id}')).toEqual({ path: '/v1/models/{model?id}', query: [] })
   })
 
+  it('treats an unbalanced brace as literal text rather than an open template', () => {
+    expect(splitPathKey('/v4/i{j?beta=true')).toEqual({
+      path: '/v4/i{j',
+      query: [{ name: 'beta', value: 'true' }],
+    })
+  })
+
   it('splits at the first question mark only', () => {
     expect(splitPathKey('/search?q=a?b')).toEqual({ path: '/search', query: [{ name: 'q', value: 'a?b' }] })
   })

--- a/packages/mock-server/src/utils/split-path-key.test.ts
+++ b/packages/mock-server/src/utils/split-path-key.test.ts
@@ -56,6 +56,13 @@ describe('splitPathKey', () => {
     })
   })
 
+  it('pins the name only when the value is a template', () => {
+    expect(splitPathKey('/pets/findByStatus?status={status}')).toEqual({
+      path: '/pets/findByStatus',
+      query: [{ name: 'status', value: undefined }],
+    })
+  })
+
   it('splits at the first question mark only', () => {
     expect(splitPathKey('/search?q=a?b')).toEqual({ path: '/search', query: [{ name: 'q', value: 'a?b' }] })
   })

--- a/packages/mock-server/src/utils/split-path-key.ts
+++ b/packages/mock-server/src/utils/split-path-key.ts
@@ -1,0 +1,84 @@
+/** A query parameter that an OpenAPI path key pins, for example `beta=true` in `/v1/messages?beta=true`. */
+export type PinnedQueryParameter = {
+  /** Decoded name of the query parameter. */
+  name: string
+  /** Decoded value the request has to send, or `undefined` when the path key only pins the name. */
+  value: string | undefined
+}
+
+/** An OpenAPI path key taken apart into the portion Hono can route and the query it pins. */
+type SplitPathKey = {
+  /** The path portion of the key, without the query string. */
+  path: string
+  /** Query parameters the key pins. Empty for a regular path key. */
+  query: PinnedQueryParameter[]
+}
+
+/**
+ * Decode one part of a query string the way `URLSearchParams` does.
+ *
+ * A malformed escape sequence is kept verbatim instead of throwing, so a single odd path key cannot
+ * take the whole server down.
+ */
+const decodeQueryPart = (value: string): string => {
+  try {
+    return decodeURIComponent(value.replace(/\+/g, ' '))
+  } catch {
+    return value
+  }
+}
+
+/**
+ * Find the `?` that starts the query string of a path key.
+ *
+ * Only a `?` outside a `{…}` template counts, so a path parameter whose name contains a `?` does not
+ * accidentally cut the key in half. Returns `-1` when the key carries no query string.
+ */
+const findQueryStart = (pathKey: string): number => {
+  let insideTemplate = false
+
+  for (let index = 0; index < pathKey.length; index++) {
+    const character = pathKey[index]
+
+    if (character === '{') {
+      insideTemplate = true
+    } else if (character === '}') {
+      insideTemplate = false
+    } else if (character === '?' && !insideTemplate) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+/**
+ * Split an OpenAPI path key into its path and its pinned query parameters.
+ *
+ * Some documents carry a literal query string in the path key to describe a variant of an operation,
+ * for example `/v1/messages?beta=true` next to `/v1/messages`. That is not a routable path, so the
+ * query has to be peeled off and matched against the incoming request separately.
+ */
+export function splitPathKey(pathKey: string): SplitPathKey {
+  const queryStart = findQueryStart(pathKey)
+
+  if (queryStart === -1) {
+    return { path: pathKey, query: [] }
+  }
+
+  const query = pathKey
+    .slice(queryStart + 1)
+    .split('&')
+    .filter((pair) => pair !== '')
+    .map((pair) => {
+      const separator = pair.indexOf('=')
+
+      // `?beta` pins the name only, `?beta=true` pins the name and the value.
+      return separator === -1
+        ? { name: decodeQueryPart(pair), value: undefined }
+        : { name: decodeQueryPart(pair.slice(0, separator)), value: decodeQueryPart(pair.slice(separator + 1)) }
+    })
+    .filter(({ name }) => name !== '')
+
+  return { path: pathKey.slice(0, queryStart), query }
+}

--- a/packages/mock-server/src/utils/split-path-key.ts
+++ b/packages/mock-server/src/utils/split-path-key.ts
@@ -1,3 +1,10 @@
+/**
+ * Matches a `{parameterName}` template inside a path key.
+ *
+ * A template has to be balanced and non-empty, so a stray brace counts as literal path text.
+ */
+export const PATH_KEY_TEMPLATE = /\{([^{}]+)\}/g
+
 /** A query parameter that an OpenAPI path key pins, for example `beta=true` in `/v1/messages?beta=true`. */
 export type PinnedQueryParameter = {
   /** Decoded name of the query parameter. */
@@ -32,19 +39,18 @@ const decodeQueryPart = (value: string): string => {
  * Find the `?` that starts the query string of a path key.
  *
  * Only a `?` outside a `{…}` template counts, so a path parameter whose name contains a `?` does not
- * accidentally cut the key in half. Returns `-1` when the key carries no query string.
+ * accidentally cut the key in half. An unbalanced brace is literal path text rather than an open
+ * template, so it cannot hide the query string of the rest of the key. Returns `-1` when the key
+ * carries no query string.
  */
 const findQueryStart = (pathKey: string): number => {
-  let insideTemplate = false
+  const templates = [...pathKey.matchAll(PATH_KEY_TEMPLATE)].map((match) => ({
+    start: match.index,
+    end: match.index + match[0].length,
+  }))
 
-  for (let index = 0; index < pathKey.length; index++) {
-    const character = pathKey[index]
-
-    if (character === '{') {
-      insideTemplate = true
-    } else if (character === '}') {
-      insideTemplate = false
-    } else if (character === '?' && !insideTemplate) {
+  for (let index = pathKey.indexOf('?'); index !== -1; index = pathKey.indexOf('?', index + 1)) {
+    if (!templates.some(({ start, end }) => index > start && index < end)) {
       return index
     }
   }

--- a/packages/mock-server/src/utils/split-path-key.ts
+++ b/packages/mock-server/src/utils/split-path-key.ts
@@ -5,6 +5,9 @@
  */
 export const PATH_KEY_TEMPLATE = /\{([^{}]+)\}/g
 
+/** Matches a query value that is nothing but a template, as in `?status={status}`. */
+const TEMPLATE_VALUE = /^\{[^{}]+\}$/
+
 /** A query parameter that an OpenAPI path key pins, for example `beta=true` in `/v1/messages?beta=true`. */
 export type PinnedQueryParameter = {
   /** Decoded name of the query parameter. */
@@ -44,7 +47,9 @@ const decodeQueryPart = (value: string): string => {
  * carries no query string.
  */
 const findQueryStart = (pathKey: string): number => {
-  const templates = [...pathKey.matchAll(PATH_KEY_TEMPLATE)].map((match) => ({
+  // A fresh instance, because `matchAll` reads the `lastIndex` of the regular expression it is
+  // given and `PATH_KEY_TEMPLATE` is shared with other modules.
+  const templates = [...pathKey.matchAll(new RegExp(PATH_KEY_TEMPLATE))].map((match) => ({
     start: match.index,
     end: match.index + match[0].length,
   }))
@@ -65,7 +70,7 @@ const findQueryStart = (pathKey: string): number => {
  * for example `/v1/messages?beta=true` next to `/v1/messages`. That is not a routable path, so the
  * query has to be peeled off and matched against the incoming request separately.
  */
-export function splitPathKey(pathKey: string): SplitPathKey {
+export const splitPathKey = (pathKey: string): SplitPathKey => {
   const queryStart = findQueryStart(pathKey)
 
   if (queryStart === -1) {
@@ -80,9 +85,18 @@ export function splitPathKey(pathKey: string): SplitPathKey {
       const separator = pair.indexOf('=')
 
       // `?beta` pins the name only, `?beta=true` pins the name and the value.
-      return separator === -1
-        ? { name: decodeQueryPart(pair), value: undefined }
-        : { name: decodeQueryPart(pair.slice(0, separator)), value: decodeQueryPart(pair.slice(separator + 1)) }
+      if (separator === -1) {
+        return { name: decodeQueryPart(pair), value: undefined }
+      }
+
+      const value = pair.slice(separator + 1)
+
+      return {
+        name: decodeQueryPart(pair.slice(0, separator)),
+        // A value that is nothing but a template (`?status={status}`) names the parameter rather
+        // than fixing it, so any value the request sends satisfies it.
+        value: TEMPLATE_VALUE.test(value) ? undefined : decodeQueryPart(value),
+      }
     })
     .filter(({ name }) => name !== '')
 

--- a/packages/mock-server/src/x-handler.test.ts
+++ b/packages/mock-server/src/x-handler.test.ts
@@ -1920,7 +1920,7 @@ describe('x-handler', () => {
     expect(await response.json()).toStrictEqual({ id: '1' })
   })
 
-  it('keeps a declared parameter that is named like a synthesized one', async () => {
+  it('keeps a declared parameter named like a synthesized one when the route has none', async () => {
     const document = {
       openapi: '3.1.0',
       info: {

--- a/packages/mock-server/src/x-handler.test.ts
+++ b/packages/mock-server/src/x-handler.test.ts
@@ -1919,4 +1919,32 @@ describe('x-handler', () => {
 
     expect(await response.json()).toStrictEqual({ id: '1' })
   })
+
+  it('keeps a declared parameter that is named like a synthesized one', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {
+        '/a/{__scalar_literal_0}': {
+          get: {
+            'x-handler': 'return req.params;',
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/a/hello')
+
+    expect(await response.json()).toStrictEqual({ __scalar_literal_0: 'hello' })
+  })
 })

--- a/packages/mock-server/src/x-handler.test.ts
+++ b/packages/mock-server/src/x-handler.test.ts
@@ -1889,4 +1889,34 @@ describe('x-handler', () => {
       expect(deleteResponse.status).toBe(204) // Should be 204 from delete, not 200 from list
     })
   })
+
+  it('hides the parameters synthesized for routing from req.params', async () => {
+    const document = {
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {
+        // The second segment cannot be routed as written, so it is registered as a parameter with a
+        // generated name. That name is an implementation detail and must not reach the handler.
+        '/{id}/items:batchGet': {
+          get: {
+            'x-handler': 'return req.params;',
+            responses: {
+              '200': {
+                description: 'OK',
+              },
+            },
+          },
+        },
+      },
+    }
+
+    const server = await createMockServer({ document })
+
+    const response = await server.request('/1/items:batchGet')
+
+    expect(await response.json()).toStrictEqual({ id: '1' })
+  })
 })


### PR DESCRIPTION
## Problem

Some OpenAPI documents describe a variant of an operation by putting a literal query string in the path key:

```yaml
paths:
  /v1/messages: …
  /v1/messages?beta=true: …
```

Anthropic's document does this on 80 of its 89 paths. `honoRouteFromPath` only mapped `{`/`}` to `:` and escaped nothing, so the `?` reached Hono's `RegExpRouter` as a regular expression quantifier. On a parameterized path the router then compiled an invalid regular expression and threw a raw `SyntaxError` while lazily building its matcher — not Hono's own `UnsupportedPathError`, so `SmartRouter` never fell back to `TrieRouter`. The server started fine and then **every** request to it failed with an empty `500`. Measured against the real document: 131 of 131 operations dead.

Nothing escaped the rest of a path key either, so a spec-derived key could act as a pattern. `/v1/operations/{name}:cancel` compiled to a plain one-segment parameter, which meant `POST /v1/operations/abc` — no `:cancel` anywhere — was answered by the *cancel* operation. A key ending in `*` silently became a catch-all.

## Solution

The query string is split off the path key at the first `?` outside a `{…}` template and matched against the incoming request instead. A variant is registered ahead of the sibling it shares a path with, behind a guard that hands the request on when the pinned parameters are absent — so `/v1/messages?beta=true` answers only requests that send `beta=true`, and `/v1/messages` keeps answering the rest. A key that pins a name without a value (`?beta`) matches any value, and so does one whose value is just a template (`?status={status}`).

A segment whose text Hono would read as routing syntax (`:`, `*`, `|`, braces outside a parameter) is registered as a parameter with an explicit pattern, which is the only way to make Hono match it verbatim. Two things that took some digging:

- Hono splices the segment *behind* a pattern into a lookahead **without escaping it**, so every segment behind a pattern has to be a pattern too — otherwise an unbalanced bracket further down the path reintroduces the same total outage. An empty segment (a trailing slash) is exempt, because `:name{}` is unparseable and Hono skips the lookahead for it anyway.
- An OpenAPI document is untrusted input, so the generated pattern must not backtrack. Every template except the last excludes the character the literal behind it starts with, which makes its match effectively atomic; the last stays greedy so `{name}:cancel` still accepts a value containing `:`. A crafted request against the naive all-greedy form blocked the event loop for **77 seconds**; it now returns in under a millisecond.

**Verified against the real document:** anthropic goes from 131/131 operations throwing to **131/131 answering 200**, with every request reaching the operation its key names (`/v1/messages` → `messages_post`, `/v1/messages?beta=true` → `beta_messages_post`).

**Verified for regressions** by differential harness across **44 real client documents / 2,339 operations / 9,686 probes**, running the pre-change and post-change sources side by side: zero regressions. The only path keys whose behavior changes are the three classes described above, and the corpus contains no `*` or literal-`:` keys at all.

### Known limitation

Hono allows one parameter per path segment, so a segment mixing a path parameter with escaped literal text (`/v1/jobs/{jobId}:cancel`) routes to the right operation but does not bind `jobId` by name; request validation reads it as missing. This is not a regression — the previous behavior lost the name too *and* matched any single segment — and it is recorded in the JSDoc, the changeset and the docs guide.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [x] I updated the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bpSdmGjRnXSQuofYEFYzz

---
_Generated by [Claude Code](https://claude.ai/code/session_011bpSdmGjRnXSQuofYEFYzz)_