### PR TITLE
feat(nextjs): support request configuration and response headers

### DIFF
--- a/.changeset/nextjs-request-configuration.md
+++ b/.changeset/nextjs-request-configuration.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nextjs-api-reference': minor
+---
+
+Support request-specific async configuration and custom response headers. Export configuration and handler option types.

--- a/documentation/integrations/nextjs.md
+++ b/documentation/integrations/nextjs.md
@@ -300,3 +300,24 @@ If Next.js has `basePath: '/platform'`, include that prefix explicitly in Scalar
 - API description: `servers: [{ url: '/platform' }]`
 
 Keep operation paths such as `/api/planets` unchanged. Next.js does not add its base path to URLs inside Scalar configuration or an API description.
+
+## Request-specific configuration
+
+Pass a function when the browser configuration depends on the incoming request. The function runs for each request and may return a promise. Configuration errors propagate to Next.js.
+
+```typescript
+// app/scalar/route.ts
+import { ApiReference } from '@scalar/nextjs-api-reference'
+
+export const GET = ApiReference(
+  (request) => ({
+    url: '/openapi.json',
+    nonce: request.headers.get('x-nonce') ?? undefined,
+  }),
+  { headers: { 'Cache-Control': 'private, no-store' } },
+)
+```
+
+Generate the nonce in your trusted Proxy or middleware and set the matching CSP response header, as described above. Configuration is sent to the browser, so do not include server secrets. Additional response headers can be supplied as a `Headers` object, header tuples, or a record. The handler always sets the HTML content type.
+
+The package exports `ApiReferenceConfiguration`, `ApiReferenceConfigurationFactory`, and `ApiReferenceOptions` for typed configuration helpers. Static configuration still returns a synchronous handler; a configuration function returns an asynchronous handler that requires a `Request`.

--- a/integrations/nextjs/index.ts
+++ b/integrations/nextjs/index.ts
@@ -1,1 +1,2 @@
 export { ApiReference } from './src'
+export type { ApiReferenceConfiguration, ApiReferenceConfigurationFactory, ApiReferenceOptions } from './src/types'

--- a/integrations/nextjs/src/ApiReference.ts
+++ b/integrations/nextjs/src/ApiReference.ts
@@ -1,36 +1,35 @@
 import { renderApiReference } from '@scalar/client-side-rendering'
 
 import { customTheme } from './custom-theme'
-import type { ApiReferenceConfiguration } from './types'
+import type { ApiReferenceConfiguration, ApiReferenceConfigurationFactory, ApiReferenceOptions } from './types'
 
