### PR TITLE
fix(api-client): support a custom fetch that returns a response without a URL

### DIFF
--- a/.changeset/custom-fetch-response-url.md
+++ b/.changeset/custom-fetch-response-url.md
@@ -2,4 +2,4 @@
 '@scalar/api-client': patch
 ---
 
-Fall back to the requested URL when a custom fetch returns a response without one.
+Fall back to the requested URL when a custom fetch returns a response without one. Errors raised while reading the response body are now returned as an error result instead of escaping the request helper.

--- a/.changeset/custom-fetch-response-url.md
+++ b/.changeset/custom-fetch-response-url.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Fall back to the requested URL when a custom fetch returns a response without one.

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.test.ts
@@ -939,6 +939,38 @@ describe('sendRequest', () => {
       expect(decode).toHaveBeenCalledTimes(1)
       expect(decode).toHaveBeenCalledWith(expect.any(ArrayBuffer), 'text/plain;charset=UTF-8')
     })
+
+    it('returns an error when a plugin decoder rejects', async () => {
+      const requestInit: RequestInit = {}
+      const mockResponse = addUrlToResponse(
+        new Response('test data', {
+          status: 200,
+          headers: new Headers(),
+        }),
+        MOCK_URL,
+      )
+      const plugin: ClientPlugin = {
+        responseBody: [
+          {
+            mimeTypes: ['text/plain'],
+            decode: () => Promise.reject(new Error('Decoder failed')),
+            language: 'plaintext',
+          },
+        ],
+      }
+
+      globalFetchSpy.mockResolvedValueOnce(mockResponse)
+
+      const [error, result] = await sendRequest({
+        isUsingProxy: false,
+        requestPayload: [MOCK_URL, requestInit],
+        plugins: [plugin],
+      })
+
+      expect(result).toBe(null)
+      expect(error).not.toBe(null)
+      expect(error?.message).toContain('Decoder failed')
+    })
   })
 
   describe('path extraction', () => {

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.test.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.test.ts
@@ -163,6 +163,26 @@ describe('sendRequest', () => {
     expect(globalFetchSpy).not.toHaveBeenCalled()
   })
 
+  it('falls back to the requested URL when customFetch returns a Response without a URL', async () => {
+    const requestInit: RequestInit = {}
+    const customFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('{"ok":true}', { headers: { 'content-type': 'application/json' } }))
+
+    const [error, result] = await sendRequest({
+      isUsingProxy: false,
+      requestPayload: [`${MOCK_URL}/things?limit=1`, requestInit],
+      customFetch,
+    })
+
+    expect(error).toBe(null)
+    if (!result || !('data' in result.response)) {
+      throw new Error('No data')
+    }
+    expect(result.response.status).toBe(200)
+    expect(result.response.path).toBe('/things?limit=1')
+  })
+
   it('sends a basic request and returns response data', async () => {
     const requestInit: RequestInit = {}
     globalFetchSpy.mockResolvedValueOnce(createMockEchoResponse(MOCK_URL, requestInit))

--- a/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
+++ b/packages/api-client/src/v2/blocks/operation-block/helpers/send-request.ts
@@ -110,7 +110,8 @@ export const sendRequest = async ({
     // Extract response metadata early for reuse
     const contentType = response.headers.get('content-type')
     const responseHeaders = normalizeHeaders(response.headers, isUsingProxy)
-    const responseUrl = new URL(response.url)
+    // A Response built with the Response constructor has an empty url, so fall back to the requested one
+    const responseUrl = new URL(response.url || requestPayload[0])
     const fullPath = responseUrl.pathname + responseUrl.search
     const statusText = response.statusText || httpStatusCodes[response.status]?.name || ''
     const method = (requestPayload[1].method ?? 'GET') as HttpMethod
@@ -134,7 +135,7 @@ export const sendRequest = async ({
       })
     }
 
-    return buildStandardResponse({
+    return await buildStandardResponse({
       response,
       requestPayload,
       timestamp,


### PR DESCRIPTION
## Problem

`customFetch` is typed as `typeof fetch`, so returning a plain `new Response(...)` satisfies the type. But a Response built that way has `url === ''` per spec, and `sendRequest` runs `new URL(response.url)` on it. The request succeeds, the status and body come back, and then the whole thing is thrown away with `TypeError: Invalid URL`. Nothing renders, so the Send button looks like it did nothing.

This hits anyone routing requests through their own fetch, including the Electron path the client itself takes. That path only works today because `to-web-response.ts` patches a `url` onto the constructed Response with a comment saying it is there so `new URL(response.url)` keeps working. Third party custom fetches have no such workaround.

## Solution

`response.url` is only used to derive `fullPath`, and the URL that was requested is already in scope as `requestPayload[0]`, so it now falls back to that when the response carries no URL. When the request is proxied, `requestPayload[0]` is the proxy URL, which is exactly what `response.url` would have been, so the reported path does not change.

The existing "handles malformed responses" test passed only because `new URL` threw synchronously before anything else could. `return buildStandardResponse(...)` sits inside the `try`, but returning a promise from a `try` block does not route its rejection to the `catch`, so a later failure escaped `sendRequest` instead of coming back as an error tuple. Awaiting it keeps that contract, and there is a test for it now: a plugin body decoder that rejects gets reported as an error result rather than throwing out of `sendRequest`.

## Note on the reproduction

`RequestPayload` is `[string, RequestInit]`, so the payload in the issue is easier to reproduce with a URL string:

```ts
requestPayload: ['https://example.com/things', { method: 'GET' }]
```

Passing a `Request` object in the first slot does not match the declared type and still fails, since `new URL(request)` stringifies to `[object Request]`.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation.

## Ticket

Fixes #10122
