### PR TITLE
docs(nextjs): add API description generation recipes

### DIFF
--- a/documentation/integrations/nextjs-recipes/hono.md
+++ b/documentation/integrations/nextjs-recipes/hono.md
@@ -1,0 +1,75 @@
+# Generate a Next.js API description with Hono
+
+Hono and `@hono/zod-openapi` can validate route data and generate an OpenAPI description from route metadata. Scalar renders it at `/scalar`.
+
+In an App Router application, install:
+
+```bash
+npm install @scalar/nextjs-api-reference hono@4 @hono/zod-openapi@1 zod@4
+```
+
+Define the endpoint and its schema:
+
+```typescript
+// app/lib/api.ts
+import { createRoute, OpenAPIHono, z } from '@hono/zod-openapi'
+
+export const api = new OpenAPIHono().basePath('/api')
+
+const planetsSchema = z.array(z.object({
+  id: z.string(),
+  name: z.string(),
+  moons: z.number().int().nonnegative(),
+}))
+
+api.openapi(createRoute({
+  method: 'get',
+  path: '/planets',
+  summary: 'List planets',
+  responses: {
+    200: {
+      description: 'The planet catalog.',
+      content: { 'application/json': { schema: planetsSchema } },
+    },
+  },
+}), (context) => context.json([
+  { id: 'earth', name: 'Earth', moons: 1 },
+  { id: 'mars', name: 'Mars', moons: 2 },
+], 200))
+```
+
+Connect Hono to Next.js:
+
+```typescript
+// app/api/[[...route]]/route.ts
+import { handle } from 'hono/vercel'
+import { api } from '../../lib/api'
+
+export const GET = handle(api)
+```
+
+Expose the generated description:
+
+```typescript
+// app/openapi.json/route.ts
+import { api } from '../lib/api'
+
+export const GET = (): Response => Response.json(api.getOpenAPI31Document({
+  openapi: '3.1.0',
+  info: { title: 'Planets API', version: '1.0.0' },
+  servers: [{ url: '/' }],
+}))
+```
+
+Mount Scalar:
+
+```typescript
+// app/scalar/route.ts
+import { ApiReference } from '@scalar/nextjs-api-reference'
+
+export const GET = ApiReference({ url: '/openapi.json' })
+```
+
+Run `npm run dev`, open <http://localhost:3000/scalar>, and send a test request for **List planets**. Expect `200` with Earth and Mars. The description should contain `/api/planets`; the server URL is `/`, so the `/api` prefix appears only once.
+
+Hono generates descriptions for routes registered with `api.openapi`. Adding an ordinary Next.js handler elsewhere does not automatically add it to Hono's description. See [Hono's Next.js adapter](https://hono.dev/docs/getting-started/nextjs) and [Zod OpenAPI](https://hono.dev/examples/zod-openapi).

--- a/documentation/integrations/nextjs-recipes/orpc.md
+++ b/documentation/integrations/nextjs-recipes/orpc.md
@@ -1,0 +1,71 @@
+# Generate a Next.js API description with oRPC
+
+Use oRPC procedure metadata for HTTP routing and OpenAPI generation, then display the generated description with Scalar at `/scalar`.
+
+This recipe was checked with oRPC 1.15.0 and Zod 4:
+
+```bash
+npm install @scalar/nextjs-api-reference @orpc/server@1.15.0 @orpc/openapi@1.15.0 @orpc/zod@1.15.0 zod@4
+```
+
+Define an HTTP procedure:
+
+```typescript
+// app/lib/router.ts
+import { os } from '@orpc/server'
+import { z } from 'zod'
+
+export const router = {
+  listPlanets: os
+    .route({ method: 'GET', path: '/planets', summary: 'List planets' })
+    .output(z.array(z.object({ id: z.string(), name: z.string(), moons: z.number().int() })))
+    .handler(() => [
+      { id: 'earth', name: 'Earth', moons: 1 },
+      { id: 'mars', name: 'Mars', moons: 2 },
+    ]),
+}
+```
+
+Use the Fetch adapter in a Route Handler:
+
+```typescript
+// app/api/[[...route]]/route.ts
+import { OpenAPIHandler } from '@orpc/openapi/fetch'
+import { router } from '../../lib/router'
+
+const handler = new OpenAPIHandler(router)
+
+export const GET = async (request: Request): Promise<Response> => {
+  const { response } = await handler.handle(request, { prefix: '/api' })
+  return response ?? new Response('Not found', { status: 404 })
+}
+```
+
+Generate the description with the Zod 4 converter:
+
+```typescript
+// app/openapi.json/route.ts
+import { OpenAPIGenerator } from '@orpc/openapi'
+import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4'
+import { router } from '../lib/router'
+
+const generator = new OpenAPIGenerator({ schemaConverters: [new ZodToJsonSchemaConverter()] })
+
+export const GET = async (): Promise<Response> => Response.json(await generator.generate(router, {
+  info: { title: 'Planets API', version: '1.0.0' },
+  servers: [{ url: '/api' }],
+}))
+```
+
+Mount Scalar:
+
+```typescript
+// app/scalar/route.ts
+import { ApiReference } from '@scalar/nextjs-api-reference'
+
+export const GET = ApiReference({ url: '/openapi.json' })
+```
+
+Run `npm run dev`, open <http://localhost:3000/scalar>, and send a test request for **List planets**. Expect `200` with Earth and Mars. The generated path is `/planets` and the server URL is `/api`, giving `/api/planets`.
+
+When adding other HTTP methods, export the matching Next.js handler too. oRPC generates this description from the router and schema converter; Scalar does not inspect your procedures. See [oRPC's OpenAPI generator](https://orpc.dev/docs/openapi/specification) and [Next.js adapter](https://orpc.dev/docs/adapters/next).

--- a/documentation/integrations/nextjs-recipes/route-handlers.md
+++ b/documentation/integrations/nextjs-recipes/route-handlers.md
@@ -1,0 +1,79 @@
+# Generate an API description from Zod schemas
+
+This recipe uses ordinary Next.js Route Handlers and Zod 4. Zod generates response schemas; you explicitly describe paths, methods, and status codes. Scalar renders the resulting OpenAPI description at `/scalar`.
+
+In an App Router application, install:
+
+```bash
+npm install @scalar/nextjs-api-reference zod@4
+```
+
+Define the response schema once:
+
+```typescript
+// app/lib/planets.ts
+import { z } from 'zod'
+
+export const planetsSchema = z.array(z.object({
+  id: z.string(),
+  name: z.string(),
+  moons: z.number().int().nonnegative(),
+}))
+
+export const planets = planetsSchema.parse([
+  { id: 'earth', name: 'Earth', moons: 1 },
+  { id: 'mars', name: 'Mars', moons: 2 },
+])
+```
+
+Use it in the endpoint:
+
+```typescript
+// app/api/planets/route.ts
+import { planets } from '../../lib/planets'
+
+export const GET = (): Response => Response.json(planets)
+```
+
+Generate the schema in the description endpoint:
+
+```typescript
+// app/openapi.json/route.ts
+import { z } from 'zod'
+import { planetsSchema } from '../lib/planets'
+
+export const GET = (): Response => Response.json({
+  openapi: '3.1.0',
+  info: { title: 'Planets API', version: '1.0.0' },
+  servers: [{ url: '/' }],
+  paths: {
+    '/api/planets': {
+      get: {
+        operationId: 'listPlanets',
+        summary: 'List planets',
+        responses: {
+          '200': {
+            description: 'The planet catalog.',
+            content: { 'application/json': { schema: z.toJSONSchema(planetsSchema) } },
+          },
+        },
+      },
+    },
+  },
+})
+```
+
+Mount Scalar:
+
+```typescript
+// app/scalar/route.ts
+import { ApiReference } from '@scalar/nextjs-api-reference'
+
+export const GET = ApiReference({ url: '/openapi.json' })
+```
+
+Run `npm run dev`, open <http://localhost:3000/scalar>, select **List planets**, open **Test Request**, and send. Expect `200` with Earth and Mars. `/openapi.json` should contain `/api/planets` and an array response schema.
+
+The relative server URL follows localhost and preview deployments. There is no automatic route discovery here. If you already use [Hono](./hono.md) or [oRPC](./orpc.md), their route metadata can generate the paths too.
+
+See [Zod JSON Schema conversion](https://zod.dev/json-schema) for unsupported schema types and conversion options. Scalar also has an experimental [`@scalar/nextjs-openapi`](https://github.com/scalar/scalar/tree/main/packages/nextjs-openapi) route scanner, currently labeled pre-alpha; it is a separate package from this renderer.

--- a/documentation/integrations/nextjs.md
+++ b/documentation/integrations/nextjs.md
@@ -260,3 +260,13 @@ export default function References() {
   )
 }
 ```
+
+## Generate your API description
+
+Choose the recipe that matches your application's routing:
+
+- [Next.js Route Handlers with Zod](./nextjs-recipes/route-handlers.md)
+- [Hono with Zod OpenAPI](./nextjs-recipes/hono.md)
+- [oRPC procedures](./nextjs-recipes/orpc.md)
+
+Each recipe includes a working endpoint, the generated OpenAPI description, and Scalar at `/scalar`.

--- a/scalar.config.json
+++ b/scalar.config.json
@@ -3260,6 +3260,24 @@
                         "description": "Add a Scalar API reference to your Nitro server for interactive OpenAPI documentation.",
                         "type": "page"
                       },
+                      "nextjs-recipes/route-handlers": {
+                        "title": "Next.js with Zod",
+                        "filepath": "documentation/integrations/nextjs-recipes/route-handlers.md",
+                        "type": "page",
+                        "showInSidebar": false
+                      },
+                      "nextjs-recipes/hono": {
+                        "title": "Next.js with Hono",
+                        "filepath": "documentation/integrations/nextjs-recipes/hono.md",
+                        "type": "page",
+                        "showInSidebar": false
+                      },
+                      "nextjs-recipes/orpc": {
+                        "title": "Next.js with oRPC",
+                        "filepath": "documentation/integrations/nextjs-recipes/orpc.md",
+                        "type": "page",
+                        "showInSidebar": false
+                      },
                       "nuxt": {
                         "title": "Nuxt",
                         "filepath": "documentation/integrations/nuxt.md",


### PR DESCRIPTION
Add working Zod, Hono, and oRPC generation recipes. All three build and pass schema checks and browser test requests.