-/**
- * The default configuration for the API Reference.
- */
-const DEFAULT_CONFIGURATION: Partial<ApiReferenceConfiguration> = {
-  _integration: 'nextjs',
+/** Render a fresh response so headers and request-specific configuration are never shared. */
+const renderResponse = (configuration: Partial<ApiReferenceConfiguration>, options: ApiReferenceOptions): Response => {
+  const { cdn, pageTitle, nonce, ...config } = { _integration: 'nextjs' as const, ...configuration }
+  const headers = new Headers(options.headers)
+  headers.set('Content-Type', 'text/html; charset=utf-8')
+
+  return new Response(renderApiReference({ config, pageTitle, cdn, nonce }, customTheme), { headers })
 }
 
-/**
- * Next.js adapter for an Api Reference
- *
- * {@link https://github.com/scalar/scalar/tree/main/documentation/configuration.md Configuration}
- *
- * @params config - the Api Reference config object
- * @params options - reserved for future use to add customization to the response
- */
-export const ApiReference = (givenConfiguration: Partial<ApiReferenceConfiguration>): (() => Response) => {
-  // Merge the defaults
-  const configuration: Partial<ApiReferenceConfiguration> = {
-    ...DEFAULT_CONFIGURATION,
-    ...givenConfiguration,
+/** Serve a standalone reference using static configuration. */
+export function ApiReference(
+  configuration: Partial<ApiReferenceConfiguration>,
+  options?: ApiReferenceOptions,
+): () => Response
+/** Resolve configuration for each request. Rejections propagate to Next.js error handling. */
+export function ApiReference(
+  configuration: ApiReferenceConfigurationFactory,
+  options?: ApiReferenceOptions,
+): (request: Request) => Promise<Response>
+export function ApiReference(
+  configuration: Partial<ApiReferenceConfiguration> | ApiReferenceConfigurationFactory,
+  options: ApiReferenceOptions = {},
+): (() => Response) | ((request: Request) => Promise<Response>) {
+  if (typeof configuration === 'function') {
+    return async (request: Request): Promise<Response> => renderResponse(await configuration(request), options)
   }
 
-  return () => {
-    const { cdn, pageTitle, nonce, ...config } = configuration
-    const referenceDocument = renderApiReference({ config, pageTitle, cdn, nonce }, customTheme)
-    return new Response(referenceDocument, {
-      status: 200,
-      headers: { 'Content-Type': 'text/html' },
-    })
-  }
+  const staticConfiguration = { ...configuration }
+  return (): Response => renderResponse(staticConfiguration, options)
 }

--- a/integrations/nextjs/src/index.ts
+++ b/integrations/nextjs/src/index.ts
@@ -1,1 +1,2 @@
 export { ApiReference } from './ApiReference'
+export type { ApiReferenceConfiguration, ApiReferenceConfigurationFactory, ApiReferenceOptions } from './types'

--- a/integrations/nextjs/src/types.ts
+++ b/integrations/nextjs/src/types.ts
@@ -1,6 +1,15 @@
 import type { HtmlRenderingConfiguration } from '@scalar/client-side-rendering'
 
-/**
- * The configuration for the Scalar API Reference for Next.js
- */
+/** Configuration serialized into the browser's API reference. Do not include server secrets. */
 export type ApiReferenceConfiguration = HtmlRenderingConfiguration
+
+/** Resolve browser configuration separately for every incoming request. */
+export type ApiReferenceConfigurationFactory = (
+  request: Request,
+) => Partial<ApiReferenceConfiguration> | Promise<Partial<ApiReferenceConfiguration>>
+
+/** HTTP response options. The HTML content type is always set by the handler. */
+export type ApiReferenceOptions = {
+  /** Additional response headers, such as Cache-Control or Content-Security-Policy. */
+  headers?: HeadersInit
+}

--- a/integrations/nextjs/test/ApiReference.test.ts
+++ b/integrations/nextjs/test/ApiReference.test.ts
@@ -1,46 +1,84 @@
-import { renderApiReference } from '@scalar/client-side-rendering'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 
-import { ApiReference } from '../src/ApiReference'
-
-vi.mock('@scalar/client-side-rendering', { spy: true })
-vi.mock('../src/custom-theme', () => ({ customTheme: '___customTheme___' }))
-
-const renderApiReferenceSpy = vi.mocked(renderApiReference)
-
-beforeEach(() => {
-  renderApiReferenceSpy.mockReset()
-})
+import { ApiReference, type ApiReferenceConfiguration, type ApiReferenceOptions } from '../src'
 
 describe('ApiReference', () => {
-  it('should return a function', () => {
-    const handler = ApiReference({})
-    expect(handler).toBeInstanceOf(Function)
+  it('returns a synchronous handler for static configuration', async () => {
+    const configuration = {
+      pageTitle: 'My API',
+      content: { openapi: '3.1.0' },
+    } satisfies Partial<ApiReferenceConfiguration>
+    const handler = ApiReference(configuration)
+    expectTypeOf(handler).returns.toEqualTypeOf<Response>()
+    const response = handler()
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8')
+    const html = await response.text()
+    expect(html).toContain('<title>My API</title>')
+    expect(html).toContain('"_integration": "nextjs"')
+    expect(html).toContain('"openapi": "3.1.0"')
   })
 
-  it('should return a Response with correct headers and body', async () => {
-    renderApiReferenceSpy.mockReturnValueOnce('___HTMLDoc___')
+  it('passes the incoming request to a synchronous configuration factory', async () => {
+    const handler = ApiReference((request) => ({ pageTitle: new URL(request.url).pathname }))
+    expectTypeOf(handler).returns.toEqualTypeOf<Promise<Response>>()
+    const response = await handler(new Request('https://example.com/scalar'))
+    expect(await response.text()).toContain('<title>/scalar</title>')
+  })
 
-    const handler = ApiReference({ title: 'Test API' })
-    const response = handler()
-
-    expect(response).toBeInstanceOf(Response)
-    expect(response.status).toBe(200)
-    expect(response.headers.get('Content-Type')).toBe('text/html')
-
-    expect(renderApiReferenceSpy).toHaveBeenCalledOnce()
-    expect(renderApiReferenceSpy).toHaveBeenCalledWith(
-      {
-        config: expect.objectContaining({
-          title: 'Test API',
-          _integration: 'nextjs', // default should be merged in
-        }),
-        cdn: undefined,
-        pageTitle: undefined,
-      },
-      '___customTheme___',
+  it('keeps concurrent asynchronous configurations separate', async () => {
+    const handler = ApiReference(async (request) => ({
+      pageTitle: await request.text(),
+      nonce: request.headers.get('x-nonce') ?? undefined,
+    }))
+    const responses = await Promise.all(
+      ['first', 'second'].map((value) =>
+        handler(
+          new Request('https://example.com/scalar', {
+            method: 'POST',
+            body: value,
+            headers: { 'x-nonce': value },
+          }),
+        ),
+      ),
     )
+    const bodies = await Promise.all(responses.map((response) => response.text()))
+    expect(bodies[0]).toContain('<title>first</title>')
+    expect(bodies[0]).toContain('nonce="first"')
+    expect(bodies[0]).not.toContain('second')
+    expect(bodies[1]).toContain('<title>second</title>')
+    expect(bodies[1]).toContain('nonce="second"')
+    expect(bodies[1]).not.toContain('first')
+  })
 
-    await expect(response.text()).resolves.toBe('___HTMLDoc___')
+  it('creates independent response headers and retains the HTML content type', () => {
+    const options = {
+      headers: new Headers({ 'Cache-Control': 'private, no-store', 'Content-Type': 'application/json' }),
+    } satisfies ApiReferenceOptions
+    const handler = ApiReference({}, options)
+    const response = handler()
+    response.headers.set('Cache-Control', 'public')
+    expect(handler().headers.get('Cache-Control')).toBe('private, no-store')
+    expect(response.headers.get('Content-Type')).toBe('text/html; charset=utf-8')
+    expect(options.headers.get('Content-Type')).toBe('application/json')
+  })
+
+  it('accepts header tuples with an asynchronous factory', async () => {
+    const handler = ApiReference(() => Promise.resolve({}), { headers: [['Cache-Control', 'no-store']] })
+    expect((await handler(new Request('https://example.com/scalar'))).headers.get('Cache-Control')).toBe('no-store')
+  })
+
+  it('propagates configuration failures', async () => {
+    const error = new Error('Configuration unavailable')
+    const handler = ApiReference(() => Promise.reject(error))
+    await expect(handler(new Request('https://example.com/scalar'))).rejects.toBe(error)
+  })
+
+  it('turns synchronous factory failures into rejected responses', async () => {
+    const error = new Error('Configuration unavailable')
+    const handler = ApiReference(() => {
+      throw error
+    })
+    await expect(handler(new Request('https://example.com/scalar'))).rejects.toBe(error)
   })
 })


### PR DESCRIPTION
Add async request configuration, response headers, and public types. Seven tests, type checking, the package build, and scoped Knip pass.
