### PR TITLE
test(highlight): re-enable linear-cost performance test

### DIFF
--- a/packages/highlight/src/langs/languages.test.ts
+++ b/packages/highlight/src/langs/languages.test.ts
@@ -207,7 +207,7 @@ describe('every bundled language', () => {
  * growth ratio rather than absolute time, so it does not turn into a flaky
  * benchmark on a loaded machine.
  */
-describe.skip('cost stays linear in line length', () => {
+describe('cost stays linear in line length', () => {
   /** One seed per rule that was quadratic once, plus untouched controls. */
   const seeds: [string, string][] = [
     ['markdown', '['], // link label


### PR DESCRIPTION
PR #9941 (a CI/release change) accidentally added `describe.skip` to the `cost stays linear in line length` test in `@scalar/highlight`. That skip had nothing to do with that PR, so this turns the test back on.

The test guards against a slow highlighter (a rule scanning a line over and over) on untrusted code blocks, so it is worth keeping on. I ran it three times and it passed every time.