### PR TITLE
fix(workspace-store): show a uuid example for version-specific uuid formats

### DIFF
--- a/.changeset/fix-uuid-version-format-example.md
+++ b/.changeset/fix-uuid-version-format-example.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Generate a proper UUID example for version-specific uuid formats (uuid1, uuid3, uuid4, uuid5), so documents from FastAPI/Pydantic get a UUID example instead of an empty one.

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
@@ -267,6 +267,22 @@ describe('getExampleFromSchema', () => {
     expect(result).toBe('hello@example.com')
   })
 
+  it('uses a uuid example for version-specific uuid formats', () => {
+    for (const format of ['uuid', 'uuid1', 'uuid3', 'uuid4', 'uuid5']) {
+      const result = getExampleFromSchema(
+        coerceValue(SchemaObjectSchema, {
+          type: 'string',
+          format,
+        }),
+        {
+          emptyString: '…',
+        },
+      )
+
+      expect(result).toBe('123e4567-e89b-12d3-a456-426614174000')
+    }
+  })
+
   it('uses variables as an example value', () => {
     expect(
       getExampleFromSchema(

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -85,7 +85,11 @@ const guessFromFormat = (
 
   // Return format-specific example if we have one and are making up data
   if (makeUpRandomData && 'format' in schema && schema.format) {
-    return genericExampleValues[schema.format] ?? fallback
+    // Some generators emit version-specific UUID formats (for example FastAPI/Pydantic
+    // uses uuid1, uuid3, uuid4 and uuid5). Treat them all like a regular uuid.
+    const format = /^uuid[1-8]$/.test(schema.format) ? 'uuid' : schema.format
+
+    return genericExampleValues[format] ?? fallback
   }
 
   return fallback


### PR DESCRIPTION
FastAPI/Pydantic emit version-specific UUID formats like `uuid4`. We only knew `uuid`, so those fields got an empty example instead of a UUID.

Now `uuid1`, `uuid3`, `uuid4`, `uuid5` (and up to `uuid8`) all use the normal UUID example. Nothing else changes, the format label still shows the exact value from the document.

This comes out of discussion #10064. A full `x-formatHints` extension felt like too much for this; a small normalization fixes the real case with no config.

## Ticket

Ref #10064