### PR TITLE
fix(workspace-store): stop truncating large numeric strings in array parameters

### DIFF
--- a/.changeset/fix-10087-array-param-precision-loss.md
+++ b/.changeset/fix-10087-array-param-precision-loss.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/api-client': patch
+---
+
+Stop truncating large numeric strings entered into `type: string` array/object query and header parameters. A value like a 20-digit reference number was accepted as valid JSON, parsed into a JS number, and lost precision beyond `Number.MAX_SAFE_INTEGER` before being sent. Such values now fall back to the comma-split string handling instead of being parsed as a number.

--- a/.changeset/fix-10087-array-param-precision-loss.md
+++ b/.changeset/fix-10087-array-param-precision-loss.md
@@ -3,4 +3,4 @@
 '@scalar/api-client': patch
 ---
 
-Stop truncating large numeric strings entered into `type: string` array/object query and header parameters. A value like a 20-digit reference number was accepted as valid JSON, parsed into a JS number, and lost precision beyond `Number.MAX_SAFE_INTEGER` before being sent. Such values now fall back to the comma-split string handling instead of being parsed as a number.
+Stop truncating large numeric strings entered into `type: string` array query and header parameters. A value like a 20-digit reference number was accepted as valid JSON, parsed into a JS number, and lost precision beyond `Number.MAX_SAFE_INTEGER` before being sent. Such values now fall back to the comma-split string handling instead of being parsed as a number.

--- a/.changeset/fix-10087-array-param-precision-loss.md
+++ b/.changeset/fix-10087-array-param-precision-loss.md
@@ -1,6 +1,5 @@
 ---
 '@scalar/workspace-store': patch
-'@scalar/api-client': patch
 ---
 
 Stop truncating large numeric strings entered into `type: string` array query and header parameters. A value like a 20-digit reference number was accepted as valid JSON, parsed into a JS number, and lost precision beyond `Number.MAX_SAFE_INTEGER` before being sent. Such values now fall back to the comma-split string handling instead of being parsed as a number.

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.test.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.test.ts
@@ -359,6 +359,22 @@ describe('de-serialize-parameter', () => {
       expect(result).toEqual(['single'])
     })
 
+    it('splits a numeric string too large for a safe JS number into an array instead of parsing it', () => {
+      const param: ParameterWithSchemaObject = {
+        name: 'Values',
+        in: 'query',
+        schema: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      }
+      const example = '40702810506710000185'
+
+      const result = deSerializeParameter(example, param)
+
+      expect(result).toEqual(['40702810506710000185'])
+    })
+
     it('still parses valid JSON arrays for array schema type', () => {
       const param: ParameterWithSchemaObject = {
         name: 'ids',

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.test.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.test.ts
@@ -361,7 +361,7 @@ describe('de-serialize-parameter', () => {
 
     it('splits a numeric string too large for a safe JS number into an array instead of parsing it', () => {
       const param: ParameterWithSchemaObject = {
-        name: 'Values',
+        name: 'values',
         in: 'query',
         schema: {
           type: 'array',
@@ -369,6 +369,22 @@ describe('de-serialize-parameter', () => {
         },
       }
       const example = '40702810506710000185'
+
+      const result = deSerializeParameter(example, param)
+
+      expect(result).toEqual(['40702810506710000185'])
+    })
+
+    it('keeps a quoted numeric string as a single-item array for array schema type', () => {
+      const param: ParameterWithSchemaObject = {
+        name: 'values',
+        in: 'query',
+        schema: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      }
+      const example = '"40702810506710000185"'
 
       const result = deSerializeParameter(example, param)
 

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
@@ -92,18 +92,20 @@ export const deSerializeSchemaValue = (example: unknown, schema: ParameterWithSc
     const type = getStructuredType(schema)
 
     if (type) {
-      let parsed: unknown
-      let isValidJson = true
       try {
-        parsed = JSON.parse(example)
-      } catch {
-        isValidJson = false
-      }
+        const parsed = JSON.parse(example)
+        if (type !== 'array' || Array.isArray(parsed)) {
+          return parsed
+        }
 
-      // A bare numeric string is valid JSON too (e.g. a 20-digit reference number), but parsing it
-      // would turn it into a precision-losing JS number instead of the array the schema expects.
-      if (isValidJson && (type !== 'array' || Array.isArray(parsed))) {
-        return parsed
+        // A bare numeric string is valid JSON too (e.g. a 20-digit reference number), but parsing it
+        // would turn it into a precision-losing JS number instead of the array the schema expects. A
+        // quoted string is a deliberate escape hatch, so keep it as a single-item array.
+        if (typeof parsed === 'string') {
+          return [parsed]
+        }
+      } catch {
+        // Not JSON at all: fall through to the comma-split handling below.
       }
 
       // Arrays: users often type `foo,bar` instead of JSON — split to match default form+explode query style.

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
@@ -92,13 +92,23 @@ export const deSerializeSchemaValue = (example: unknown, schema: ParameterWithSc
     const type = getStructuredType(schema)
 
     if (type) {
+      let parsed: unknown
+      let isValidJson = true
       try {
-        return JSON.parse(example)
+        parsed = JSON.parse(example)
       } catch {
-        // Arrays: users often type `foo,bar` instead of JSON — split to match default form+explode query style.
-        if (type === 'array') {
-          return example.split(/,\s?/).filter((v) => v !== '')
-        }
+        isValidJson = false
+      }
+
+      // A bare numeric string is valid JSON too (e.g. a 20-digit reference number), but parsing it
+      // would turn it into a precision-losing JS number instead of the array the schema expects.
+      if (isValidJson && (type !== 'array' || Array.isArray(parsed))) {
+        return parsed
+      }
+
+      // Arrays: users often type `foo,bar` instead of JSON — split to match default form+explode query style.
+      if (type === 'array') {
+        return example.split(/,\s?/).filter((v) => v !== '')
       }
     }
   }


### PR DESCRIPTION
## Problem

Query and header parameters typed as an array of strings go through `JSON.parse` before being sent, since that is how a comma-separated or JSON-array input gets turned into a real array. A bare numeric string is valid JSON on its own though, so typing a 20-digit value like `40702810506710000185` into a `type: string` array field parses it into a JS number and loses precision past `Number.MAX_SAFE_INTEGER`, sending `...000000` instead of the original digits.

## Solution

`deSerializeSchemaValue` now only trusts the `JSON.parse` result for an array-typed field when it actually parsed to an array. A quoted string (`"40702810506710000185"`) still parses to a single-item array, matching the escape hatch reported in the issue. Any other non-array result falls back to the same comma-split handling already used for plain non-JSON input like `foo,bar`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

Fixes #10087
