### PR TITLE
fix(api-client): send edited query parameters

### DIFF
--- a/.changeset/enable-edited-query-parameters.md
+++ b/.changeset/enable-edited-query-parameters.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Enable optional query parameters when their value is entered.

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.test.ts
@@ -345,6 +345,59 @@ describe('RequestTableRow', () => {
     })
   })
 
+  it('enables an optional parameter disabled by default when its value is updated', async () => {
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: {
+          name: 'date',
+          value: '',
+          isDisabled: true,
+          isDisabledByDefault: true,
+          originalParameter: {
+            name: 'date',
+            in: 'query',
+            required: false,
+          },
+        },
+        environment,
+      },
+      global: { stubs: { RouterLink: true } },
+    })
+
+    const valueInput = wrapper.findAllComponents({ name: 'CodeInputLite' })[1]
+    await valueInput?.vm.$emit('update:modelValue', '2025-09-01')
+
+    expect(wrapper.emitted('upsertRow')?.[0]?.[0]).toStrictEqual({
+      name: 'date',
+      value: '2025-09-01',
+      isDisabled: false,
+    })
+  })
+
+  it('keeps an explicitly disabled parameter disabled when its value is updated', async () => {
+    const wrapper = mount(RequestTableRow, {
+      props: {
+        data: {
+          name: 'x-scenario-id',
+          value: 'scenario_a',
+          isDisabled: true,
+          isDisabledByDefault: false,
+        },
+        environment,
+      },
+      global: { stubs: { RouterLink: true } },
+    })
+
+    const valueInput = wrapper.findAllComponents({ name: 'CodeInputLite' })[1]
+    await valueInput?.vm.$emit('update:modelValue', 'scenario_b')
+
+    expect(wrapper.emitted('upsertRow')?.[0]?.[0]).toStrictEqual({
+      name: 'x-scenario-id',
+      value: 'scenario_b',
+      isDisabled: true,
+    })
+  })
+
   it('preserves isDisabled=false when value input is updated', async () => {
     const wrapper = mount(RequestTableRow, {
       props: {

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -36,6 +36,8 @@ export type TableRow = {
   globalRoute?: ApiReferenceEvents['ui:navigate']
   /** Whether the parameter is disabled/inactive */
   isDisabled?: boolean
+  /** Whether an optional parameter is disabled because it has no explicit x-disabled value */
+  isDisabledByDefault?: boolean
   /** OpenAPI schema object with type, validation rules, examples, etc. */
   schema?: SchemaObject
   /** Whether the parameter is required */
@@ -177,6 +179,12 @@ const handleUpdateRow = (
   }
   if (payload.value !== undefined) {
     value.value = payload.value
+
+    // Optional parameters start unchecked, but entering a value expresses intent to send it.
+    // Explicit x-disabled values stay unchanged so a deliberate opt-out is preserved.
+    if (data.isDisabledByDefault) {
+      isDisabled.value = false
+    }
   }
 
   // Is disabled should only be updated when explicitly provided in the payload

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.test.ts
@@ -573,4 +573,49 @@ describe('createParameterRows', () => {
       },
     ])
   })
+
+  it('marks optional query, header, and cookie parameters disabled by default', () => {
+    const parameters: ParameterObject[] = [
+      { name: 'query', in: 'query', schema: { type: 'string' } },
+      { name: 'header', in: 'header', schema: { type: 'string' } },
+      { name: 'cookie', in: 'cookie', schema: { type: 'string' } },
+    ]
+
+    expect(
+      parameters.map((parameter) => {
+        const [row] = createParameterRows(parameter, 'default')
+
+        return {
+          name: row?.name,
+          isDisabled: row?.isDisabled,
+          isDisabledByDefault: row?.isDisabledByDefault,
+        }
+      }),
+    ).toStrictEqual([
+      { name: 'query', isDisabled: true, isDisabledByDefault: true },
+      { name: 'header', isDisabled: true, isDisabledByDefault: true },
+      { name: 'cookie', isDisabled: true, isDisabledByDefault: true },
+    ])
+  })
+
+  it('does not mark an explicitly disabled parameter as disabled by default', () => {
+    const parameter: ParameterObject = {
+      name: 'header',
+      in: 'header',
+      schema: { type: 'string' },
+      examples: {
+        default: {
+          value: 'scenario_a',
+          'x-disabled': true,
+        },
+      },
+    }
+
+    const [row] = createParameterRows(parameter, 'default')
+
+    expect({
+      isDisabled: row?.isDisabled,
+      isDisabledByDefault: row?.isDisabledByDefault,
+    }).toStrictEqual({ isDisabled: true, isDisabledByDefault: undefined })
+  })
 })

--- a/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/create-parameter-rows.ts
@@ -91,6 +91,7 @@ const toTableRow = ({
   schema,
   isRequired,
   isDisabled,
+  isDisabledByDefault,
   sourceParameterValuePath,
 }: {
   parameter: ParameterObject
@@ -100,6 +101,7 @@ const toTableRow = ({
   schema: SchemaObject | undefined
   isRequired: boolean | undefined
   isDisabled: boolean
+  isDisabledByDefault?: boolean
   sourceParameterValuePath?: string[]
 }): TableRow => ({
   name,
@@ -108,6 +110,7 @@ const toTableRow = ({
   schema,
   isRequired,
   isDisabled,
+  ...(isDisabledByDefault ? { isDisabledByDefault: true } : {}),
   originalParameter: parameter,
   sourceParameterValuePath,
 })
@@ -134,6 +137,7 @@ const toSingleParameterRow = (
   schema: SchemaObject | undefined,
   value: unknown,
   isDisabled: boolean,
+  isDisabledByDefault: boolean,
 ): TableRow =>
   toTableRow({
     parameter,
@@ -143,6 +147,7 @@ const toSingleParameterRow = (
     schema,
     isRequired: parameter.required,
     isDisabled,
+    isDisabledByDefault,
   })
 
 /**
@@ -164,6 +169,7 @@ const getExpandedPropertyRows = ({
   namePrefix,
   mode,
   isDisabled,
+  isDisabledByDefault,
   hiddenValuePaths,
   renamedValuePaths,
   renameTargetPaths,
@@ -175,6 +181,7 @@ const getExpandedPropertyRows = ({
   namePrefix: string
   mode: ExpansionMode
   isDisabled: boolean
+  isDisabledByDefault: boolean
   hiddenValuePaths: ReadonlySet<string>
   renamedValuePaths: ReadonlyMap<string, string[]>
   renameTargetPaths: ReadonlySet<string>
@@ -220,6 +227,7 @@ const getExpandedPropertyRows = ({
           schema: undefined,
           isRequired: false,
           isDisabled,
+          isDisabledByDefault,
           sourceParameterValuePath: renamedTo,
         }),
       ]
@@ -246,6 +254,7 @@ const getExpandedPropertyRows = ({
         namePrefix: name,
         mode,
         isDisabled,
+        isDisabledByDefault,
         hiddenValuePaths,
         renamedValuePaths,
         renameTargetPaths,
@@ -268,6 +277,7 @@ const getExpandedPropertyRows = ({
         schema: resolvedPropertySchema,
         isRequired: requiredProperties.has(propertyName),
         isDisabled,
+        isDisabledByDefault,
         sourceParameterValuePath: path,
       }),
     ]
@@ -314,6 +324,7 @@ const getUnmappedValueRows = ({
   schemaRows,
   mode,
   isDisabled,
+  isDisabledByDefault,
   renamedValuePaths,
 }: {
   parameter: ParameterObject
@@ -321,6 +332,7 @@ const getUnmappedValueRows = ({
   schemaRows: TableRow[]
   mode: ExpansionMode
   isDisabled: boolean
+  isDisabledByDefault: boolean
   renamedValuePaths: ReadonlyMap<string, string[]>
 }): TableRow[] => {
   // Skip the renamed-away source paths too: the value move is debounced, so the old key lingers in
@@ -346,6 +358,7 @@ const getUnmappedValueRows = ({
         schema: undefined,
         isRequired: false,
         isDisabled,
+        isDisabledByDefault,
         sourceParameterValuePath: path,
       })
     })
@@ -369,12 +382,13 @@ export const createParameterRows = (
 ): TableRow[] => {
   const example = getExample(parameter, exampleKey, undefined)
   const isDisabled = isParamDisabled(parameter, example)
+  const isDisabledByDefault = isDisabled && example?.['x-disabled'] === undefined
   const schema = getParameterSchema(parameter)
   const mode = getExpansionMode(parameter, schema)
 
   // Non-expandable parameters: render as a single row.
   if (mode === null || !schema || !isObjectSchema(schema)) {
-    return [toSingleParameterRow(parameter, schema, example?.value, isDisabled)]
+    return [toSingleParameterRow(parameter, schema, example?.value, isDisabled, isDisabledByDefault)]
   }
 
   // Expand into per-property rows. The deserialized value is used so existing per-property values
@@ -383,7 +397,7 @@ export const createParameterRows = (
 
   // Fall back to a single row only when the schema has no properties to expand.
   if (!schema.properties) {
-    return [toSingleParameterRow(parameter, schema, example?.value, isDisabled)]
+    return [toSingleParameterRow(parameter, schema, example?.value, isDisabled, isDisabledByDefault)]
   }
 
   const hiddenValuePaths = new Set(options.hiddenValuePaths?.map(toPathKey) ?? [])
@@ -400,6 +414,7 @@ export const createParameterRows = (
     namePrefix: mode === 'deepObject' ? parameter.name : '',
     mode,
     isDisabled,
+    isDisabledByDefault,
     hiddenValuePaths,
     renamedValuePaths,
     renameTargetPaths,
@@ -413,6 +428,7 @@ export const createParameterRows = (
     schemaRows: rows,
     mode,
     isDisabled,
+    isDisabledByDefault,
     renamedValuePaths,
   })
 


### PR DESCRIPTION
Enable optional query parameters when you enter a value.

Fixes #10084