### PR TITLE
fix(workspace-store): escape component keys when writing chunks

### DIFF
--- a/.changeset/workspace-store-component-key-traversal.md
+++ b/.changeset/workspace-store-component-key-traversal.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Escape OpenAPI component keys when writing static workspace chunks so a document with a key like `../../evil` cannot write files outside the assets directory

--- a/packages/workspace-store/src/server.test.ts
+++ b/packages/workspace-store/src/server.test.ts
@@ -473,6 +473,40 @@ describe('create-server-store', () => {
 
       await fs.rmdir(basePath, { recursive: true })
     })
+
+    it('escapes malicious component keys so chunks cannot escape the directory', async () => {
+      const dir = randomUUID()
+
+      const store = await createServerWorkspaceStore({
+        mode: 'static',
+        directory: dir,
+        documents: [
+          {
+            name: 'doc',
+            document: {
+              openapi: '3.1.0',
+              info: { title: 'Evil', version: '1.0.0' },
+              paths: {},
+              components: { schemas: { '../../../pwned': { type: 'string' } } },
+            },
+          },
+        ],
+      })
+
+      await store.generateWorkspaceChunks()
+
+      const basePath = `${cwd()}/${dir}`
+
+      // The slashes in the key are escaped, so it collapses into a single filename inside the
+      // schemas directory instead of walking up the tree.
+      const written = await fs.readdir(`${basePath}/chunks/doc/components/schemas`)
+      expect(written).toEqual(['..~1..~1..~1pwned.json'])
+
+      // Without escaping the write would have landed at `${basePath}/chunks/pwned.json`.
+      await expect(fs.access(`${basePath}/chunks/pwned.json`)).rejects.toThrow()
+
+      await fs.rm(basePath, { recursive: true, force: true })
+    })
   })
 
   describe('load document on the workspace', () => {

--- a/packages/workspace-store/src/server.ts
+++ b/packages/workspace-store/src/server.ts
@@ -216,7 +216,10 @@ export function externalizeComponentReferences(
       const ref =
         meta.mode === 'ssr'
           ? `${meta.baseUrl}/${meta.name}/components/${type}/${name}#`
-          : `./chunks/${meta.name}/components/${type}/${name}.json#`
+          : // Escape the type and name so the static reference matches the escaped filename written
+            // by generateWorkspaceChunks, and so a key like `../../evil` cannot point outside the
+            // chunks directory.
+            `./chunks/${meta.name}/components/${escapeJsonPointer(type)}/${escapeJsonPointer(name)}.json#`
 
       result[type][name] = { '$ref': ref, $global: true }
     })
@@ -640,11 +643,15 @@ export async function createServerWorkspaceStore(
         // Write the components chunks
         if (components) {
           for (const [type, component] of Object.entries(components as Record<string, Record<string, unknown>>)) {
-            const componentPath = `${basePath}/chunks/${name}/components/${type}`
+            // Escape the component type and key the same way operation paths are escaped. Component
+            // keys come from the OpenAPI document, so a key like `../../evil` would otherwise let a
+            // document write chunk files outside the assets directory. escapeJsonPointer turns every
+            // `/` into `~1`, collapsing the value into a single safe path segment.
+            const componentPath = `${basePath}/chunks/${name}/components/${escapeJsonPointer(type)}`
             await fs.mkdir(componentPath, { recursive: true })
 
             for (const [key, value] of Object.entries(component)) {
-              await fs.writeFile(`${componentPath}/${key}.json`, JSON.stringify(value))
+              await fs.writeFile(`${componentPath}/${escapeJsonPointer(key)}.json`, JSON.stringify(value))
             }
           }
         }


### PR DESCRIPTION
generateWorkspaceChunks wrote each OpenAPI component to a file named after its key without escaping it. A component key like `../../evil` could write outside the assets directory during a static build.

Component keys and types are now escaped with escapeJsonPointer, the same helper already used for operation paths, both when writing the chunk file and in the static $ref that points at it. Operation paths were already safe, so only components changed.

Added a test that a malicious key stays inside the chunks directory.