### PR TITLE
fix(workspace-store): keep chunk paths portable

### DIFF
--- a/.changeset/portable-chunk-paths.md
+++ b/.changeset/portable-chunk-paths.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Keep chunk filenames inside the output directory and match their references on Windows.

--- a/.changeset/portable-chunk-paths.md
+++ b/.changeset/portable-chunk-paths.md
@@ -2,4 +2,4 @@
 '@scalar/workspace-store': patch
 ---
 
-Keep chunk filenames inside the output directory and match their references on Windows.
+Keep chunk filenames inside the output directory and match their references on Windows. Reject existing symlinks below the output root when writing chunks and the workspace manifest.

--- a/packages/workspace-store/README.md
+++ b/packages/workspace-store/README.md
@@ -95,6 +95,12 @@ const chunk = store.get('#/document-name/components/schemas/Person')
 
 Create a new store in static mode
 
+Static generation treats the real path of the configured output directory as its trusted root,
+so an intentionally symlinked output directory is supported. Existing symbolic links below that
+root, including chunk files and `scalar-workspace.json`, are rejected. Keep the output directory
+and its ancestors under trusted control throughout generation: filesystem checks do not protect
+against an untrusted process concurrently replacing files or directories.
+
 ```ts
 // Create the store
 const store = await createServerWorkspaceStore({

--- a/packages/workspace-store/src/helpers/create-chunk-writer.test.ts
+++ b/packages/workspace-store/src/helpers/create-chunk-writer.test.ts
@@ -1,0 +1,29 @@
+import fs from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { createChunkWriter } from './create-chunk-writer'
+
+describe('create-chunk-writer', () => {
+  it('rejects paths outside the output root before creating directories or files', async () => {
+    const fixture = await fs.mkdtemp(join(tmpdir(), 'scalar-chunk-boundary-'))
+    const directory = join(fixture, 'output')
+
+    try {
+      const writeChunk = await createChunkWriter(directory)
+
+      await expect(writeChunk(['..', 'outside', 'marker.json'], {})).rejects.toThrow(
+        'Chunk path must stay inside the output directory',
+      )
+      await expect(writeChunk([join(fixture, 'absolute', 'marker.json')], {})).rejects.toThrow(
+        'Chunk path must stay inside the output directory',
+      )
+      expect(await fs.readdir(fixture)).toStrictEqual(['output'])
+      expect(await fs.readdir(directory)).toStrictEqual([])
+    } finally {
+      await fs.rm(fixture, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/workspace-store/src/helpers/create-chunk-writer.ts
+++ b/packages/workspace-store/src/helpers/create-chunk-writer.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs/promises'
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
+
+/**
+ * Creates a JSON writer rooted at the real output directory. The caller must keep this
+ * directory and its ancestors safe from concurrent changes by untrusted processes.
+ */
+export const createChunkWriter = async (
+  directory: string,
+): Promise<(segments: string[], value: unknown) => Promise<void>> => {
+  await fs.mkdir(directory, { recursive: true })
+  // Configured output roots may intentionally be symlinks, as may system directories such as /tmp.
+  const root = await fs.realpath(directory)
+
+  return async (segments, value): Promise<void> => {
+    const filename = resolve(root, ...segments)
+    const relativePath = relative(root, filename)
+    if (!relativePath || isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
+      throw new Error('Chunk path must stay inside the output directory')
+    }
+
+    // Check each ancestor before creating its children: recursive mkdir would follow a symlink
+    // and could create directories outside the root before we had a chance to validate it.
+    let parent = root
+    const parentPath = relative(root, dirname(filename))
+    for (const segment of parentPath ? parentPath.split(sep) : []) {
+      parent = resolve(parent, segment)
+      await fs.mkdir(parent).catch((error: unknown) => {
+        if (!(error instanceof Error && 'code' in error && error.code === 'EEXIST')) {
+          throw error
+        }
+      })
+      const stat = await fs.lstat(parent)
+      if (!stat.isDirectory() || stat.isSymbolicLink()) {
+        throw new Error('Chunk directories must be real directories, not symbolic links')
+      }
+    }
+
+    const stat = await fs.lstat(filename).catch((error: unknown) => {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        return undefined
+      }
+      throw error
+    })
+    if (stat && (!stat.isFile() || stat.isSymbolicLink())) {
+      throw new Error('Chunk destinations must be regular files, not symbolic links')
+    }
+    await fs.writeFile(filename, JSON.stringify(value))
+  }
+}

--- a/packages/workspace-store/src/helpers/encode-chunk-name.test.ts
+++ b/packages/workspace-store/src/helpers/encode-chunk-name.test.ts
@@ -1,0 +1,42 @@
+import { win32 } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import { encodeChunkName } from './encode-chunk-name'
+
+describe('encode-chunk-name', () => {
+  it.each([
+    '..\\..\\outside',
+    '../outside',
+    'C:\\outside',
+    '\\\\server\\share',
+    '..',
+    '.',
+    '',
+    'name:stream',
+    'name#fragment',
+    'name%2fpath',
+  ])('keeps %s inside a Windows directory', (name) => {
+    const encoded = encodeChunkName(name)
+    const root = 'C:\\public\\chunks'
+
+    expect(win32.dirname(win32.resolve(root, `${encoded}.json`))).toBe(root)
+    expect(encoded).not.toMatch(/[\\/:*?"<>|#%]/)
+    expect(encoded === '' || encoded === '.' || encoded === '..').toBe(false)
+  })
+
+  it('preserves normal JSON Pointer filenames', () => {
+    expect(encodeChunkName('/users/{id}')).toBe('~1users~1{id}')
+    expect(encodeChunkName('User')).toBe('User')
+  })
+
+  it('keeps escaped names distinct from literal escape sequences', () => {
+    expect(encodeChunkName('\\')).toBe('~x5c~')
+    expect(encodeChunkName('~x5c~')).toBe('~0x5c~0')
+  })
+
+  it.each(['CON', 'NUL.txt', 'aux', 'com1', 'LPT9', 'name.'])('avoids Windows reserved filename %s', (name) => {
+    expect(encodeChunkName(name)).not.toBe(name)
+    expect(encodeChunkName(name).endsWith('.')).toBe(false)
+  })
+})

--- a/packages/workspace-store/src/helpers/encode-chunk-name.ts
+++ b/packages/workspace-store/src/helpers/encode-chunk-name.ts
@@ -1,0 +1,14 @@
+import { escapeJsonPointer } from '@scalar/json-magic/helpers/escape-json-pointer'
+
+/** Encodes a chunk name as one portable filename and URL segment. */
+export const encodeChunkName = (name: string): string => {
+  // JSON Pointer escaping preserves existing names and reserves ~x for filesystem escapes.
+  const escaped = escapeJsonPointer(name).replace(
+    /[^a-zA-Z0-9_.~{}-]/gu,
+    (character) => `~x${character.codePointAt(0)?.toString(16)}~`,
+  )
+  const portable = escaped.replace(/\.+$/, (dots) => dots.replaceAll('.', '~x2e~'))
+
+  // Windows device names remain reserved even when followed by a file extension.
+  return /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i.test(portable) || portable === '' ? `~x~${portable}` : portable
+}

--- a/packages/workspace-store/src/server-chunks.test.ts
+++ b/packages/workspace-store/src/server-chunks.test.ts
@@ -1,12 +1,12 @@
 import fs from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, relative, win32 } from 'node:path'
+import { dirname, join, relative, win32 } from 'node:path'
 
 import { getValueAtPath } from '@scalar/helpers/object/get-value-at-path'
 import { describe, expect, it } from 'vitest'
 
 import { isOpenApiDocument } from './schemas/type-guards'
-import { createServerWorkspaceStore } from './server'
+import { WORKSPACE_FILE_NAME, createServerWorkspaceStore } from './server'
 
 // Verify filenames against the references consumed by a static server, including Windows separators.
 describe('server-chunks', () => {
@@ -34,6 +34,8 @@ describe('server-chunks', () => {
         ],
       })
       await store.generateWorkspaceChunks()
+      // Existing regular files remain valid destinations when regenerating the same workspace.
+      await store.generateWorkspaceChunks()
       const workspace = store.getWorkspace()
       const document = workspace.documents[name]
       if (!isOpenApiDocument(document)) {
@@ -59,6 +61,91 @@ describe('server-chunks', () => {
       }
     } finally {
       await fs.rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    { path: WORKSPACE_FILE_NAME, type: 'file' },
+    { path: 'chunks', type: 'dir' },
+    { path: 'chunks/doc/components', type: 'dir' },
+    { path: 'chunks/doc/components/schemas/User.json', type: 'file' },
+    { path: 'chunks/doc/operations', type: 'dir' },
+    { path: 'chunks/doc/operations/~1users/get.json', type: 'file' },
+  ] as const)('rejects a pre-existing $type symlink at $path', async ({ path, type }) => {
+    const fixture = await fs.mkdtemp(join(tmpdir(), 'scalar-chunk-symlink-'))
+    const directory = join(fixture, 'output')
+    const outside = join(fixture, 'outside')
+    const destination = join(directory, path)
+
+    try {
+      await fs.mkdir(outside)
+      const marker = join(outside, 'untouched.json')
+      await fs.writeFile(marker, 'untouched')
+      await fs.mkdir(dirname(destination), { recursive: true })
+      await fs.symlink(type === 'dir' ? outside : marker, destination, type)
+      const store = await createServerWorkspaceStore({
+        mode: 'static',
+        directory: relative(process.cwd(), directory),
+        documents: [
+          {
+            name: 'doc',
+            document: {
+              openapi: '3.1.0',
+              info: { title: 'Symlinks', version: '1' },
+              components: { schemas: { User: { type: 'string' } } },
+              paths: { '/users': { get: { responses: { '200': { description: 'OK' } } } } },
+            },
+          },
+        ],
+      })
+
+      await expect(store.generateWorkspaceChunks()).rejects.toThrow('not symbolic links')
+      expect(await fs.readFile(marker, 'utf8')).toBe('untouched')
+      expect(await fs.readdir(outside)).toStrictEqual(['untouched.json'])
+    } finally {
+      await fs.rm(fixture, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a dangling manifest symlink without creating its target', async () => {
+    const fixture = await fs.mkdtemp(join(tmpdir(), 'scalar-chunk-dangling-'))
+    const directory = join(fixture, 'output')
+    const target = join(fixture, 'outside.json')
+
+    try {
+      await fs.mkdir(directory)
+      await fs.symlink(target, join(directory, WORKSPACE_FILE_NAME), 'file')
+      const store = await createServerWorkspaceStore({
+        mode: 'static',
+        directory: relative(process.cwd(), directory),
+        documents: [],
+      })
+
+      await expect(store.generateWorkspaceChunks()).rejects.toThrow('not symbolic links')
+      await expect(fs.lstat(target)).rejects.toHaveProperty('code', 'ENOENT')
+    } finally {
+      await fs.rm(fixture, { recursive: true, force: true })
+    }
+  })
+
+  it('uses an intentionally symlinked output directory as the trusted root', async () => {
+    const fixture = await fs.mkdtemp(join(tmpdir(), 'scalar-chunk-root-'))
+    const directory = join(fixture, 'output')
+    const target = join(fixture, 'real-output')
+
+    try {
+      await fs.mkdir(target)
+      await fs.symlink(target, directory, 'dir')
+      const store = await createServerWorkspaceStore({
+        mode: 'static',
+        directory: relative(process.cwd(), directory),
+        documents: [],
+      })
+
+      await store.generateWorkspaceChunks()
+      expect(JSON.parse(await fs.readFile(join(target, WORKSPACE_FILE_NAME), 'utf8'))).toStrictEqual({ documents: {} })
+    } finally {
+      await fs.rm(fixture, { recursive: true, force: true })
     }
   })
 })

--- a/packages/workspace-store/src/server-chunks.test.ts
+++ b/packages/workspace-store/src/server-chunks.test.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, relative, win32 } from 'node:path'
+
+import { getValueAtPath } from '@scalar/helpers/object/get-value-at-path'
+import { describe, expect, it } from 'vitest'
+
+import { isOpenApiDocument } from './schemas/type-guards'
+import { createServerWorkspaceStore } from './server'
+
+// Verify filenames against the references consumed by a static server, including Windows separators.
+describe('server-chunks', () => {
+  it('writes Windows-sensitive component and operation names to matching contained references', async () => {
+    const directory = await fs.mkdtemp(join(tmpdir(), 'scalar-chunks-'))
+    const name = '..\\document'
+    const schemaName = '..\\..\\outside#fragment%2f'
+    const operationPath = '/..\\..\\outside'
+    const schema = { type: 'string' }
+
+    try {
+      const store = await createServerWorkspaceStore({
+        mode: 'static',
+        directory: relative(process.cwd(), directory),
+        documents: [
+          {
+            name,
+            document: {
+              openapi: '3.1.0',
+              info: { title: 'Paths', version: '1' },
+              components: { schemas: { [schemaName]: schema } },
+              paths: { [operationPath]: { get: { responses: { '200': { description: 'OK' } } } } },
+            },
+          },
+        ],
+      })
+      await store.generateWorkspaceChunks()
+      const workspace = store.getWorkspace()
+      const document = workspace.documents[name]
+      if (!isOpenApiDocument(document)) {
+        throw new Error('Expected an OpenAPI document')
+      }
+      const schemaRef = getValueAtPath(document, ['components', 'schemas', schemaName, '$ref'])
+      const operationRef = getValueAtPath(document, ['paths', operationPath, 'get', '$ref'])
+      expect(typeof schemaRef).toBe('string')
+      expect(typeof operationRef).toBe('string')
+      if (typeof schemaRef !== 'string' || typeof operationRef !== 'string') {
+        throw new Error('Expected static chunk references')
+      }
+      for (const ref of [schemaRef, operationRef]) {
+        const path = ref.replace(/^\.\//, '').replace(/#$/, '')
+        expect(path).not.toContain('\\')
+        const windowsRelative = win32.relative('C:\\public', win32.resolve('C:\\public', path))
+        expect(windowsRelative.startsWith('chunks\\')).toBe(true)
+        expect(windowsRelative).not.toContain('..\\')
+        const contents: unknown = JSON.parse(await fs.readFile(join(directory, path), 'utf8'))
+        if (ref === schemaRef) {
+          expect(contents).toStrictEqual(schema)
+        }
+      }
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/workspace-store/src/server.ts
+++ b/packages/workspace-store/src/server.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
 import { cwd } from 'node:process'
 
 import { upgrade as upgradeAsyncApi } from '@scalar/asyncapi-upgrader'
@@ -8,6 +9,7 @@ import { preventPollution } from '@scalar/helpers/object/prevent-pollution'
 import { type LoaderPlugin, extensions as bundleExtensions } from '@scalar/json-magic/bundle'
 import { fetchUrls, readFiles } from '@scalar/json-magic/bundle/plugins/node'
 import { escapeJsonPointer } from '@scalar/json-magic/helpers/escape-json-pointer'
+import { unescapeJsonPointer } from '@scalar/json-magic/helpers/unescape-json-pointer'
 import { createMagicProxy, getRaw } from '@scalar/json-magic/magic-proxy'
 import { upgrade } from '@scalar/openapi-upgrader'
 import { asyncApiObjectSchema } from '@scalar/schemas/asyncapi/3.1'
@@ -15,6 +17,7 @@ import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import { type Schema, coerce } from '@scalar/validation'
 
 import { deepClone } from '@/helpers/deep-clone'
+import { encodeChunkName } from '@/helpers/encode-chunk-name'
 import { forEachPathItemOperation, getResolvedPathItem } from '@/helpers/for-each-path-item-operation'
 import { keyOf } from '@/helpers/general'
 import { getResolvedRef } from '@/helpers/get-resolved-ref'
@@ -219,10 +222,7 @@ export function externalizeComponentReferences(
       const ref =
         meta.mode === 'ssr'
           ? `${meta.baseUrl}/${meta.name}/components/${type}/${name}#`
