### PR TITLE
fix(workspace-store): prevent precision loss for numeric strings in array schema parameters

### DIFF
--- a/.changeset/kind-planes-hang.md
+++ b/.changeset/kind-planes-hang.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+fix(workspace-store): preserve numeric-string precision when deserializing array schema parameters

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.test.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.test.ts
@@ -1,8 +1,6 @@
-import type {
-  ParameterObject,
-  ParameterWithSchemaObject,
-} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { describe, expect, it } from 'vitest'
+
+import type { ParameterObject, ParameterWithSchemaObject } from '@/schemas/v3.1/strict/openapi-document'
 
 import { deSerializeParameter } from './de-serialize-parameter'
 
@@ -421,6 +419,38 @@ describe('de-serialize-parameter', () => {
           tags: ['admin', 'user'],
         },
       })
+    })
+
+    it('preserves precision for large numeric strings in array schema parameters', () => {
+      const param: ParameterWithSchemaObject = {
+        name: 'Values',
+        in: 'query',
+        schema: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      }
+      const example = '40702810506710000185'
+
+      const result = deSerializeParameter(example, param)
+
+      expect(result).toEqual(['40702810506710000185'])
+    })
+
+    it('preserves precision for multiple large numeric strings in array schema parameters', () => {
+      const param: ParameterWithSchemaObject = {
+        name: 'Values',
+        in: 'query',
+        schema: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      }
+      const example = '40702810506710000185, 40702810506710000186'
+
+      const result = deSerializeParameter(example, param)
+
+      expect(result).toEqual(['40702810506710000185', '40702810506710000186'])
     })
   })
 })

--- a/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
+++ b/packages/workspace-store/src/request-example/builder/header/de-serialize-parameter.ts
@@ -1,8 +1,5 @@
-import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
-import type {
-  ParameterObject,
-  ParameterWithSchemaObject,
-} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+import { getResolvedRef } from '@/helpers/get-resolved-ref'
+import type { ParameterObject, ParameterWithSchemaObject } from '@/schemas/v3.1/strict/openapi-document'
 
 /**
  * Coerces a parameter example from the UI (always a string from CodeInput) into a value
@@ -91,14 +88,26 @@ export const deSerializeSchemaValue = (example: unknown, schema: ParameterWithSc
   if (typeof example === 'string') {
     const type = getStructuredType(schema)
 
-    if (type) {
+    if (type === 'array') {
       try {
-        return JSON.parse(example)
-      } catch {
-        // Arrays: users often type `foo,bar` instead of JSON — split to match default form+explode query style.
-        if (type === 'array') {
-          return example.split(/,\s?/).filter((v) => v !== '')
+        const parsed = JSON.parse(example)
+        if (Array.isArray(parsed)) {
+          return parsed
         }
+      } catch {
+        // Fall through to comma splitting
+      }
+      return example.split(/,\s?/).filter((v) => v !== '')
+    }
+
+    if (type === 'object') {
+      try {
+        const parsed = JSON.parse(example)
+        if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+          return parsed
+        }
+      } catch {
+        // Return example as-is if invalid JSON
       }
     }
   }


### PR DESCRIPTION
## Summary
Fixes #10087

When entering a numeric string exceeding `Number.MAX_SAFE_INTEGER` (e.g. `40702810506710000185`) in an array query parameter (such as `type: array` with `items: { type: string }`), `deSerializeSchemaValue` previously ran `JSON.parse(example)`. Because a standalone numeric string is valid JSON, `JSON.parse` parsed it as a JavaScript number without throwing an error, causing IEEE 754 precision loss that truncated the trailing digits into `40702810506710000000`.

## Changes
- In `deSerializeSchemaValue`, verify that the result of `JSON.parse` for `type === "array"` is actually an array (`Array.isArray(parsed)`) before returning it. If it is a scalar/single value or comma-separated list, fall through to string splitting to preserve exact string values without precision loss.
- For `type === "object"`, verify that `parsed` is a non-null object before returning.
- Added unit tests in `de-serialize-parameter.test.ts` verifying precision preservation for single and multiple large numeric string parameters.
