### PR TITLE
fix(mock-server): require permission for inline file references

### DIFF
--- a/.changeset/explicit-file-reference-permissions.md
+++ b/.changeset/explicit-file-reference-permissions.md
@@ -1,0 +1,6 @@
+---
+'@scalar/json-magic': patch
+'@scalar/mock-server': patch
+---
+
+Require explicit directory access for local references in inline API descriptions and prevent remote documents from loading local files. Local-file inputs retain access to their own directory.

--- a/documentation/guides/mock-server/getting-started.md
+++ b/documentation/guides/mock-server/getting-started.md
@@ -95,6 +95,23 @@ serve(
 )
 ```
 
+### Local file references
+
+When `document` is a local file path, its references can read files within that file's directory.
+Objects, inline JSON or YAML, and remote URLs do not get access to the working directory by default.
+For an inline description that needs local files, grant access to a specific directory:
+
+```typescript
+const app = await createMockServer({
+  document,
+  fileReferences: { basePath: './api-descriptions' },
+})
+```
+
+Relative file references are resolved from this directory. References outside it, including symbolic
+links pointing outside it, are refused. Remote documents cannot read local files, even when a local
+description references them or `fileReferences` is configured.
+
 ### Authentication
 
 You can define security schemes in your OpenAPI document and the mock server will validate the authentication. On startup it prints instructions on how to authenticate, which you can turn off — see [Silencing startup logging](#silencing-startup-logging):

--- a/packages/json-magic/src/bundle/bundle.ts
+++ b/packages/json-magic/src/bundle/bundle.ts
@@ -301,6 +301,9 @@ type Config = {
    */
   plugins: Plugin[]
 
+  /** Refuse filesystem references from remotely loaded documents, including after a local $id override. */
+  blockRemoteFileReferences?: boolean
+
   /**
    * Optional root object that serves as the base document when bundling a subpart.
    * This allows resolving references relative to the root document's location,
@@ -621,6 +624,7 @@ export async function bundle(input: UnknownObject | string, config: Config) {
     depth = 0,
     currentPath: readonly string[] = [],
     parent: UnknownObject = null,
+    remoteSource = isHttpUrl(config.origin ?? '') || (typeof input === 'string' && isHttpUrl(input)),
   ) => {
     // If a maximum depth is set in the config, stop bundling when the current depth reaches or exceeds it
     if (config.depth !== undefined && depth > config.depth) {
@@ -675,7 +679,15 @@ export async function bundle(input: UnknownObject | string, config: Config) {
           // referenced by this local reference to ensure the partial bundle is complete.
           // This includes not just the direct reference but also all its dependencies,
           // creating a complete and self-contained partial bundle.
-          await bundler(targetValue.value, targetValue.context, isChunkParent, depth + 1, segments, parent)
+          await bundler(
+            targetValue.value,
+            targetValue.context,
+            isChunkParent,
+            depth + 1,
+            segments,
+            parent,
+            remoteSource,
+          )
         }
         await executeHooks('onAfterNodeProcess', root as UnknownObject, context)
         return
@@ -686,6 +698,14 @@ export async function bundle(input: UnknownObject | string, config: Config) {
       // Combine the current origin with the new path to resolve relative references
       // correctly within the context of the external file being processed
       const resolvedPath = resolveReferencePath(id ?? origin, prefix)
+
+      // Use where the document was loaded, not its mutable $id, and enforce before consulting the cache.
+      if (config.blockRemoteFileReferences && remoteSource && isFilePath(resolvedPath)) {
+        await executeHooks('onResolveStart', root)
+        await executeHooks('onResolveError', root)
+        await executeHooks('onAfterNodeProcess', root as UnknownObject, context)
+        return
+      }
       const relativePath = toRelativePath(resolvedPath, defaultOrigin)
 
       // Generate a unique compressed path for the external document
@@ -727,11 +747,15 @@ export async function bundle(input: UnknownObject | string, config: Config) {
           // to handle any nested references it may contain. We pass the resolvedPath as the new origin
           // to ensure any relative references within this content are resolved correctly relative to
           // their new location in the bundled document.
-          await bundler(result.data, isChunk ? origin : resolvedPath, isChunk, depth + 1, [
-            config.externalDocumentsKey,
-            compressedPath,
-            documentRoot[config.externalDocumentsMappingsKey],
-          ])
+          await bundler(
+            result.data,
+            isChunk ? origin : resolvedPath,
+            isChunk,
+            depth + 1,
+            [config.externalDocumentsKey, compressedPath, documentRoot[config.externalDocumentsMappingsKey]],
+            null,
+            remoteSource || isHttpUrl(resolvedPath),
+          )
 
           // Store the mapping between hashed keys and original URLs in x-ext-urls
           // This allows tracking which external URLs were bundled and their corresponding locations
@@ -789,7 +813,15 @@ export async function bundle(input: UnknownObject | string, config: Config) {
         continue
       }
 
-      await bundler(root[key], id ?? origin, isChunkParent, depth + 1, [...currentPath, key], root as UnknownObject)
+      await bundler(
+        root[key],
+        id ?? origin,
+        isChunkParent,
+        depth + 1,
+        [...currentPath, key],
+        root as UnknownObject,
+        remoteSource,
+      )
     }
 
     await executeHooks('onAfterNodeProcess', root as UnknownObject, context)

--- a/packages/json-magic/src/bundle/file-reference-policy.test.ts
+++ b/packages/json-magic/src/bundle/file-reference-policy.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { type LoaderPlugin, bundle } from './bundle'
+import { readFiles } from './plugins/read-files'
+
+const directories: string[] = []
+
+const createFixture = async (): Promise<{ directory: string; file: string }> => {
+  const directory = await mkdtemp(join(tmpdir(), 'scalar-file-policy-'))
+  directories.push(directory)
+  const file = join(directory, 'allowed.json')
+  await writeFile(file, JSON.stringify({ type: 'string', description: 'local-fixture-marker' }))
+  return { directory, file }
+}
+
+// Controlled loader data exercises remote provenance without relying on external network services.
+const remoteLoader = (documents: Record<string, unknown>): LoaderPlugin => ({
+  type: 'loader',
+  validate: (value) => Object.hasOwn(documents, value),
+  exec: (value) => Promise.resolve({ ok: true, data: documents[value], raw: JSON.stringify(documents[value]) }),
+})
+
+describe('file-reference-policy', () => {
+  afterEach(async () => {
+    await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+  })
+
+  it('blocks a remote root from reading a local file after changing its base with $id', async () => {
+    const { directory, file } = await createFixture()
+    const url = 'https://example.com/api.json'
+    const result = await bundle(url, {
+      blockRemoteFileReferences: true,
+      plugins: [
+        remoteLoader({ [url]: { $id: join(directory, 'remote.json'), properties: { local: { $ref: file } } } }),
+        readFiles({ basePath: directory }),
+      ],
+      treeShake: false,
+    })
+
+    expect(JSON.stringify(result)).not.toContain('local-fixture-marker')
+    expect(result).toMatchObject({ properties: { local: { $ref: file } } })
+  })
+
+  it.each([false, true])(
+    'keeps remote provenance when a local description loads a remote chunk (%s)',
+    async (global) => {
+      const { directory, file } = await createFixture()
+      const url = 'https://example.com/schema.json'
+      const remote = {
+        $id: join(directory, 'remote.json'),
+        title: 'remote-holder',
+        properties: { local: { $ref: file } },
+      }
+      const result = await bundle(
+        { remote: { $ref: url, $global: global } },
+        {
+          origin: join(directory, 'api.json'),
+          blockRemoteFileReferences: true,
+          plugins: [remoteLoader({ [url]: remote }), readFiles({ basePath: directory })],
+          treeShake: false,
+        },
+      )
+
+      expect(JSON.stringify(result)).not.toContain('local-fixture-marker')
+      expect(remote.properties.local.$ref).toBe(file)
+    },
+  )
+
+  it('checks permissions before reusing a file cached by a trusted local reference', async () => {
+    const { directory, file } = await createFixture()
+    const url = 'https://example.com/schema.json'
+    const remote = { $id: join(directory, 'remote.json'), properties: { local: { $ref: file } } }
+    const result = await bundle(
+      { local: { $ref: file }, remote: { $ref: url } },
+      {
+        origin: join(directory, 'api.json'),
+        blockRemoteFileReferences: true,
+        plugins: [remoteLoader({ [url]: remote }), readFiles({ basePath: directory })],
+        treeShake: false,
+      },
+    )
+
+    expect(JSON.stringify(result)).toContain('local-fixture-marker')
+    expect(remote.properties.local.$ref).toBe(file)
+  })
+
+  it('keeps URL input remote when the caller supplies a local origin', async () => {
+    const { directory, file } = await createFixture()
+    const url = 'https://example.com/api.json'
+    const result = await bundle(url, {
+      origin: join(directory, 'api.json'),
+      blockRemoteFileReferences: true,
+      plugins: [remoteLoader({ [url]: { properties: { local: { $ref: file } } } }), readFiles({ basePath: directory })],
+      treeShake: false,
+    })
+
+    expect(JSON.stringify(result)).not.toContain('local-fixture-marker')
+    expect(result).toMatchObject({ properties: { local: { $ref: file } } })
+  })
+
+  it('allows remote documents to resolve other remote documents', async () => {
+    const url = 'https://example.com/api.json'
+    const result = await bundle(url, {
+      blockRemoteFileReferences: true,
+      plugins: [
+        remoteLoader({
+          [url]: { properties: { remote: { $ref: './schema.json' } } },
+          'https://example.com/schema.json': { type: 'string', description: 'remote-fixture-marker' },
+        }),
+      ],
+      treeShake: false,
+    })
+
+    expect(JSON.stringify(result)).toContain('remote-fixture-marker')
+  })
+})

--- a/packages/mock-server/src/create-mock-server.ts
+++ b/packages/mock-server/src/create-mock-server.ts
@@ -106,6 +106,7 @@ export async function createMockServer(configuration: MockServerOptions): Promis
 
   /** Dereferenced OpenAPI document */
   const schema = await processOpenApiDocument(configuration?.document ?? configuration?.specification, {
+    fileReferences: configuration.fileReferences,
     remoteFetchLimits: configuration.remoteFetchLimits,
   })
 

--- a/packages/mock-server/src/types.ts
+++ b/packages/mock-server/src/types.ts
@@ -38,6 +38,13 @@ type BaseMockServerOptions = {
   document?: string | Record<string, any>
 
   /**
+   * Permit local references within this directory for an inline or local API description.
+   * Local-file inputs default to their own directory. Inline and remote inputs cannot read files
+   * by default. Remotely loaded documents cannot reference local files, even with this option.
+   */
+  fileReferences?: { basePath: string }
+
+  /**
    * Callback function to be called before each request is processed.
    */
   onRequest?: (data: { context: Context; operation: OpenAPIV3_1.OperationObject }) => void

--- a/packages/mock-server/src/utils/process-openapi-document.test.ts
+++ b/packages/mock-server/src/utils/process-openapi-document.test.ts
@@ -1,10 +1,11 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { createServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
+import { createMockServer } from '../create-mock-server'
 import { processOpenApiDocument } from './process-openapi-document'
 
 describe('processOpenApiDocument', () => {
@@ -42,6 +43,131 @@ describe('processOpenApiDocument', () => {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()))
       })
+    }
+  })
+
+  it.each(['object', 'json', 'yaml'] as const)(
+    'does not read local files from an inline %s description by default',
+    async (format) => {
+      const directory = await mkdtemp(join(process.cwd(), '.scalar-inline-files-'))
+      const file = join(directory, 'fixture.json')
+      await writeFile(file, JSON.stringify({ type: 'string', description: 'local-fixture-marker' }))
+      try {
+        const document = {
+          openapi: '3.1.0',
+          info: { title: 'Test', version: '1' },
+          paths: {},
+          components: { schemas: { Example: { $ref: file } } },
+        }
+        const inputs = {
+          json: JSON.stringify(document),
+          yaml: `openapi: 3.1.0\ninfo: {title: Test, version: '1'}\npaths: {}\ncomponents:\n  schemas:\n    Example:\n      $ref: ${file}`,
+          object: document,
+        }
+        const input = inputs[format]
+        const result = await processOpenApiDocument(input)
+        expect(JSON.stringify(result)).not.toContain('local-fixture-marker')
+      } finally {
+        await rm(directory, { recursive: true, force: true })
+      }
+    },
+  )
+
+  it('resolves permitted relative file references in an inline description', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'scalar-allowed-files-'))
+    await writeFile(
+      join(directory, 'fixture.json'),
+      JSON.stringify({ type: 'string', description: 'permitted-fixture-marker' }),
+    )
+    try {
+      const result = await processOpenApiDocument(
+        {
+          openapi: '3.1.0',
+          info: { title: 'Test', version: '1' },
+          paths: {},
+          components: { schemas: { Example: { $ref: './fixture.json' } } },
+        },
+        { fileReferences: { basePath: directory } },
+      )
+      expect(JSON.stringify(result)).toContain('permitted-fixture-marker')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('uses file-reference permissions from the public mock-server options', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'scalar-public-file-options-'))
+    await writeFile(join(directory, 'fixture.json'), JSON.stringify({ type: 'string', const: 'permitted-response' }))
+    try {
+      const app = await createMockServer({
+        logger: false,
+        fileReferences: { basePath: directory },
+        document: {
+          openapi: '3.1.0',
+          info: { title: 'Test', version: '1' },
+          paths: {
+            '/value': {
+              get: {
+                responses: {
+                  '200': { description: 'OK', content: { 'application/json': { schema: { $ref: './fixture.json' } } } },
+                },
+              },
+            },
+          },
+        },
+      })
+      const response = await app.request('/value')
+      expect(response.status).toBe(200)
+      expect(await response.json()).toBe('permitted-response')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps local file inputs scoped to their own directory', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'scalar-local-files-'))
+    await writeFile(
+      join(directory, 'fixture.json'),
+      JSON.stringify({ type: 'string', description: 'permitted-local-marker' }),
+    )
+    const document = {
+      openapi: '3.1.0',
+      info: { title: 'Test', version: '1' },
+      paths: {},
+      components: { schemas: { Example: { $ref: './fixture.json' } } },
+    }
+    const input = join(directory, 'api.json')
+    await writeFile(input, JSON.stringify(document))
+    try {
+      const result = await processOpenApiDocument(input)
+      expect(JSON.stringify(result)).toContain('permitted-local-marker')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects symlinks and traversal outside an explicitly permitted directory', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'scalar-confined-files-'))
+    const allowed = join(directory, 'allowed')
+    await mkdir(allowed)
+    await writeFile(
+      join(directory, 'outside.json'),
+      JSON.stringify({ type: 'string', description: 'outside-fixture-marker' }),
+    )
+    await symlink(join(directory, 'outside.json'), join(allowed, 'link.json'))
+    try {
+      const result = await processOpenApiDocument(
+        {
+          openapi: '3.1.0',
+          info: { title: 'Test', version: '1' },
+          paths: {},
+          components: { schemas: { Traversal: { $ref: '../outside.json' }, Symlink: { $ref: './link.json' } } },
+        },
+        { fileReferences: { basePath: allowed } },
+      )
+      expect(JSON.stringify(result)).not.toContain('outside-fixture-marker')
+    } finally {
+      await rm(directory, { recursive: true, force: true })
     }
   })
 

--- a/packages/mock-server/src/utils/process-openapi-document.ts
+++ b/packages/mock-server/src/utils/process-openapi-document.ts
@@ -1,18 +1,14 @@
 import path from 'node:path'
-import { cwd } from 'node:process'
 
 import { bundle } from '@scalar/json-magic/bundle'
-import {
-  type RemoteFetchLimits,
-  fetchUrls,
-  parseJson,
-  parseYaml,
-  readFiles,
-} from '@scalar/json-magic/bundle/plugins/node'
+import { fetchUrls, parseJson, parseYaml, readFiles } from '@scalar/json-magic/bundle/plugins/node'
 import { isFilePath } from '@scalar/json-magic/helpers/is-file-path'
+import { isHttpUrl } from '@scalar/json-magic/helpers/is-http-url'
 import { createMagicProxy } from '@scalar/json-magic/magic-proxy'
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { upgrade } from '@scalar/openapi-upgrader'
+
+import type { MockServerOptions } from '@/types'
 
 /**
  * Processes an OpenAPI document by bundling external references, upgrading to OpenAPI 3.1,
@@ -24,12 +20,13 @@ import { upgrade } from '@scalar/openapi-upgrader'
  * the whole document up front.
  *
  * @param document - The OpenAPI document to process. Can be a string (URL/path) or an object.
+ * @param config - Optional local-reference directory permission and remote download limits.
  * @returns A promise that resolves to the OpenAPI 3.1 document with lazily resolvable references.
  * @throws Error if the document cannot be processed or is invalid.
  */
 export async function processOpenApiDocument(
   document: string | Record<string, any> | undefined,
-  options: { remoteFetchLimits?: Partial<RemoteFetchLimits> } = {},
+  config: Pick<MockServerOptions, 'fileReferences' | 'remoteFetchLimits'> = {},
 ): Promise<OpenAPIV3_1.Document> {
   // Handle empty/undefined input gracefully
   if (!document || (typeof document === 'object' && Object.keys(document).length === 0)) {
@@ -46,10 +43,14 @@ export async function processOpenApiDocument(
 
   let bundled: Record<string, any>
 
-  // Confine local file `$ref`s to the document's own directory (or the working directory when the
-  // document is an object or inline string), and refuse to fetch private or internal addresses.
-  // Without these guards a `$ref` could read arbitrary local files or reach internal services.
-  const basePath = typeof document === 'string' && isFilePath(document) ? path.dirname(path.resolve(document)) : cwd()
+  const localInput = typeof document === 'string' && isFilePath(document)
+  const inputDirectory = localInput ? path.dirname(path.resolve(document)) : undefined
+  const basePath = config.fileReferences ? path.resolve(config.fileReferences.basePath) : inputDirectory
+  // An explicit directory also supplies the base for relative references in inline descriptions.
+  const origin =
+    basePath && !localInput && !(typeof document === 'string' && isHttpUrl(document))
+      ? path.join(basePath, 'inline.json')
+      : undefined
 
   try {
     // Bundle external references with Node.js plugins
@@ -58,9 +59,11 @@ export async function processOpenApiDocument(
       plugins: [
         parseJson(),
         parseYaml(),
-        readFiles({ basePath }),
-        fetchUrls({ blockPrivateNetworks: true, limits: options.remoteFetchLimits }),
+        ...(basePath ? [readFiles({ basePath })] : []),
+        fetchUrls({ blockPrivateNetworks: true, limits: config.remoteFetchLimits }),
       ],
+      origin,
+      blockRemoteFileReferences: true,
       treeShake: false,
     })
   } catch (error) {


### PR DESCRIPTION
Require explicit file access for inline descriptions. Keep remote references from reading local files. Adds tests and docs.

Builds on #10117.