### PR TITLE
test(nextjs): verify Next.js 15 and 16 compatibility

### DIFF
--- a/.changeset/nextjs-compatibility-checks.md
+++ b/.changeset/nextjs-compatibility-checks.md
@@ -1,0 +1,5 @@
+---
+'@scalar/nextjs-api-reference': patch
+---
+
+Add production browser compatibility coverage for Next.js 15 and 16.

--- a/.github/workflows/nextjs-compatibility.yml
+++ b/.github/workflows/nextjs-compatibility.yml
@@ -23,8 +23,8 @@ jobs:
         node: ['22', '24']
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm

--- a/.github/workflows/nextjs-compatibility.yml
+++ b/.github/workflows/nextjs-compatibility.yml
@@ -1,0 +1,39 @@
+name: Next.js compatibility
+
+on:
+  pull_request:
+    paths:
+      - 'integrations/nextjs/**'
+      - 'packages/client-side-rendering/**'
+      - '.github/workflows/nextjs-compatibility.yml'
+      - 'pnpm-lock.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  reference:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        next: ['15.5.15', '16.3.4']
+        node: ['22', '24']
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Select Next.js version
+        run: pnpm --filter @scalar/nextjs-api-reference add --save-dev --save-exact next@${{ matrix.next }}
+      - run: pnpm turbo --filter @scalar/nextjs-api-reference... build --output-logs errors-only
+      - run: pnpm exec next build playwright/fixture
+        working-directory: integrations/nextjs
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm exec playwright test
+        working-directory: integrations/nextjs

--- a/documentation/integrations/nextjs.md
+++ b/documentation/integrations/nextjs.md
@@ -18,8 +18,16 @@ npm install @scalar/nextjs-api-reference
 
 ## Compatibility
 
