### PR TITLE
fix(mock-server): limit remote reference loading

### DIFF
--- a/.changeset/bounded-remote-reference-loading.md
+++ b/.changeset/bounded-remote-reference-loading.md
@@ -1,0 +1,6 @@
+---
+'@scalar/json-magic': patch
+'@scalar/mock-server': patch
+---
+
+Bound guarded remote document loading with a shared 10-second deadline, a 5 MiB decompressed response limit, a 20 MiB aggregate byte limit, and at most 100 remote loads, including transitive references. Cancel outstanding streams and connections when a limit is exceeded. Configure these limits through the Node fetch plugin's `limits` option or the mock server's `remoteFetchLimits` option; use a fresh plugin instance for each bundle. Generic unguarded fetch plugins retain their existing behavior unless limits are explicitly supplied.

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -268,6 +268,35 @@ const document = {
 
 ## Advanced Features
 
+### Remote document limits
+
+The mock server limits remote document downloads, including the root URL and any URLs reached through external `$ref` values. These limits are shared across one document load, including concurrent downloads and references found in downloaded documents.
+
+| Option | Default | Applies to |
+| --- | --- | --- |
+| `timeoutMs` | `10_000` (10 seconds) | Total elapsed time from the first remote load, including DNS, queued requests, and response bodies |
+| `maxResponseBytes` | `5 * 1024 * 1024` (5 MiB) | Decompressed bytes in each response |
+| `maxTotalBytes` | `20 * 1024 * 1024` (20 MiB) | Decompressed bytes across all responses |
+| `maxRequests` | `100` | Total remote loads, including transitive references |
+
+Set `remoteFetchLimits` when larger API descriptions need more room. Omitted options keep their defaults; values must be positive integers.
+
+```ts
+import { createMockServer } from '@scalar/mock-server'
+
+const app = await createMockServer({
+  document: 'https://example.com/openapi.json',
+  remoteFetchLimits: {
+    timeoutMs: 30_000,
+    maxResponseBytes: 10 * 1024 * 1024,
+    maxTotalBytes: 40 * 1024 * 1024,
+    maxRequests: 200,
+  },
+})
+```
+
+Exceeding a limit cancels outstanding remote downloads. References that could not be loaded remain unresolved; if the root document cannot be loaded, the server cannot start. Increasing these limits does not allow access to private network addresses.
+
 ### Request Validation
 
 The mock server enforces your OpenAPI contract by default. Each request is validated against the matched operation before a mock response is generated:

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-budget.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-budget.test.ts
@@ -1,0 +1,79 @@
+import { gzipSync } from 'node:zlib'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { createFetchBudget, readBoundedBody, withAbort } from './fetch-budget'
+
+describe('fetch-budget', () => {
+  it('reads normal streaming input within the budget', async () => {
+    const budget = createFetchBudget({ maxResponseBytes: 5, maxTotalBytes: 5 })
+    const result = await readBoundedBody(new Response('hello').body, budget, budget.start())
+    expect(new TextDecoder().decode(result)).toBe('hello')
+  })
+
+  it('cancels an oversized response before retaining all its chunks', async () => {
+    const cancel = vi.fn()
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new Uint8Array(4))
+      },
+      cancel,
+    })
+    const budget = createFetchBudget({ maxResponseBytes: 5 })
+    await expect(readBoundedBody(body, budget, budget.start())).rejects.toThrow('response byte limit')
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it('counts decompressed bytes instead of the compressed Content-Length', async () => {
+    const compressed = gzipSync('x'.repeat(10_000))
+    expect(compressed.byteLength).toBeLessThan(100)
+    const body = new Response(compressed).body?.pipeThrough(new DecompressionStream('gzip')) ?? null
+    const budget = createFetchBudget({ maxResponseBytes: 100 })
+    await expect(readBoundedBody(body, budget, budget.start())).rejects.toThrow('response byte limit')
+  })
+
+  it('cancels a slow stream at the shared deadline', async () => {
+    const cancel = vi.fn()
+    const body = new ReadableStream<Uint8Array>({ cancel })
+    const budget = createFetchBudget({ timeoutMs: 20 })
+    await expect(readBoundedBody(body, budget, budget.start())).rejects.toThrow()
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it('aborts concurrent readers when their aggregate bytes exceed the budget', async () => {
+    const budget = createFetchBudget({ maxTotalBytes: 5 })
+    const firstSignal = budget.start()
+    const secondSignal = budget.start()
+    const pendingCancel = vi.fn()
+    const pending = readBoundedBody(new ReadableStream({ cancel: pendingCancel }), budget, firstSignal)
+    const rejection = expect(pending).rejects.toThrow('total byte limit')
+    await expect(readBoundedBody(new Response('123456').body, budget, secondSignal)).rejects.toThrow('total byte limit')
+    await rejection
+    expect(pendingCancel).toHaveBeenCalledOnce()
+    expect(firstSignal.aborted).toBe(true)
+  })
+
+  it('shares accounting across completed responses', async () => {
+    const budget = createFetchBudget({ maxResponseBytes: 5, maxTotalBytes: 5 })
+    await readBoundedBody(new Response('123').body, budget, budget.start())
+    await expect(readBoundedBody(new Response('456').body, budget, budget.start())).rejects.toThrow('total byte limit')
+  })
+
+  it('does not reset the deadline between requests', async () => {
+    const budget = createFetchBudget({ timeoutMs: 20 })
+    const first = budget.start()
+    await expect(withAbort(new Promise(() => undefined), first)).rejects.toThrow()
+    expect(() => budget.start()).toThrow()
+  })
+
+  it('limits the total number of loads and cancels active requests', () => {
+    const budget = createFetchBudget({ maxRequests: 1 })
+    const signal = budget.start()
+    expect(() => budget.start()).toThrow('reference count limit')
+    expect(signal.aborted).toBe(true)
+  })
+
+  it.each([0, -1, Number.POSITIVE_INFINITY, Number.NaN, 0.5])('rejects invalid limits %s', (maxRequests) => {
+    expect(() => createFetchBudget({ maxRequests })).toThrow('Invalid remote fetch limit')
+  })
+})

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-budget.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-budget.ts
@@ -1,0 +1,129 @@
+/** Limits shared by every remote document loaded through one fetch plugin instance. */
+export type RemoteFetchLimits = {
+  /** Overall elapsed time from the first load, including DNS and queued requests. Defaults to 10 seconds. */
+  timeoutMs: number
+  /** Maximum decompressed bytes in one response. Defaults to 5 MiB. */
+  maxResponseBytes: number
+  /** Maximum decompressed bytes across all responses. Defaults to 20 MiB. */
+  maxTotalBytes: number
+  /** Maximum remote loads, including the root URL and transitive references. Defaults to 100. */
+  maxRequests: number
+}
+
+/** Shared accounting and cancellation for a document's remote references. */
+export type FetchBudget = {
+  start: () => AbortSignal
+  consume: (bytes: number, responseBytes: number) => void
+}
+
+/** Creates a fresh budget for one bundle operation; generic unguarded plugins do not enable it by default. */
+export const createFetchBudget = (options: Partial<RemoteFetchLimits> = {}): FetchBudget => {
+  const limits: RemoteFetchLimits = {
+    timeoutMs: 10_000,
+    maxResponseBytes: 5 * 1024 * 1024,
+    maxTotalBytes: 20 * 1024 * 1024,
+    maxRequests: 100,
+    ...options,
+  }
+  for (const [key, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value <= 0 || (key === 'timeoutMs' && value > 2_147_483_647)) {
+      throw new Error(`Invalid remote fetch limit: ${key}`)
+    }
+  }
+  const controller = new AbortController()
+  let deadline: AbortSignal | undefined
+  let requests = 0
+  let totalBytes = 0
+  const fail = (message: string): never => {
+    const error = new Error(message)
+    controller.abort(error)
+    throw error
+  }
+
+  return {
+    start: (): AbortSignal => {
+      deadline ??= AbortSignal.any([controller.signal, AbortSignal.timeout(limits.timeoutMs)])
+      deadline.throwIfAborted()
+      requests++
+      if (requests > limits.maxRequests) {
+        fail('Remote reference count limit exceeded')
+      }
+      return deadline
+    },
+    consume: (bytes, responseBytes): void => {
+      deadline?.throwIfAborted()
+      totalBytes += bytes
+      if (responseBytes > limits.maxResponseBytes) {
+        fail('Remote response byte limit exceeded')
+      }
+      if (totalBytes > limits.maxTotalBytes) {
+        fail('Remote total byte limit exceeded')
+      }
+    },
+  }
+}
+
+/** Stops waiting on non-cancellable work such as DNS when the document deadline expires. */
+export const withAbort = <T>(promise: Promise<T>, signal: AbortSignal): Promise<T> => {
+  return new Promise<T>((resolve, reject) => {
+    const abort = (): void => reject(signal.reason)
+    signal.addEventListener('abort', abort, { once: true })
+    // Attach both handlers even when already aborted so late DNS/stream failures remain handled.
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', abort)
+        resolve(value)
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', abort)
+        reject(error)
+      },
+    )
+    if (signal.aborted) {
+      signal.removeEventListener('abort', abort)
+      abort()
+    }
+  })
+}
+
+type ByteStream = {
+  getReader: () => {
+    read: () => Promise<{ done: true; value?: Uint8Array } | { done?: false; value: Uint8Array }>
+    cancel: () => Promise<void>
+  }
+}
+
+/** Reads decompressed stream chunks, accounting before retaining each chunk in memory. */
+export const readBoundedBody = async (
+  body: ByteStream | null,
+  budget: FetchBudget,
+  signal: AbortSignal,
+): Promise<Uint8Array<ArrayBuffer>> => {
+  if (!body) {
+    return new Uint8Array()
+  }
+  const reader = body.getReader()
+  const chunks: Uint8Array[] = []
+  let bytes = 0
+  try {
+    while (true) {
+      const chunk = await withAbort(reader.read(), signal)
+      if (chunk.done) {
+        break
+      }
+      bytes += chunk.value.byteLength
+      budget.consume(chunk.value.byteLength, bytes)
+      chunks.push(chunk.value)
+    }
+    const result = new Uint8Array(bytes)
+    let offset = 0
+    for (const chunk of chunks) {
+      result.set(chunk, offset)
+      offset += chunk.byteLength
+    }
+    return result
+  } finally {
+    // Cancellation may itself wait on an uncooperative custom stream. Do not let it extend the deadline.
+    void reader.cancel().catch(() => undefined)
+  }
+}

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-limits.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-limits.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { bundle } from '@/bundle'
+import { parseJson } from '@/bundle/plugins/parse-json'
+
+import { fetchUrls } from './index'
+
+describe('fetch-limits', () => {
+  it('bounds transitive references with one budget per plugin', async () => {
+    const fetch = vi.fn((input: string | URL | Request): Promise<Response> => {
+      const url = String(input)
+      const index = Number(url.split('/').at(-1))
+      return Promise.resolve(new Response(JSON.stringify({ next: { $ref: `https://example.com/${index + 1}` } })))
+    })
+    await bundle(
+      { next: { $ref: 'https://example.com/0' } },
+      {
+        treeShake: false,
+        plugins: [parseJson(), fetchUrls({ fetch, limits: { maxRequests: 3 } })],
+      },
+    )
+    expect(fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('keeps unguarded callers unlimited unless limits are requested', async () => {
+    const fetch = vi.fn(() => Promise.resolve(new Response('{"ok":true}')))
+    const plugin = fetchUrls({ fetch })
+    await plugin.exec('https://example.com/one')
+    await plugin.exec('https://example.com/two')
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(fetch.mock.calls[0]).toStrictEqual(['https://example.com/one', { headers: undefined }])
+  })
+
+  it('shares aggregate byte accounting between concurrent loads', async () => {
+    const fetch = vi.fn(() => Promise.resolve(new Response('{"ok":true}')))
+    const plugin = fetchUrls({ fetch, limits: { maxTotalBytes: 15 } })
+    const results = await Promise.all([plugin.exec('https://example.com/one'), plugin.exec('https://example.com/two')])
+    expect(results.filter((result) => result.ok).length).toBeLessThan(2)
+    expect(await plugin.exec('https://example.com/three')).toStrictEqual({ ok: false })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-public-url-limits.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-public-url-limits.test.ts
@@ -1,0 +1,82 @@
+import { type Server, createServer } from 'node:http'
+import { gzipSync } from 'node:zlib'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { createFetchBudget } from './fetch-budget'
+import { fetchPublicUrl } from './fetch-public-url'
+
+// Exercise the real transport against a local fixture after the separately tested public-host check.
+vi.mock('./is-blocked-host', () => ({
+  resolvePublicHost: () => Promise.resolve([{ address: '127.0.0.1', family: 4 }]),
+}))
+
+const listen = async (server: Server): Promise<number> => {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected a TCP address')
+  }
+  return address.port
+}
+
+const close = async (server: Server): Promise<void> => {
+  server.closeAllConnections()
+  await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+}
+
+describe('fetch-public-url-limits', () => {
+  it('rejects a compressed response based on decompressed stream bytes', async () => {
+    const compressed = gzipSync(JSON.stringify({ value: 'x'.repeat(10_000) }))
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { 'Content-Encoding': 'gzip', 'Content-Length': compressed.byteLength })
+      response.end(compressed)
+    })
+    const port = await listen(server)
+    try {
+      const budget = createFetchBudget({ maxResponseBytes: 100 })
+      await expect(fetchPublicUrl(`http://fixture.example:${port}`, undefined, budget, budget.start())).rejects.toThrow(
+        'response byte limit',
+      )
+    } finally {
+      await close(server)
+    }
+  })
+
+  it('aborts a stalled response and closes its connection at the deadline', async () => {
+    let finishClosed: (() => void) | undefined
+    const closed = new Promise<void>((resolve) => {
+      finishClosed = resolve
+    })
+    const server = createServer((_request, response) => {
+      response.once('close', () => finishClosed?.())
+      response.writeHead(200)
+      response.write('{')
+    })
+    const port = await listen(server)
+    try {
+      const budget = createFetchBudget({ timeoutMs: 1_000 })
+      await expect(
+        fetchPublicUrl(`http://fixture.example:${port}`, undefined, budget, budget.start()),
+      ).rejects.toThrow()
+      await closed
+    } finally {
+      await close(server)
+    }
+  })
+
+  it('returns a normal response through the bounded transport', async () => {
+    const server = createServer((_request, response) => response.end('{"ok":true}'))
+    const port = await listen(server)
+    try {
+      const budget = createFetchBudget()
+      const response = await fetchPublicUrl(`http://fixture.example:${port}`, undefined, budget, budget.start())
+      expect(await response.json()).toStrictEqual({ ok: true })
+    } finally {
+      await close(server)
+    }
+  })
+})

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-public-url.test.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-public-url.test.ts
@@ -5,6 +5,7 @@ import type { LookupFunction } from 'node:net'
 import { Agent, Response as UndiciResponse, fetch } from 'undici'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { createFetchBudget } from './fetch-budget'
 import { fetchPublicUrl } from './fetch-public-url'
 
 vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }))
