### PR TITLE
docs(nuxt): explain static site generation

### DIFF
--- a/documentation/integrations/nuxt.md
+++ b/documentation/integrations/nuxt.md
@@ -104,13 +104,109 @@ export default defineNuxtConfig({
 })
 ```
 
+## Static site generation
+
+You can generate the API reference as static HTML with Nuxt and deploy it without a Node.js server. Keep SSR enabled (the Nuxt default): setting `ssr: false` generates a client-rendered shell instead of the API reference content.
+
+### Configure the reference
+
+Install `@scalar/nuxt` using the [quick setup](#quick-setup) above. Save an OpenAPI document as `openapi.json` in your Nuxt project root. For example:
+
+```json
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Static Pets API",
+    "version": "1.0.0"
+  },
+  "servers": [{ "url": "https://api.example.com" }],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List pets",
+        "tags": ["Pets"],
+        "responses": {
+          "200": { "description": "A list of pets" }
+        }
+      }
+    }
+  }
+}
+```
+
+Import it in `nuxt.config.ts` and add the reference's base path to Nitro's prerender routes:
+
+```ts
+import document from './openapi.json'
+
+export default defineNuxtConfig({
+  modules: ['@scalar/nuxt'],
+  scalar: {
+    content: document,
+    pathRouting: {
+      basePath: '/docs',
+    },
+  },
+  nitro: {
+    prerender: {
+      routes: ['/docs'],
+      crawlLinks: true,
+    },
+  },
+})
+```
+
+The module registers a catch-all route, so explicitly adding `/docs` gives the prerenderer a starting point even if no other page links to it. With `crawlLinks: true`, Nitro follows links in the rendered reference and generates the linked tag and operation routes too. For the example above, this includes `/docs/tag/pets/GET/pets`.
+
+Your app also needs a home page because `nuxt generate` tries to prerender `/`. If you do not already have one, create `app/pages/index.vue` in Nuxt 4 (`pages/index.vue` in Nuxt 3):
+
+```vue
+<template>
+  <main>
+    <h1>API documentation</h1>
+    <NuxtLink to="/docs">Read the API reference</NuxtLink>
+  </main>
+</template>
+```
+
+If your app has a custom `app.vue`, make sure it renders `<NuxtPage />` so the module's routes can render.
+
+### Generate and preview
+
+Run these commands from your Nuxt project:
+
+```bash
+npx nuxt generate
+npx serve .output/public
+```
+
+Open `/docs/` on the preview server. Deploy the contents of `.output/public`, including the `_nuxt` assets and payload files, to your static host. No Nitro server is needed in production. See [Nuxt prerendering](https://nuxt.com/docs/4.x/getting-started/prerendering) for more details.
+
+Before deploying, check that:
+
+- `.output/public/docs/index.html` contains your API title and operation text as HTML, not only inside a script or payload.
+- The reference remains readable with JavaScript disabled. Search and request testing need JavaScript.
+- An operation URL opens directly and still works after refreshing. For this example, check `/docs/tag/pets/GET/pets/` and its generated `index.html` file.
+
+The static host must serve generated directory indexes. Routes the crawler does not discover need explicit entries in `nitro.prerender.routes`; a client-side fallback alone does not generate their HTML. If you customize slugs or hide navigation links, verify the resulting URLs and output files instead of assuming every route was crawled.
+
+### Documents and multiple references
+
+You can replace `content` with `url` to fetch an API description during generation. The URL must be reachable from the build environment. For a local public file, place it at `public/openapi.json` and use `url: '/openapi.json'`. Regenerate and redeploy when the API description changes: the generated HTML and Nuxt payload contain a snapshot from the build.
+
+For multiple references, add each configured base path to `nitro.prerender.routes`. For the `/yaml` and `/json` configurations shown above, use `routes: ['/yaml', '/json']` and keep `crawlLinks: true`.
+
+Static hosting does not run your Nuxt server routes. If you use Nitro's experimental OpenAPI generation, ensure the API description is available during prerendering and that any API endpoints used by the reference are hosted separately. Use absolute URLs in the OpenAPI `servers` array so “Test Request” calls your deployed API.
+
+Nuxt handles rendering and client hydration itself; you do not need `@scalar/server-side-rendering`. To generate a standalone HTML reference without Nuxt, see [static site generation with the server-side renderer](../server-side-rendering.md#static-site-generation).
+
 ## Using with Tailwind CSS
 
 If your Nuxt project uses Tailwind CSS v4, you need to set the CSS layer order so that Tailwind's utility classes take priority over Scalar's styles. Add this to the top of your main CSS file (for example, `assets/css/main.css`):
 
 ```css
 @layer scalar-base, scalar-theme, scalar-config, theme, base, components, utilities;
