### PR TITLE
docs: refresh product docs for recent registry & SDK changes

### DIFF
--- a/documentation/guides/docs/configuration/llms-txt.md
+++ b/documentation/guides/docs/configuration/llms-txt.md
@@ -2,6 +2,8 @@
 
 Every published Scalar Docs site automatically serves `/llms.txt` and `/llms-full.txt` so AI agents and LLMs can read your documentation. These files follow the [llms.txt convention](https://llmstxt.org) and are generated for you. You do not configure or author them.
 
+Hidden pages are left out of both files, matching your sidebar and sitemap.
+
 ## llms.txt
 
 `llms.txt` is a structured index of your site. It starts with an H1 for your site title and a short summary as a blockquote, followed by `##` sections that mirror your navigation groups. Each section is a bullet list of links to the pages, pointing at their `.md` URLs, with the page description where one is available.

--- a/documentation/guides/registry/cli.md
+++ b/documentation/guides/registry/cli.md
@@ -82,9 +82,9 @@ scalar document lint ./openapi.yaml --rule https://registry.scalar.com/@your-tea
 ```
 
 > [!NOTE]
-> We do not currently support AsyncAPI for `validate` and `lint`. `validate` checks your document against the OpenAPI specification, and `lint` runs the `spectral:oas` ruleset, so pointing either one at an [AsyncAPI](../../asyncapi.md) document reports errors that do not apply to it. Publishing an AsyncAPI document to the registry works as normal.
+> `scalar document lint` also supports [AsyncAPI](../../asyncapi.md). It detects the document type and runs Spectral's `spectral:asyncapi` ruleset instead of `spectral:oas`, so linting an AsyncAPI document reports issues that actually apply to it. `scalar document validate` remains OpenAPI-only — pointed at an AsyncAPI document it stops with a clear message and suggests `lint` instead. Publishing an AsyncAPI document to the registry works as normal.
 >
-> Need it? Tell us on [GitHub](https://github.com/scalar/scalar/issues/new) or email [support@scalar.com](mailto:support@scalar.com).
+> Need AsyncAPI support for `validate` too? Tell us on [GitHub](https://github.com/scalar/scalar/issues/new) or email [support@scalar.com](mailto:support@scalar.com).
 
 ## Team Management
 If you're part of multiple teams, you can manage which team is active:

--- a/documentation/guides/registry/schemas.md
+++ b/documentation/guides/registry/schemas.md
@@ -96,6 +96,16 @@ The registry path follows this format:
 registry.scalar.com/@your-team/schemas/your-schema-name@version
 ```
 
+### Pin to a specific sha
+
+Anywhere a version can go, you can put a sha instead — either the document's content sha or the git commit it came from:
+
+```
+registry.scalar.com/@your-team/schemas/your-schema-name@03e959a
+```
+
+The sha can be a prefix (6 to 64 hex characters) and is matched like git: a prefix that matches more than one document returns a 404 rather than guessing. Versions always win, so a value that matches an existing version keeps resolving to that version. A full 64-character content sha on a public document is immutable, so it is served with a long-lived cache. Sha addressing works the same way for APIs (`/@your-team/apis/…@<sha>`).
+
 ## Reference Schemas in Your APIs
 
 Once you've published a schema, you can reference it in your OpenAPI documents using `$ref`. This allows you to reuse the same JSON Schema definition across multiple APIs.

--- a/documentation/guides/sdks/managing.md
+++ b/documentation/guides/sdks/managing.md
@@ -66,4 +66,4 @@ You do not need a GitHub repository to use a generated SDK. From a version's det
 
 ## Settings
 
-From the SDK settings you can rename the SDK, edit its description and namespace, set its registry visibility to public or private, manage which groups can access a private SDK, and delete the SDK. Deleting an SDK removes its versions and registry entries; code already pushed to GitHub or published to a registry is not affected.
+From the SDK settings — the **General** card on the studio's **Advanced** tab — you can rename the SDK, edit its description and namespace, set its registry visibility to public or private, manage which groups can access a private SDK, and delete the SDK. Renaming changes the display name only; the package names, registry URLs, and slug stay the same. Deleting an SDK removes its versions and registry entries; code already pushed to GitHub or published to a registry is not affected.

--- a/documentation/guides/sdks/publishing/overview.md
+++ b/documentation/guides/sdks/publishing/overview.md
@@ -93,6 +93,12 @@ The registry key depends on the target (`npm`, `pypi`, `cargo`, `maven`, and so 
 
 Publishing requires a [linked repository](github.md): a target with no `destinations.production` gets no workflows at all.
 
+## Package name availability
+
+When you enable publishing, the dialog checks the target's package name against its registry and tells you whether it looks available or already taken — so you catch a name conflict up front, not after a release merges and the publish step fails.
+
+A taken name is a **warning, never a block**: the registry cannot tell whether a name is already yours, and republishing under your own name is normal. The check runs for **npm** and **PyPI** today; other registries show nothing.
+
 ## Authentication
 
 By default Scalar uses **OIDC trusted publishing** wherever the registry supports it. The publish job exchanges a short-lived GitHub identity token for a registry credential at publish time, so there is **no token to create, store, or rotate**. You register your repository and workflow as a trusted publisher on the registry once.


### PR DESCRIPTION
Documentation follow-ups for recent product changes. Docs-only, no code.

- **Registry CLI** — the note claiming `lint` does not support AsyncAPI is now wrong; `scalar document lint` auto-detects AsyncAPI and runs `spectral:asyncapi`. Only `validate` stays OpenAPI-only.
- **Registry serving URLs** — document pinning APIs/schemas to a content or commit sha (`@<sha>`).
- **SDK publishing** — document the package-name availability check in the release dialog (npm + PyPI, warning-only).
- **SDK settings** — clarify the rename lives on the studio's Advanced tab and changes the display name only.
- **llms.txt** — note that hidden pages are excluded.