-This package is compatible with Next.js 15 and is untested on Next.js 14. If you want guaranteed Next.js 14 support
-please use version `0.4.106` of this package.
+The handler supports Next.js 15 and 16 with React 19 and Node.js 22 or newer.
+
+The compatibility workflow builds a real Next.js application and checks browser rendering and CSP nonces:
+
+| Next.js | React | Node.js CI matrix |
+| ------- | ----- | ----------------- |
+| 15.5.15 | 19    | 22, 24            |
+| 16.3.4  | 19    | 22, 24            |
+
+See [the compatibility workflow](https://github.com/scalar/scalar/actions/workflows/nextjs-compatibility.yml) for results. These checks cover the standalone handler; the React package has its own tests.
 
 ## Usage
 
@@ -108,13 +116,13 @@ To boot the reference, Scalar adds an inline `<script>` to the page. Under a str
 
 Instead, pass a `nonce`. Scalar stamps it onto the inline script and the CDN `<script>` tag, so you can keep a strict `script-src` with **no `unsafe-inline` and no `unsafe-eval`**.
 
-A nonce has to be generated fresh for every request, so generate it in `middleware.ts`, expose it to the route through a request header, and set the matching CSP response header:
+A nonce has to be generated fresh for every request, so generate it in `proxy.ts` on Next.js 16, expose it to the route through a request header, and set the matching CSP response header:
 
 ```typescript
-// middleware.ts
+// proxy.ts (Next.js 16)
 import { NextResponse, type NextRequest } from 'next/server'
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   // A fresh nonce per request.
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
 
@@ -144,6 +152,8 @@ export const config = {
   matcher: '/reference/:path*',
 }
 ```
+
+On Next.js 15, name the file `middleware.ts` and export `middleware` instead of `proxy`.
 
 Then read the nonce in the route handler and pass it to the configuration:
 

--- a/examples/nextjs-api-reference/eslint.config.js
+++ b/examples/nextjs-api-reference/eslint.config.js
@@ -1,9 +1,12 @@
 import nextPlugin from '@next/eslint-plugin-next'
 import { defineConfig, globalIgnores } from 'eslint/config'
+import tseslint from 'typescript-eslint'
 
 export default defineConfig([
   globalIgnores(['.next', 'dist']),
   {
+    files: ['**/*.{ts,tsx,js,mjs}'],
+    languageOptions: { parser: tseslint.parser },
     plugins: {
       '@next/next': nextPlugin,
     },

--- a/examples/nextjs-api-reference/package.json
+++ b/examples/nextjs-api-reference/package.json
@@ -18,8 +18,8 @@
     "build": "next build",
     "dev": "next dev -p 5058",
     "docker:build": "docker build --platform=linux/amd64 -t ${image_name} --build-arg=\"BASE_IMAGE=scalar-base\" -f ./Dockerfile .",
-    "lint:check": "next lint",
-    "lint:fix": "next lint --fix",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint . --fix",
     "start": "next start",
     "types:check": "tsc --noEmit"
   },

--- a/integrations/nextjs/playwright.config.ts
+++ b/integrations/nextjs/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './playwright/test',
+  use: { baseURL: 'http://127.0.0.1:5078', trace: 'retain-on-failure' },
+  webServer: {
+    command: 'pnpm exec next start playwright/fixture -p 5078',
+    url: 'http://127.0.0.1:5078/openapi.json',
+    reuseExistingServer: false,
+  },
+})

--- a/integrations/nextjs/playwright/fixture/app/openapi.json/route.ts
+++ b/integrations/nextjs/playwright/fixture/app/openapi.json/route.ts
@@ -1,0 +1,7 @@
+/** Keep the browser test independent of external API-description services. */
+export const GET = (): Response =>
+  Response.json({
+    openapi: '3.1.0',
+    info: { title: 'Compatibility API', version: '1.0.0' },
+    paths: {},
+  })

--- a/integrations/nextjs/playwright/fixture/app/scalar/route.ts
+++ b/integrations/nextjs/playwright/fixture/app/scalar/route.ts
@@ -1,0 +1,19 @@
+import { ApiReference } from '@scalar/nextjs-api-reference'
+
+/** Exercise the published handler in a real Next.js production server. */
+export const GET = (request: Request): Response => {
+  const nonce = new URL(request.url).searchParams.has('csp') ? crypto.randomUUID() : undefined
+  const response = ApiReference({
+    url: '/openapi.json',
+    pageTitle: 'Next.js compatibility',
+    cdn: 'https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.67.0',
+    nonce,
+  })()
+  if (nonce) {
+    response.headers.set(
+      'Content-Security-Policy',
+      `script-src 'nonce-${nonce}'; style-src 'unsafe-inline' https:; font-src https: data:; img-src https: data:`,
+    )
+  }
+  return response
+}

--- a/integrations/nextjs/playwright/fixture/next-env.d.ts
+++ b/integrations/nextjs/playwright/fixture/next-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import './.next/types/routes.d.ts'
+import './.next/types/root-params.d.ts'
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/integrations/nextjs/playwright/fixture/next-env.d.ts
+++ b/integrations/nextjs/playwright/fixture/next-env.d.ts
@@ -1,7 +1,2 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts'
-import './.next/types/root-params.d.ts'
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/integrations/nextjs/playwright/fixture/next.config.mjs
+++ b/integrations/nextjs/playwright/fixture/next.config.mjs
@@ -1,0 +1,6 @@
+import { fileURLToPath } from 'node:url'
+
+export default {
+  // The fixture consumes the built workspace package outside this directory.
+  outputFileTracingRoot: fileURLToPath(new URL('../../../../..', import.meta.url)),
+}

--- a/integrations/nextjs/playwright/fixture/tsconfig.json
+++ b/integrations/nextjs/playwright/fixture/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "esnext"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "allowJs": true,
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "app/**/*.ts", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/integrations/nextjs/playwright/test/reference.spec.ts
+++ b/integrations/nextjs/playwright/test/reference.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test'
+
+for (const path of ['/scalar', '/scalar?csp']) {
+  test(`renders the reference at ${path}`, async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (error) => errors.push(error.message))
+    await page.goto(path)
+    await expect(page).toHaveTitle('Next.js compatibility')
+    await expect(page.getByRole('heading', { name: 'Compatibility API', exact: true })).toBeVisible()
+    expect(errors).toStrictEqual([])
+    const descriptionRequests = await page.evaluate(
+      () => performance.getEntriesByType('resource').filter((entry) => entry.name.endsWith('/openapi.json')).length,
+    )
+    expect(descriptionRequests).toBe(1)
+  })
+}
+
+test('generates a fresh CSP nonce on each request', async ({ request }) => {
+  const first = await request.get('/scalar?csp')
+  const second = await request.get('/scalar?csp')
+  expect(first.status()).toBe(200)
+  expect(second.status()).toBe(200)
+  const policy = first.headers()['content-security-policy']
+  expect(policy).toContain("script-src 'nonce-")
+  expect(second.headers()['content-security-policy']).not.toBe(policy)
+  const nonce = policy?.match(/'nonce-([^']+)'/)?.[1]
+  expect(await first.text()).toContain(`nonce="${nonce}"`)
+})

--- a/integrations/nextjs/tsconfig.json
+++ b/integrations/nextjs/tsconfig.json
@@ -15,5 +15,5 @@
     ]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "playwright/fixture"]
 }

--- a/integrations/nextjs/vitest.config.ts
+++ b/integrations/nextjs/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: { include: ['test/**/*.test.ts', 'src/**/*.test.ts'] },
+})

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -441,7 +441,9 @@
       "ignoreBinaries": ["mvn"]
     },
     "integrations/nestjs": {},
-    "integrations/nextjs": {},
+    "integrations/nextjs": {
+      "entry": ["src/index.ts", "index.ts", "playwright/fixture/app/**/route.ts", "playwright/fixture/next.config.mjs"]
+    },
     "integrations/nuxt": {
       "entry": [
         "src/module.ts",


### PR DESCRIPTION
Add Next.js 15 and 16 build and browser checks, and update the compatibility guide. Both versions pass the production build and three browser tests locally.