-@import "tailwindcss";
+@import 'tailwindcss';
 ```
 
 For full details, see [Embedding with CSS Frameworks](../themes.md#embedding-with-css-frameworks).

--- a/documentation/server-side-rendering.md
+++ b/documentation/server-side-rendering.md
@@ -13,7 +13,7 @@ npm install @scalar/server-side-rendering
 Render the HTML and JS once at startup, then serve from memory:
 
 ```ts
-import { renderApiReference, getJsAsset } from '@scalar/server-side-rendering'
+import { getJsAsset, renderApiReference } from '@scalar/server-side-rendering'
 
 // Render the HTML once at startup
 const html = await renderApiReference({
@@ -33,7 +33,7 @@ app.get('/scalar', (c) => c.html(html))
 app.get('/scalar/scalar.js', (c) =>
   c.body(js, {
     headers: { 'content-type': 'application/javascript' },
-  })
+  }),
 )
 ```
 
@@ -48,11 +48,48 @@ The standalone JS bundle from `getJsAsset()` handles client-side hydration. Serv
 
 ## Options
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `config` | `AnyApiReferenceConfiguration` | — | The API reference [configuration](./configuration.md) |
-| `pageTitle` | `string` | `'Scalar API Reference'` | Page title for the HTML document |
-| `css` | `string` | Built-in styles | Override the default CSS |
-| `cdn` | `string` | `'/scalar/scalar.js'` | URL path where the standalone JS bundle is served |
+| Option      | Type                           | Default                  | Description                                           |
+| ----------- | ------------------------------ | ------------------------ | ----------------------------------------------------- |
+| `config`    | `AnyApiReferenceConfiguration` | —                        | The API reference [configuration](./configuration.md) |
+| `pageTitle` | `string`                       | `'Scalar API Reference'` | Page title for the HTML document                      |
+| `css`       | `string`                       | Built-in styles          | Override the default CSS                              |
+| `cdn`       | `string`                       | `'/scalar/scalar.js'`    | URL path where the standalone JS bundle is served     |
 
 The `config` option accepts the same configuration as all other Scalar integrations — [read more about configuration](./configuration.md).
+
+## Static site generation
+
+You can also run the renderer at build time and write its output to disk. The resulting HTML and JavaScript can be deployed to a static host without a running Node.js server.
+
+Save your OpenAPI document as `openapi.json`, then create `generate-docs.mjs`:
+
+```js
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+
+import { getJsAsset, renderApiReference } from '@scalar/server-side-rendering'
+
+const content = JSON.parse(await readFile('openapi.json', 'utf8'))
+
+const html = await renderApiReference({
+  pageTitle: 'My API Reference',
+  config: { content },
+  cdn: './scalar.js',
+})
+
+await mkdir('dist/docs', { recursive: true })
+await writeFile('dist/docs/index.html', html)
+await writeFile('dist/docs/scalar.js', getJsAsset())
+```
+
+Generate and preview the site:
+
+```bash
+node generate-docs.mjs
+npx serve dist
+```
+
+Open `/docs/` on the preview server and deploy the contents of `dist` to your static host. Keep the trailing slash on `/docs/` so the relative `./scalar.js` URL resolves to `/docs/scalar.js`. If your host does not redirect directory URLs, configure that redirect or use an absolute asset URL in `cdn`.
+
+This example uses Scalar's default hash routing: operation links stay within the same HTML file, so the host does not need a fallback for nested routes. The HTML contains the rendered reference; JavaScript enables search and request testing. Re-run the script and deploy again when the API description changes. Use absolute URLs in the document's `servers` array to direct requests to your API rather than the static host.
+
+For a Nuxt application, use the [Nuxt static site generation guide](./integrations/nuxt.md#static-site-generation) instead. Nuxt manages its own rendering, payloads, and JavaScript assets, so it does not need this package.


### PR DESCRIPTION
Add guides for generating static API references with Nuxt and the standalone renderer. Cover setup, deployment, and operation links.

Tested both examples in temporary playgrounds, including content without JavaScript, search, and page refreshes.

## Ticket

Closes #1446
