### PR TITLE
fix(api-reference): label array composition models

### DIFF
--- a/.changeset/fix-array-composition-labels.md
+++ b/.changeset/fix-array-composition-labels.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Show referenced model names for array branches in schema composition selectors.

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
@@ -73,6 +73,39 @@ describe('SchemaComposition', () => {
       const tab = wrapper.find('.composition-selector-label')
       expect(tab.text()).toBe('array string[]')
     })
+
+    it('uses the referenced model name for array composition options', () => {
+      const resourceObject = {
+        '$ref': '#/components/schemas/ResourceObject',
+        '$ref-value': {
+          title: 'ResourceObject',
+          type: 'object',
+        },
+      }
+      const wrapper = mount(SchemaComposition, {
+        props: {
+          eventBus: null,
+          composition: 'oneOf',
+          schema: coerceValue(SchemaObjectSchema, {
+            oneOf: [
+              resourceObject,
+              {
+                type: 'array',
+                items: resourceObject,
+              },
+            ],
+          }),
+          level: 0,
+          options: {},
+        },
+      })
+
+      const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+      expect(listbox.props('options')).toEqual([
+        { id: '0', label: 'ResourceObject' },
+        { id: '1', label: 'ResourceObject[]' },
+      ])
+    })
   })
 
   describe('composition display', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.test.ts
@@ -106,6 +106,42 @@ describe('SchemaComposition', () => {
         { id: '1', label: 'ResourceObject[]' },
       ])
     })
