### PR TITLE
docs(company): add Founding Account Executive to careers

### DIFF
--- a/documentation/guides/company.md
+++ b/documentation/guides/company.md
@@ -374,6 +374,7 @@ We are the API company, giving you industry-best interfaces for your APIs so you
       <span class="company-career-location">Europe, North America, Remote</span>
       <scalar-icon class="relative" src="phosphor/bold/arrow-up-right"></scalar-icon>
     </a>
+    <!-- Product engineering candidates apply through the Fullstack Engineer posting, so this row intentionally shares its Ashby link. -->
     <a class="company-career-row" target="_blank" href="https://jobs.ashbyhq.com/scalar/aa017463-43c4-407c-b6c9-b59076f01d82">
       <span class="company-career-role t-editor__anchor">Senior / Staff Product Engineer</span>
       <span class="company-career-location">Europe, North America, Remote</span>
@@ -390,13 +391,13 @@ We are the API company, giving you industry-best interfaces for your APIs so you
       <span class="company-career-location">San Francisco, CA</span>
       <scalar-icon class="relative" src="phosphor/bold/arrow-up-right"></scalar-icon>
     </a>
-    <a class="company-career-row" target="_blank" href="https://jobs.ashbyhq.com/scalar/830eca96-dc30-46bd-a0f1-951c0dcdd9ea">
-      <span class="company-career-role t-editor__anchor">Sales Development Representative</span>
+    <a class="company-career-row" target="_blank" href="https://jobs.ashbyhq.com/scalar/274bf7b1-be2a-45e4-9910-eb9bbced8366">
+      <span class="company-career-role t-editor__anchor">Founding Solutions Engineer</span>
       <span class="company-career-location">San Francisco, CA</span>
       <scalar-icon class="relative" src="phosphor/bold/arrow-up-right"></scalar-icon>
     </a>
-    <a class="company-career-row" target="_blank" href="https://jobs.ashbyhq.com/scalar/274bf7b1-be2a-45e4-9910-eb9bbced8366">
-      <span class="company-career-role t-editor__anchor">Founding Solutions Engineer</span>
+    <a class="company-career-row" target="_blank" href="https://jobs.ashbyhq.com/scalar/b1e4ce53-ab1c-486a-94a6-a639537a0344">
+      <span class="company-career-role t-editor__anchor">Founding Account Executive</span>
       <span class="company-career-location">San Francisco, CA</span>
       <scalar-icon class="relative" src="phosphor/bold/arrow-up-right"></scalar-icon>
     </a>


### PR DESCRIPTION
Adds the new **Founding Account Executive** posting to the careers section of the company page, and cleans up two pre-existing issues in the same section.

## What changed

**New role.** The Sales section now lists Founding Account Executive (San Francisco, CA), linking to [its Ashby posting](https://jobs.ashbyhq.com/scalar/b1e4ce53-ab1c-486a-94a6-a639537a0344).

**Removed a duplicate.** Sales Development Representative was listed twice with an identical title, location, and link. One row is gone.

**Documented the Product Engineer link.** The Senior / Staff Product Engineer row points at the Fullstack Engineer's Ashby posting. That is intentional — product engineering candidates apply through the Fullstack req — but it reads as a copy-paste bug, so there is now an HTML comment above it explaining why. The link itself is unchanged, and the comment does not render on the page.

## Notes for reviewers

The public posting URL was derived from the posting ID in the Ashby admin link and verified against Ashby's public job board API, which returns `Founding Account Executive`, department Sales, location "San Francisco, CA, United States". The board has exactly five listed postings; after this change the careers page matches it, except for the Product Engineer row noted above.

Heads up for later: the Engineering rows read "Senior / Staff Fullstack Engineer" and "Senior / Staff Platform Engineer" here, while Ashby calls them "Senior Fullstack Engineer" and "Senior Platform Engineer". The "/ Staff" is site-only phrasing and was left alone, but the titles will drift if the reqs are renamed in Ashby.

No changeset: this touches `documentation/` only, not `packages/`, `integrations/`, or `projects/`.

## Visual

Content-only change to a rendered list of links — no styling or layout changes. The new row uses the same markup as its siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)