### PR TITLE
fix(mock-server): confine asyncapi $ref resolution to block ssrf and file reads

### DIFF
--- a/.changeset/mock-server-asyncapi-ref-guard.md
+++ b/.changeset/mock-server-asyncapi-ref-guard.md
@@ -1,0 +1,5 @@
+---
+'@scalar/mock-server': patch
+---
+
+Confine AsyncAPI $ref resolution the same way OpenAPI does, so a document cannot read local files or reach private network addresses through external refs.

--- a/packages/mock-server/src/utils/process-asyncapi-document.test.ts
+++ b/packages/mock-server/src/utils/process-asyncapi-document.test.ts
@@ -1,0 +1,49 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { processAsyncApiDocument } from './process-asyncapi-document'
+
+describe('processAsyncApiDocument', () => {
+  it('does not read files outside the working directory through a $ref', async () => {
+    const secretDir = await mkdtemp(join(tmpdir(), 'scalar-mock-asyncapi-secret-'))
+    const secretFile = join(secretDir, 'secret.json')
+    await writeFile(secretFile, JSON.stringify({ secret: 'do-not-leak' }))
+
+    try {
+      const document = {
+        asyncapi: '3.1.0',
+        info: { title: 'Test', version: '1.0.0' },
+        channels: {},
+        operations: {},
+        components: { schemas: { Leaked: { $ref: secretFile } } },
+      }
+
+      const result = await processAsyncApiDocument(document)
+
+      // The out-of-tree file must not be inlined into the bundled document.
+      expect(JSON.stringify(result)).not.toContain('do-not-leak')
+    } finally {
+      await rm(secretDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not fetch private network addresses through a $ref', async () => {
+    const document = {
+      asyncapi: '3.1.0',
+      info: { title: 'Test', version: '1.0.0' },
+      channels: {},
+      operations: {},
+      // The cloud metadata endpoint is a classic SSRF target; it must never be fetched and inlined.
+      components: { schemas: { Leaked: { $ref: 'http://169.254.169.254/latest/meta-data/' } } },
+    }
+
+    const result = await processAsyncApiDocument(document)
+
+    // The $ref must stay unresolved rather than the private address being fetched and inlined.
+    expect(JSON.stringify(result)).toContain('169.254.169.254')
+    expect(JSON.stringify(result)).toContain('$ref')
+  })
+})

--- a/packages/mock-server/src/utils/process-asyncapi-document.ts
+++ b/packages/mock-server/src/utils/process-asyncapi-document.ts
@@ -1,5 +1,9 @@
+import path from 'node:path'
+import { cwd } from 'node:process'
+
 import { bundle } from '@scalar/json-magic/bundle'
 import { fetchUrls, parseJson, parseYaml, readFiles } from '@scalar/json-magic/bundle/plugins/node'
+import { isFilePath } from '@scalar/json-magic/helpers/is-file-path'
 import { createMagicProxy } from '@scalar/json-magic/magic-proxy'
 import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 
@@ -36,10 +40,15 @@ export async function processAsyncApiDocument(
 
   let bundled: Record<string, any>
 
+  // Confine local file `$ref`s to the document's own directory (or the working directory when the
+  // document is an object or inline string), and refuse to fetch private or internal addresses.
+  // Without these guards a `$ref` could read arbitrary local files or reach internal services.
+  const basePath = typeof document === 'string' && isFilePath(document) ? path.dirname(path.resolve(document)) : cwd()
+
   try {
     // Bundle external references; parse string inputs (JSON or YAML) along the way.
     bundled = await bundle(document, {
-      plugins: [parseJson(), parseYaml(), readFiles(), fetchUrls()],
+      plugins: [parseJson(), parseYaml(), readFiles({ basePath }), fetchUrls({ blockPrivateNetworks: true })],
       treeShake: false,
     })
   } catch (error) {


### PR DESCRIPTION
The OpenAPI mock server already blocks file reads and private network requests through `$ref` (PR #10079). The AsyncAPI path did not. This applies the same guards there.