### PR TITLE
fix(proxy): limit redirects to the same origin

### DIFF
--- a/.changeset/proxy-redirect-origins.md
+++ b/.changeset/proxy-redirect-origins.md
@@ -1,0 +1,4 @@
+---
+---
+
+Only follow proxy redirects with the same scheme, hostname, and port.

--- a/.changeset/proxy-redirect-origins.md
+++ b/.changeset/proxy-redirect-origins.md
@@ -1,4 +1,0 @@
----
----
-
-Only follow proxy redirects with the same scheme, hostname, and port.

--- a/projects/proxy-scalar-com/README.md
+++ b/projects/proxy-scalar-com/README.md
@@ -13,7 +13,7 @@ in browser environments.
 ## Features
 
 - Full CORS support
-- Handles HTTP redirects while preserving headers
+- Follows same-origin HTTP redirects while preserving headers. Redirects to another scheme, hostname, or effective port are rejected to protect credentials in headers and request bodies.
 - Supports HTTPS (and even self-signed certificates)
 - Request logging with method and target URL
 - Health check endpoint at `/ping`

--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -131,15 +131,26 @@ func dialAddr(ip net.IP, port string) string {
 	return fmt.Sprintf("[%s]:%s", ip.String(), port)
 }
 
-// isCredentialHeader reports whether a header carries credentials that must not
-// be forwarded to a different host during a redirect.
-func isCredentialHeader(header string) bool {
-	switch strings.ToLower(header) {
-	case "authorization", "proxy-authorization", "cookie":
-		return true
-	default:
-		return false
+// sameOrigin requires the same scheme, hostname, and effective port before
+// following a redirect. Arbitrary headers and request bodies can carry secrets,
+// so a list of known credential headers cannot safely authorize another origin.
+func sameOrigin(initial, destination *url.URL) bool {
+	effectivePort := func(u *url.URL) string {
+		if port := u.Port(); port != "" {
+			return port
+		}
+		switch strings.ToLower(u.Scheme) {
+		case "http":
+			return "80"
+		case "https":
+			return "443"
+		default:
+			return ""
+		}
 	}
+	return strings.EqualFold(initial.Scheme, destination.Scheme) &&
+		strings.EqualFold(initial.Hostname(), destination.Hostname()) &&
+		effectivePort(initial) == effectivePort(destination)
 }
 
 // Check if a given hostname or IP resolves to any blocked CIDR
@@ -413,21 +424,26 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 				return fmt.Errorf("redirect to blocked host: %s", req.URL.Host)
 			}
 
-			// Copy headers from the original request to maintain authentication
-			// and other important headers through redirect chains. When the
-			// redirect points at a different host, credential headers are
-			// dropped so a target that redirects to an attacker-controlled host
-			// cannot collect the user's Authorization, Cookie, or
-			// Proxy-Authorization headers.
-			original := via[0]
-			sameHost := strings.EqualFold(req.URL.Hostname(), original.URL.Hostname())
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
 
-			for key, values := range original.Header {
-				if !sameHost && isCredentialHeader(key) {
-					continue
+			// Returning the redirect response itself would let the browser
+			// follow its Location with custom credential headers. Reject it
+			// instead, before any request reaches the other origin.
+			if !sameOrigin(via[0].URL, req.URL) {
+				return fmt.Errorf("redirect to a different origin is not allowed")
+			}
+
+			// Go can strip credentials when only hostname casing changes.
+			// Restore missing credentials from the preceding trusted hop,
+			// preserving Go's cookie updates and method-specific body headers.
+			for _, header := range []string{"Authorization", "Proxy-Authorization", "Cookie", "Cookie2", "Www-Authenticate", "Proxy-Authenticate"} {
+				if _, present := req.Header[header]; !present {
+					if values, exists := via[len(via)-1].Header[header]; exists {
+						req.Header[header] = append([]string(nil), values...)
+					}
 				}
-
-				req.Header[key] = values
 			}
 
 			return nil
@@ -481,6 +497,18 @@ func (ps *ProxyServer) executeProxyRequest(w http.ResponseWriter, r *http.Reques
 
 	// Close response body when done to prevent resource leaks
 	defer resp.Body.Close()
+
+	// A 307/308 with a non-replayable body is returned without CheckRedirect.
+	// Reject cross-origin Locations here too so the browser cannot replay the
+	// original request outside the proxy's origin policy.
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 && resp.Header.Get("Location") != "" {
+		destination, err := resp.Location()
+		if err != nil || !sameOrigin(remote, destination) {
+			err := fmt.Errorf("redirect to a different origin is not allowed")
+			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			return err
+		}
+	}
 
 	// Copy headers from final response, but skip CORS headers
 	for key, values := range resp.Header {

--- a/projects/proxy-scalar-com/main_test.go
+++ b/projects/proxy-scalar-com/main_test.go
@@ -349,45 +349,6 @@ func TestProxyBehavior(t *testing.T) {
 		}
 	})
 
-	t.Run("Strips credential headers on cross-host redirect", func(t *testing.T) {
-		// The final server sits on a different hostname than the initial
-		// request and must not receive the caller's credentials.
-		finalServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
-			if auth := r.Header.Get("Authorization"); auth != "" {
-				t.Errorf("Authorization header leaked across hosts: %s", auth)
-			}
-			if _, exists := r.Header["Cookie"]; exists {
-				t.Errorf("Cookie header leaked across hosts: %v", r.Header["Cookie"])
-			}
-			w.Write([]byte("final destination"))
-		})
-		defer finalServer.server.Close()
-
-		initialServer := setupTestServer(func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, finalServer.url, http.StatusTemporaryRedirect)
-		})
-		defer initialServer.server.Close()
-
-		// Reach the initial server through "localhost" so its hostname differs
-		// from the final server's "127.0.0.1", exercising the cross-host path.
-		initialURL := strings.Replace(initialServer.url, "127.0.0.1", "localhost", 1)
-
-		req := httptest.NewRequest(http.MethodGet, "/?scalar_url="+initialURL, nil)
-		req.Header.Set("Authorization", "Bearer secret-token")
-		req.Header.Set("X-Scalar-Cookie", "session=secret")
-		w := httptest.NewRecorder()
-
-		proxyServer.handleRequest(w, req)
-
-		if w.Code != http.StatusOK {
-			t.Errorf("Expected status code %d, got %d", http.StatusOK, w.Code)
-		}
-
-		if w.Body.String() != "final destination" {
-			t.Errorf("Expected body 'final destination', got '%s'", w.Body.String())
-		}
-	})
-
 	t.Run("Keeps credential headers on same-host redirect", func(t *testing.T) {
 		gotAuth := ""
 		server := setupTestServer(func(w http.ResponseWriter, r *http.Request) {

--- a/projects/proxy-scalar-com/redirect_test.go
+++ b/projects/proxy-scalar-com/redirect_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestRedirectOriginPolicy(t *testing.T) {
+	tests := []struct {
+		name         string
+		destination  string
+		intermediate bool
+		allowed      bool
+		body         bool
+		loop         bool
+	}{
+		{name: "same-origin redirect loop", destination: "https://api.example/initial", loop: true},
+		{name: "non-replayable credential body", destination: "https://other.example/final", body: true},
+		{name: "unrelated hostname", destination: "https://other.example/final"},
+		{name: "subdomain", destination: "https://sub.api.example/final"},
+		{name: "scheme downgrade", destination: "http://api.example/final"},
+		{name: "different port", destination: "https://api.example:8443/final"},
+		{name: "cross-origin second hop", destination: "https://other.example/final", intermediate: true},
+		{name: "same origin", destination: "https://api.example/final", allowed: true},
+		{name: "explicit default port", destination: "https://api.example:443/final", allowed: true},
+		{name: "case insensitive hostname", destination: "https://API.example/final", allowed: true},
+		{name: "same-origin chain", destination: "https://api.example/final", intermediate: true, allowed: true},
+	}
+	for _, tc := range tests {
+		for _, status := range []int{301, 302, 303, 307, 308} {
+			t.Run(fmt.Sprintf("%s/%d", tc.name, status), func(t *testing.T) {
+				var mu sync.Mutex
+				var requests []*http.Request
+				proxy := NewProxyServer(true)
+				// Exercise net/http's real redirect header copying without DNS or network
+				// access. Every attempted outbound request is recorded, even if its host
+				// would otherwise resolve outside this test.
+				dial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+					client, server := net.Pipe()
+					go func() {
+						defer server.Close()
+						request, err := http.ReadRequest(bufio.NewReader(server))
+						if err != nil {
+							return
+						}
+						mu.Lock()
+						requests = append(requests, request)
+						mu.Unlock()
+						if request.URL.Path == "/final" {
+							fmt.Fprint(server, "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK")
+							return
+						}
+						destination := tc.destination
+						if tc.intermediate && request.URL.Path == "/initial" {
+							destination = "https://api.example/middle"
+						}
+						fmt.Fprintf(server, "HTTP/1.1 %d Redirect\r\nLocation: %s\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", status, destination)
+					}()
+					return client, nil
+				}
+				proxy.transport = &http.Transport{DialContext: dial, DialTLSContext: dial}
+				defer proxy.transport.CloseIdleConnections()
+				target := "https://api.example/initial"
+				remote, err := url.Parse(target)
+				if err != nil {
+					t.Fatal(err)
+				}
+				request := httptest.NewRequest(http.MethodGet, "/", nil)
+				if tc.body {
+					request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader("secret=request-body"))
+				}
+				request.Header.Set("Authorization", "Bearer test-secret")
+				request.Header.Set("Proxy-Authorization", "Basic test-secret")
+				request.Header.Set("X-Scalar-Cookie", "session=test-secret")
+				request.Header.Set("X-Api-Key", "test-secret")
+				request.Header.Set("Arbitrary-Credential", "test-secret")
+				response := httptest.NewRecorder()
+				err = proxy.executeProxyRequest(response, request, remote, target)
+				mu.Lock()
+				defer mu.Unlock()
+				expectedRequests := 1
+				if tc.loop {
+					expectedRequests = 10
+				}
+				if tc.intermediate {
+					expectedRequests++
+				}
+				if tc.allowed {
+					expectedRequests++
+					if err != nil || response.Code != http.StatusOK {
+						t.Fatalf("same-origin redirect failed: status=%d error=%v", response.Code, err)
+					}
+					final := requests[len(requests)-1]
+					for _, header := range []string{"Authorization", "Proxy-Authorization", "Cookie", "X-Api-Key", "Arbitrary-Credential"} {
+						if final.Header.Get(header) == "" {
+							t.Errorf("same-origin request lost %s", header)
+						}
+					}
+				} else {
+					if err == nil || response.Code != http.StatusServiceUnavailable {
+						t.Fatalf("cross-origin redirect accepted: status=%d error=%v", response.Code, err)
+					}
+					if response.Header().Get("Location") != "" {
+						t.Error("response lets the browser follow the unsafe redirect")
+					}
+				}
+				if len(requests) != expectedRequests {
+					t.Errorf("sent %d requests, want %d", len(requests), expectedRequests)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
Only follow redirects with the same scheme, hostname, and port. Keep credentials and request bodies from reaching another origin.
