### PR TITLE
perf(docs): stop the head scripts from blocking first paint

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -12,25 +12,32 @@
     "head": {
       "scripts": [
         {
-          "path": "documentation/assets/landing.js"
+          "path": "documentation/assets/landing.js",
+          "defer": true
         },
         {
-          "path": "documentation/assets/powered-by.js"
+          "path": "documentation/assets/powered-by.js",
+          "defer": true
         },
         {
-          "path": "documentation/assets/fathom.js"
+          "path": "documentation/assets/fathom.js",
+          "defer": true
         },
         {
-          "path": "documentation/assets/posthog.js"
+          "path": "documentation/assets/posthog.js",
+          "defer": true
         },
         {
-          "path": "documentation/assets/apollo.js"
+          "path": "documentation/assets/apollo.js",
+          "defer": true
         },
         {
-          "path": "documentation/assets/vector.js"
+          "path": "documentation/assets/vector.js",
+          "defer": true
         },
         {
-          "url": "https://cdn-cookieyes.com/client_data/3515bc1505967122c1cef7c0f2247082/script.js"
+          "url": "https://cdn-cookieyes.com/client_data/3515bc1505967122c1cef7c0f2247082/script.js",
+          "async": true
         }
       ],
       "styles": [


### PR DESCRIPTION
## Problem

PageSpeed Insights (mobile) scores `https://scalar.com/products/docs` at **55**, with FCP 4.3 s and LCP 8.6 s. The single largest render-blocking item is our own `siteConfig.head.scripts`: all seven load as synchronous `<script>` tags, and the platform places sync scripts *ahead of the stylesheet* (capo ordering), so the browser cannot paint anything until every one of them has downloaded and executed. Lighthouse's render-blocking insight attributes **640–790 ms** to them on a mobile profile; the cross-origin CookieYes loader alone is ~770 ms of that (DNS + TLS + download before the parser can continue).

None of these scripts needs to run before first paint:

| Script | Why deferring is safe |
| --- | --- |
| `landing.js` | Runs its `init*()` functions immediately, then watches DOM mutations. With `defer` it runs once after parsing, when the elements it looks for exist. |
| `powered-by.js` | Already gates on `document.readyState` / `DOMContentLoaded`. |
| `fathom.js` | Already gates on `document.readyState` / `DOMContentLoaded`. |
| `posthog.js` | The snippet queues calls until the bundle arrives; `init` timing is unchanged. |
| `apollo.js` / `vector.js` | Inject async loader tags; nothing else on the page reads their globals synchronously. |
| CookieYes | Loader; the banner renders on DOM ready either way. |

Report: https://pagespeed.web.dev/analysis/https-scalar-com-products-docs/wpm117ksxj

## Solution

Use the `defer` / `async` script attributes the platform added in scalar/scalar-org#6034 (already live — the deployed bundle emits them):

- `defer: true` on the six local scripts. They keep their relative order and run after parsing, before `DOMContentLoaded`, so anything that depends on `landing.js` running before `posthog.js` is unaffected. The platform's head ordering then sorts them *after* the stylesheet.
- `async: true` on the CookieYes loader so it stops holding the parser while it connects to `cdn-cookieyes.com`.

Validated with `npx @scalar/cli@latest project check-config` (the same check CI runs).

**One thing to confirm before merging:** if we rely on CookieYes' script auto-blocking (holding trackers until consent), keep that tag synchronous and drop that hunk. Today the PostHog, Vector and Apollo bundles load before any consent interaction in the Lighthouse trace, so I do not believe we depend on it, but it is a compliance call rather than a performance one.

Alternatives considered: `tagPosition: bodyClose` (would also unblock paint but changes when `landing.js` runs relative to hydration more than `defer` does) and leaving CookieYes sync (keeps ~770 ms of the blocking on mobile).

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. — not applicable, site configuration only
- [ ] I added tests. — not applicable
- [ ] I updated the documentation. — not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
