### PR TITLE
fix(themes): resolve the color mode from css at first paint

### DIFF
--- a/.changeset/color-scheme-pre-paint.md
+++ b/.changeset/color-scheme-pre-paint.md
@@ -1,0 +1,11 @@
+---
+'@scalar/server-side-rendering': patch
+'@scalar/use-hooks': patch
+'@scalar/themes': patch
+---
+
+Resolve the color mode from CSS at first paint, so a server-rendered page no longer flashes white before hydration.
+
+Theme tokens are scoped to the `dark-mode` / `light-mode` class on `<body>`, so until JavaScript added that class there was nothing to resolve and the page painted white. `@scalar/themes` now declares `color-scheme: light dark` on `:root` with `light-dark()` values for the tokens that paint large areas, which the browser resolves against the operating system before any script runs. An explicit choice still wins: `useColorMode` pins `color-scheme` on `<html>` for a chosen mode and clears it for `system`, and `renderApiReference` writes it into the markup when `darkMode` or `forceDarkModeState` is set — so a configured reference paints correctly even when the inline script never runs.
+
+The class layer is unchanged and still wins inside `<body>`, so rendering after hydration is identical and customer themes selecting against `.dark-mode` keep working. Browsers without `light-dark()` fall back to the previous behavior.

--- a/packages/server-side-rendering/src/ssr.test.ts
+++ b/packages/server-side-rendering/src/ssr.test.ts
@@ -110,7 +110,7 @@ describe('ssr', () => {
       const script = generateBodyScript({ darkMode: true })
 
       expect(script).not.toContain('matchMedia')
-      expect(script).toContain('set(true)')
+      expect(script).toContain('set(true,1)')
     })
 
     it('handles array configurations', () => {
@@ -135,6 +135,25 @@ describe('ssr', () => {
       expect(script).toContain('localStorage')
       expect(script).toContain('matchMedia')
       expect(script).not.toContain('window.__pwned=2')
+    })
+
+    it('pins color-scheme on the document element when the mode is forced', () => {
+      expect(generateBodyScript({ forceDarkModeState: 'dark' })).toContain("style.colorScheme='dark'")
+      expect(generateBodyScript({ forceDarkModeState: 'light' })).toContain("style.colorScheme='light'")
+    })
+
+    it('pins color-scheme for a stored preference', () => {
+      const script = generateBodyScript({})
+
+      // The pin flag makes an explicit user choice override the stylesheet default.
+      expect(script).toContain("set(s==='dark',1)")
+    })
+
+    it('does not pin color-scheme on the system fallback', () => {
+      const script = generateBodyScript({})
+
+      // Freezing it to whatever matchMedia reported at load would stop the OS tracking live.
+      expect(script).toContain("matchMedia('(prefers-color-scheme:dark)').matches,0)")
     })
   })
 
@@ -382,6 +401,25 @@ describe('ssr', () => {
           css: '',
         }),
       ).rejects.toThrow('Cannot serialize function at "metaData.onLoaded" for SSR hydration.')
+    })
+
+    /** Read just the opening tag — the inlined stylesheet has `color-scheme` declarations too. */
+    const getHtmlTag = (html: string): string =>
+      html.slice(html.indexOf('<html'), html.indexOf('>', html.indexOf('<html')) + 1)
+
+    it('renders color-scheme onto <html> for a configured mode', async () => {
+      const forcedDark = await renderApiReference({ config: { forceDarkModeState: 'dark' } })
+      expect(getHtmlTag(forcedDark)).toContain('color-scheme: dark')
+
+      const configuredLight = await renderApiReference({ config: { darkMode: false } })
+      expect(getHtmlTag(configuredLight)).toContain('color-scheme: light')
+    })
+
+    it('omits color-scheme from <html> when no mode is configured', async () => {
+      // Unconfigured, the stylesheet stays in charge and the OS decides the first paint.
+      const html = await renderApiReference({ config: {} })
+
+      expect(getHtmlTag(html)).not.toContain('color-scheme')
     })
   })
 

