### PR TITLE
feat(mock-server): run handler and seed code in a QuickJS sandbox

### DIFF
--- a/.changeset/mock-server-quickjs-sandbox.md
+++ b/.changeset/mock-server-quickjs-sandbox.md
@@ -1,0 +1,9 @@
+---
+'@scalar/mock-server': minor
+---
+
+Run `x-handler` and `x-seed` code in a real sandbox
+
+Handler and seed code used to run with the `Function` constructor, which gave it full access to the Node.js host (`process`, `require`, and more). It now runs inside a QuickJS WebAssembly sandbox with memory and time limits, so even untrusted code from a remote or `$ref`-loaded document cannot reach the host.
+
+The `store`, `faker`, `req`, `res`, `schema`, and `seed` APIs work as before. The one exception is faker methods that take a callback (for example `faker.helpers.multiple(fn)`), which are no longer supported because functions cannot cross the sandbox boundary.

--- a/packages/mock-server/package.json
+++ b/packages/mock-server/package.json
@@ -67,6 +67,7 @@
     "ajv": "catalog:*",
     "ajv-formats": "catalog:*",
     "hono": "catalog:*",
+    "quickjs-emscripten": "catalog:*",
     "yaml": "catalog:*"
   },
   "devDependencies": {

--- a/packages/mock-server/src/utils/build-handler-context.ts
+++ b/packages/mock-server/src/utils/build-handler-context.ts
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
@@ -16,7 +15,6 @@ import { type StoreOperationTracking, createStoreWrapper } from './store-wrapper
  */
 export type HandlerContext = {
   store: ReturnType<typeof createStoreWrapper>['wrappedStore']
-  faker: typeof faker
   req: {
     body: any
     params: Record<string, string>
@@ -136,7 +134,6 @@ export async function buildHandlerContext(
   return {
     context: {
       store: wrappedStore,
-      faker,
       req: {
         body,
         params: pathParameters(c),

--- a/packages/mock-server/src/utils/build-seed-context.ts
+++ b/packages/mock-server/src/utils/build-seed-context.ts
@@ -1,102 +1,26 @@
-import { faker } from '@faker-js/faker'
-
 import { store } from '../libs/store'
 import { createStoreWrapper } from './store-wrapper'
 
 /**
- * Seed helper function type.
- */
-type SeedHelper = {
-  /**
-   * Create n items using a factory function.
-   */
-  count: (n: number, factory: () => any) => any[]
-  /**
-   * Create items from an array of objects.
-   */
-  (items: any[]): any[]
-  /**
-   * Create a single item using a factory function (shorthand for count(1, factory)).
-   */
-  (factory: () => any): any
-}
-
-/**
  * Context object provided to x-seed code.
+ *
+ * The `seed` helper itself lives inside the sandbox (see `sandbox.ts`); it
+ * persists generated items through this store using the schema key as the
+ * collection name.
  */
 export type SeedContext = {
   store: ReturnType<typeof createStoreWrapper>['wrappedStore']
-  faker: typeof faker
-  seed: SeedHelper
   schema: string
 }
 
 /**
- * Build the seed context with a seed helper function.
- * The seed helper automatically uses the schema key as the collection name.
+ * Build the seed context for a schema.
  */
 export function buildSeedContext(schemaKey: string): SeedContext {
   const { wrappedStore } = createStoreWrapper(store)
 
-  /**
-   * Seed helper function that provides a Laravel-inspired API.
-   */
-  const seedHelper = ((arg1: number | any[] | (() => any), arg2?: () => any) => {
-    // Case 1: seed.count(n, factory)
-    if (typeof arg1 === 'number' && typeof arg2 === 'function') {
-      const count = arg1
-      const factory = arg2
-      const items: any[] = []
-
-      for (let i = 0; i < count; i++) {
-        const item = factory()
-        const created = wrappedStore.create(schemaKey, item)
-        items.push(created)
-      }
-
-      return items
-    }
-
-    // Case 2: seed(array)
-    if (Array.isArray(arg1)) {
-      const items: any[] = []
-
-      for (const item of arg1) {
-        const created = wrappedStore.create(schemaKey, item)
-        items.push(created)
-      }
-
-      return items
-    }
-
-    // Case 3: seed(factory) - single item
-    if (typeof arg1 === 'function') {
-      const factory = arg1
-      const item = factory()
-      const created = wrappedStore.create(schemaKey, item)
-      return created
-    }
-
-    throw new Error('Invalid seed() usage. Use seed.count(n, factory), seed(array), or seed(factory)')
-  }) as SeedHelper
-
-  // Add count method to the function
-  seedHelper.count = (n: number, factory: () => any) => {
-    const items: any[] = []
-
-    for (let i = 0; i < n; i++) {
-      const item = factory()
-      const created = wrappedStore.create(schemaKey, item)
-      items.push(created)
-    }
-
-    return items
-  }
-
   return {
     store: wrappedStore,
-    faker,
-    seed: seedHelper,
     schema: schemaKey,
   }
 }

--- a/packages/mock-server/src/utils/execute-handler.ts
+++ b/packages/mock-server/src/utils/execute-handler.ts
@@ -1,4 +1,5 @@
 import type { HandlerContext } from './build-handler-context'
+import { runInSandbox } from './sandbox'
 
 /**
  * Result of executing a handler, including the result and operation tracking.
@@ -8,28 +9,18 @@ type HandlerExecutionResult = {
 }
 
 /**
- * Execute handler code in a sandboxed environment.
- * The code has access only to the provided context (store, faker, req, res).
+ * Execute handler code inside the QuickJS sandbox.
+ *
+ * The handler can only reach the `store` and `faker` bridges and the injected
+ * `req`/`res` inputs. It cannot touch the host runtime, so even untrusted code
+ * from a remote or `$ref`-loaded document is safe to run.
  */
 export async function executeHandler(code: string, context: HandlerContext): Promise<HandlerExecutionResult> {
-  // Create a function that executes the handler code with the context
-  // Using Function constructor to create a sandboxed environment
-  // The code is wrapped in a function body that returns the result
-  const handlerFunction = new Function(
-    'store',
-    'faker',
-    'req',
-    'res',
-    `
-    ${code}
-  `,
-  )
-  const result = handlerFunction(context.store, context.faker, context.req, context.res)
-
-  // If the result is a Promise, await it
-  if (result instanceof Promise) {
-    return { result: await result }
-  }
+  const result = await runInSandbox({
+    code,
+    store: context.store,
+    jsonGlobals: { req: context.req, res: context.res },
+  })
 
   return { result }
 }

--- a/packages/mock-server/src/utils/execute-seed.ts
+++ b/packages/mock-server/src/utils/execute-seed.ts
@@ -1,4 +1,5 @@
 import type { SeedContext } from './build-seed-context'
+import { runInSandbox } from './sandbox'
 
 /**
  * Result of executing a seed handler.
@@ -8,35 +9,19 @@ type SeedExecutionResult = {
 }
 
 /**
- * Execute seed code in a sandboxed environment.
- * The code has access only to the provided context (store, faker, seed, schema).
+ * Execute seed code inside the QuickJS sandbox.
+ *
+ * The seed code can only reach the `store` and `faker` bridges and the `seed`
+ * helper, which persists generated items through the store. It cannot touch the
+ * host runtime.
  */
 export async function executeSeed(code: string, context: SeedContext): Promise<SeedExecutionResult> {
-  // Create a function that executes the seed code with the context
-  // Using Function constructor to create a sandboxed environment
-  // The code is wrapped in a function body that returns the result
-  const seedFunction = new Function(
-    'store',
-    'faker',
-    'seed',
-    'schema',
-    `
-    ${code}
-  `,
-  )
+  const result = await runInSandbox({
+    code,
+    store: context.store,
+    jsonGlobals: { schema: context.schema },
+    includeSeed: true,
+  })
 
-  // Execute the seed function with the context
-  try {
-    const result = seedFunction(context.store, context.faker, context.seed, context.schema)
-
-    // If the result is a Promise, await it
-    if (result instanceof Promise) {
-      return { result: await result }
-    }
-
-    return { result }
-  } catch (error) {
-    // Re-throw to be caught by the caller
-    throw error
-  }
+  return { result }
 }

--- a/packages/mock-server/src/utils/sandbox.test.ts
+++ b/packages/mock-server/src/utils/sandbox.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+
+import { Store } from '../libs/store'
+import { runInSandbox } from './sandbox'
+import { createStoreWrapper } from './store-wrapper'
+
+describe('sandbox', () => {
+  describe('escape attempts', () => {
+    it('has no access to host globals', async () => {
+      const result = await runInSandbox({
+        code: `return {
+          process: typeof process,
+          require: typeof require,
+          fetch: typeof fetch,
+          global: typeof global,
+          globalThis: typeof globalThis.process,
+        }`,
+        store: new Store(),
+      })
+
+      expect(result).toEqual({
+        process: 'undefined',
+        require: 'undefined',
+        fetch: 'undefined',
+        global: 'undefined',
+        globalThis: 'undefined',
+      })
+    })
+
+    it('cannot reach the host through the Function constructor', async () => {
+      // Even if guest code builds a fresh function, the host runtime is not reachable
+      // from inside the WebAssembly guest, so `process` is still undefined.
+      const result = await runInSandbox({
+        code: `return this.constructor.constructor('return typeof process')()`,
+        store: new Store(),
+      })
+
+      expect(result).toBe('undefined')
+    })
+
+    it('cannot pollute host prototypes', async () => {
+      await runInSandbox({
+        code: `Object.prototype.polluted = 'yes'; return 1`,
+        store: new Store(),
+      })
+
+      expect({} as Record<string, unknown>).not.toHaveProperty('polluted')
+    })
+
+    it('rejects dangerous property paths on the faker bridge', async () => {
+      await expect(
+        runInSandbox({
+          code: `return faker.constructor('return 1')`,
+          store: new Store(),
+        }),
+      ).rejects.toThrow(/not accessible/)
+
+      await expect(
+        runInSandbox({
+          code: `return faker.string.__proto__.constructor('return 1')`,
+          store: new Store(),
+        }),
+      ).rejects.toThrow(/not accessible/)
+    })
+  })
+
+  describe('resource limits', () => {
+    it('enforces the memory limit', async () => {
+      await expect(
+        runInSandbox({
+          code: 'return new Array(100_000_000).fill(0).length',
+          store: new Store(),
+        }),
+      ).rejects.toThrow()
+    })
+
+    it('enforces the time limit on an infinite loop', async () => {
+      await expect(
+        runInSandbox({
+          code: 'while (true) {}',
+          store: new Store(),
+        }),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('bridges', () => {
+    it('exposes faker', async () => {
+      const uuid = await runInSandbox({
+        code: 'return faker.string.uuid()',
+        store: new Store(),
+      })
+
+      expect(uuid).toMatch(/^[0-9a-f-]{36}$/)
+    })
+
+    it('surfaces a helpful error for unknown faker methods', async () => {
+      await expect(
+        runInSandbox({
+          code: 'return faker.not.real()',
+          store: new Store(),
+        }),
+      ).rejects.toThrow(/faker/)
+    })
+
+    it('reads the injected req and res inputs', async () => {
+      const result = await runInSandbox({
+        code: `return { name: req.query.name, status: res['200'] }`,
+        store: new Store(),
+        jsonGlobals: { req: { query: { name: 'scalar' } }, res: { '200': { ok: true } } },
+      })
+
+      expect(result).toEqual({ name: 'scalar', status: { ok: true } })
+    })
+
+    it('creates and lists items through the store bridge', async () => {
+      const store = new Store()
+
+      const items = await runInSandbox({
+        code: `store.create('users', { name: 'Ada' }); return store.list('users')`,
+        store,
+      })
+
+      expect(items).toHaveLength(1)
+      expect(items).toMatchObject([{ name: 'Ada' }])
+      expect(store.list('users')).toHaveLength(1)
+    })
+
+    it('records store operations on the tracked wrapper', async () => {
+      const { wrappedStore, tracking } = createStoreWrapper(new Store())
+
+      await runInSandbox({
+        code: `store.create('users', { name: 'Ada' }); return null`,
+        store: wrappedStore,
+      })
+
+      expect(tracking.operations.map((operation) => operation.operation)).toContain('create')
+    })
+
+    it('awaits promises returned from handler code', async () => {
+      const result = await runInSandbox({
+        code: 'const value = await Promise.resolve(42); return value',
+        store: new Store(),
+      })
+
+      expect(result).toBe(42)
+    })
+  })
+
+  describe('seed helper', () => {
+    it('creates a single item from a factory', async () => {
+      const store = new Store()
+
+      await runInSandbox({
+        code: 'seed(() => ({ name: faker.person.fullName() }))',
+        store,
+        jsonGlobals: { schema: 'people' },
+        includeSeed: true,
+      })
+
+      expect(store.list('people')).toHaveLength(1)
+    })
+
+    it('creates many items with seed.count', async () => {
+      const store = new Store()
+
+      await runInSandbox({
+        code: 'seed.count(3, () => ({ id: faker.string.uuid() }))',
+        store,
+        jsonGlobals: { schema: 'people' },
+        includeSeed: true,
+      })
+
+      expect(store.list('people')).toHaveLength(3)
+    })
+
+    it('creates items from an array', async () => {
+      const store = new Store()
+
+      await runInSandbox({
+        code: `seed([{ name: 'Ada' }, { name: 'Alan' }])`,
+        store,
+        jsonGlobals: { schema: 'people' },
+        includeSeed: true,
+      })
+
+      expect(store.list('people')).toHaveLength(2)
+    })
+  })
+})

--- a/packages/mock-server/src/utils/sandbox.ts
+++ b/packages/mock-server/src/utils/sandbox.ts
@@ -1,0 +1,316 @@
+import { faker } from '@faker-js/faker'
+import { getQuickJS } from 'quickjs-emscripten'
+
+import type { StoreInterface } from './store-wrapper'
+
+/**
+ * Maximum memory the sandboxed guest may allocate. Handler and seed code only
+ * shuffles small amounts of mock data around, so this is generous while still
+ * bounding a runaway allocation.
+ */
+const MEMORY_LIMIT_BYTES = 64 * 1024 * 1024
+
+/**
+ * Maximum wall-clock time a single handler or seed run may take. This is the
+ * only defence against an infinite loop, since the guest cannot reach anything
+ * else on the host.
+ */
+const EXECUTION_TIMEOUT_MS = 1_000
+
+/**
+ * Property names that let code climb from an object onto its prototype chain and
+ * ultimately reach the host `Function` constructor. They are never legitimate
+ * faker module or method names, so the bridge refuses to walk through them.
+ */
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+/** Store methods the guest bridge is allowed to call. */
+const STORE_METHODS = new Set<keyof StoreInterface>(['list', 'get', 'create', 'update', 'delete', 'clear'])
+
+/**
+ * The QuickJS WebAssembly module is expensive to instantiate, so it is loaded
+ * once and shared. Each run still gets its own isolated context and runtime.
+ */
+let quickJSModule: ReturnType<typeof getQuickJS> | undefined
+const loadQuickJS = () => (quickJSModule ??= getQuickJS())
+
+/**
+ * Options for {@link runInSandbox}.
+ */
+type RunInSandboxOptions = {
+  /** User-supplied handler or seed code. It runs inside an async wrapper, so top-level `return` and `await` work. */
+  code: string
+  /** Host store bridge (already wrapped with operation tracking). */
+  store: StoreInterface
+  /** Plain-JSON values exposed to the guest as globals (for example `req`, `res`, `schema`). */
+  jsonGlobals?: Record<string, unknown>
+  /** When true, exposes the guest-side `seed` helper. Requires a `schema` entry in {@link jsonGlobals}. */
+  includeSeed?: boolean
+}
+
+/**
+ * Envelope returned by the host bridges. Errors are marshaled as data instead of
+ * thrown so nothing but plain JSON ever crosses the sandbox boundary.
+ */
+type BridgeEnvelope = { ok: true; value: unknown } | { ok: false; error: string }
+
+/**
+ * Walk faker with a guest-provided property path and invoke the resolved method.
+ * The faker instance lives on the host; only the path and JSON arguments cross
+ * the boundary, so guest code can never obtain a reference to faker itself.
+ */
+function callFaker(path: string[], args: unknown[]): unknown {
+  const method = path.at(-1)
+
+  if (method === undefined || FORBIDDEN_KEYS.has(method)) {
+    throw new Error(`faker: "${method}" is not accessible`)
+  }
+
+  // Resolve everything except the last segment to the faker module owning the method.
+  let receiver: any = faker
+
+  for (const key of path.slice(0, -1)) {
+    if (FORBIDDEN_KEYS.has(key)) {
+      throw new Error(`faker: "${key}" is not accessible`)
+    }
+
+    receiver = receiver?.[key]
+
+    if (receiver === undefined || receiver === null) {
+      throw new Error(`faker: "${key}" does not exist`)
+    }
+  }
+
+  const fn = receiver?.[method]
+
+  if (typeof fn !== 'function') {
+    throw new Error(`faker: "${path.join('.')}" is not a function`)
+  }
+
+  // Bind to the resolved module so faker methods keep their expected `this`.
+  return fn.apply(receiver, args)
+}
+
+/**
+ * Run a store method requested by the guest and return a JSON envelope.
+ */
+function runStoreBridge(store: StoreInterface, method: string, argsJson: string): string {
+  try {
+    if (!STORE_METHODS.has(method as keyof StoreInterface)) {
+      throw new Error(`store: "${method}" is not a method`)
+    }
+
+    const args = JSON.parse(argsJson) as unknown[]
+    const result = (store[method as keyof StoreInterface] as (...args: unknown[]) => unknown)(...args)
+
+    return serializeEnvelope({ ok: true, value: result ?? null })
+  } catch (error) {
+    return serializeEnvelope({ ok: false, error: error instanceof Error ? error.message : String(error) })
+  }
+}
+
+/**
+ * Run a faker call requested by the guest and return a JSON envelope.
+ */
+function runFakerBridge(pathJson: string, argsJson: string): string {
+  try {
+    const path = JSON.parse(pathJson) as string[]
+    const args = JSON.parse(argsJson) as unknown[]
+
+    return serializeEnvelope({ ok: true, value: callFaker(path, args) ?? null })
+  } catch (error) {
+    return serializeEnvelope({ ok: false, error: error instanceof Error ? error.message : String(error) })
+  }
+}
+
+/**
+ * Serialize a bridge envelope. Faker occasionally returns values such as `Date`
+ * that JSON cannot represent as-is; those are converted to their JSON form,
+ * which matches what handler code would send over the wire anyway.
+ */
+function serializeEnvelope(envelope: BridgeEnvelope): string {
+  return JSON.stringify(envelope)
+}
+
+/**
+ * Guest-side bootstrap. It rebuilds `store` and `faker` on top of the host
+ * bridges so guest code sees the same API as before, but every call is just a
+ * JSON message to the host.
+ */
+const GUEST_PRELUDE = `
+  const __unwrap = (raw) => {
+    const parsed = JSON.parse(raw)
+    if (!parsed.ok) {
+      throw new Error(parsed.error)
+    }
+    return parsed.value
+  }
+
+  const store = {
+    list: (...args) => __unwrap(__store('list', JSON.stringify(args))),
+    get: (...args) => __unwrap(__store('get', JSON.stringify(args))),
+    create: (...args) => __unwrap(__store('create', JSON.stringify(args))),
+    update: (...args) => __unwrap(__store('update', JSON.stringify(args))),
+    delete: (...args) => __unwrap(__store('delete', JSON.stringify(args))),
+    clear: (...args) => __unwrap(__store('clear', JSON.stringify(args))),
+  }
+
+  const __makeFaker = (path) =>
+    new Proxy(function () {}, {
+      get: (_target, prop) => (typeof prop === 'string' ? __makeFaker(path.concat(prop)) : undefined),
+      apply: (_target, _thisArg, args) => __unwrap(__faker(JSON.stringify(path), JSON.stringify(args))),
+    })
+  const faker = __makeFaker([])
+`
+
+/**
+ * Guest-side `seed` helper. It mirrors the Laravel-inspired API and runs the
+ * factory callbacks inside the sandbox, persisting through the `store` bridge.
+ */
+const SEED_PRELUDE = `
+  const seed = (() => {
+    const create = (item) => store.create(schema, item)
+    const helper = (arg1, arg2) => {
+      if (typeof arg1 === 'number' && typeof arg2 === 'function') {
+        const items = []
+        for (let index = 0; index < arg1; index++) {
+          items.push(create(arg2()))
+        }
+        return items
+      }
+      if (Array.isArray(arg1)) {
+        return arg1.map(create)
+      }
+      if (typeof arg1 === 'function') {
+        return create(arg1())
+      }
+      throw new Error('Invalid seed() usage. Use seed.count(n, factory), seed(array), or seed(factory)')
+    }
+    helper.count = (n, factory) => {
+      const items = []
+      for (let index = 0; index < n; index++) {
+        items.push(create(factory()))
+      }
+      return items
+    }
+    return helper
+  })()
+`
+
+/**
+ * Assemble the full guest program: bridges, injected JSON globals, the optional
+ * seed helper, and the user code wrapped in an async IIFE whose result becomes
+ * the completion value QuickJS hands back.
+ */
+function buildGuestSource(code: string, jsonGlobalNames: string[], includeSeed: boolean): string {
+  const jsonGlobals = jsonGlobalNames.map((name) => `const ${name} = JSON.parse(__json_${name})`).join('\n')
+
+  return `
+    ${GUEST_PRELUDE}
+    ${jsonGlobals}
+    ${includeSeed ? SEED_PRELUDE : ''}
+    ;(async () => {
+      ${code}
+    })()
+  `
+}
+
+/**
+ * Rebuild a host error from a dumped QuickJS error so callers see a normal
+ * `Error` instead of an opaque value.
+ */
+function toError(dumped: unknown): Error {
+  if (dumped instanceof Error) {
+    return dumped
+  }
+
+  if (dumped && typeof dumped === 'object' && 'message' in dumped) {
+    const error = new Error(String((dumped as { message: unknown }).message))
+    const name = (dumped as { name?: unknown }).name
+    if (typeof name === 'string') {
+      error.name = name
+    }
+    return error
+  }
+
+  return new Error(typeof dumped === 'string' ? dumped : 'Sandbox execution failed')
+}
+
+/**
+ * Execute untrusted handler or seed code inside a QuickJS WebAssembly sandbox.
+ *
+ * The guest has no access to the host runtime (`process`, `require`, `fetch`,
+ * the `Function` constructor, and so on). It can only talk to the `store` and
+ * `faker` bridges and read the injected JSON globals. Memory and time limits
+ * bound the remaining denial-of-service risk.
+ */
+export async function runInSandbox(options: RunInSandboxOptions): Promise<unknown> {
+  const { code, store, jsonGlobals = {}, includeSeed = false } = options
+
+  const quickJS = await loadQuickJS()
+  const context = quickJS.newContext()
+
+  try {
+    const { runtime } = context
+    runtime.setMemoryLimit(MEMORY_LIMIT_BYTES)
+
+    const deadline = Date.now() + EXECUTION_TIMEOUT_MS
+    runtime.setInterruptHandler(() => Date.now() > deadline)
+
+    // Host bridge: store operations run the real (tracked) store and return JSON.
+    const storeBridge = context.newFunction('__store', (methodHandle, argsHandle) =>
+      context.newString(runStoreBridge(store, context.getString(methodHandle), context.getString(argsHandle))),
+    )
+    context.setProp(context.global, '__store', storeBridge)
+    storeBridge.dispose()
+
+    // Host bridge: faker. Only a property path and JSON arguments cross the boundary.
+    const fakerBridge = context.newFunction('__faker', (pathHandle, argsHandle) =>
+      context.newString(runFakerBridge(context.getString(pathHandle), context.getString(argsHandle))),
+    )
+    context.setProp(context.global, '__faker', fakerBridge)
+    fakerBridge.dispose()
+
+    // Inject read-only inputs (req/res/schema) as JSON strings the guest parses.
+    for (const [name, value] of Object.entries(jsonGlobals)) {
+      const handle = context.newString(JSON.stringify(value ?? null))
+      context.setProp(context.global, `__json_${name}`, handle)
+      handle.dispose()
+    }
+
+    const evalResult = context.evalCode(buildGuestSource(code, Object.keys(jsonGlobals), includeSeed))
+
+    if (evalResult.error) {
+      const error = context.dump(evalResult.error)
+      evalResult.error.dispose()
+      throw toError(error)
+    }
+
+    // The completion value is the async IIFE's promise. Resolve it, then drain the
+    // job queue; every host bridge is synchronous, so one pass settles the promise.
+    const promiseHandle = evalResult.value
+    const resolved = context.resolvePromise(promiseHandle)
+    promiseHandle.dispose()
+
+    const jobs = runtime.executePendingJobs()
+    if (jobs.error) {
+      const error = context.dump(jobs.error)
+      jobs.error.dispose()
+      throw toError(error)
+    }
+
+    const settled = await resolved
+    if (settled.error) {
+      const error = context.dump(settled.error)
+      settled.error.dispose()
+      throw toError(error)
+    }
+
+    const value = context.dump(settled.value)
+    settled.value.dispose()
+
+    return value
+  } finally {
+    context.dispose()
+  }
+}

--- a/packages/mock-server/src/utils/store-wrapper.ts
+++ b/packages/mock-server/src/utils/store-wrapper.ts
@@ -3,7 +3,7 @@ import type { Store } from '../libs/store'
 /**
  * Public interface of the Store class (methods only, no private properties).
  */
-type StoreInterface = Pick<Store, 'list' | 'get' | 'create' | 'update' | 'delete' | 'clear'>
+export type StoreInterface = Pick<Store, 'list' | 'get' | 'create' | 'update' | 'delete' | 'clear'>
 
 /**
  * Represents a single store operation with its result.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ catalogs:
     posthog-js:
       specifier: 1.407.5
       version: 1.407.5
+    quickjs-emscripten:
+      specifier: 0.32.0
+      version: 0.32.0
     radix-vue:
       specifier: ^1.9.17
       version: 1.9.17
@@ -2134,6 +2137,9 @@ importers:
       hono:
         specifier: catalog:*
         version: 4.12.9
+      quickjs-emscripten:
+        specifier: catalog:*
+        version: 0.32.0
       yaml:
         specifier: catalog:*
         version: 2.9.0
@@ -5953,6 +5959,21 @@ packages:
   '@jest/types@29.6.3':
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jitl/quickjs-ffi-types@0.32.0':
+    resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    resolution: {integrity: sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==}
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    resolution: {integrity: sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==}
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    resolution: {integrity: sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==}
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
 
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
@@ -16519,6 +16540,13 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  quickjs-emscripten-core@0.32.0:
+    resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
+
+  quickjs-emscripten@0.32.0:
+    resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
+    engines: {node: '>=16.0.0'}
+
   radix-vue@1.9.17:
     resolution: {integrity: sha512-mVCu7I2vXt1L2IUYHTt0sZMz7s1K2ZtqKeTIxG3yC5mMFfLBG4FtE1FDeRMpDd+Hhg/ybi9+iXmAP1ISREndoQ==}
     peerDependencies:
@@ -23468,6 +23496,24 @@ snapshots:
       '@types/node': 24.10.13
       '@types/yargs': 17.0.32
       chalk: 4.1.2
+
+  '@jitl/quickjs-ffi-types@0.32.0': {}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
 
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
@@ -36431,6 +36477,18 @@ snapshots:
   quick-format-unescaped@4.0.4: {}
 
   quick-lru@5.1.1: {}
+
+  quickjs-emscripten-core@0.32.0:
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  quickjs-emscripten@0.32.0:
+    dependencies:
+      '@jitl/quickjs-wasmfile-debug-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-debug-sync': 0.32.0
+      '@jitl/quickjs-wasmfile-release-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-release-sync': 0.32.0
+      quickjs-emscripten-core: 0.32.0
 
   radix-vue@1.9.17(vue@3.5.40(typescript@5.9.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,6 +88,7 @@ catalogs:
     neverpanic: 0.0.8
     picomatch: ^4.0.4
     postcss: ^8.4.38
+    quickjs-emscripten: 0.32.0
     radix-vue: ^1.9.17
     react-dom: ^19.2.3
     react: ^19.2.3


### PR DESCRIPTION
Handler (`x-handler`) and seed (`x-seed`) code used to run with the `Function` constructor, which gave it full access to the Node.js host (`process`, `require`, and more). It now runs inside a QuickJS WebAssembly sandbox with memory and time limits, so it can only reach the `store`, `faker`, `req`, `res`, `schema`, and `seed` APIs.

Everything works as before, with one exception: faker methods that take a callback (like `faker.helpers.multiple(fn)`) are no longer supported, because functions cannot cross the sandbox boundary.