### PR TITLE
docs(starlight): add integration to docs sidebar

### DIFF
--- a/scalar.config.json
+++ b/scalar.config.json
@@ -3357,6 +3357,12 @@
                         "description": "Add a Scalar API reference to your Spry application for interactive OpenAPI documentation.",
                         "type": "page"
                       },
+                      "starlight": {
+                        "title": "Starlight",
+                        "filepath": "documentation/integrations/starlight.md",
+                        "description": "Add a Scalar API reference to your Astro Starlight docs for interactive OpenAPI documentation.",
+                        "type": "page"
+                      },
                       "sveltekit": {
                         "title": "SvelteKit",
                         "filepath": "documentation/integrations/sveltekit.md",


### PR DESCRIPTION
Add the existing Starlight guide to the docs sidebar.