@@ -84,6 +85,15 @@ describe('fetch-public-url', () => {
     expect(await result.text()).toBe('')
     expect(readBody).not.toHaveBeenCalled()
     expect(vi.mocked(Agent).mock.instances[0].destroy).toHaveBeenCalledOnce()
+  })
+
+  it('stops waiting for DNS when the shared deadline expires', async () => {
+    lookupAll.mockReturnValueOnce(new Promise(() => undefined))
+    const budget = createFetchBudget({ timeoutMs: 20 })
+
+    await expect(fetchPublicUrl('https://api.example.com', undefined, budget, budget.start())).rejects.toThrow()
+    expect(fetch).not.toHaveBeenCalled()
+    expect(Agent).not.toHaveBeenCalled()
   })
 
   it('closes the connection when fetching fails', async () => {

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-public-url.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/fetch-public-url.ts
@@ -1,15 +1,23 @@
 import { Agent, fetch } from 'undici'
 
+import { type FetchBudget, createFetchBudget, readBoundedBody, withAbort } from './fetch-budget'
 import { resolvePublicHost } from './is-blocked-host'
 
 /** Fetches through a connection pinned to validated addresses while preserving the host and TLS name. */
-export const fetchPublicUrl = async (url: string, headers?: HeadersInit): Promise<Response> => {
+export const fetchPublicUrl = async (
+  url: string,
+  headers?: HeadersInit,
+  budget: FetchBudget = createFetchBudget(),
+  signal: AbortSignal = budget.start(),
+): Promise<Response> => {
   const target = new URL(url)
   if (target.protocol !== 'http:' && target.protocol !== 'https:') {
     throw new Error('Only HTTP and HTTPS URLs are supported')
   }
 
-  const addresses = await resolvePublicHost(target.hostname)
+  const resolution = resolvePublicHost(target.hostname)
+  const addresses = await withAbort(resolution, signal)
+  signal.throwIfAborted()
   if (!addresses) {
     throw new Error('Refused to fetch a private or internal address')
   }
@@ -32,8 +40,10 @@ export const fetchPublicUrl = async (url: string, headers?: HeadersInit): Promis
       headers: Object.fromEntries(new Headers(headers)),
       redirect: 'error',
       dispatcher,
+      signal,
     })
-    const body = !response.ok || [204, 205].includes(response.status) ? null : await response.arrayBuffer()
+    const body =
+      !response.ok || [204, 205].includes(response.status) ? null : await readBoundedBody(response.body, budget, signal)
 
     return new Response(body, {
       status: response.status,

--- a/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
+++ b/packages/json-magic/src/bundle/plugins/fetch-urls/index.ts
@@ -4,6 +4,8 @@ import type { LoaderPlugin, ResolveResult } from '@/bundle'
 import { isHttpUrl } from '@/helpers/is-http-url'
 import { normalize } from '@/helpers/normalize'
 
+import { type FetchBudget, type RemoteFetchLimits, createFetchBudget, readBoundedBody, withAbort } from './fetch-budget'
+
 type FetchConfig = Partial<{
   headers: { headers: HeadersInit; domains: string[] }[]
   /** Custom transports cannot be combined with blockPrivateNetworks. */
@@ -14,6 +16,8 @@ type FetchConfig = Partial<{
    * existing callers keep working unchanged.
    */
   blockPrivateNetworks: boolean
+  /** Shared document limits; enabled by default with blockPrivateNetworks. Use a fresh plugin per bundle. */
+  limits: Partial<RemoteFetchLimits>
 }>
 
 /**
@@ -46,27 +50,35 @@ export async function fetchUrl(
   url: string,
   limiter: <T>(fn: () => Promise<T>) => Promise<T>,
   config?: FetchConfig,
+  budget?: FetchBudget,
 ): Promise<ResolveResult> {
   try {
     const host = getHost(url)
     const headers = config?.headers?.find((a) => a.domains.find((d) => d === host) !== undefined)?.headers
     const guarded = config?.blockPrivateNetworks && typeof window === 'undefined'
 
+    const activeBudget = budget ?? (guarded || config?.limits ? createFetchBudget(config?.limits) : undefined)
+    const signal = activeBudget?.start()
     const result = await limiter(async () => {
+      signal?.throwIfAborted()
       if (guarded) {
         // A custom fetch can ignore the pinned connection and resolve the host again.
         if (config?.fetch) {
           throw new Error('Custom fetch cannot be combined with private network blocking')
         }
         const { fetchPublicUrl } = await import('./fetch-public-url')
-        return fetchPublicUrl(url, headers)
+        return fetchPublicUrl(url, headers, activeBudget, signal)
       }
 
-      return (config?.fetch ?? fetch)(url, { headers })
+      const request = (config?.fetch ?? fetch)(url, { headers, ...(signal ? { signal } : {}) })
+      return signal ? withAbort(request, signal) : request
     })
 
     if (result.ok) {
-      const body = await result.text()
+      const body =
+        activeBudget && signal && !guarded
+          ? new TextDecoder().decode(await readBoundedBody(result.body, activeBudget, signal))
+          : await result.text()
 
       return {
         ok: true,
@@ -109,9 +121,11 @@ export function fetchUrls(config?: FetchConfig & Partial<{ limit: number | null 
   // If there is a limit specified we limit the number of concurrent calls
   const limiter = config?.limit ? createLimiter(config.limit) : <T>(fn: () => Promise<T>) => fn()
 
+  const budget = config?.blockPrivateNetworks || config?.limits ? createFetchBudget(config?.limits) : undefined
+
   return {
     type: 'loader',
     validate: isHttpUrl,
-    exec: (value) => fetchUrl(value, limiter, config),
+    exec: (value) => fetchUrl(value, limiter, config, budget),
   }
 }

--- a/packages/json-magic/src/bundle/plugins/node.ts
+++ b/packages/json-magic/src/bundle/plugins/node.ts
@@ -1,5 +1,6 @@
 // biome-ignore lint/performance/noBarrelFile: entrypoint
 export { fetchUrls } from './fetch-urls'
+export type { RemoteFetchLimits } from './fetch-urls/fetch-budget'
 export { parseJson } from './parse-json'
 export { parseYaml } from './parse-yaml'
 export { readFiles } from './read-files'

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -105,7 +105,9 @@ export async function createMockServer(configuration: MockServerOptions): Promis
   })
 
   /** Dereferenced OpenAPI document */
-  const schema = await processOpenApiDocument(configuration?.document ?? configuration?.specification)
+  const schema = await processOpenApiDocument(configuration?.document ?? configuration?.specification, {
+    remoteFetchLimits: configuration.remoteFetchLimits,
+  })
 
   // Seed data from schemas with x-seed extension
   // This happens before routes are set up so data is available immediately

--- a/packages/mock-server/src/types.ts
+++ b/packages/mock-server/src/types.ts
@@ -1,3 +1,4 @@
+import type { RemoteFetchLimits } from '@scalar/json-magic/bundle/plugins/node'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import type { Context } from 'hono'
 
@@ -19,6 +20,9 @@ type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyo
 export type MockServerLogger = (line: string) => void
 
 type BaseMockServerOptions = {
+  /** Remote document limits: 10s total, 5 MiB per response, 20 MiB total, and 100 loads by default. */
+  remoteFetchLimits?: Partial<RemoteFetchLimits>
+
   /**
    * The OpenAPI document to use for mocking.
    * Can be a string (URL or file path) or an object.

--- a/packages/mock-server/src/utils/process-openapi-document.ts
+++ b/packages/mock-server/src/utils/process-openapi-document.ts
@@ -2,7 +2,13 @@ import path from 'node:path'
 import { cwd } from 'node:process'
 
 import { bundle } from '@scalar/json-magic/bundle'
-import { fetchUrls, parseJson, parseYaml, readFiles } from '@scalar/json-magic/bundle/plugins/node'
+import {
+  type RemoteFetchLimits,
+  fetchUrls,
+  parseJson,
+  parseYaml,
+  readFiles,
+} from '@scalar/json-magic/bundle/plugins/node'
 import { isFilePath } from '@scalar/json-magic/helpers/is-file-path'
 import { createMagicProxy } from '@scalar/json-magic/magic-proxy'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
@@ -23,6 +29,7 @@ import { upgrade } from '@scalar/openapi-upgrader'
  */
 export async function processOpenApiDocument(
   document: string | Record<string, any> | undefined,
+  options: { remoteFetchLimits?: Partial<RemoteFetchLimits> } = {},
 ): Promise<OpenAPIV3_1.Document> {
   // Handle empty/undefined input gracefully
   if (!document || (typeof document === 'object' && Object.keys(document).length === 0)) {
@@ -48,7 +55,12 @@ export async function processOpenApiDocument(
     // Bundle external references with Node.js plugins
     // Include parseJson and parseYaml to handle string inputs
     bundled = await bundle(document, {
-      plugins: [parseJson(), parseYaml(), readFiles({ basePath }), fetchUrls({ blockPrivateNetworks: true })],
+      plugins: [
+        parseJson(),
+        parseYaml(),
+        readFiles({ basePath }),
+        fetchUrls({ blockPrivateNetworks: true, limits: options.remoteFetchLimits }),
+      ],
       treeShake: false,
     })
   } catch (error) {


### PR DESCRIPTION
Limit remote reference time, size, and count. Adds configurable limits and tests.

Builds on #10112.
