### PR TITLE
fix(mock-server): confine $ref resolution to block SSRF and file reads

### DIFF
--- a/.changeset/mock-server-ref-ssrf-file-read.md
+++ b/.changeset/mock-server-ref-ssrf-file-read.md
@@ -1,0 +1,6 @@
+---
+'@scalar/mock-server': patch
+'@scalar/json-magic': patch
+---
+
+Harden the mock server against SSRF and local file disclosure through OpenAPI `$ref`s. External `$ref` resolution now refuses to fetch private, loopback, link-local, and metadata addresses, and confines local file reads to the document's directory. The `fetchUrls` and `readFiles` bundling plugins gain opt-in `blockPrivateNetworks` and `basePath` options, so other callers keep their current behavior unless they opt in.

--- a/packages/json-magic/src/bundle/plugins/browser.ts
+++ b/packages/json-magic/src/bundle/plugins/browser.ts
@@ -1,4 +1,4 @@
 // biome-ignore lint/performance/noBarrelFile: entrypoint
-export { fetchUrls } from './fetch-urls'
+export { fetchUrls } from './fetch-urls/browser'
 export { parseJson } from './parse-json'
 export { parseYaml } from './parse-yaml'

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/browser.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/browser.ts
@@ -24,7 +24,7 @@ const getHost = (url: string): string | null => {
 /**
  * Fetches and normalizes data from a remote URL in a browser environment.
  */
-export const fetchUrl = async (
+const fetchUrl = async (
   url: string,
   limiter: <T>(fn: () => Promise<T>) => Promise<T>,
   config?: FetchConfig,

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/browser.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/browser.ts
@@ -1,0 +1,68 @@
+import { createLimiter } from '@scalar/helpers/general/create-limiter'
+
+import type { LoaderPlugin, ResolveResult } from '@/bundle'
+import { isHttpUrl } from '@/helpers/is-http-url'
+import { normalize } from '@/helpers/normalize'
+
+type FetchConfig = Partial<{
+  headers: { headers: HeadersInit; domains: string[] }[]
+  fetch: (input: string | URL | globalThis.Request, init?: RequestInit) => Promise<Response>
+}>
+
+/**
+ * Safely checks for host from a URL.
+ * Needed because we cannot create a URL from a relative remote URL such as examples/openapi.json.
+ */
+const getHost = (url: string): string | null => {
+  try {
+    return new URL(url).host
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Fetches and normalizes data from a remote URL in a browser environment.
+ */
+export const fetchUrl = async (
+  url: string,
+  limiter: <T>(fn: () => Promise<T>) => Promise<T>,
+  config?: FetchConfig,
+): Promise<ResolveResult> => {
+  try {
+    const host = getHost(url)
+    const headers = config?.headers?.find((a) => a.domains.find((d) => d === host) !== undefined)?.headers
+    const exec = config?.fetch ?? fetch
+    const result = await limiter(() => exec(url, { headers }))
+
+    if (result.ok) {
+      const body = await result.text()
+      return { ok: true, data: normalize(body), raw: body }
+    }
+
+    const contentType = result.headers.get('Content-Type') ?? ''
+
+    if (['text/html', 'application/xml'].includes(contentType)) {
+      console.warn(`[WARN] We only support JSON/YAML formats, received ${contentType}`)
+    }
+
+    console.warn(`[WARN] Fetch failed with status ${result.status} ${result.statusText} for URL: ${url}`)
+    return { ok: false }
+  } catch {
+    console.warn(`[WARN] Failed to parse JSON/YAML from URL: ${url}`)
+    return { ok: false }
+  }
+}
+
+/**
+ * Creates a browser-safe plugin for handling remote URL references.
+ */
+export const fetchUrls = (config?: FetchConfig & Partial<{ limit: number | null }>): LoaderPlugin => {
+  const limiter = config?.limit ? createLimiter(config.limit) : <T>(fn: () => Promise<T>) => fn()
+
+  return {
+    type: 'loader',
+    validate: isHttpUrl,
+    exec: (value) => fetchUrl(value, limiter, config),
+  }
+}

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.test.ts
@@ -168,3 +168,31 @@ describe('fetchUrls', () => {
     expect(fetch).toHaveBeenCalledTimes(6)
   })
 })
+
+describe('fetchUrl blockPrivateNetworks', () => {
+  const noLimit = <T>(fn: () => Promise<T>) => fn()
+
+  it('refuses a private or metadata address without calling fetch', async () => {
+    const fetch = vi.fn(async () => new Response('{}', { status: 200 }))
+
+    const result = await fetchUrl('http://169.254.169.254/latest/meta-data/', noLimit, {
+      blockPrivateNetworks: true,
+      fetch,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('still fetches a public address', async () => {
+    const fetch = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }))
+
+    const result = await fetchUrl('http://93.184.216.34/', noLimit, {
+      blockPrivateNetworks: true,
+      fetch,
+    })
+
+    expect(fetch).toHaveBeenCalled()
+    expect(result.ok).toBe(true)
+  })
+})

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.test.ts
@@ -195,4 +195,17 @@ describe('fetchUrl blockPrivateNetworks', () => {
     expect(fetch).toHaveBeenCalled()
     expect(result.ok).toBe(true)
   })
+
+  it('does not follow redirects under the guard', async () => {
+    let receivedInit: RequestInit | undefined
+    const fetch = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
+      receivedInit = init
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+
+    await fetchUrl('http://93.184.216.34/', noLimit, { blockPrivateNetworks: true, fetch })
+
+    // A redirect would otherwise let a public URL bounce to an internal target.
+    expect(receivedInit?.redirect).toBe('error')
+  })
 })

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
@@ -7,6 +7,12 @@ import { normalize } from '@/helpers/normalize'
 type FetchConfig = Partial<{
   headers: { headers: HeadersInit; domains: string[] }[]
   fetch: (input: string | URL | globalThis.Request, init?: RequestInit) => Promise<Response>
+  /**
+   * When true, refuse to fetch URLs that resolve to a private, loopback, link-local, or otherwise
+   * internal address. Only enforced in Node, where DNS resolution is available. Off by default so
+   * existing callers keep working unchanged.
+   */
+  blockPrivateNetworks: boolean
 }>
 
 /**
@@ -16,6 +22,17 @@ type FetchConfig = Partial<{
 const getHost = (url: string): string | null => {
   try {
     return new URL(url).host
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Safely reads the hostname (without port) from a URL, for the private-address check.
+ */
+const getHostname = (url: string): string | null => {
+  try {
+    return new URL(url).hostname
   } catch {
     return null
   }
@@ -41,6 +58,23 @@ export async function fetchUrl(
   config?: FetchConfig,
 ): Promise<ResolveResult> {
   try {
+    // SSRF guard: optionally refuse to fetch internal or private targets before making the request.
+    // Only runs in Node, since the browser build has no DNS access and its own network isolation.
+    if (config?.blockPrivateNetworks && typeof window === 'undefined') {
+      const hostname = getHostname(url)
+
+      if (hostname) {
+        const { isBlockedHost } = await import('./is-blocked-host')
+
+        if (await isBlockedHost(hostname)) {
+          console.warn(`[WARN] Refused to fetch a private or internal address: ${url}`)
+          return {
+            ok: false,
+          }
+        }
+      }
+    }
+
     const host = getHost(url)
 
     // Get the headers that match the domain

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
@@ -82,9 +82,16 @@ export async function fetchUrl(
 
     const exec = config?.fetch ?? fetch
 
+    // Under the SSRF guard, do not follow redirects. Otherwise a public URL that passes the host
+    // check above could redirect to an internal target (for example the metadata endpoint) that
+    // the redirect would reach without being re-validated.
+    const redirect: RequestRedirect | undefined =
+      config?.blockPrivateNetworks && typeof window === 'undefined' ? 'error' : undefined
+
     const result = await limiter(() =>
       exec(url, {
         headers,
+        redirect,
       }),
     )
 

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/is-blocked-host.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/is-blocked-host.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { isBlockedHost } from './is-blocked-host'
+
+describe('isBlockedHost', () => {
+  it('blocks loopback, private, link-local, CGNAT, and metadata addresses', async () => {
+    const blocked = [
+      '127.0.0.1',
+      '10.0.0.1',
+      '172.16.0.1',
+      '192.168.1.1',
+      '169.254.169.254', // cloud metadata
+      '100.64.0.1', // carrier-grade NAT
+      '::1',
+      'fe80::1',
+      'fc00::1',
+      '::ffff:169.254.169.254', // IPv4-mapped
+      '2002:a9fe:a9fe::', // 6to4 -> 169.254.169.254
+      '64:ff9b::a9fe:a9fe', // NAT64 -> 169.254.169.254
+      '2001::1', // Teredo
+    ]
+
+    for (const host of blocked) {
+      expect(await isBlockedHost(host), host).toBe(true)
+    }
+  })
+
+  it('tolerates a bracketed IPv6 literal', async () => {
+    expect(await isBlockedHost('[::1]')).toBe(true)
+  })
+
+  it('allows public addresses', async () => {
+    const allowed = ['8.8.8.8', '1.1.1.1', '2606:4700:4700::1111']
+
+    for (const host of allowed) {
+      expect(await isBlockedHost(host), host).toBe(false)
+    }
+  })
+})

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/is-blocked-host.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/is-blocked-host.ts
@@ -1,0 +1,96 @@
+import { lookup } from 'node:dns/promises'
+import { BlockList, isIP, isIPv4 } from 'node:net'
+
+/**
+ * Address ranges that must never be reachable through a bundled `$ref`.
+ *
+ * Covers loopback, private, link-local (including the cloud metadata endpoint 169.254.169.254),
+ * carrier-grade NAT, and their IPv6 equivalents. The IPv6 transition ranges (6to4, NAT64, Teredo,
+ * IPv4-compatible) are blocked wholesale so an address like 64:ff9b::a9fe:a9fe cannot smuggle a
+ * private IPv4 destination past the checks. Those ranges are deprecated or rarely used for real API
+ * hosting, so blocking them outright is a safe trade.
+ */
+const blockList = new BlockList()
+
+blockList.addAddress('0.0.0.0', 'ipv4')
+blockList.addSubnet('127.0.0.0', 8, 'ipv4')
+blockList.addSubnet('10.0.0.0', 8, 'ipv4')
+blockList.addSubnet('172.16.0.0', 12, 'ipv4')
+blockList.addSubnet('192.168.0.0', 16, 'ipv4')
+blockList.addSubnet('169.254.0.0', 16, 'ipv4')
+blockList.addSubnet('100.64.0.0', 10, 'ipv4')
+
+blockList.addSubnet('::', 96, 'ipv6') // unspecified, loopback (::1), and deprecated IPv4-compatible
+blockList.addSubnet('fe80::', 10, 'ipv6') // link-local
+blockList.addSubnet('fc00::', 7, 'ipv6') // unique local
+blockList.addSubnet('2002::', 16, 'ipv6') // 6to4
+blockList.addSubnet('64:ff9b::', 96, 'ipv6') // NAT64
+blockList.addSubnet('2001::', 32, 'ipv6') // Teredo
+
+/**
+ * Checks whether a single IP address falls inside a blocked range.
+ */
+const ipIsBlocked = (ip: string): boolean => {
+  const family = isIP(ip)
+
+  if (family === 0) {
+    // Not a valid IP, block to be safe
+    return true
+  }
+
+  if (blockList.check(ip, family === 4 ? 'ipv4' : 'ipv6')) {
+    return true
+  }
+
+  // Normalize an IPv4-mapped IPv6 address (::ffff:x.x.x.x, in dotted or hex form) and re-check it
+  // against the IPv4 rules, since it targets the embedded IPv4 destination.
+  const dotted = ip.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i)
+
+  if (dotted && isIPv4(dotted[1]) && blockList.check(dotted[1], 'ipv4')) {
+    return true
+  }
+
+  const hex = ip.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i)
+
+  if (hex) {
+    const high = Number.parseInt(hex[1], 16)
+    const low = Number.parseInt(hex[2], 16)
+    const mapped = `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`
+
+    if (blockList.check(mapped, 'ipv4')) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Reports whether a hostname resolves to a private, loopback, link-local, or otherwise internal
+ * address that a bundled `$ref` should not be allowed to reach.
+ *
+ * Literal IPs are checked directly. Hostnames are resolved via DNS and every returned address is
+ * checked, so a name that points at an internal IP is rejected. A host that cannot be resolved is
+ * treated as blocked.
+ *
+ * This lives in a Node-only module because it depends on `node:dns` and `node:net`. Load it with a
+ * dynamic import so the browser build of the fetch plugin stays free of Node built-ins.
+ *
+ * @param hostname - The hostname or IP (brackets around an IPv6 literal are tolerated).
+ */
+export const isBlockedHost = async (hostname: string): Promise<boolean> => {
+  const host = hostname.replace(/^\[/, '').replace(/\]$/, '')
+
+  if (isIP(host)) {
+    return ipIsBlocked(host)
+  }
+
+  try {
+    const addresses = await lookup(host, { all: true })
+
+    return addresses.some(({ address }) => ipIsBlocked(address))
+  } catch {
+    // Block when the host cannot be resolved
+    return true
+  }
+}

--- a/packages/json-magic/src/bundle/plugins/read-files/index.test.ts
+++ b/packages/json-magic/src/bundle/plugins/read-files/index.test.ts
@@ -33,4 +33,26 @@ describe('readFile', () => {
 
     expect(result.data).toEqual({ a: 'a' })
   })
+
+  it('refuses to read files outside the base path', async () => {
+    const os = await import('node:os')
+    const path = await import('node:path')
+
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), 'scalar-readfiles-'))
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'scalar-secret-'))
+
+    try {
+      await fs.writeFile(path.join(base, 'ok.json'), JSON.stringify({ ok: true }))
+      await fs.writeFile(path.join(outside, 'secret.json'), JSON.stringify({ secret: true }))
+
+      // A file inside the base path still reads.
+      expect((await readFile(path.join(base, 'ok.json'), base)).ok).toBe(true)
+
+      // A file outside the base path is refused, even though it exists and parses.
+      expect((await readFile(path.join(outside, 'secret.json'), base)).ok).toBe(false)
+    } finally {
+      await fs.rm(base, { recursive: true, force: true })
+      await fs.rm(outside, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/json-magic/src/bundle/plugins/read-files/index.test.ts
+++ b/packages/json-magic/src/bundle/plugins/read-files/index.test.ts
@@ -55,4 +55,25 @@ describe('readFile', () => {
       await fs.rm(outside, { recursive: true, force: true })
     }
   })
+
+  it('refuses a symlink inside the base path that points outside it', async () => {
+    const os = await import('node:os')
+    const path = await import('node:path')
+
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), 'scalar-readfiles-'))
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'scalar-secret-'))
+
+    try {
+      await fs.writeFile(path.join(outside, 'secret.json'), JSON.stringify({ secret: true }))
+
+      // A symlink that lives inside the base directory but resolves to a file outside it.
+      const link = path.join(base, 'link.json')
+      await fs.symlink(path.join(outside, 'secret.json'), link)
+
+      expect((await readFile(link, base)).ok).toBe(false)
+    } finally {
+      await fs.rm(base, { recursive: true, force: true })
+      await fs.rm(outside, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/json-magic/src/bundle/plugins/read-files/index.ts
+++ b/packages/json-magic/src/bundle/plugins/read-files/index.ts
@@ -4,11 +4,28 @@ import type { LoaderPlugin, ResolveResult } from '@/bundle'
 import { isFilePath } from '@/helpers/is-file-path'
 import { normalize } from '@/helpers/normalize'
 
+type FsPromises = typeof import('node:fs/promises')
+
 /**
- * Reports whether a resolved file path escapes the allowed base directory.
+ * Resolves a path to its real location, following symlinks. Falls back to a lexical resolve when the
+ * path does not exist yet, so a missing file is still confined (the read fails afterwards anyway).
  */
-const isOutsideBasePath = (filePath: string, basePath: string): boolean => {
-  const relative = path.relative(path.resolve(basePath), path.resolve(filePath))
+const realpathOrResolve = async (fs: FsPromises, target: string): Promise<string> => {
+  try {
+    return await fs.realpath(path.resolve(target))
+  } catch {
+    return path.resolve(target)
+  }
+}
+
+/**
+ * Reports whether a file escapes the allowed base directory. Symlinks are dereferenced first, so a
+ * link inside the base directory cannot point at a file outside it.
+ */
+const isOutsideBasePath = async (fs: FsPromises, filePath: string, basePath: string): Promise<boolean> => {
+  const realBase = await realpathOrResolve(fs, basePath)
+  const realTarget = await realpathOrResolve(fs, filePath)
+  const relative = path.relative(realBase, realTarget)
 
   return relative === '..' || relative.startsWith('../') || path.isAbsolute(relative)
 }
@@ -35,9 +52,9 @@ export async function readFile(filePath: string, basePath?: string): Promise<Res
     throw 'Can not use readFiles plugin outside of a node environment'
   }
 
-  // Confine reads to basePath when provided, so a `$ref` like `../../../../etc/passwd` cannot read
-  // files outside the document's directory.
-  if (basePath !== undefined && isOutsideBasePath(filePath, basePath)) {
+  // Confine reads to basePath when provided, so a `$ref` like `../../../../etc/passwd` (or a symlink
+  // pointing outside the directory) cannot read files outside the document's directory.
+  if (basePath !== undefined && (await isOutsideBasePath(fs, filePath, basePath))) {
     console.warn(`[WARN] Refused to read a file outside the allowed directory: ${filePath}`)
     return {
       ok: false,

--- a/packages/json-magic/src/bundle/plugins/read-files/index.ts
+++ b/packages/json-magic/src/bundle/plugins/read-files/index.ts
@@ -1,10 +1,22 @@
+import path from 'pathe'
+
 import type { LoaderPlugin, ResolveResult } from '@/bundle'
 import { isFilePath } from '@/helpers/is-file-path'
 import { normalize } from '@/helpers/normalize'
 
 /**
+ * Reports whether a resolved file path escapes the allowed base directory.
+ */
+const isOutsideBasePath = (filePath: string, basePath: string): boolean => {
+  const relative = path.relative(path.resolve(basePath), path.resolve(filePath))
+
+  return relative === '..' || relative.startsWith('../') || path.isAbsolute(relative)
+}
+
+/**
  * Reads and normalizes data from a local file
- * @param path - The file path to read from
+ * @param filePath - The file path to read from
+ * @param basePath - When set, reads are confined to this directory so a `$ref` cannot escape it
  * @returns A promise that resolves to either the normalized data or an error result
  * @example
  * ```ts
@@ -16,15 +28,24 @@ import { normalize } from '@/helpers/normalize'
  * }
  * ```
  */
-export async function readFile(path: string): Promise<ResolveResult> {
+export async function readFile(filePath: string, basePath?: string): Promise<ResolveResult> {
   const fs = typeof window === 'undefined' ? await import('node:fs/promises') : undefined
 
   if (fs === undefined) {
     throw 'Can not use readFiles plugin outside of a node environment'
   }
 
+  // Confine reads to basePath when provided, so a `$ref` like `../../../../etc/passwd` cannot read
+  // files outside the document's directory.
+  if (basePath !== undefined && isOutsideBasePath(filePath, basePath)) {
+    console.warn(`[WARN] Refused to read a file outside the allowed directory: ${filePath}`)
+    return {
+      ok: false,
+    }
+  }
+
   try {
-    const fileContents = await fs.readFile(path, { encoding: 'utf-8' })
+    const fileContents = await fs.readFile(filePath, { encoding: 'utf-8' })
 
     return {
       ok: true,
@@ -43,16 +64,17 @@ export async function readFile(path: string): Promise<ResolveResult> {
  * This plugin validates and reads data from local filesystem paths.
  *
  * @returns A plugin object with validate and exec functions
+ * @param config - Optional settings. `basePath` confines reads to a directory.
  * @example
  * const filePlugin = readFiles()
  * if (filePlugin.validate('./local-schema.json')) {
  *   const result = await filePlugin.exec('./local-schema.json')
  * }
  */
-export function readFiles(): LoaderPlugin {
+export function readFiles(config?: { basePath?: string }): LoaderPlugin {
   return {
     type: 'loader',
     validate: isFilePath,
-    exec: readFile,
+    exec: (value) => readFile(value, config?.basePath),
   }
 }

--- a/packages/mock-server/src/utils/process-openapi-document.test.ts
+++ b/packages/mock-server/src/utils/process-openapi-document.test.ts
@@ -1,0 +1,31 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { processOpenApiDocument } from './process-openapi-document'
+
+describe('processOpenApiDocument', () => {
+  it('does not read files outside the working directory through a $ref', async () => {
+    const secretDir = await mkdtemp(join(tmpdir(), 'scalar-mock-secret-'))
+    const secretFile = join(secretDir, 'secret.json')
+    await writeFile(secretFile, JSON.stringify({ secret: 'do-not-leak' }))
+
+    try {
+      const document = {
+        openapi: '3.1.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {},
+        components: { schemas: { Leaked: { $ref: secretFile } } },
+      }
+
+      const result = await processOpenApiDocument(document)
+
+      // The out-of-tree file must not be inlined into the bundled document.
+      expect(JSON.stringify(result)).not.toContain('do-not-leak')
+    } finally {
+      await rm(secretDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/mock-server/src/utils/process-openapi-document.ts
+++ b/packages/mock-server/src/utils/process-openapi-document.ts
@@ -1,5 +1,9 @@
+import path from 'node:path'
+import { cwd } from 'node:process'
+
 import { bundle } from '@scalar/json-magic/bundle'
 import { fetchUrls, parseJson, parseYaml, readFiles } from '@scalar/json-magic/bundle/plugins/node'
+import { isFilePath } from '@scalar/json-magic/helpers/is-file-path'
 import { createMagicProxy } from '@scalar/json-magic/magic-proxy'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { upgrade } from '@scalar/openapi-upgrader'
@@ -35,11 +39,16 @@ export async function processOpenApiDocument(
 
   let bundled: Record<string, any>
 
+  // Confine local file `$ref`s to the document's own directory (or the working directory when the
+  // document is an object or inline string), and refuse to fetch private or internal addresses.
+  // Without these guards a `$ref` could read arbitrary local files or reach internal services.
+  const basePath = typeof document === 'string' && isFilePath(document) ? path.dirname(path.resolve(document)) : cwd()
+
   try {
     // Bundle external references with Node.js plugins
     // Include parseJson and parseYaml to handle string inputs
     bundled = await bundle(document, {
-      plugins: [parseJson(), parseYaml(), readFiles(), fetchUrls()],
+      plugins: [parseJson(), parseYaml(), readFiles({ basePath }), fetchUrls({ blockPrivateNetworks: true })],
       treeShake: false,
     })
   } catch (error) {


### PR DESCRIPTION
The mock server bundles external OpenAPI `$ref`s, which could fetch any URL and read any local file. A document could use a `$ref` to reach internal services (for example the cloud metadata endpoint) or read files like /etc/passwd.

External `$ref` resolution is now guarded:

- Remote refs no longer resolve to private, loopback, link-local, or metadata addresses. IPv6 transition ranges are blocked too.
- Local file refs are confined to the document's own directory (or the working directory for object and inline documents).

The guards are opt-in options on the shared `fetchUrls` and `readFiles` plugins (`blockPrivateNetworks` and `basePath`), so other callers keep working unchanged. Only the mock server opts in.

Added tests for the address checker, the file confinement, and the mock server wiring.