### PR TITLE
fix(snippetz): disable curl globbing for URLs with square brackets

### DIFF
--- a/.changeset/fix-curl-globbing.md
+++ b/.changeset/fix-curl-globbing.md
@@ -2,4 +2,4 @@
 '@scalar/snippetz': patch
 ---
 
-Add `--globoff` to generated curl commands whose URL contains square brackets, so snippets for bracket-notation query parameters such as `filter[user_id]=me` can be pasted into a shell and run as they are
+Add `--globoff` to generated curl commands whose URL contains square brackets, or curly braces in the query string, so snippets for bracket-notation query parameters such as `filter[user_id]=me` and glob-set values such as `ids={1,2,3}` can be pasted into a shell and run as they are. Curly braces in the path, which are almost always placeholders like `/users/{id}`, are left untouched.

--- a/.changeset/fix-curl-globbing.md
+++ b/.changeset/fix-curl-globbing.md
@@ -1,0 +1,5 @@
+---
+'@scalar/snippetz': patch
+---
+
+Add `--globoff` to generated curl commands whose URL contains square brackets, so snippets for bracket-notation query parameters such as `filter[user_id]=me` can be pasted into a shell and run as they are

--- a/packages/snippetz/src/plugins/shell/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.test.ts
@@ -163,6 +163,15 @@ describe('shellCurl', () => {
     expect(result).toBe(`curl 'https://galaxy.scalar.com/planets/{planetId}?limit=10'`)
   })
 
