### PR TITLE
fix(openapi-parser): handle component keys safely

### DIFF
--- a/.changeset/merge-component-keys.md
+++ b/.changeset/merge-component-keys.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-parser': patch
+---
+
+Ignore unsafe component keys and check own properties when joining API descriptions.

--- a/packages/openapi-parser/src/utils/join/join.test.ts
+++ b/packages/openapi-parser/src/utils/join/join.test.ts
@@ -1,7 +1,61 @@
-import { join } from '@/utils/join/join'
 import { describe, expect, it } from 'vitest'
 
+import { join } from '@/utils/join/join'
+
 describe('join', () => {
+  it.each(['__proto__', 'constructor', 'prototype'])('ignores unsafe component type %s', async (key) => {
+    const input = JSON.parse(`{"components":{"${key}":{"scalarJoinMarker":{"type":"string"}}}}`)
+
+    const result = await join([input])
+
+    expect(result).toStrictEqual({
+      ok: true,
+      document: {
+        info: {},
+        paths: {},
+        components: undefined,
+        servers: undefined,
+        tags: undefined,
+        webhooks: undefined,
+      },
+    })
+    expect(Object.hasOwn(Object.prototype, 'scalarJoinMarker')).toBe(false)
+    expect(Reflect.get({}, 'scalarJoinMarker')).toBeUndefined()
+  })
+
+  it('keeps inherited-looking component names as own data without false conflicts', async () => {
+    const result = await join([{ components: { schemas: { toString: { type: 'string' } } } }])
+
+    expect(result).toStrictEqual({
+      ok: true,
+      document: {
+        info: {},
+        paths: {},
+        servers: undefined,
+        tags: undefined,
+        webhooks: undefined,
+        components: { schemas: { toString: { type: 'string' } } },
+      },
+    })
+  })
+
+  it.each(['__proto__', 'constructor', 'prototype'])('ignores unsafe component name %s', async (key) => {
+    const input = JSON.parse(`{"components":{"schemas":{"${key}":{"type":"string"},"Safe":{"type":"number"}}}}`)
+    const result = await join([input])
+
+    expect(result).toStrictEqual({
+      ok: true,
+      document: {
+        info: {},
+        paths: {},
+        servers: undefined,
+        tags: undefined,
+        webhooks: undefined,
+        components: { schemas: { Safe: { type: 'number' } } },
+      },
+    })
+  })
+
   it('should handle joining info objects, prioritizing the first input document', async () => {
     const result = await join([
       {

--- a/packages/openapi-parser/src/utils/join/join.test.ts
+++ b/packages/openapi-parser/src/utils/join/join.test.ts
@@ -3,6 +3,44 @@ import { describe, expect, it } from 'vitest'
 import { join } from '@/utils/join/join'
 
 describe('join', () => {
+  it.each([null, undefined, false, 0, ''])('replaces lower-precedence falsy path items (%s)', async (value) => {
+    for (const field of ['paths', 'webhooks']) {
+      const result = await join([{ [field]: { '/a': { get: {} } } }, { [field]: { '/a': value } }])
+
+      expect(result).toStrictEqual({
+        ok: true,
+        document: {
+          info: {},
+          paths: {},
+          components: undefined,
+          servers: undefined,
+          tags: undefined,
+          webhooks: undefined,
+          [field]: { '/a': { get: {} } },
+        },
+      })
+    }
+  })
+
+  it.each([null, undefined, false, 0, ''])('replaces lower-precedence falsy components (%s)', async (value) => {
+    const result = await join([
+      { components: { schemas: { Example: { type: 'string' } } } },
+      { components: { schemas: { Example: value } } },
+    ])
+
+    expect(result).toStrictEqual({
+      ok: true,
+      document: {
+        info: {},
+        paths: {},
+        components: { schemas: { Example: { type: 'string' } } },
+        servers: undefined,
+        tags: undefined,
+        webhooks: undefined,
+      },
+    })
+  })
+
   it.each(['__proto__', 'constructor', 'prototype'])('ignores unsafe component type %s', async (key) => {
     const input = JSON.parse(`{"components":{"${key}":{"scalarJoinMarker":{"type":"string"}}}}`)
 

--- a/packages/openapi-parser/src/utils/join/join.ts
+++ b/packages/openapi-parser/src/utils/join/join.ts
@@ -1,3 +1,4 @@
+import { isPollutionKey } from '@scalar/helpers/object/prevent-pollution'
 import { bundle } from '@scalar/json-magic/bundle'
 import type {
   ComponentsObject,
@@ -71,7 +72,11 @@ const mergePaths = (inputs: PathsObject[]) => {
     }
 
     for (const [path, pathItem] of Object.entries(paths)) {
-      if (!result[path]) {
+      if (isPollutionKey(path)) {
+        continue
+      }
+
+      if (!Object.hasOwn(result, path)) {
         // If the path does not exist, add it directly
         result[path] = pathItem
         continue
@@ -155,12 +160,20 @@ const mergeComponents = (inputs: ComponentsObject[]) => {
 
     // Merge each component type (schemas, responses, parameters, etc.)
     for (const [key, value] of Object.entries(components)) {
+      if (isPollutionKey(key)) {
+        continue
+      }
+
       for (const [name, component] of Object.entries(value)) {
-        if (!result[key]) {
+        if (isPollutionKey(name)) {
+          continue
+        }
+
+        if (!Object.hasOwn(result, key)) {
           result[key] = {}
         }
 
-        if (result[key][name]) {
+        if (Object.hasOwn(result[key], name)) {
           // If the component already exists, record a conflict
           conflicts.push({ componentType: key, name })
         } else {
@@ -228,7 +241,16 @@ const prefixComponents = async (inputs: OpenApiDocumentV3_1[], prefixes: string[
               const prefix = prefixes[index]
 
               Object.keys(node).forEach((key) => {
+                if (isPollutionKey(key)) {
+                  delete node[key]
+                  return
+                }
+
                 const newKey = `${prefix ?? ''}${key}`
+                if (isPollutionKey(newKey)) {
+                  delete node[key]
+                  return
+                }
                 const childNode = node[key]
                 delete node[key]
                 node[newKey] = childNode

--- a/packages/openapi-parser/src/utils/join/join.ts
+++ b/packages/openapi-parser/src/utils/join/join.ts
@@ -76,7 +76,7 @@ const mergePaths = (inputs: PathsObject[]) => {
         continue
       }
 
-      if (!Object.hasOwn(result, path)) {
+      if (!Object.hasOwn(result, path) || !result[path]) {
         // If the path does not exist, add it directly
         result[path] = pathItem
         continue
@@ -173,7 +173,7 @@ const mergeComponents = (inputs: ComponentsObject[]) => {
           result[key] = {}
         }
 
-        if (Object.hasOwn(result[key], name)) {
+        if (Object.hasOwn(result[key], name) && result[key][name]) {
           // If the component already exists, record a conflict
           conflicts.push({ componentType: key, name })
         } else {


### PR DESCRIPTION
Ignore unsafe component keys and check own properties when joining API descriptions.