--- a/packages/server-side-rendering/src/ssr.test.ts
+++ b/packages/server-side-rendering/src/ssr.test.ts
@@ -408,11 +408,12 @@ describe('ssr', () => {
       html.slice(html.indexOf('<html'), html.indexOf('>', html.indexOf('<html')) + 1)
 
     it('renders color-scheme onto <html> for a configured mode', async () => {
+      // Matched loosely because unhead normalizes the declaration it renders (`color-scheme:dark`).
       const forcedDark = await renderApiReference({ config: { forceDarkModeState: 'dark' } })
-      expect(getHtmlTag(forcedDark)).toContain('color-scheme: dark')
+      expect(getHtmlTag(forcedDark)).toMatch(/color-scheme:\s*dark/)
 
       const configuredLight = await renderApiReference({ config: { darkMode: false } })
-      expect(getHtmlTag(configuredLight)).toContain('color-scheme: light')
+      expect(getHtmlTag(configuredLight)).toMatch(/color-scheme:\s*light/)
     })
 
     it('omits color-scheme from <html> when no mode is configured', async () => {

--- a/packages/server-side-rendering/src/ssr.ts
+++ b/packages/server-side-rendering/src/ssr.ts
@@ -35,6 +35,30 @@ function parseDarkMode(config: Record<string, unknown>): boolean | null {
 }
 
 /**
+ * Resolve the `color-scheme` to render onto `<html>`, or `null` to let the stylesheet's
+ * `color-scheme: light dark` follow the operating system.
+ *
+ * A configured reference needs the concrete value in the markup: a light-only site on a dark
+ * machine would otherwise paint dark and snap to light once the script ran — or stay dark, if the
+ * script never runs at all.
+ */
+function resolveInitialColorScheme(config: Record<string, unknown>): 'dark' | 'light' | null {
+  const forced = parseForceDarkModeState(config)
+
+  if (forced) {
+    return forced
+  }
+
+  const darkMode = parseDarkMode(config)
+
+  if (darkMode !== null) {
+    return darkMode ? 'dark' : 'light'
+  }
+
+  return null
+}
+
+/**
  * Generate an inline script that detects the user's color mode preference
  * and applies the correct class to <body> before content paints.
  *
@@ -55,17 +79,21 @@ export function generateBodyScript(configuration: AnyApiReferenceConfiguration):
 
   /** When forceDarkModeState is set, we do not need runtime detection at all. */
   if (forced) {
-    return `<script>(function(){var cl=document.body.classList;cl.remove('dark-mode','light-mode');cl.add('${forced === 'dark' ? 'dark-mode' : 'light-mode'}')})()</script>`
+    return `<script>(function(){var cl=document.body.classList;cl.remove('dark-mode','light-mode');cl.add('${forced === 'dark' ? 'dark-mode' : 'light-mode'}');document.documentElement.style.colorScheme='${forced}'})()</script>`
   }
 
   /**
    * Runtime detection script: checks localStorage first, then system preference,
    * then falls back to the darkMode config value.
+   *
+   * The script's `pin` argument writes `color-scheme` to `<html>`. Explicit choices pin it; the
+   * system fallback does not, so the stylesheet keeps tracking the OS live instead of freezing at
+   * whatever was read on load.
    */
   const fallback =
-    darkMode === null ? `set(window.matchMedia('(prefers-color-scheme:dark)').matches)` : `set(${darkMode})`
+    darkMode === null ? `set(window.matchMedia('(prefers-color-scheme:dark)').matches,0)` : `set(${darkMode},1)`
 
-  return `<script>(function(){var cl=document.body.classList;function set(d){cl.remove('dark-mode','light-mode');cl.add(d?'dark-mode':'light-mode')}try{var s=localStorage.getItem('colorMode');if(s==='dark'||s==='light'){set(s==='dark');return}}catch(e){}${fallback}})()</script>`
+  return `<script>(function(){var cl=document.body.classList;function set(d,pin){cl.remove('dark-mode','light-mode');cl.add(d?'dark-mode':'light-mode');if(pin){document.documentElement.style.colorScheme=d?'dark':'light'}}try{var s=localStorage.getItem('colorMode');if(s==='dark'||s==='light'){set(s==='dark',1);return}}catch(e){}${fallback}})()</script>`
 }
 
 /**
@@ -94,11 +122,15 @@ function getInitialBodyClass(configuration: AnyApiReferenceConfiguration): 'dark
 
 type RenderedSsrHead = Awaited<ReturnType<typeof renderSSRHead>>
 
-const createHeadInstance = (pageTitle?: string) =>
+const createHeadInstance = (pageTitle?: string, colorScheme?: 'dark' | 'light' | null) =>
   createHead({
     init: [
       {
-        htmlAttrs: { lang: 'en' },
+        htmlAttrs: {
+          lang: 'en',
+          // Omitted when unconfigured, so the stylesheet keeps following the OS.
+          ...(colorScheme ? { style: `color-scheme: ${colorScheme}` } : {}),
+        },
         ...(pageTitle ? { title: pageTitle } : {}),
       },
     ],
@@ -138,7 +170,7 @@ async function renderApiReferenceApp(options: {
       return () => h(ApiReference, { configuration: normalizedConfiguration })
     },
   })
-  const head = createHeadInstance(options.pageTitle)
+  const head = createHeadInstance(options.pageTitle, resolveInitialColorScheme(normalizedConfiguration))
   app.use(head)
   app.config.idPrefix = 'scalar-refs'
 

--- a/packages/themes/src/base/color-scheme.css
+++ b/packages/themes/src/base/color-scheme.css
@@ -1,0 +1,19 @@
+/**
+ * Resolves the color mode at first paint, before the mode class exists.
+ *
+ * Theme tokens are scoped to `.dark-mode` / `.light-mode` on `<body>`, so until JavaScript adds
+ * that class there is nothing to resolve and the page paints white. `light-dark()` resolves
+ * against the computed `color-scheme`, which — unlike `prefers-color-scheme` — JavaScript can
+ * still override, so an explicit mode wins later without a second theming system.
+ *
+ * These are the default theme's values, not the active preset's. They only cover the window
+ * before hydration, where the alternative is white; the class layer wins by proximity afterwards.
+ */
+:root {
+  color-scheme: light dark;
+
+  --scalar-background-1: light-dark(#fff, #0f0f0f);
+  --scalar-background-2: light-dark(#f6f6f6, #1a1a1a);
+  --scalar-color-1: light-dark(#1b1b1b, #e7e7e7);
+  --scalar-border-color: light-dark(#dfdfdf, #2d2d2d);
+}

--- a/packages/themes/src/style.css
+++ b/packages/themes/src/style.css
@@ -3,6 +3,7 @@
 /* Import core stylesheets  */
 @import "./base/reset.css";
 @import "./base/scrollbars.css";
+@import "./base/color-scheme.css" layer(scalar-base);
 
 /* Import a copy of the base variables and default theme */
 @import "./base/variables.css" layer(scalar-base);

--- a/packages/use-hooks/src/useColorMode/useColorMode.test.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.test.ts
@@ -25,6 +25,7 @@ describe('useColorMode', () => {
 
     // Reset the DOM
     document.body.classList.remove('dark-mode', 'light-mode')
+    document.documentElement.style.removeProperty('color-scheme')
 
     // Clear localStorage
     localStorage.clear()
@@ -303,5 +304,51 @@ describe('useColorMode', () => {
 
     const { darkLightMode } = useColorMode()
     expect(darkLightMode.value).toBe('dark') // Should default to dark when matchMedia is unavailable
+  })
+
+  it.each(['light', 'dark'] as const)('pins color-scheme on the document element for %s', async (mode) => {
+    const { setColorMode } = useColorMode()
+
+    setColorMode(mode)
+    await nextTick()
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe(mode)
+  })
+
+  it('leaves color-scheme unset in system mode so the stylesheet follows the OS', async () => {
+    const { setColorMode } = useColorMode()
+
+    setColorMode('system')
+    await nextTick()
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('')
+  })
+
+  it('clears the pinned color-scheme when switching from an explicit mode back to system', async () => {
+    const { setColorMode } = useColorMode()
+
+    setColorMode('dark')
+    await nextTick()
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('dark')
+
+    setColorMode('system')
+    await nextTick()
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('')
+  })
+
+  it.each(['light', 'dark'] as const)('pins color-scheme from overrideColorMode: %s', (overrideColorMode) => {
+    useColorMode({ overrideColorMode })
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe(overrideColorMode)
+  })
+
+  it('pins color-scheme from a stored preference that disagrees with the system', () => {
+    vi.spyOn(window, 'matchMedia').mockImplementation(createMatchMediaMock('dark'))
+    localStorage.setItem('colorMode', 'light')
+
+    useColorMode()
+
+    expect(document.body.classList.contains('light-mode')).toBe(true)
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light')
   })
 })

--- a/packages/use-hooks/src/useColorMode/useColorMode.ts
+++ b/packages/use-hooks/src/useColorMode/useColorMode.ts
@@ -74,7 +74,13 @@ export function useColorMode(
     set: (value) => setColorMode(value ? 'dark' : 'light'),
   })
 
-  /** Applies the appropriate color mode class to the body. */
+  /**
+   * Applies the color mode to the document.
+   *
+   * The class stays on `<body>`, where customer themes select against it. `color-scheme` goes on
+   * `<html>` as an inline style — what the stylesheet's `light-dark()` tokens resolve against, and
+   * a property rather than a class so nothing can be coupled to it.
+   */
   function applyBodyColorMode(): void {
     if (typeof document === 'undefined' || typeof window === 'undefined') {
       return
@@ -86,6 +92,16 @@ export function useColorMode(
 
     // An `overrideColorMode` of `system` reaches here unresolved, and has always rendered as light.
     applyColorMode(classMode === 'dark' ? 'dark' : 'light')
+
+    // The requested mode, not the resolved one: `system` clears the pin so the stylesheet's
+    // `color-scheme: light dark` takes over and the OS drives the theme natively.
+    const requestedMode = overrideColorMode ?? colorMode.value
+
+    if (requestedMode === 'system') {
+      document.documentElement.style.removeProperty('color-scheme')
+    } else {
+      document.documentElement.style.colorScheme = requestedMode
+    }
   }
 
   // Priority: overrideColorMode -> localStorage -> initialColorMode


### PR DESCRIPTION
## Problem

Theme tokens are all scoped to `.dark-mode` / `.light-mode` on `<body>`, so until JS adds that class there's nothing to resolve and the page paints white. That's a flash on SSG, and permanently white if JS is disabled or the inline script gets blocked by CSP.

## Solution

Adds a `:root` layer using `light-dark()`, which the browser resolves against the OS before any script runs. It resolves against the computed `color-scheme` rather than `prefers-color-scheme`, so JS can still override it and we don't end up with two theming systems.

* New `base/color-scheme.css` — `color-scheme: light dark` plus `light-dark()` for the four tokens that paint large areas
* `useColorMode` pins `color-scheme` on `<html>` for an explicit mode, clears it for `system`
* `renderApiReference` renders it into the markup when `darkMode` / `forceDarkModeState` is set, so a configured reference is right even with no JS
* Class layer is untouched — rendering after hydration is identical, and customer themes selecting `.dark-mode` keep working

`light-dark()` wants Safari 17.5 / Chrome 123, a bit newer than Tailwind v4's floor. Older browsers drop it as invalid and fall back to exactly today's behaviour, since the class layer is still there.

Before / After

_(video will go here — it's a pre-paint thing, so it needs a throttled recording rather than a screenshot)_

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation