### PR TITLE
docs(galaxy): add OpenAPI link examples

### DIFF
--- a/.changeset/galaxy-link-objects.md
+++ b/.changeset/galaxy-link-objects.md
@@ -1,0 +1,5 @@
+---
+'@scalar/galaxy': patch
+---
+
+Add OpenAPI Link Object examples to the 3.1 and 3.2 documents.

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -155,7 +155,7 @@ paths:
               description: Return to the first page using the requested page size.
               parameters:
                 query.limit: '$request.query.limit'
-                query.offset: 0
+                query.offset: '0'
       x-post-response: |
         pm.test("Status code is 200", () => {
           pm.response.to.have.status(200);

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -144,6 +144,18 @@ paths:
                     $dynamicAnchor: itemType
                     $ref: '#/components/schemas/Planet'
                 $ref: '#/components/schemas/PaginatedResource'
+          links:
+            GetFirstPlanet:
+              operationId: getPlanet
+              description: Retrieve the first planet when the response contains at least one planet.
+              parameters:
+                path.planetId: '$response.body#/data/0/id'
+            FirstPage:
+              operationId: getAllData
+              description: Return to the first page using the requested page size.
+              parameters:
+                query.limit: '$request.query.limit'
+                query.offset: 0
       x-post-response: |
         pm.test("Status code is 200", () => {
           pm.response.to.have.status(200);
@@ -345,6 +357,9 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/Planet'
+          links:
+            GetPlanet:
+              $ref: '#/components/links/GetPlanet'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -699,7 +714,7 @@ components:
   links:
     GetPlanet:
       operationId: getPlanet
-      description: Retrieve the created planet using the ID returned in the response.
+      description: Retrieve the planet using the ID returned in the response.
       parameters:
         planetId: '$response.body#/id'
   securitySchemes:

--- a/packages/galaxy/src/documents/3.1.yaml
+++ b/packages/galaxy/src/documents/3.1.yaml
@@ -237,6 +237,15 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/Planet'
+          links:
+            GetPlanet:
+              $ref: '#/components/links/GetPlanet'
+            UpdatePlanet:
+              operationRef: '#/paths/~1planets~1%7BplanetId%7D/put'
+              description: Update the created planet using its ID and response body.
+              parameters:
+                planetId: '$response.body#/id'
+              requestBody: '$response.body'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -286,6 +295,12 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/Planet'
+          links:
+            DeletePlanet:
+              operationId: deletePlanet
+              description: Delete this planet using the ID from the request path.
+              parameters:
+                planetId: '$request.path.planetId'
         '404':
           $ref: '#/components/responses/NotFound'
       x-post-response: |
@@ -681,6 +696,12 @@ webhooks:
           pm.response.to.have.status(200);
         });
 components:
+  links:
+    GetPlanet:
+      operationId: getPlanet
+      description: Retrieve the created planet using the ID returned in the response.
+      parameters:
+        planetId: '$response.body#/id'
   securitySchemes:
     bearerAuth:
       type: http

--- a/packages/galaxy/src/documents/3.2.yaml
+++ b/packages/galaxy/src/documents/3.2.yaml
@@ -257,6 +257,15 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/Planet'
+          links:
+            GetPlanet:
+              $ref: '#/components/links/GetPlanet'
+            UpdatePlanet:
+              operationRef: '#/paths/~1planets~1%7BplanetId%7D/put'
+              description: Update the created planet using its ID and response body.
+              parameters:
+                planetId: '$response.body#/id'
+              requestBody: '$response.body'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -388,6 +397,12 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/Planet'
+          links:
+            DeletePlanet:
+              operationId: deletePlanet
+              description: Delete this planet using the ID from the request path.
+              parameters:
+                planetId: '$request.path.planetId'
         '404':
           $ref: '#/components/responses/NotFound'
       x-post-response: |
@@ -901,6 +916,12 @@ webhooks:
           pm.response.to.have.status(200);
         });
 components:
+  links:
+    GetPlanet:
+      operationId: getPlanet
+      description: Retrieve the created planet using the ID returned in the response.
+      parameters:
+        planetId: '$response.body#/id'
   securitySchemes:
     bearerAuth:
       type: http

--- a/packages/galaxy/src/documents/3.2.yaml
+++ b/packages/galaxy/src/documents/3.2.yaml
@@ -175,7 +175,7 @@ paths:
               description: Return to the first page using the requested page size.
               parameters:
                 query.limit: '$request.query.limit'
-                query.offset: 0
+                query.offset: '0'
       x-post-response: |
         pm.test("Status code is 200", () => {
           pm.response.to.have.status(200);

--- a/packages/galaxy/src/documents/3.2.yaml
+++ b/packages/galaxy/src/documents/3.2.yaml
@@ -164,6 +164,18 @@ paths:
                     $dynamicAnchor: itemType
                     $ref: '#/components/schemas/Planet'
                 $ref: '#/components/schemas/PaginatedResource'
+          links:
+            GetFirstPlanet:
+              operationId: getPlanet
+              description: Retrieve the first planet when the response contains at least one planet.
+              parameters:
+                path.planetId: '$response.body#/data/0/id'
+            FirstPage:
+              operationId: getAllData
+              description: Return to the first page using the requested page size.
+              parameters:
+                query.limit: '$request.query.limit'
+                query.offset: 0
       x-post-response: |
         pm.test("Status code is 200", () => {
           pm.response.to.have.status(200);
@@ -447,6 +459,9 @@ paths:
             application/xml:
               schema:
                 $ref: '#/components/schemas/Planet'
+          links:
+            GetPlanet:
+              $ref: '#/components/links/GetPlanet'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -518,6 +533,9 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/Planet'
+            links:
+              GetPlanet:
+                $ref: '#/components/links/GetPlanet'
           '404':
             $ref: '#/components/responses/NotFound'
   /planets/{planetId}/image:
@@ -919,7 +937,7 @@ components:
   links:
     GetPlanet:
       operationId: getPlanet
-      description: Retrieve the created planet using the ID returned in the response.
+      description: Retrieve the planet using the ID returned in the response.
       parameters:
         planetId: '$response.body#/id'
   securitySchemes:


### PR DESCRIPTION
Add links to both Galaxy examples, including list navigation and shared links after create, update, and copy.

Validation, 13 tests, formatting, and types pass.

## Ticket

See https://github.com/scalar/scalar/discussions/632
