### PR TITLE
fix(api-client): keep the request body example on first Test Request open

### DIFF
--- a/.changeset/fix-test-request-first-open-example.md
+++ b/.changeset/fix-test-request-first-open-example.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fix the Test Request body showing schema defaults instead of the example on first open. This happened for the first operation when its body used oneOf/anyOf and had a named example.

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBody.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBody.test.ts
@@ -130,6 +130,56 @@ describe('RequestBody', () => {
     ])
   })
 
+  it('keeps the named example when the selection is first established on open', async () => {
+    // On the first open of a composition body the modal applies the reference's selection, moving it
+    // from empty to populated. That is not a user branch switch, so the body must keep its named
+    // example instead of regenerating schema defaults (issue #10075).
+    const requestBody: RequestBodyObject = {
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            anyOf: [
+              { type: 'object', properties: { source: { type: 'string', default: 'file' } } },
+              { type: 'object', properties: { source: { type: 'string', default: 'service' } } },
+            ],
+          },
+          examples: {
+            named: { value: { source: 'named-example-value' } },
+          },
+        },
+      },
+    }
+
+    const wrapper = mount(RequestBody, {
+      props: {
+        ...defaultProps,
+        exampleKey: 'named',
+        requestBody,
+        requestBodyCompositionSelection: {},
+      },
+      global: {
+        stubs: {
+          ScalarButton: true,
+          ScalarIcon: true,
+          ScalarListbox: true,
+          CollapsibleSection: { template: '<div><slot /></div>' },
+          DataTable: { template: '<div><slot /></div>' },
+          DataTableHeader: { template: '<div><slot /></div>' },
+          DataTableRow: { template: '<div><slot /></div>' },
+          CodeInput: true,
+        },
+      },
+    })
+
+    await wrapper.setProps({
+      requestBodyCompositionSelection: { 'requestBody.anyOf': 0 },
+    })
+    await nextTick()
+
+    expect(wrapper.emitted('update:value')).toBeUndefined()
+  })
+
   it('preserves edits when the selected discriminator branch is unchanged', async () => {
     const requestBody: RequestBodyObject = {
       content: {

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBody.vue
@@ -254,12 +254,19 @@ watch(
       requestBody !== previousRequestBody || exampleKey !== previousExampleKey
     const selectionChanged = selection !== previousSelection
 
+    // Going from no selection to a populated one is the modal applying the reference's selection as
+    // the panel opens, not the user switching branches. Resetting here would discard the body's named
+    // example on the very first open (issue #10075), so only a change between two populated selections
+    // counts as a real branch switch.
+    const hadNoPreviousSelection = previousSelection === '{}'
+
     // Only a genuine branch switch within the same operation should reset the edited body. An empty
     // selection means there is no composition to switch between (or the selection was cleared on an
     // operation change), so there is nothing to reset.
     if (
       operationChanged ||
       !selectionChanged ||
+      hadNoPreviousSelection ||
       Object.keys(requestBodyCompositionSelection ?? {}).length === 0
     ) {
       return


### PR DESCRIPTION
Opening Test Request on the first operation showed schema defaults instead of the example, when that operation used oneOf/anyOf and had a named example. The panel read the modal setting its initial selection as a branch switch and regenerated the body from the schema. Now it only regenerates on a real branch switch.

Fixes #10075