### PR TITLE
fix(proxy): handle NAT64 address ranges correctly

### DIFF
--- a/.changeset/proxy-translation-addresses.md
+++ b/.changeset/proxy-translation-addresses.md
@@ -1,0 +1,4 @@
+---
+---
+
+Block local NAT64 addresses and match the standard NAT64 prefix precisely.

--- a/.changeset/proxy-translation-addresses.md
+++ b/.changeset/proxy-translation-addresses.md
@@ -1,4 +1,0 @@
----
----
-
-Block local NAT64 addresses and match the standard NAT64 prefix precisely.

--- a/projects/proxy-scalar-com/addresses_test.go
+++ b/projects/proxy-scalar-com/addresses_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestLocalNAT64Addresses(t *testing.T) {
+	// RFC 6052 permits multiple IPv4 offsets. Block the entire RFC 8215 local
+	// translation prefix rather than interpreting every address as a /96.
+	for _, address := range []string{
+		"64:ff9b:1:0:c0:a801:100:0", // /64 translation of 192.168.1.1
+		"64:ff9b:1::a9fe:a9fe",      // /96 translation of metadata address
+		"64:ff9b:1::808:808",        // public destinations in the local-use prefix also blocked
+	} {
+		t.Run(address, func(t *testing.T) {
+			if !ipIsBlocked(net.ParseIP(address)) {
+				t.Error("local translation address allowed")
+			}
+			proxy := NewProxyServer(false)
+			remote := "http://" + net.JoinHostPort(address, "80")
+			if _, errors := proxy.validateScalarURL(remote); len(errors) == 0 {
+				t.Error("URL validation accepted local translation address")
+			}
+			if _, err := proxy.transport.DialContext(context.Background(), "tcp", net.JoinHostPort(address, "80")); err == nil || !strings.Contains(err.Error(), "blocked") {
+				t.Errorf("dial did not block translation address: %v", err)
+			}
+		})
+	}
+	// Sharing the first 32 bits does not make an address part of 64:ff9b::/96.
+	if embedded := embeddedIPv4s(net.ParseIP("64:ff9b:2::c0a8:101")); len(embedded) != 0 {
+		t.Errorf("decoded unrelated prefix: %v", embedded)
+	}
+}

--- a/projects/proxy-scalar-com/main.go
+++ b/projects/proxy-scalar-com/main.go
@@ -31,6 +31,8 @@ func init() {
 		"192.168.0.0/16",
 		"100.64.0.0/10",
 		"fc00::/7",
+		// Local NAT64 prefixes can encode private IPv4 at several offsets.
+		"64:ff9b:1::/48",
 	}
 
 	for _, cidr := range cidrs {
@@ -80,7 +82,7 @@ func embeddedIPv4s(ip net.IP) []net.IP {
 	}
 
 	// NAT64 well-known prefix 64:ff9b::/96, IPv4 in the last 4 bytes.
-	if ip16[0] == 0x00 && ip16[1] == 0x64 && ip16[2] == 0xff && ip16[3] == 0x9b {
+	if ip16[0] == 0x00 && ip16[1] == 0x64 && ip16[2] == 0xff && ip16[3] == 0x9b && isZeros(ip16[4:12]) {
 		embedded = append(embedded, net.IPv4(ip16[12], ip16[13], ip16[14], ip16[15]))
 	}
 


### PR DESCRIPTION
Block local NAT64 addresses and match the standard NAT64 prefix precisely.
