### PR TITLE
fix(api-reference): preserve standalone configuration sources

### DIFF
--- a/.changeset/clean-wombats-listen.md
+++ b/.changeset/clean-wombats-listen.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Preserve multiple sources supplied through the standalone data-configuration attribute

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -460,6 +460,23 @@ describe('getConfigurationFromDataAttributes', () => {
     })
   })
 
+  it('preserves multiple sources from the data-configuration attribute', () => {
+    global.document = createHtmlDocument(`
+      <html>
+        <body>
+          <script
+            id="api-reference"
+            data-configuration='{"sources":[{"url":"/public.json"},{"url":"/admin.json"}]}'></script>
+        </body>
+      </html>
+    `)
+
+    expect(getConfigurationFromDataAttributes(document)).toEqual({
+      _integration: 'html',
+      sources: [{ url: '/public.json' }, { url: '/admin.json' }],
+    })
+  })
+
   it('handles deprecated data-spec attribute with warning', () => {
     global.document = createHtmlDocument(`
       <html>

--- a/packages/api-reference/src/standalone/lib/html-api.test.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.test.ts
@@ -471,9 +471,51 @@ describe('getConfigurationFromDataAttributes', () => {
       </html>
     `)
 
-    expect(getConfigurationFromDataAttributes(document)).toEqual({
+    // toStrictEqual guarantees we do not emit a stray `proxyUrl: undefined` when none is configured.
+    expect(getConfigurationFromDataAttributes(document)).toStrictEqual({
       _integration: 'html',
       sources: [{ url: '/public.json' }, { url: '/admin.json' }],
+    })
+  })
+
+  it('preserves shared configuration and the proxy url alongside multiple sources', () => {
+    global.document = createHtmlDocument(`
+      <html>
+        <body>
+          <script
+            id="api-reference"
+            data-proxy-url="https://proxy.example.com"
+            data-configuration='{"theme":"purple","sources":[{"url":"/public.json"},{"url":"/admin.json"}]}'></script>
+        </body>
+      </html>
+    `)
+
+    expect(getConfigurationFromDataAttributes(document)).toStrictEqual({
+      _integration: 'html',
+      proxyUrl: 'https://proxy.example.com',
+      theme: 'purple',
+      sources: [{ url: '/public.json' }, { url: '/admin.json' }],
+    })
+  })
+
+  it('falls back to single-source parsing when the sources array is empty', () => {
+    global.document = createHtmlDocument(`
+      <html>
+        <body>
+          <script
+            id="api-reference"
+            data-url="/openapi.json"
+            data-configuration='{"sources":[]}'></script>
+        </body>
+      </html>
+    `)
+
+    // An empty sources array carries no documents, so the data-url should still be picked up
+    // and the (unusable) sources key should be dropped by the single-source schema.
+    expect(getConfigurationFromDataAttributes(document)).toEqual({
+      ...baseConfig,
+      default: false,
+      url: '/openapi.json',
     })
   })
 

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -75,13 +75,13 @@ const releaseStandaloneStyles = (doc: Document): void => {
   }
 }
 
-/**
- * Reading the configuration from the data-attributes.
- */
 type DataAttributeConfiguration =
   | ApiReferenceConfigurationWithSource
   | Partial<ApiReferenceConfigurationWithMultipleSources>
 
+/**
+ * Reading the configuration from the data-attributes.
+ */
 export function getConfigurationFromDataAttributes(doc: Document): DataAttributeConfiguration {
   const specElement = doc.querySelector('[data-spec]')
   const specUrlElement = doc.querySelector('[data-spec-url]')
@@ -183,11 +183,17 @@ export function getConfigurationFromDataAttributes(doc: Document): DataAttribute
     // Stay quiet.
   } else {
     const configuration = getConfiguration()
+    const proxyUrl = getProxyUrl()
 
-    if (isConfigurationWithSources(configuration)) {
+    // A non-empty `sources` array means the user configured multiple documents. Preserve it as-is
+    // rather than passing it through the single-source schema, which would strip the property and
+    // leave the reference with no documents to render. An empty array carries no documents, so we
+    // fall through to the single-source parsing below (which can still pick up a data-url/content).
+    if (isConfigurationWithSources(configuration) && configuration.sources?.length) {
       return {
         _integration: 'html',
-        proxyUrl: getProxyUrl(),
+        // Only include `proxyUrl` when one is actually configured so we do not emit `proxyUrl: undefined`.
+        ...(proxyUrl ? { proxyUrl } : {}),
         ...configuration,
       }
     }
@@ -196,7 +202,7 @@ export function getConfigurationFromDataAttributes(doc: Document): DataAttribute
 
     return apiReferenceConfigurationWithSourceSchema({
       _integration: 'html',
-      proxyUrl: getProxyUrl(),
+      proxyUrl,
       ...configuration,
       ...urlOrContent,
     })

--- a/packages/api-reference/src/standalone/lib/html-api.ts
+++ b/packages/api-reference/src/standalone/lib/html-api.ts
@@ -1,9 +1,11 @@
 import { apiReferenceConfigurationWithSourceSchema } from '@scalar/schemas/api-reference'
 import type {
   AnyApiReferenceConfiguration,
+  ApiReferenceConfigurationWithMultipleSources,
   ApiReferenceConfigurationWithSource,
   CreateApiReference,
 } from '@scalar/types/api-reference'
+import { isConfigurationWithSources } from '@scalar/types/api-reference'
 import { createHead } from '@unhead/vue/client'
 import { createApp, createSSRApp, h, reactive } from 'vue'
 
@@ -76,7 +78,11 @@ const releaseStandaloneStyles = (doc: Document): void => {
 /**
  * Reading the configuration from the data-attributes.
  */
-export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceConfigurationWithSource {
+type DataAttributeConfiguration =
+  | ApiReferenceConfigurationWithSource
+  | Partial<ApiReferenceConfigurationWithMultipleSources>
+
+export function getConfigurationFromDataAttributes(doc: Document): DataAttributeConfiguration {
   const specElement = doc.querySelector('[data-spec]')
   const specUrlElement = doc.querySelector('[data-spec-url]')
   const configurationScriptElement = doc.querySelector('#api-reference[data-configuration]')
@@ -176,12 +182,22 @@ export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceC
   if (!specUrlElement && !specElement && !getSpecScriptTag(doc)) {
     // Stay quiet.
   } else {
+    const configuration = getConfiguration()
+
+    if (isConfigurationWithSources(configuration)) {
+      return {
+        _integration: 'html',
+        proxyUrl: getProxyUrl(),
+        ...configuration,
+      }
+    }
+
     const urlOrContent = getContent() ? { content: getContent() } : { url: getUrl() }
 
     return apiReferenceConfigurationWithSourceSchema({
       _integration: 'html',
       proxyUrl: getProxyUrl(),
-      ...getConfiguration(),
+      ...configuration,
       ...urlOrContent,
     })
   }
@@ -193,7 +209,7 @@ export function getConfigurationFromDataAttributes(doc: Document): ApiReferenceC
  * Mount the Scalar API Reference on a given document.
  * Read the HTML data-attributes for configuration.
  */
-export function findDataAttributes(doc: Document, configuration: ApiReferenceConfigurationWithSource) {
+export function findDataAttributes(doc: Document, configuration: DataAttributeConfiguration) {
   /** @deprecated Use the new <script id="api-reference" data-url="/scalar.json" /> API instead. */
   const specElement = doc.querySelector('[data-spec]')
   /** @deprecated Use the new <script id="api-reference" data-url="/scalar.json" /> API instead. */

--- a/packages/api-reference/test/standalone/document-loading.e2e.ts
+++ b/packages/api-reference/test/standalone/document-loading.e2e.ts
@@ -39,4 +39,21 @@ test.describe
 
       shutdown()
     })
+
+    test('renders multiple documents from a data-configuration sources array', async ({ page }) => {
+      const { url, shutdown } = await serveHTMLExample(
+        join(import.meta.dirname, 'html', 'data-configuration-sources.html'),
+      )
+
+      // The first source is the default document.
+      await page.goto(url)
+      await expect(page.getByRole('heading', { name: 'Public API', level: 1 })).toBeVisible()
+
+      // Switching document via the `?api=<slug>` query parameter renders the second source. Before
+      // the fix the top-level `sources` array was stripped, so neither document rendered at all.
+      await page.goto(`${url}?api=admin`)
+      await expect(page.getByRole('heading', { name: 'Admin API', level: 1 })).toBeVisible()
+
+      shutdown()
+    })
   })

--- a/packages/api-reference/test/standalone/html/data-configuration-sources.html
+++ b/packages/api-reference/test/standalone/html/data-configuration-sources.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Scalar API Reference</title>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <!--
+      Two documents configured through the standalone `data-configuration` attribute.
+      This is the exact path fixed by "preserve standalone configuration sources": the
+      top-level `sources` array must survive to the renderer instead of being stripped.
+    -->
+    <script
+      id="api-reference"
+      data-configuration='{
+        "sources": [
+          {
+            "slug": "public",
+            "content": {
+              "openapi": "3.1.0",
+              "info": { "title": "Public API", "version": "1.0.0" },
+              "paths": {}
+            }
+          },
+          {
+            "slug": "admin",
+            "content": {
+              "openapi": "3.1.0",
+              "info": { "title": "Admin API", "version": "1.0.0" },
+              "paths": {}
+            }
+          }
+        ]
+      }'></script>
+    <script src="/scalar.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## What changed

- preserve a `sources` array supplied through the standalone `data-configuration` attribute
- keep the existing single-source parsing and migration path unchanged
- add regression coverage for two configured OpenAPI document sources
- add a patch changeset for `@scalar/api-reference`

The HTML reader previously passed every parsed configuration through the single-source schema before mounting the reference. That schema removes the top-level `sources` property, leaving the normalized configuration list empty and producing `Document not found in configList`.

## Validation

- `pnpm test` in `packages/api-reference`: 1,787 passed, 1 skipped, 3 todo
- `pnpm types:check` in `packages/api-reference`
- `pnpm knip`
- `pnpm changeset status`
- `pnpm build:packages`

## Ticket

See https://github.com/scalar/scalar/discussions/10124