+
+    // Same as above, but the referenced schema has no `title`, so the label has
+    // to be derived from the `$ref` key alone — closer to the document in the
+    // original report (https://github.com/scalar/scalar/issues/10059).
+    it('derives the array item name from the $ref key when it has no title', () => {
+      const resourceObject = {
+        '$ref': '#/components/schemas/ResourceObject',
+        '$ref-value': {
+          type: 'object',
+          properties: { id: { type: 'string' } },
+        },
+      }
+      const wrapper = mount(SchemaComposition, {
+        props: {
+          eventBus: null,
+          composition: 'oneOf',
+          schema: coerceValue(SchemaObjectSchema, {
+            oneOf: [
+              resourceObject,
+              {
+                type: 'array',
+                items: resourceObject,
+              },
+            ],
+          }),
+          level: 0,
+          options: {},
+        },
+      })
+
+      const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+      expect(listbox.props('options')).toEqual([
+        { id: '0', label: 'ResourceObject' },
+        { id: '1', label: 'ResourceObject[]' },
+      ])
+    })
   })
 
   describe('composition display', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -11,7 +11,6 @@ import type {
   DiscriminatorObject,
   SchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { isArraySchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 import { computed, inject, ref, watch } from 'vue'
 
 import type { SchemaOptions } from '@/components/Content/Schema/types'
@@ -25,7 +24,7 @@ import { getSchemaType } from './helpers/get-schema-type'
 import { partitionAllOfCompositions } from './helpers/partition-all-of-compositions'
 import { type CompositionKeyword } from './helpers/schema-composition'
 import { getCycleKey } from './helpers/schema-cycle'
-import { getModelNameFromSchema } from './helpers/schema-name'
+import { getModelNameWithArray } from './helpers/schema-name'
 import Schema from './Schema.vue'
 
 const props = withDefaults(
@@ -84,31 +83,19 @@ const composition = computed(() =>
     .filter((it) => isDefined(it.value)),
 )
 
-const getCompositionOptionLabel = (schema: SchemaObject): string => {
-  const modelName = getModelNameFromSchema(schema)
-  if (modelName) {
-    return modelName.label
-  }
-
-  if (isArraySchema(schema) && schema.items) {
-    const itemName = getModelNameFromSchema(schema.items)
-    if (itemName) {
-      return `${itemName.label}[]`
-    }
-  }
-
-  return getSchemaType(schema) || translate('schema.schema')
-}
-
 /**
  * Generate listbox options for the composition selector.
  * Each option represents a schema in the composition with a human-readable label.
- * Prefers schema title/name over structural type when present.
+ * Prefers schema title/name (including array item models, e.g. `Model[]`) over
+ * structural type when present.
  */
 const listboxOptions = computed((): ScalarListboxOption[] =>
   composition.value.map((schema, index: number) => {
     const resolved = resolve.schema(schema.original!)
-    return { id: String(index), label: getCompositionOptionLabel(resolved) }
+    const label =
+      (getModelNameWithArray(resolved)?.label ?? getSchemaType(resolved)) ||
+      translate('schema.schema')
+    return { id: String(index), label }
   }),
 )
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaComposition.vue
@@ -11,6 +11,7 @@ import type {
   DiscriminatorObject,
   SchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { isArraySchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 import { computed, inject, ref, watch } from 'vue'
 
 import type { SchemaOptions } from '@/components/Content/Schema/types'
@@ -83,6 +84,22 @@ const composition = computed(() =>
     .filter((it) => isDefined(it.value)),
 )
 
+const getCompositionOptionLabel = (schema: SchemaObject): string => {
+  const modelName = getModelNameFromSchema(schema)
+  if (modelName) {
+    return modelName.label
+  }
+
+  if (isArraySchema(schema) && schema.items) {
+    const itemName = getModelNameFromSchema(schema.items)
+    if (itemName) {
+      return `${itemName.label}[]`
+    }
+  }
+
+  return getSchemaType(schema) || translate('schema.schema')
+}
+
 /**
  * Generate listbox options for the composition selector.
  * Each option represents a schema in the composition with a human-readable label.
@@ -91,10 +108,7 @@ const composition = computed(() =>
 const listboxOptions = computed((): ScalarListboxOption[] =>
   composition.value.map((schema, index: number) => {
     const resolved = resolve.schema(schema.original!)
-    const label =
-      (getModelNameFromSchema(resolved)?.label ?? getSchemaType(resolved)) ||
-      translate('schema.schema')
-    return { id: String(index), label }
+    return { id: String(index), label: getCompositionOptionLabel(resolved) }
   }),
 )
 

--- a/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaPropertyHeading.vue
@@ -20,7 +20,7 @@ import {
   isModelLinkable,
   type ModelLinkOptions,
 } from './helpers/is-model-linkable'
-import { getModelNameFromSchema } from './helpers/schema-name'
+import { getModelNameWithArray } from './helpers/schema-name'
 import RenderString from './RenderString.vue'
 import SchemaPropertyDefault from './SchemaPropertyDefault.vue'
 import SchemaPropertyDetail from './SchemaPropertyDetail.vue'
@@ -234,19 +234,7 @@ const modelLink = computed(() => {
     return { schemaKey: props.modelName, label: props.modelName }
   }
 
-  const modelName = getModelNameFromSchema(props.value)
-  if (modelName) {
-    return { schemaKey: modelName.schemaKey, label: modelName.label }
-  }
-
-  if (isArraySchema(props.value) && props.value.items) {
-    const itemName = getModelNameFromSchema(props.value.items)
-    return itemName
-      ? { schemaKey: itemName.schemaKey, label: `${itemName.label}[]` }
-      : null
-  }
-
-  return null
+  return getModelNameWithArray(props.value)
 })
 
 /** Whether the model name links to the models section, or renders as plain text. */

--- a/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/schema-name.ts
@@ -1,16 +1,10 @@
 import { resolve } from '@scalar/workspace-store/resolve'
 import type { SchemaObject, SchemaReferenceType } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { isArraySchema } from '@scalar/workspace-store/schemas/v3.1/strict/type-guards'
 
 import { getRefName, getSchemaRefName } from './get-ref-name'
 
-/**
- * Extract schema name from various schema formats
- *
- * Handles $ref, title, name, type, and schema dictionary lookup
- */
-export const getModelNameFromSchema = (
-  schemaOrRef: SchemaObject | SchemaReferenceType<SchemaObject>,
-): {
+type SchemaModelName = {
   /**
    * The key in `components.schemas` (extracted from `$ref`), used for sidebar
    * navigation. Only set when the `$ref` actually targets
@@ -20,7 +14,16 @@ export const getModelNameFromSchema = (
   schemaKey: string | null
   /** The human-readable name to display (schema.title, schema.name, or ref key). */
   label: string
-} | null => {
+}
+
+/**
+ * Extract schema name from various schema formats
+ *
+ * Handles $ref, title, name, type, and schema dictionary lookup
+ */
+export const getModelNameFromSchema = (
+  schemaOrRef: SchemaObject | SchemaReferenceType<SchemaObject>,
+): SchemaModelName | null => {
   if (!schemaOrRef) {
     return null
   }
@@ -44,6 +47,31 @@ export const getModelNameFromSchema = (
     const label = getRefName(schemaOrRef.$ref)
     if (label) {
       return { schemaKey, label }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Model name for a schema, resolving array branches too: an inline
+ * `{ type: 'array', items: { $ref: Model } }` becomes `Model[]` instead of the
+ * structural `array object[]`. Returns `null` when no model name applies (for
+ * example an array of primitives), so callers can fall back to `getSchemaType`.
+ */
+export const getModelNameWithArray = (
+  schemaOrRef: SchemaObject | SchemaReferenceType<SchemaObject>,
+): SchemaModelName | null => {
+  const direct = getModelNameFromSchema(schemaOrRef)
+  if (direct) {
+    return direct
+  }
+
+  const schema = resolve.schema(schemaOrRef)
+  if (isArraySchema(schema) && schema.items) {
+    const itemName = getModelNameFromSchema(schema.items)
+    if (itemName) {
+      return { schemaKey: itemName.schemaKey, label: `${itemName.label}[]` }
     }
   }
 


### PR DESCRIPTION
## Problem

Schema composition selectors label an inline array branch whose `items` references a model as the generic `array object[]`. This hides the referenced model name and is inconsistent with the resolved schema rendered below the selector.

## Solution

Resolve composition labels in this order:

1. Use the model name for a directly referenced schema.
2. For an array schema, resolve the model name from `items` and append `[]`.
3. Keep the existing structural type and translated schema fallbacks.

A focused component regression test covers `ResourceObject` alongside `ResourceObject[]`.

## Visual

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/taljeon/scalar/codex-artifacts-scalar-10059/pr-artifacts/scalar-10059/base.jpg" alt="Before: array branch is labeled array object[]" width="600" /> | <img src="https://raw.githubusercontent.com/taljeon/scalar/codex-artifacts-scalar-10059/pr-artifacts/scalar-10059/head.jpg" alt="After: array branch is labeled ResourceObject[]" width="600" /> |

## Validation

- `pnpm --filter @scalar/api-reference exec vitest run src/components/Content/Schema/SchemaComposition.test.ts` — 15 tests passed
- `pnpm --filter @scalar/api-reference types:check`
- `pnpm build:packages` — 49/49 tasks passed
- `pnpm build:integrations` — 42/42 tasks passed
- Full `@scalar/api-reference` suite — 1,774 tests passed; 11 network-dependent SSR tests were rerun with network access and all 11 passed
- Biome, Prettier, and ESLint checks on the changed source files passed without errors

Repo-wide `pnpm knip` still reports the existing root `lefthook` dev dependency and `ignoreDependencies` configuration hint; this change does not touch either file.

## Ticket

Fixes #10059

## AI assistance

I used Codex to assist with implementation and validation, then reviewed the source diff, tests, rendered output, and publication metadata before submission.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation. <!-- Not needed: no public API or workflow changed. -->
