### PR TITLE
fix(docs): correct how API reference sources stay up to date

### DIFF
--- a/.agents/skills/scalar-docs/SKILL.md
+++ b/.agents/skills/scalar-docs/SKILL.md
@@ -175,6 +175,8 @@ API reference from file, Registry, or URL:
 }
 ```
 
+All three sources are read at publish time. Only the Registry source republishes the site on its own when the document changes; `filepath` and `url` stay as they were until the next publish. Never point `url` at a Registry document — use `namespace` and `slug` so the reference keeps itself current.
+
 Display modes: `folder` (default), `flat`, `nested`.
 
 **Single page mode:** Set `singlePage: true` to render all operations on a single page instead of creating separate pages for each operation:

--- a/documentation/guides/docs/configuration/navigation.md
+++ b/documentation/guides/docs/configuration/navigation.md
@@ -390,6 +390,8 @@ Scalar supports three ways to generate API references:
 
 An API reference entry accepts `type: "openapi"` or `type: "asyncapi"`. Use whichever matches your document — the format is detected automatically.
 
+Whichever source you pick, the API document is read when your site is published, and the reference that gets rendered from it is part of that publish. Only the Registry updates your published site on its own — see [Keeping a reference up to date](#keeping-a-reference-up-to-date).
+
 ### 1. Files
 
 Reference an API document stored in your repository by specifying a relative path from your configuration root:
@@ -426,11 +428,13 @@ scalar registry publish ./openapi.yaml \
 }
 ```
 
-When someone updates that API document in the Registry, Scalar republishes any connected Docs project that references it. This keeps your API documentation up to date automatically.
+When someone updates that API document in the Registry, Scalar republishes every Docs project that references it, usually within a minute. This is the only source that reaches your published site without you publishing again.
+
+Leave `version` out to follow the latest version, or set it to pin the reference to one version.
 
 ### 3. URL
 
-Fetch an API document from a remote URL. The document is fetched on each page load, keeping your documentation in sync with your live API:
+Fetch an API document from a remote URL:
 
 ```json
 "/api": {
@@ -439,6 +443,20 @@ Fetch an API document from a remote URL. The document is fetched on each page lo
   "url": "https://example.com/openapi.json"
 }
 ```
+
+The document is fetched while your site is being published, not when a visitor loads the page. Your reference shows the document as it was at that moment and keeps showing it until you publish again, so later changes at that URL do not reach your site on their own.
+
+If the URL points at a document in the Scalar Registry, use `namespace` and `slug` instead. A Registry URL looks like it would stay current, but as a `url` it is a snapshot like any other, and it does not get the automatic republishing described above.
+
+### Keeping a reference up to date
+
+| Source               | When the document is read | Reaches your published site on its own |
+| -------------------- | ------------------------- | -------------------------------------- |
+| `filepath`           | At publish time           | No — publish again                     |
+| `namespace` + `slug` | At publish time           | Yes — a Registry update republishes it |
+| `url`                | At publish time           | No — publish again                     |
+
+If you want an API reference that keeps itself current, publish the document to the Registry and reference it by `namespace` and `slug`.
 
 ### AsyncAPI
 
@@ -461,10 +479,10 @@ The entry renders your channels, operations, and messages in the sidebar. See [A
 | `type`       | `"openapi" \| "asyncapi"`        | Yes      | Marks the entry as an API reference                              |
 | `title`      | `string`                         | No       | The display text in the navigation                               |
 | `filepath`   | `string`                         | No       | Relative path to the API document                                |
-| `url`        | `string`                         | No       | URL to fetch the API document from                               |
+| `url`        | `string`                         | No       | URL to fetch the API document from at publish time               |
 | `namespace`  | `string`                         | No       | Registry namespace (when using Registry)                         |
 | `slug`       | `string`                         | No       | Registry slug (when using Registry)                              |
-| `version`    | `string`                         | No       | Registry version (when using Registry)                           |
+| `version`    | `string`                         | No       | Registry version (when using Registry). Defaults to `latest`     |
 | `icon`       | `string`                         | No       | An icon to display next to the reference. Accepts a built-in [icon key](../components/icons.mdx#built-in-icons) (Phosphor or Simple Icons) or a [custom URL](../components/icons.mdx#custom-icons). |
 | `mode`       | `"flat" \| "nested" \| "folder"` | No       | How the API reference is displayed in the sidebar                |
 | `singlePage` | `boolean`                        | No       | Render all operations on a single page (defaults to `false`)     |


### PR DESCRIPTION
## Problem

The URL source for an API reference route was documented like this:

> Fetch an API document from a remote URL. **The document is fetched on each page load, keeping your documentation in sync with your live API**

That is not what happens. `loadLiveLinkOpenapiContent` runs in the SSG **preprocess** stage, so the document is fetched once while the site is being published and baked into that publish. A `url` reference is a snapshot, exactly like a `filepath` one.

Read literally, the old sentence tells you the opposite — that a `url` reference keeps itself current. Someone acting on it will pick `url` precisely when they want a reference that stays fresh, which is the one thing it does not do.

This is not hypothetical. A customer configured:

```json
"/reference": {
  "type": "openapi",
  "title": "API references",
  "url": "https://registry.scalar.com/@their-namespace/apis/their-api@latest"
}
```

A live link, pointing at our own Registry, at `@latest`. The intent could not be clearer: always serve the newest version. But because it is a `url` and not `namespace` + `slug`, `getConfigEmbeddedRegistryApis` collects nothing, the publish record is stamped with `registryApis: []`, and the `api-version-upserted` republish fan-out matches no record. New endpoints pushed to the Registry stayed invisible on their live site until whenever they next published — 22 hours in the case that surfaced this, and their publish gaps in that same week ranged from 1 to 40 hours.

It read as a caching bug for a day. It was a docs bug.

## Solution

In `documentation/guides/docs/configuration/navigation.md`:

- Replace the false claim in the URL section with what actually happens: the document is fetched while the site is being published, not per page load, and later changes at that URL do not reach the site on their own.
- Steer the specific trap: if the URL points at a Registry document, use `namespace` and `slug` instead. That is the shape the republish fan-out can see.
- State the timing up front, so it is visible before the reader picks a source.
- Add a **Keeping a reference up to date** table comparing all three sources, since "will this stay current?" is the actual question people bring to this page.
- Sharpen the Registry section: it is the only source that reaches a published site without publishing again. Document that `version` defaults to `latest`.
- Note in the properties table that `url` is fetched at publish time and that `version` defaults to `latest`.

Also added the same distinction to `.agents/skills/scalar-docs/SKILL.md`, which lists the three sources with no update semantics at all — an agent writing a config from it today would produce the same broken shape.

Timings are from production: registry-push-to-republish measured 0–39 seconds across 25 samples in three days, hence "usually within a minute".

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not applicable: documentation and agent-skill prose only, no package changes. -->
- [ ] I added tests. <!-- Not applicable: prose only. -->
- [x] I updated the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTXbBBtofHsBYKmadCroJM

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTXbBBtofHsBYKmadCroJM)_