### PR TITLE
fix(json-magic): pin requests to validated addresses

### DIFF
--- a/.changeset/pin-validated-addresses.md
+++ b/.changeset/pin-validated-addresses.md
@@ -1,0 +1,5 @@
+---
+'@scalar/json-magic': patch
+---
+
+Pin guarded requests to validated public IP addresses and reject custom transports that bypass the connection checks.

--- a/packages/json-magic/package.json
+++ b/packages/json-magic/package.json
@@ -114,6 +114,7 @@
   "dependencies": {
     "@scalar/helpers": "workspace:*",
     "pathe": "^2.0.3",
+    "undici": "catalog:*",
     "yaml": "catalog:*"
   },
   "devDependencies": {

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-public-url.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-public-url.test.ts
@@ -1,0 +1,95 @@
+import type { LookupAddress, LookupAllOptions } from 'node:dns'
+import { lookup } from 'node:dns/promises'
+import type { LookupFunction } from 'node:net'
+
+import { Agent, Response as UndiciResponse, fetch } from 'undici'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { fetchPublicUrl } from './fetch-public-url'
+
+vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }))
+vi.mock('undici', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('undici')>()),
+  Agent: vi.fn(
+    class {
+      destroy = vi.fn().mockResolvedValue(undefined)
+    },
+  ),
+  fetch: vi.fn(),
+}))
+
+const lookupAll = vi.mocked(lookup as (hostname: string, options: LookupAllOptions) => Promise<LookupAddress[]>)
+
+describe('fetch-public-url', () => {
+  afterEach(() => vi.resetAllMocks())
+
+  it('pins the connection to the validated answer when DNS changes', async () => {
+    lookupAll
+      .mockResolvedValueOnce([{ address: '93.184.216.34', family: 4 }])
+      .mockResolvedValueOnce([{ address: '127.0.0.1', family: 4 }])
+    vi.mocked(fetch).mockImplementationOnce(async (url, options) => {
+      expect(String(url)).toBe('https://api.example.com/schema.json')
+      expect(options?.redirect).toBe('error')
+      expect(options?.headers).toStrictEqual({ authorization: 'Bearer test' })
+      expect(options?.dispatcher).toBe(vi.mocked(Agent).mock.instances[0])
+      const connect = vi.mocked(Agent).mock.calls[0][0]?.connect
+      if (!connect || typeof connect === 'function' || !('lookup' in connect) || !connect.lookup) {
+        throw new Error('A pinned lookup is required')
+      }
+      const pinnedLookup: LookupFunction = connect.lookup
+      const address = await new Promise((resolve, reject) => {
+        pinnedLookup('api.example.com', { all: true }, (error, result) => (error ? reject(error) : resolve(result)))
+      })
+      expect(address).toStrictEqual([{ address: '93.184.216.34', family: 4 }])
+      const single = await new Promise((resolve, reject) => {
+        pinnedLookup('api.example.com', {}, (error, result, family) =>
+          error ? reject(error) : resolve({ address: result, family }),
+        )
+      })
+      expect(single).toStrictEqual({ address: '93.184.216.34', family: 4 })
+      return new UndiciResponse('{"type":"string"}')
+    })
+
+    const result = await fetchPublicUrl('https://api.example.com/schema.json', { Authorization: 'Bearer test' })
+
+    expect(await result.json()).toStrictEqual({ type: 'string' })
+    expect(lookup).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(Agent).mock.instances[0].destroy).toHaveBeenCalledOnce()
+  })
+
+  it('blocks a DNS answer containing both public and private addresses before fetching', async () => {
+    lookupAll.mockReset().mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '127.0.0.1', family: 4 },
+    ])
+
+    await expect(fetchPublicUrl('https://api.example.com')).rejects.toThrow('private or internal')
+    expect(fetch).not.toHaveBeenCalled()
+    expect(Agent).not.toHaveBeenCalled()
+  })
+
+  it('blocks local NAT64 translation addresses before fetching', async () => {
+    await expect(fetchPublicUrl('http://[64:ff9b:1:0:c0:a801:100:0]')).rejects.toThrow('private or internal')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('does not read error response bodies before rejecting the response', async () => {
+    const response = new UndiciResponse('An error body', { status: 500 })
+    const readBody = vi.spyOn(response, 'arrayBuffer')
+    vi.mocked(fetch).mockResolvedValueOnce(response)
+
+    const result = await fetchPublicUrl('https://93.184.216.34')
+
+    expect(result.status).toBe(500)
+    expect(await result.text()).toBe('')
+    expect(readBody).not.toHaveBeenCalled()
+    expect(vi.mocked(Agent).mock.instances[0].destroy).toHaveBeenCalledOnce()
+  })
+
+  it('closes the connection when fetching fails', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('Connection failed'))
+
+    await expect(fetchPublicUrl('https://93.184.216.34')).rejects.toThrow('Connection failed')
+    expect(vi.mocked(Agent).mock.instances[0].destroy).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-public-url.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-public-url.ts
@@ -1,0 +1,46 @@
+import { Agent, fetch } from 'undici'
+
+import { resolvePublicHost } from './is-blocked-host'
+
+/** Fetches through a connection pinned to validated addresses while preserving the host and TLS name. */
+export const fetchPublicUrl = async (url: string, headers?: HeadersInit): Promise<Response> => {
+  const target = new URL(url)
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    throw new Error('Only HTTP and HTTPS URLs are supported')
+  }
+
+  const addresses = await resolvePublicHost(target.hostname)
+  if (!addresses) {
+    throw new Error('Refused to fetch a private or internal address')
+  }
+
+  // Never resolve the hostname again when connecting. A later DNS answer could point at a private IP.
+  const dispatcher = new Agent({
+    connect: {
+      lookup: (_hostname, options, callback) => {
+        if (options.all) {
+          callback(null, addresses)
+        } else {
+          callback(null, addresses[0].address, addresses[0].family)
+        }
+      },
+    },
+  })
+
+  try {
+    const response = await fetch(target, {
+      headers: Object.fromEntries(new Headers(headers)),
+      redirect: 'error',
+      dispatcher,
+    })
+    const body = !response.ok || [204, 205].includes(response.status) ? null : await response.arrayBuffer()
+
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: Object.fromEntries(response.headers),
+    })
+  } finally {
+    await dispatcher.destroy()
+  }
+}

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.test.ts
@@ -184,28 +184,15 @@ describe('fetchUrl blockPrivateNetworks', () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
-  it('still fetches a public address', async () => {
-    const fetch = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }))
+  it('rejects custom transports that could bypass the guarded connection', async () => {
+    const fetch = vi.fn(async () => new Response('{}', { status: 200 }))
 
     const result = await fetchUrl('http://93.184.216.34/', noLimit, {
       blockPrivateNetworks: true,
       fetch,
     })
 
-    expect(fetch).toHaveBeenCalled()
-    expect(result.ok).toBe(true)
-  })
-
-  it('does not follow redirects under the guard', async () => {
-    let receivedInit: RequestInit | undefined
-    const fetch = vi.fn((_url: string | URL | Request, init?: RequestInit) => {
-      receivedInit = init
-      return Promise.resolve(new Response('{}', { status: 200 }))
-    })
-
-    await fetchUrl('http://93.184.216.34/', noLimit, { blockPrivateNetworks: true, fetch })
-
-    // A redirect would otherwise let a public URL bounce to an internal target.
-    expect(receivedInit?.redirect).toBe('error')
+    expect(result).toStrictEqual({ ok: false })
+    expect(fetch).not.toHaveBeenCalled()
   })
 })

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
@@ -6,6 +6,7 @@ import { normalize } from '@/helpers/normalize'
 
 type FetchConfig = Partial<{
   headers: { headers: HeadersInit; domains: string[] }[]
+  /** Custom transports cannot be combined with blockPrivateNetworks. */
   fetch: (input: string | URL | globalThis.Request, init?: RequestInit) => Promise<Response>
   /**
    * When true, refuse to fetch URLs that resolve to a private, loopback, link-local, or otherwise
@@ -22,17 +23,6 @@ type FetchConfig = Partial<{
 const getHost = (url: string): string | null => {
   try {
     return new URL(url).host
-  } catch {
-    return null
-  }
-}
-
-/**
- * Safely reads the hostname (without port) from a URL, for the private-address check.
- */
-const getHostname = (url: string): string | null => {
-  try {
-    return new URL(url).hostname
   } catch {
     return null
   }
@@ -58,42 +48,22 @@ export async function fetchUrl(
   config?: FetchConfig,
 ): Promise<ResolveResult> {
   try {
-    // SSRF guard: optionally refuse to fetch internal or private targets before making the request.
-    // Only runs in Node, since the browser build has no DNS access and its own network isolation.
-    if (config?.blockPrivateNetworks && typeof window === 'undefined') {
-      const hostname = getHostname(url)
-
-      if (hostname) {
-        const { isBlockedHost } = await import('./is-blocked-host')
-
-        if (await isBlockedHost(hostname)) {
-          console.warn(`[WARN] Refused to fetch a private or internal address: ${url}`)
-          return {
-            ok: false,
-          }
-        }
-      }
-    }
-
     const host = getHost(url)
-
-    // Get the headers that match the domain
     const headers = config?.headers?.find((a) => a.domains.find((d) => d === host) !== undefined)?.headers
+    const guarded = config?.blockPrivateNetworks && typeof window === 'undefined'
 
-    const exec = config?.fetch ?? fetch
+    const result = await limiter(async () => {
+      if (guarded) {
+        // A custom fetch can ignore the pinned connection and resolve the host again.
+        if (config?.fetch) {
+          throw new Error('Custom fetch cannot be combined with private network blocking')
+        }
+        const { fetchPublicUrl } = await import('./fetch-public-url')
+        return fetchPublicUrl(url, headers)
+      }
 
-    // Under the SSRF guard, do not follow redirects. Otherwise a public URL that passes the host
-    // check above could redirect to an internal target (for example the metadata endpoint) that
-    // the redirect would reach without being re-validated.
-    const redirect: RequestRedirect | undefined =
-      config?.blockPrivateNetworks && typeof window === 'undefined' ? 'error' : undefined
-
-    const result = await limiter(() =>
-      exec(url, {
-        headers,
-        redirect,
-      }),
-    )
+      return (config?.fetch ?? fetch)(url, { headers })
+    })
 
     if (result.ok) {
       const body = await result.text()

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/is-blocked-host.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/is-blocked-host.ts
@@ -1,3 +1,4 @@
+import type { LookupAddress } from 'node:dns'
 import { lookup } from 'node:dns/promises'
 import { BlockList, isIP, isIPv4 } from 'node:net'
 
@@ -25,6 +26,7 @@ blockList.addSubnet('fe80::', 10, 'ipv6') // link-local
 blockList.addSubnet('fc00::', 7, 'ipv6') // unique local
 blockList.addSubnet('2002::', 16, 'ipv6') // 6to4
 blockList.addSubnet('64:ff9b::', 96, 'ipv6') // NAT64
+blockList.addSubnet('64:ff9b:1::', 48, 'ipv6') // local NAT64 translation prefixes
 blockList.addSubnet('2001::', 32, 'ipv6') // Teredo
 
 /**
@@ -78,19 +80,18 @@ const ipIsBlocked = (ip: string): boolean => {
  *
  * @param hostname - The hostname or IP (brackets around an IPv6 literal are tolerated).
  */
-export const isBlockedHost = async (hostname: string): Promise<boolean> => {
+export const isBlockedHost = async (hostname: string): Promise<boolean> => (await resolvePublicHost(hostname)) === null
+
+/** Resolves a host once and returns only validated public addresses, or null when blocked. */
+export const resolvePublicHost = async (hostname: string): Promise<LookupAddress[] | null> => {
   const host = hostname.replace(/^\[/, '').replace(/\]$/, '')
 
-  if (isIP(host)) {
-    return ipIsBlocked(host)
-  }
-
   try {
-    const addresses = await lookup(host, { all: true })
+    const family = isIP(host)
+    const addresses = family ? [{ address: host, family }] : await lookup(host, { all: true })
 
-    return addresses.some(({ address }) => ipIsBlocked(address))
+    return addresses.length === 0 || addresses.some(({ address }) => ipIsBlocked(address)) ? null : addresses
   } catch {
-    // Block when the host cannot be resolved
-    return true
+    return null
   }
 }

--- a/packages/mock-server/src/utils/process-openapi-document.test.ts
+++ b/packages/mock-server/src/utils/process-openapi-document.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -7,6 +8,43 @@ import { describe, expect, it } from 'vitest'
 import { processOpenApiDocument } from './process-openapi-document'
 
 describe('processOpenApiDocument', () => {
+  it('does not request loopback URLs through a $ref', async () => {
+    const requests: string[] = []
+    const server = createServer((request, response) => {
+      requests.push(request.url ?? '')
+      response.setHeader('Content-Type', 'application/json')
+      response.end(JSON.stringify({ secret: 'internal-service-secret' }))
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected a TCP server address')
+      }
+
+      const document = {
+        openapi: '3.1.0',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {},
+        components: { schemas: { Leaked: { $ref: `http://127.0.0.1:${address.port}/secret.json` } } },
+      }
+
+      const result = await processOpenApiDocument(document)
+
+      expect(requests).toStrictEqual([])
+      expect(JSON.stringify(result)).not.toContain('internal-service-secret')
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+    }
+  })
+
   it('does not read files outside the working directory through a $ref', async () => {
     const secretDir = await mkdtemp(join(tmpdir(), 'scalar-mock-secret-'))
     const secretFile = join(secretDir, 'secret.json')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2063,6 +2063,9 @@ importers:
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
+      undici:
+        specifier: catalog:*
+        version: 7.24.4
       yaml:
         specifier: catalog:*
         version: 2.9.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2064,7 +2064,7 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       undici:
-        specifier: catalog:*
+        specifier: 7.24.4
         version: 7.24.4
       yaml:
         specifier: catalog:*


### PR DESCRIPTION
Pin guarded requests to validated public IP addresses. Reject custom transports that bypass these checks.
