### PR TITLE
fix(openapi-parser): guard `mergeObjects` against prototype pollution

### DIFF
--- a/.changeset/openapi-parser-merge-objects-proto-pollution.md
+++ b/.changeset/openapi-parser-merge-objects-proto-pollution.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+Guard mergeObjects (used by join) against prototype pollution, so a `__proto__`, `constructor`, or `prototype` key in an input document can no longer reach Object.prototype

--- a/packages/openapi-parser/src/utils/join/merge-objects.test.ts
+++ b/packages/openapi-parser/src/utils/join/merge-objects.test.ts
@@ -1,5 +1,6 @@
+import { describe, expect, it } from 'vitest'
+
 import { mergeObjects } from '@/utils/join/merge-objects'
-import { expect, it, describe } from 'vitest'
 
 describe('mergeObjects', () => {
   it('should merge objects that does not have any conflicting keys', () => {
@@ -132,5 +133,25 @@ describe('mergeObjects', () => {
       },
       b: 2,
     })
+  })
+
+  it('does not pollute Object.prototype through a malicious __proto__ key', () => {
+    // JSON.parse keeps `__proto__` as an own enumerable key (unlike an object literal), which is the
+    // exact vector a crafted document would use.
+    const malicious = JSON.parse('{ "__proto__": { "polluted": "yes" } }')
+
+    mergeObjects({}, malicious)
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    expect(Object.prototype).not.toHaveProperty('polluted')
+  })
+
+  it('does not pollute through a constructor key', () => {
+    const malicious = JSON.parse('{ "constructor": { "prototype": { "polluted": "yes" } } }')
+
+    mergeObjects({}, malicious)
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    expect(Object.prototype).not.toHaveProperty('polluted')
   })
 })

--- a/packages/openapi-parser/src/utils/join/merge-objects.ts
+++ b/packages/openapi-parser/src/utils/join/merge-objects.ts
@@ -1,3 +1,5 @@
+import { isPollutionKey } from '@scalar/helpers/object/prevent-pollution'
+
 /**
  * Deep merges two objects, combining their properties recursively.
  *
@@ -19,6 +21,13 @@
  */
 export const mergeObjects = <R>(a: Record<string, unknown>, b: Record<string, unknown>): R => {
   for (const key in b) {
+    // Skip inherited keys and prototype pollution vectors such as an own `__proto__` key that
+    // survives JSON.parse. Without this guard the recursive merge below would walk into
+    // Object.prototype and pollute it for the whole process.
+    if (!Object.hasOwn(b, key) || isPollutionKey(key)) {
+      continue
+    }
+
     if (!(key in a)) {
       a[key] = b[key]
     } else {


### PR DESCRIPTION
mergeObjects (used by openapi-parser's join) merged keys from an input document without guarding prototype pollution keys. A document with an own `__proto__`, `constructor`, or `prototype` key (which survives JSON.parse) could pollute Object.prototype for the whole process.

Those keys are now skipped, reusing the isPollutionKey helper from @scalar/helpers. join is not called by any Scalar app, so this mainly protects code that calls join directly.

Added tests for the __proto__ and constructor vectors.