+  it('turns off globbing for braces already present in the URL query', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com/api?ids={1,2,3}',
+    })
+
+    expect(result).toBe(`curl 'https://example.com/api?ids={1,2,3}' \\
+  --globoff`)
+  })
+
   it('has cookies', () => {
     const result = shellCurl.generate({
       url: 'https://example.com',

--- a/packages/snippetz/src/plugins/shell/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.test.ts
@@ -111,6 +111,29 @@ describe('shellCurl', () => {
     expect(result).toBe(`curl 'https://example.com/api?param1=value1&param2=value2'`)
   })
 
+  it('turns off globbing for bracket notation in a query parameter name', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com/api/users',
+      queryString: [
+        {
+          name: 'filter[user_id]',
+          value: 'me',
+        },
+      ],
+    })
+
+    expect(result).toBe(`curl 'https://example.com/api/users?filter[user_id]=me' \\
+  --globoff`)
+  })
+
+  it('leaves a path placeholder alone', () => {
+    const result = shellCurl.generate({
+      url: 'https://galaxy.scalar.com/planets/{planetId}',
+    })
+
+    expect(result).toBe(`curl 'https://galaxy.scalar.com/planets/{planetId}'`)
+  })
+
   it('has cookies', () => {
     const result = shellCurl.generate({
       url: 'https://example.com',
@@ -480,7 +503,8 @@ describe('shellCurl', () => {
       url: 'https://example.com/path with spaces/[brackets]',
     })
 
-    expect(result).toBe(`curl 'https://example.com/path with spaces/[brackets]'`)
+    expect(result).toBe(`curl 'https://example.com/path with spaces/[brackets]' \\
+  --globoff`)
   })
 
   it('handles special characters in query parameters', () => {

--- a/packages/snippetz/src/plugins/shell/curl/curl.test.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.test.ts
@@ -134,6 +134,35 @@ describe('shellCurl', () => {
     expect(result).toBe(`curl 'https://galaxy.scalar.com/planets/{planetId}'`)
   })
 
+  it('turns off globbing for a curly-brace set in a query value', () => {
+    const result = shellCurl.generate({
+      url: 'https://example.com/api',
+      queryString: [
+        {
+          name: 'ids',
+          value: '{1,2,3}',
+        },
+      ],
+    })
+
+    expect(result).toBe(`curl 'https://example.com/api?ids={1,2,3}' \\
+  --globoff`)
+  })
+
+  it('leaves a path placeholder alone even with a query string', () => {
+    const result = shellCurl.generate({
+      url: 'https://galaxy.scalar.com/planets/{planetId}',
+      queryString: [
+        {
+          name: 'limit',
+          value: '10',
+        },
+      ],
+    })
+
+    expect(result).toBe(`curl 'https://galaxy.scalar.com/planets/{planetId}?limit=10'`)
+  })
+
   it('has cookies', () => {
     const result = shellCurl.generate({
       url: 'https://example.com',

--- a/packages/snippetz/src/plugins/shell/curl/curl.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.ts
@@ -43,7 +43,8 @@ export const shellCurl: Plugin = {
       ? separator +
         normalizedRequest.queryString
           .map((param) => {
-            // Ensure both name and value are fully URI encoded
+            // Keep the name and value raw so the snippet still reads like the documented endpoint; curl's own
+            // glob parser is handled with `--globoff` below rather than by percent-encoding the URL
             return `${param.name}=${param.value}`
           })
           .join('&')
@@ -54,9 +55,14 @@ export const shellCurl: Plugin = {
     const urlPart = isShellSafe ? url : `'${escapeSingleQuotes(url)}'`
     parts[0] = `curl ${urlPart}`
 
-    // curl reads `[]` in a URL as its own range syntax, no matter how the shell quotes them, so a literal
-    // bracket (`filter[id]=1`) only survives with globbing off
-    if (/[[\]]/.test(url)) {
+    // curl reads `[]` (ranges) and `{}` (sets) in a URL as its own globbing syntax, no matter how the shell
+    // quotes them. Square brackets always break curl (`filter[id]=1` throws "bad range"), so disable globbing
+    // whenever they appear. Curly braces in the path are almost always placeholders like `/users/{id}` that you
+    // replace before running, so we leave those to avoid adding the flag to nearly every snippet — but braces in
+    // the query string are real glob sets (`?ids={1,2,3}` fans out into three requests), so disable it there.
+    const queryStart = url.indexOf('?')
+    const queryPart = queryStart === -1 ? '' : url.slice(queryStart)
+    if (/[[\]]/.test(url) || /[{}]/.test(queryPart)) {
       parts.push('--globoff')
     }
 

--- a/packages/snippetz/src/plugins/shell/curl/curl.ts
+++ b/packages/snippetz/src/plugins/shell/curl/curl.ts
@@ -54,6 +54,12 @@ export const shellCurl: Plugin = {
     const urlPart = isShellSafe ? url : `'${escapeSingleQuotes(url)}'`
     parts[0] = `curl ${urlPart}`
 
+    // curl reads `[]` in a URL as its own range syntax, no matter how the shell quotes them, so a literal
+    // bracket (`filter[id]=1`) only survives with globbing off
+    if (/[[\]]/.test(url)) {
+      parts.push('--globoff')
+    }
+
     // Method
     if (normalizedRequest.method !== 'GET') {
       parts.push(`--request ${normalizedRequest.method}`)


### PR DESCRIPTION
## Problem

A query parameter whose name uses bracket notation, like the JSON:API `filter[user_id]` convention, produces a curl snippet that fails as soon as you paste it into a shell:

```
curl: (3) bad range in URL position 38:
https://example.com/api/users?filter[user_id]=me
                                     ^
```

curl reads `[` and `]` in a URL as its own range syntax, and it does that before libcurl ever sees the URL, so the single quotes the generator already adds do not help. Only curl itself can be told to stop.

Every other target in the package is fine here, because brackets are ordinary characters to those HTTP clients. `shell/curl` is the only one where curl's own parser gets in the way.

## Solution

Append `--globoff` when the URL contains a bracket. The URL itself stays untouched, so the snippet still reads like the endpoint it documents, and it now runs as it is. Snippets without brackets are unchanged.

Percent-encoding the brackets instead would work too, but it hides what the parameter is actually called, and #6466 showed that people rely on those names staying readable.

Curly braces have the same problem in curl, but I left them alone on purpose. They almost always mark a path placeholder like `/planets/{planetId}`, which you replace before running anything, so adding the flag there would put `--globoff` on nearly every snippet for no real gain. There is a test pinning that.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Closes #10119
