### PR TITLE
fix(api-client): do not send optional form-body properties by default

### DIFF
--- a/.changeset/fix-10045-optional-body-properties.md
+++ b/.changeset/fix-10045-optional-body-properties.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+---
+
+Stop sending optional form-body properties by default. Optional `multipart/form-data` and `application/x-www-form-urlencoded` properties now start unchecked and are left out of the request unless you enable them, matching how optional parameters already behave. Required properties are unaffected.

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
@@ -343,6 +343,50 @@ describe('getFormBodyRows', () => {
       expect(result[0]?.isDisabled).toBe(false)
     })
 
+    it('does not disable nested optional leaves, so the panel matches the send (issue #10045)', () => {
+      // The send side only drops top-level optional properties, so a nested optional leaf must
+      // stay enabled — otherwise the panel would show it unchecked while it is still transmitted.
+      const example: ExampleObject = {
+        value: { props: { name: '', note: '' } },
+      }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        required: ['props'],
+        properties: {
+          props: {
+            type: 'object',
+            required: ['name'],
+            properties: {
+              name: { type: 'string' },
+              note: { type: 'string' },
+            },
+          },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'multipart/form-data', formBodySchema)
+      const note = result.find((row) => row.name === 'props.note')
+      expect(note?.isRequired).toBe(false)
+      // Optional but nested → left enabled to stay consistent with the request.
+      expect(note?.isDisabled).toBe(false)
+    })
+
+    it('keeps an example-only key named like an Object.prototype member enabled (issue #10045)', () => {
+      const example: ExampleObject = {
+        value: { name: 'a', toString: 'b' },
+      }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        required: ['name'],
+        properties: { name: { type: 'string' } },
+      }
+
+      const result = getFormBodyRows(example, 'application/x-www-form-urlencoded', formBodySchema)
+      const extra = result.find((row) => row.name === 'toString')
+      // Undeclared, so it is not auto-disabled by the schema default.
+      expect(extra?.isDisabled).toBe(false)
+    })
+
     it('expands nested object properties into dotted rows (widget #4834 example)', () => {
       const example: ExampleObject = {
         value: {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
@@ -302,6 +302,47 @@ describe('getFormBodyRows', () => {
       expect(result[1].isRequired).toBe(true)
     })
 
+    it('disables optional properties by default and keeps required ones enabled (issue #10045)', () => {
+      const example: ExampleObject = { value: { name: '', note: '', mode: 'none' } }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: { type: 'string' },
+          note: { type: 'string' },
+          mode: { type: 'string', enum: ['none', 'fast', 'slow'] },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'application/x-www-form-urlencoded', formBodySchema)
+      const byName = Object.fromEntries(result.map((row) => [row.name, row]))
+
+      // Required property stays enabled; optional properties default to disabled (unchecked).
+      expect(byName['name']?.isDisabled).toBe(false)
+      expect(byName['note']?.isDisabled).toBe(true)
+      expect(byName['mode']?.isDisabled).toBe(true)
+    })
+
+    it('keeps an explicit isDisabled from a stored form-row array (issue #10045)', () => {
+      // Once the user checks an optional box the value is stored as a row array with an
+      // explicit isDisabled, which must win over the schema-derived default.
+      const example: ExampleObject = {
+        value: [{ name: 'note', value: 'hi', isDisabled: false }],
+      }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: { type: 'string' },
+          note: { type: 'string' },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'application/x-www-form-urlencoded', formBodySchema)
+      expect(result[0]?.name).toBe('note')
+      expect(result[0]?.isDisabled).toBe(false)
+    })
+
     it('expands nested object properties into dotted rows (widget #4834 example)', () => {
       const example: ExampleObject = {
         value: {

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
@@ -167,15 +167,18 @@ export const getFormBodyRows = (
     row.description = propSchema?.description
     row.isRequired = leaf?.isRequired ?? requiredSet?.has(name) ?? false
 
-    // Optional properties the schema declares default to disabled (unchecked), matching how
-    // optional parameters behave. An explicit `isDisabled` (from a stored form-row array) always
-    // wins, and example-only keys the schema does not declare stay enabled.
-    if (isDisabled === undefined) {
-      const isDeclared =
-        leaf !== undefined || (schemaWithProperties.properties ? name in schemaWithProperties.properties : false)
-      if (isDeclared) {
-        row.isDisabled = !row.isRequired
-      }
+    // Top-level optional properties default to disabled (unchecked), matching how optional
+    // parameters behave. Scoped to top-level declared properties on purpose: the send side
+    // (`build-request-body`) only drops top-level optional keys, so auto-disabling a nested
+    // leaf (e.g. `props.name`) would leave it unchecked yet still transmitted. `Object.hasOwn`
+    // (not `in`) keeps example-only keys named like `Object.prototype` members enabled. An
+    // explicit `isDisabled` (from a stored form-row array) always wins.
+    if (
+      isDisabled === undefined &&
+      schemaWithProperties.properties &&
+      Object.hasOwn(schemaWithProperties.properties, name)
+    ) {
+      row.isDisabled = !row.isRequired
     }
     return row
   }

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
@@ -149,13 +149,13 @@ export const getFormBodyRows = (
   const mapRow = ({
     name,
     value,
-    isDisabled = false,
+    isDisabled,
   }: {
     name: string
     value: string | File
     isDisabled?: boolean
   }): TableRow => {
-    const row: TableRow = { name, value, isDisabled }
+    const row: TableRow = { name, value, isDisabled: isDisabled ?? false }
     if (!schemaWithProperties || !name) {
       return row
     }
@@ -166,6 +166,17 @@ export const getFormBodyRows = (
     row.schema = propSchema
     row.description = propSchema?.description
     row.isRequired = leaf?.isRequired ?? requiredSet?.has(name) ?? false
+
+    // Optional properties the schema declares default to disabled (unchecked), matching how
+    // optional parameters behave. An explicit `isDisabled` (from a stored form-row array) always
+    // wins, and example-only keys the schema does not declare stay enabled.
+    if (isDisabled === undefined) {
+      const isDeclared =
+        leaf !== undefined || (schemaWithProperties.properties ? name in schemaWithProperties.properties : false)
+      if (isDeclared) {
+        row.isDisabled = !row.isRequired
+      }
+    }
     return row
   }
 

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -533,7 +533,7 @@ describe('buildRequestBody', () => {
     expect(result.value[1].value).toBe('Test file')
   })
 
-  it('builds FormData for schema-generated multipart/form-data object examples', () => {
+  it('builds FormData for schema-generated multipart/form-data object examples, omitting optional properties', () => {
     const requestBody = coerceValue(RequestBodyObjectSchema, {
       content: {
         'multipart/form-data': {
@@ -560,18 +560,45 @@ describe('buildRequestBody', () => {
     expect(result?.mode).toBe('formdata')
     assert(result?.mode === 'formdata')
 
+    // Only the required `image` is sent; the optional `description` is left out by default,
+    // matching how optional parameters are dropped. See issue #10045.
     expect(result.value).toStrictEqual([
       {
         type: 'text',
         key: 'image',
         value: '@filename',
       },
-      {
-        type: 'text',
-        key: 'description',
-        value: 'An image upload',
-      },
     ])
+  })
+
+  it('omits optional form properties but keeps required ones (issue #10045)', () => {
+    const schema = {
+      type: 'object',
+      required: ['name'],
+      properties: {
+        name: { type: 'string' },
+        note: { type: 'string' },
+        mode: { type: 'string', enum: ['none', 'fast', 'slow'] },
+      },
+    }
+
+    const urlencoded = buildRequestBody(
+      coerceValue(RequestBodyObjectSchema, {
+        content: { 'application/x-www-form-urlencoded': { schema } },
+      }),
+      'default',
+    )
+    assert(urlencoded?.mode === 'urlencoded')
+    expect(urlencoded.value.map((v) => v.key)).toEqual(['name'])
+
+    const multipart = buildRequestBody(
+      coerceValue(RequestBodyObjectSchema, {
+        content: { 'multipart/form-data': { schema } },
+      }),
+      'default',
+    )
+    assert(multipart?.mode === 'formdata')
+    expect(multipart.value.map((v) => v.key)).toEqual(['name'])
   })
 
   it('returns File bodies for raw binary request examples', () => {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.test.ts
@@ -601,6 +601,50 @@ describe('buildRequestBody', () => {
     expect(multipart.value.map((v) => v.key)).toEqual(['name'])
   })
 
+  it('keeps a property marked required inside an allOf member (issue #10045)', () => {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
+      content: {
+        'application/x-www-form-urlencoded': {
+          schema: {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            // `name` is required via a composition member, not the top-level `required`.
+            allOf: [{ required: ['name'] }],
+          },
+        },
+      },
+    })
+
+    const result = buildRequestBody(requestBody, 'default')
+    assert(result?.mode === 'urlencoded')
+    // Composed schemas are left untouched so an effectively-required field is never dropped.
+    expect(result.value.map((v) => v.key)).toContain('name')
+  })
+
+  it('keeps an undeclared key named like an Object.prototype member (issue #10045)', () => {
+    const requestBody = coerceValue(RequestBodyObjectSchema, {
+      content: {
+        'application/x-www-form-urlencoded': {
+          schema: {
+            type: 'object',
+            required: ['name'],
+            properties: { name: { type: 'string' } },
+          },
+          examples: {
+            default: {
+              // `toString` is not declared in the schema, so it must be kept, not dropped.
+              value: { name: 'a', toString: 'keep-me' },
+            },
+          },
+        },
+      },
+    })
+
+    const result = buildRequestBody(requestBody, 'default')
+    assert(result?.mode === 'urlencoded')
+    expect(result.value.map((v) => v.key)).toContain('toString')
+  })
+
   it('returns File bodies for raw binary request examples', () => {
     const mockFile = new File(['binary content'], 'payload.bin', { type: 'application/octet-stream' })
     const requestBody = {

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -5,6 +5,7 @@ import { getResolvedRef, mergeSiblingReferences } from '@scalar/workspace-store/
 import { unpackProxyObject } from '@scalar/workspace-store/helpers/unpack-proxy'
 import type { SchemaObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import type { RequestBodyObject } from '@scalar/workspace-store/schemas/v3.1/strict/request-body'
+import { isObjectSchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 
 import { getExampleFromBody } from './get-request-body-example'
 import { getSelectedBodyContentType } from './get-selected-body-content-type'
@@ -78,6 +79,22 @@ export const buildRequestBody = (
   if (!example) {
     return null
   }
+
+  // Optional body properties default to "not sent", matching how optional parameters are
+  // dropped by `isParamDisabled`. We only know a property is optional when the body has an
+  // object schema that declares it outside `required`, so undeclared and required keys are
+  // always kept. This mirrors the unchecked-by-default checkbox in the Test Request panel.
+  // The array (edited) form path is unaffected: it carries its own per-row `isDisabled`.
+  const resolvedBodySchema = getResolvedRef(requestBody.content[bodyContentType]?.schema, mergeSiblingReferences) as
+    | SchemaObject
+    | undefined
+  const bodyProperties =
+    resolvedBodySchema && isObjectSchema(resolvedBodySchema) ? resolvedBodySchema.properties : undefined
+  const requiredBodyProperties = new Set(
+    resolvedBodySchema && isObjectSchema(resolvedBodySchema) ? (resolvedBodySchema.required ?? []) : [],
+  )
+  const isOptionalBodyProperty = (key: string) =>
+    Boolean(bodyProperties && key in bodyProperties && !requiredBodyProperties.has(key))
 
   // Form data - array format (from UI editor)
   if (
@@ -226,6 +243,10 @@ export const buildRequestBody = (
 
     // Convert object properties to form fields
     for (const [key, value] of Object.entries(example.value)) {
+      // Optional properties are left out unless the user enabled them (edited form path).
+      if (isOptionalBodyProperty(key)) {
+        continue
+      }
       if (key && value !== undefined && value !== null) {
         const partEncoding = requestBody.content[bodyContentType]?.encoding?.[key]
 
@@ -259,6 +280,11 @@ export const buildRequestBody = (
 
     for (const [key, value] of Object.entries(example.value)) {
       if (!key || value === undefined || value === null) {
+        continue
+      }
+
+      // Optional properties are left out unless the user enabled them (edited form path).
+      if (isOptionalBodyProperty(key)) {
         continue
       }
 

--- a/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
+++ b/packages/workspace-store/src/request-example/builder/body/build-request-body.ts
@@ -88,13 +88,17 @@ export const buildRequestBody = (
   const resolvedBodySchema = getResolvedRef(requestBody.content[bodyContentType]?.schema, mergeSiblingReferences) as
     | SchemaObject
     | undefined
-  const bodyProperties =
-    resolvedBodySchema && isObjectSchema(resolvedBodySchema) ? resolvedBodySchema.properties : undefined
-  const requiredBodyProperties = new Set(
-    resolvedBodySchema && isObjectSchema(resolvedBodySchema) ? (resolvedBodySchema.required ?? []) : [],
-  )
+  const objectBodySchema = resolvedBodySchema && isObjectSchema(resolvedBodySchema) ? resolvedBodySchema : undefined
+  // Composition (allOf/oneOf/anyOf) can mark a property required inside a subschema we do not
+  // merge here, so skip dropping entirely for composed schemas rather than risk removing an
+  // effectively-required field.
+  const isComposed = Boolean(objectBodySchema?.allOf || objectBodySchema?.oneOf || objectBodySchema?.anyOf)
+  const bodyProperties = objectBodySchema && !isComposed ? objectBodySchema.properties : undefined
+  const requiredBodyProperties = new Set(objectBodySchema && !isComposed ? (objectBodySchema.required ?? []) : [])
+  // `Object.hasOwn` (not `in`) so an undeclared key named like an `Object.prototype` member
+  // (`toString`, `constructor`, …) is not misread as declared-and-optional and dropped.
   const isOptionalBodyProperty = (key: string) =>
-    Boolean(bodyProperties && key in bodyProperties && !requiredBodyProperties.has(key))
+    Boolean(bodyProperties && Object.hasOwn(bodyProperties, key) && !requiredBodyProperties.has(key))
 
   // Form data - array format (from UI editor)
   if (


### PR DESCRIPTION
Optional form-body fields (`multipart/form-data` and `application/x-www-form-urlencoded`) were checked and sent by default. Now they start unchecked and are only sent if you enable them — the same way optional parameters already work. Required fields are unchanged.

Scope: form bodies only. JSON bodies are left for a follow-up (their raw editor needs a different approach).

## Ticket

Fixes #10045
