### PR TITLE
fix(docs): match the header divider selector to the deployed renderer

### DIFF
--- a/documentation/assets/styles.css
+++ b/documentation/assets/styles.css
@@ -20,6 +20,12 @@
    item. The row gap then falls on both sides of the line, which centers it
    between the dropdown and the link without hard coding any spacing.
 
+   The selector matches any `nav` inside the header rather than one named nav
+   class. The published CLI renders the header nav as `.navigation`, while the
+   renderer deployed to scalar.com splits the row into start and end regions and
+   names both `.t-header__nav`. Keying on the class showed the line in a local
+   preview and never on the live site.
+
    `:has(~ a)` keeps a dropdown that ends the row from trailing a stray line.
    The general sibling combinator is deliberate. An open dropdown mounts its
    panel as the wrapper's next sibling, so `+ a` stops matching the moment the
@@ -27,7 +33,7 @@
 
    The line is decoration, so `pointer-events: none` stops a click on it from
    registering on the wrapper, which is the dropdown's own root element. */
-.header .navigation > .contents:has(~ a)::after {
+.header nav > .contents:has(~ a)::after {
   content: "";
   align-self: center;
   pointer-events: none;


### PR DESCRIPTION
## Problem

The header divider shipped in #10092 but never showed up on scalar.com.

The deploy was fine. `https://scalar.com/styles.css` serves the rule verbatim, so the CSS was live and simply matched nothing.

The selector was written against the header markup produced by the published CLI, which renders the header nav as `.navigation`. The renderer deployed to scalar.com is newer: it splits the header row into start and end regions and names both navs `.t-header__nav`.

```
div.t-header__start > nav.t-header__nav     Home, Docs, Pricing
div.t-header__end   > nav.t-header__nav     Resources dropdown, Log in, Register
```

So `.header .navigation > .contents` matched zero elements in production, while matching correctly in a local preview. That gap between the published CLI and the deployed renderer is why local verification passed and the live site never changed.

## Solution

Match any `nav` inside the header instead of one named nav class:

```diff
-.header .navigation > .contents:has(~ a)::after {
+.header nav > .contents:has(~ a)::after {
```

Nothing else about the rule changes. The mechanics it relies on hold in the deployed markup too, which I checked rather than assumed: the dropdown wrapper is still `display: contents`, the row is still a flex row with a 16px gap, and an open dropdown still mounts its panel as the wrapper's next sibling, which is exactly what `:has(~ a)` exists to survive.

## Visual

Verified by injecting the corrected rule into the live site, and separately against a local preview running the published CLI, at 1440px wide.

| | scalar.com (`.t-header__nav`) | Local preview (`.navigation`) |
| --- | --- | --- |
| Elements matched | 1 | 1 |
| Rendered size | 0.5px x 18px | 0.5px x 18px |
| Color | `#dfdfdf` | `#dfdfdf` |
| Space each side | 16px | 16px |
| Shift when dropdown opens | 0px | 0px |
| Hit-tests as a click target | no | no |

Screenshots have to be attached through the web UI, since GitHub only mints attachment URLs on upload.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. <!-- Not required: this touches only `documentation/assets/styles.css`, no `packages/*`, `integrations/*` or `projects/*` code. -->
- [ ] I added tests. <!-- A single global CSS rule; there is no unit-testable surface. Verified against the live site and a local preview instead. -->
- [x] I updated the documentation. <!-- The rule's comment now records why it matches on the element and not the nav class. -->

## Ticket

Follow-up to #10092

🤖 Generated with [Claude Code](https://claude.com/claude-code)