-          : // Escape the type and name so the static reference matches the escaped filename written
-            // by generateWorkspaceChunks, and so a key like `../../evil` cannot point outside the
-            // chunks directory.
-            `./chunks/${meta.name}/components/${escapeJsonPointer(type)}/${escapeJsonPointer(name)}.json#`
+          : `./chunks/${encodeChunkName(meta.name)}/components/${encodeChunkName(type)}/${encodeChunkName(name)}.json#`
 
       result[type][name] = { '$ref': ref, $global: true }
     })
@@ -261,7 +261,7 @@ export function externalizePathReferences(
         const ref =
           meta.mode === 'ssr'
             ? `${meta.baseUrl}/${meta.name}/operations/${escapedPath}/${type}#`
-            : `./chunks/${meta.name}/operations/${escapedPath}/${type}.json#`
+            : `./chunks/${encodeChunkName(meta.name)}/operations/${encodeChunkName(path)}/${type}.json#`
 
         result[path][type] = { '$ref': ref, $global: true }
       } else if (type !== '$ref' && type !== '$ref-value') {
@@ -641,32 +641,41 @@ export async function createServerWorkspaceStore(
       // Write the workspace contents on the file system
       await fs.writeFile(`${basePath}/${WORKSPACE_FILE_NAME}`, JSON.stringify(workspace))
 
-      // Write the chunks
+      const chunksPath = resolve(basePath, 'chunks')
+      const writeChunk = async (segments: string[], value: unknown): Promise<void> => {
+        const filename = resolve(chunksPath, ...segments)
+        const relativePath = relative(chunksPath, filename)
+        if (isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
+          throw new Error('Chunk path must stay inside the chunks directory')
+        }
+        await fs.mkdir(resolve(filename, '..'), { recursive: true })
+        await fs.writeFile(filename, JSON.stringify(value))
+      }
+
       for (const [name, { components, operations }] of Object.entries(assets)) {
-        // Write the components chunks
         if (components) {
           for (const [type, component] of Object.entries(components)) {
-            // Escape the component type and key the same way operation paths are escaped. Component
-            // keys come from the OpenAPI document, so a key like `../../evil` would otherwise let a
-            // document write chunk files outside the assets directory. escapeJsonPointer turns every
-            // `/` into `~1`, collapsing the value into a single safe path segment.
-            const componentPath = `${basePath}/chunks/${name}/components/${escapeJsonPointer(type)}`
-            await fs.mkdir(componentPath, { recursive: true })
-
             for (const [key, value] of Object.entries(component)) {
-              await fs.writeFile(`${componentPath}/${escapeJsonPointer(key)}.json`, JSON.stringify(value))
+              await writeChunk(
+                [encodeChunkName(name), 'components', encodeChunkName(type), `${encodeChunkName(key)}.json`],
+                value,
+              )
             }
           }
         }
 
-        // Write the operations chunks
         if (operations) {
           for (const [path, methods] of Object.entries(operations)) {
-            const operationPath = `${basePath}/chunks/${name}/operations/${path}`
-            await fs.mkdir(operationPath, { recursive: true })
-
             for (const [method, operation] of Object.entries(methods)) {
-              await fs.writeFile(`${operationPath}/${method}.json`, JSON.stringify(operation))
+              await writeChunk(
+                [
+                  encodeChunkName(name),
+                  'operations',
+                  encodeChunkName(unescapeJsonPointer(path)),
+                  `${encodeChunkName(method)}.json`,
+                ],
+                operation,
+              )
             }
           }
         }

--- a/packages/workspace-store/src/server.ts
+++ b/packages/workspace-store/src/server.ts
@@ -1,5 +1,3 @@
-import fs from 'node:fs/promises'
-import { isAbsolute, relative, resolve, sep } from 'node:path'
 import { cwd } from 'node:process'
 
 import { upgrade as upgradeAsyncApi } from '@scalar/asyncapi-upgrader'
@@ -16,6 +14,7 @@ import { asyncApiObjectSchema } from '@scalar/schemas/asyncapi/3.1'
 import type { AsyncApiDocument } from '@scalar/types/asyncapi/3.1'
 import { type Schema, coerce } from '@scalar/validation'
 
+import { createChunkWriter } from '@/helpers/create-chunk-writer'
 import { deepClone } from '@/helpers/deep-clone'
 import { encodeChunkName } from '@/helpers/encode-chunk-name'
 import { forEachPathItemOperation, getResolvedPathItem } from '@/helpers/for-each-path-item-operation'
@@ -636,28 +635,15 @@ export async function createServerWorkspaceStore(
 
       // Write the workspace document
       const basePath = `${cwd()}/${workspaceProps.directory ?? DEFAULT_ASSETS_FOLDER}`
-      await fs.mkdir(basePath, { recursive: true })
-
-      // Write the workspace contents on the file system
-      await fs.writeFile(`${basePath}/${WORKSPACE_FILE_NAME}`, JSON.stringify(workspace))
-
-      const chunksPath = resolve(basePath, 'chunks')
-      const writeChunk = async (segments: string[], value: unknown): Promise<void> => {
-        const filename = resolve(chunksPath, ...segments)
-        const relativePath = relative(chunksPath, filename)
-        if (isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith(`..${sep}`)) {
-          throw new Error('Chunk path must stay inside the chunks directory')
-        }
-        await fs.mkdir(resolve(filename, '..'), { recursive: true })
-        await fs.writeFile(filename, JSON.stringify(value))
-      }
+      const writeChunk = await createChunkWriter(basePath)
+      await writeChunk([WORKSPACE_FILE_NAME], workspace)
 
       for (const [name, { components, operations }] of Object.entries(assets)) {
         if (components) {
           for (const [type, component] of Object.entries(components)) {
             for (const [key, value] of Object.entries(component)) {
               await writeChunk(
-                [encodeChunkName(name), 'components', encodeChunkName(type), `${encodeChunkName(key)}.json`],
+                ['chunks', encodeChunkName(name), 'components', encodeChunkName(type), `${encodeChunkName(key)}.json`],
                 value,
               )
             }
@@ -669,6 +655,7 @@ export async function createServerWorkspaceStore(
             for (const [method, operation] of Object.entries(methods)) {
               await writeChunk(
                 [
+                  'chunks',
                   encodeChunkName(name),
                   'operations',
                   encodeChunkName(unescapeJsonPointer(path)),


### PR DESCRIPTION
Keep chunk filenames portable and inside the output directory. Reject symlink destinations. Adds regression tests.
