### PR TITLE
fix(proxy): expose deployed commit in OpenAPI

### DIFF
--- a/projects/proxy-scalar-com/Dockerfile
+++ b/projects/proxy-scalar-com/Dockerfile
@@ -2,8 +2,12 @@
 FROM golang:1.26.2-alpine AS build
 WORKDIR /app
 
+ARG COMMIT_SHA=dev
+
 COPY ./main.go ./
 COPY ./public ./public
+
+RUN sed -i "s/__COMMIT_SHA__/${COMMIT_SHA}/" public/openapi.yaml
 
 RUN go build main.go
 

--- a/projects/proxy-scalar-com/cloudbuild.yaml
+++ b/projects/proxy-scalar-com/cloudbuild.yaml
@@ -7,6 +7,8 @@ steps:
         'build',
         '-t',
         'gcr.io/${_PROJECT_ID}/${_SERVICE_GO_PROXY}',
+        '--build-arg',
+        'COMMIT_SHA=$COMMIT_SHA',
         '-f',
         './Dockerfile',
         '.',

--- a/projects/proxy-scalar-com/main_test.go
+++ b/projects/proxy-scalar-com/main_test.go
@@ -83,6 +83,10 @@ func TestBasicEndpoints(t *testing.T) {
 		if len(w.Body.String()) == 0 {
 			t.Error("Expected non-empty YAML response")
 		}
+
+		if !strings.Contains(w.Body.String(), "version: __COMMIT_SHA__") {
+			t.Error("Expected OpenAPI document to contain the commit SHA placeholder")
+		}
 	})
 
 	t.Run("Root path with query params requires scalar_url", func(t *testing.T) {

--- a/projects/proxy-scalar-com/public/openapi.yaml
+++ b/projects/proxy-scalar-com/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.1
 info:
   title: Scalar Proxy
   description: A proxy server that forwards requests to specified URLs, allowing cross-origin requests by handling CORS headers.
-  version: 1.0.0
+  version: __COMMIT_SHA__
 
 servers:
   - url: https://proxy.scalar.com


### PR DESCRIPTION
Adds the deployed commit hash to the proxy OpenAPI version.