### PR TITLE
feat(release-notes): select a built-in provider by name in the config

### DIFF
--- a/.changeset/thick-pandas-shave.md
+++ b/.changeset/thick-pandas-shave.md
@@ -1,0 +1,15 @@
+---
+'@scalar/release-notes': minor
+---
+
+feat: select a built-in provider by name in the config and add a pull request context switch
+
+`provider` now accepts `'anthropic'` or `'openai'` in addition to a custom provider object, and `model` and `apiKeyEnv` are config fields, so a config file (including `release-notes.config.json`) can pick a built-in provider without importing a factory. A `provider` value that is neither a known name nor a provider object now throws a clear error instead of failing later with `provider.generateJson is not a function`.
+
+A config-level `model` now reaches the provider, custom providers included, where previously only `--model` did. Set `github.pullRequestContext: false` (or pass `--no-pull-request-context`) to skip fetching pull request titles and descriptions and generate from the CHANGELOG alone. The default system prompt no longer describes a pull request context block when none was fetched.
+
+`model` and `apiKeyEnv` only apply to the provider their own layer of configuration selects, so settings written for one provider are never handed to another. Selecting a different provider with `--provider`, or in a config file that overrides a base config, drops the model id and API key environment variable that came with the provider it replaced. A config that names no provider counts as selecting the default one.
+
+The exported `PromptContext` handed to a `prompts.systemPrompt` callback gained an `includePullRequestContext` field, so a custom prompt can react to the same signal the default prompt does. `PromptContext`, the `ProviderOption` type, and the `hasBuiltInProviderApiKey` helper (the check the CLI uses to skip gracefully when a key is missing) are now exported.
+
+The exported `ResolvedReleaseNotesConfig` type changed shape: `provider` is now required and always a constructed provider, and `builtInProviderName` was added. Because provider resolution now happens while the config is read, `sync-release-notes-markdown` validates the `provider` field too, even though it does no AI work.

--- a/packages/release-notes/README.md
+++ b/packages/release-notes/README.md
@@ -43,17 +43,21 @@ scalar-release-notes \
 Create `release-notes.config.mjs`:
 
 ```js
-import { createAnthropicProvider, defineReleaseNotesConfig } from '@scalar/release-notes'
+import { defineReleaseNotesConfig } from '@scalar/release-notes'
 
 export default defineReleaseNotesConfig({
-  provider: createAnthropicProvider({
-    apiKey: process.env.ANTHROPIC_API_KEY,
-    model: 'claude-sonnet-4-5',
-  }),
+  // A built-in provider name: 'anthropic' (default) or 'openai'.
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-5',
+  // Environment variable holding the provider API key.
+  // Defaults to ANTHROPIC_API_KEY or OPENAI_API_KEY.
+  apiKeyEnv: 'ANTHROPIC_API_KEY',
   github: {
     repo: 'owner/repo',
     token: process.env.GITHUB_TOKEN,
     baseBranch: 'main',
+    // Set to false to generate from the CHANGELOG alone, with no GitHub API calls.
+    pullRequestContext: true,
   },
   products: [
     {
@@ -69,37 +73,70 @@ export default defineReleaseNotesConfig({
 })
 ```
 
+For full control over how a provider is created, pass a provider object instead of a name. See [Providers](#providers).
+
 JavaScript, JSON, and TypeScript config files are discovered by name. TypeScript config loading depends on your runtime being able to import `.ts` files, for example through `tsx`.
 
 The published JSON Schema for `RELEASE_NOTES.json` is available at `@scalar/release-notes/schema`.
 
+## Pull request context
+
+When `github.repo` is configured, every referenced pull request (`#123`) is fetched from the GitHub REST API and its title and description are fed to the provider as extra context. Turn it off to skip those calls and generate from the CHANGELOG alone:
+
+```js
+export default defineReleaseNotesConfig({
+  github: {
+    repo: 'owner/repo',
+    pullRequestContext: false,
+  },
+})
+```
+
+Or per run:
+
+```bash
+scalar-release-notes --all --no-pull-request-context
+```
+
+The flag only turns pull request context off. There is no counterpart that turns it back on for a config that set `pullRequestContext: false`.
+
 ## Providers
+
+A built-in provider is selected by name (`'anthropic'` or `'openai'`) in the config or with `--provider`, and is constructed with its defaults. Pass a provider object instead when you need control over how it is built.
+
+`model` and `apiKeyEnv` belong to the provider their own config selects, so switching provider drops them. Passing `--provider openai` ignores the `model` and `apiKeyEnv` of a config that selects Anthropic, whether it names Anthropic or relies on the default. Pass `--model` and `--api-key-env` alongside it to set them for the new provider.
 
 Use Anthropic:
 
 ```js
-import { createAnthropicProvider } from '@scalar/release-notes'
+import { createAnthropicProvider, defineReleaseNotesConfig } from '@scalar/release-notes'
 
-createAnthropicProvider({
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  model: 'claude-sonnet-4-5',
+export default defineReleaseNotesConfig({
+  provider: createAnthropicProvider({
+    apiKey: process.env.ANTHROPIC_API_KEY,
+    model: 'claude-sonnet-4-5',
+  }),
 })
 ```
 
 Use OpenAI:
 
 ```js
-import { createOpenAIProvider } from '@scalar/release-notes'
+import { createOpenAIProvider, defineReleaseNotesConfig } from '@scalar/release-notes'
 
-createOpenAIProvider({
-  apiKey: process.env.OPENAI_API_KEY,
-  model: 'gpt-4.1-mini',
+export default defineReleaseNotesConfig({
+  provider: createOpenAIProvider({
+    apiKey: process.env.OPENAI_API_KEY,
+    model: 'gpt-4.1-mini',
+  }),
 })
 ```
 
 Use a custom provider:
 
 ```js
+import { defineReleaseNotesConfig } from '@scalar/release-notes'
+
 export default defineReleaseNotesConfig({
   provider: {
     name: 'internal-agent',
@@ -109,6 +146,8 @@ export default defineReleaseNotesConfig({
   },
 })
 ```
+
+A provider object builds itself, so the top-level `apiKeyEnv` does not apply to it. A top-level `model` still does: it is passed to `generateJson`.
 
 The provider can return either a JSON object or a JSON string. The package validates the result before writing `RELEASE_NOTES.json`.
 
@@ -136,7 +175,7 @@ OpenAI:
 
 ## Markdown Sync
 
-Regenerate Markdown from JSON without using AI:
+Regenerate Markdown from JSON without using AI. The config file is still read and its `provider` field still validated, so an unusable `provider` value fails here too:
 
 ```bash
 scalar-release-notes sync-release-notes-markdown \

--- a/packages/release-notes/src/commands/generate.test.ts
+++ b/packages/release-notes/src/commands/generate.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { ReleaseNotesConfig } from '../config/types'
 import { createReleaseNotesGeneratorCommand } from './generate'
 
 describe('generate', () => {
@@ -13,6 +14,7 @@ describe('generate', () => {
   afterEach(async () => {
     process.env = { ...originalEnv }
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
 
     await Promise.all(temporaryDirectories.map((directory) => rm(directory, { recursive: true, force: true })))
     temporaryDirectories.length = 0
@@ -24,7 +26,7 @@ describe('generate', () => {
 
     const changelogPath = join(directory, 'CHANGELOG.md')
     await writeFile(join(directory, 'package.json'), JSON.stringify({ name: '@example/client', version: '1.0.0' }))
-    await writeFile(changelogPath, ['# @example/client', '', '## 1.0.0', '', '- Added release notes.'].join('\n'))
+    await writeFile(changelogPath, ['# @example/client', '', '## 1.0.0', '', '- Added release notes (#123)'].join('\n'))
 
     return {
       changelogPath,
@@ -78,5 +80,103 @@ describe('generate', () => {
     ).resolves.toBe(command)
 
     expect(warn).toHaveBeenCalledWith('No API key set for the openai provider; skipping release-notes generation.')
+  })
+
+  /** Write a JSON config file into a fresh directory and point config discovery at it. */
+  const createJsonConfig = async (config: unknown): Promise<void> => {
+    const directory = await mkdtemp(join(tmpdir(), 'scalar-release-notes-config-'))
+    temporaryDirectories.push(directory)
+
+    await writeFile(join(directory, 'release-notes.config.json'), JSON.stringify(config))
+    process.env.INIT_CWD = directory
+  }
+
+  it('skips generation with a warning when a config file selects a built-in provider by name', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    delete process.env.OPENAI_API_KEY
+    await createJsonConfig({ provider: 'openai', products: [] })
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const command = createReleaseNotesGeneratorCommand()
+
+    await expect(command.parseAsync(['--all'], { from: 'user' })).resolves.toBe(command)
+
+    expect(warn).toHaveBeenCalledWith('No API key set for the openai provider; skipping release-notes generation.')
+  })
+
+  it('looks the API key up in the environment variable named by a config-level apiKeyEnv', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    delete process.env.CUSTOM_ANTHROPIC_KEY
+    await createJsonConfig({ provider: 'anthropic', apiKeyEnv: 'CUSTOM_ANTHROPIC_KEY', products: [] })
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    await expect(createReleaseNotesGeneratorCommand().parseAsync(['--all'], { from: 'user' })).resolves.toBeDefined()
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipping release-notes generation'))
+
+    // The same config now finds a key, so it gets past the guard and fails on the empty product list.
+    process.env.CUSTOM_ANTHROPIC_KEY = 'sk-test'
+
+    await expect(createReleaseNotesGeneratorCommand().parseAsync(['--all'], { from: 'user' })).rejects.toThrow(
+      'No products configured.',
+    )
+  })
+
+  describe('--no-pull-request-context', () => {
+    /** A config whose single product references a pull request, so PR fetching has something to find. */
+    const createProductConfig = async (): Promise<ReleaseNotesConfig> => {
+      const { changelogPath, outputPath } = await createTemporaryPackage()
+
+      return {
+        provider: { name: 'test', generateJson: async () => ({ version: '1.0.0', title: 'Imports are easier' }) },
+        github: { repo: 'example/repo' },
+        products: [
+          {
+            slug: 'client',
+            packageName: '@example/client',
+            displayName: 'Example Client',
+            description: 'an API client for Example',
+            changelogPath,
+            outputPath,
+          },
+        ],
+      }
+    }
+
+    it('skips the GitHub API when the flag is passed', async () => {
+      process.env.INIT_CWD = import.meta.dirname
+      const baseConfig = await createProductConfig()
+      const fetchSpy = vi.fn<typeof fetch>()
+      vi.stubGlobal('fetch', fetchSpy)
+      const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+      const command = createReleaseNotesGeneratorCommand(baseConfig)
+
+      await expect(
+        command.parseAsync(['--product', 'client', '--no-pull-request-context', '--dry-run'], { from: 'user' }),
+      ).resolves.toBe(command)
+
+      expect(fetchSpy).not.toHaveBeenCalled()
+      // The run must reach the provider, otherwise it would skip the fetch for the wrong reason.
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Imports are easier'))
+    })
+
+    it('fetches pull requests when the flag is not passed', async () => {
+      process.env.INIT_CWD = import.meta.dirname
+      const baseConfig = await createProductConfig()
+      const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ number: 123, title: 'Add an import flow', body: 'Why it matters.' }), {
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      vi.stubGlobal('fetch', fetchSpy)
+      vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+      const command = createReleaseNotesGeneratorCommand(baseConfig)
+
+      await expect(command.parseAsync(['--product', 'client', '--dry-run'], { from: 'user' })).resolves.toBe(command)
+
+      expect(fetchSpy).toHaveBeenCalledWith('https://api.github.com/repos/example/repo/pulls/123', expect.anything())
+    })
   })
 })

--- a/packages/release-notes/src/commands/generate.ts
+++ b/packages/release-notes/src/commands/generate.ts
@@ -1,11 +1,6 @@
 import { Command } from 'commander'
 
-import {
-  type CliConfigOverrides,
-  createBuiltInProvider,
-  hasBuiltInProviderApiKey,
-  readReleaseNotesConfig,
-} from '../config/read-config'
+import { type CliConfigOverrides, hasBuiltInProviderApiKey, readReleaseNotesConfig } from '../config/read-config'
 import type { BuiltInProviderName, ReleaseNotesConfig, ReleaseNotesProduct } from '../config/types'
 import { getChangedPathsForReleaseFiltering } from '../core/detect-versioned-changelog-paths'
 import { runReleaseNotesGeneratorForProduct } from '../core/run-release-notes-generator'
@@ -29,6 +24,7 @@ type CommandOptions = {
   baseBranch?: string
   config?: string
   markdownOutput: boolean
+  pullRequestContext: boolean
 }
 
 const createAdHocProduct = (
@@ -64,6 +60,7 @@ const resolveCliOverrides = (options: CommandOptions): CliConfigOverrides => {
     apiKeyEnv: options.apiKeyEnv,
     repo: options.repo,
     baseBranch: options.baseBranch,
+    pullRequestContext: options.pullRequestContext,
   }
 }
 
@@ -95,11 +92,10 @@ export const createReleaseNotesGeneratorCommand = (baseConfig: ReleaseNotesConfi
     .option('--dry-run', 'Print the generated note instead of writing it', false)
     .option('--force', 'With --all, generate release notes for every configured product', false)
     .option('--no-markdown-output', 'Skip Markdown regeneration')
+    .option('--no-pull-request-context', 'Skip fetching pull request titles and descriptions for AI context')
     .action(async (options: CommandOptions) => {
       const cliOverrides = resolveCliOverrides(options)
       const config = await readReleaseNotesConfig(cliOverrides, baseConfig)
-
-      const builtInProvider = cliOverrides.provider ?? 'anthropic'
 
       // When relying on a built-in provider, skip gracefully if its API key is missing.
       // This keeps `pnpm release:version --all` from failing on forks, contributor
@@ -109,19 +105,12 @@ export const createReleaseNotesGeneratorCommand = (baseConfig: ReleaseNotesConfi
       // environment variable name. The env var name is harmless to log, but keeping
       // it out of the message avoids a false-positive clear-text-logging alert from
       // CodeQL, whose name-based heuristic flags anything derived from `apiKeyEnv`.
-      const usesBuiltInProvider = Boolean(cliOverrides.provider) || !config.provider
-      if (usesBuiltInProvider && !hasBuiltInProviderApiKey(builtInProvider, options.apiKeyEnv)) {
-        console.warn(`No API key set for the ${builtInProvider} provider; skipping release-notes generation.`)
+      if (config.builtInProviderName && !hasBuiltInProviderApiKey(config.builtInProviderName, config.apiKeyEnv)) {
+        console.warn(
+          `No API key set for the ${config.builtInProviderName} provider; skipping release-notes generation.`,
+        )
         return
       }
-
-      const provider =
-        config.provider ??
-        createBuiltInProvider({
-          provider: builtInProvider,
-          model: options.model,
-          apiKeyEnv: options.apiKeyEnv,
-        })
 
       const products = options.all
         ? config.products
@@ -143,10 +132,10 @@ export const createReleaseNotesGeneratorCommand = (baseConfig: ReleaseNotesConfi
       for (const product of products) {
         await runReleaseNotesGeneratorForProduct({
           product,
-          provider,
+          provider: config.provider,
           version: options.version,
           date: options.date,
-          model: options.model,
+          model: config.model,
           dryRun: options.dryRun,
           changedPaths,
           writeMarkdown: options.markdownOutput,

--- a/packages/release-notes/src/config/read-config.test.ts
+++ b/packages/release-notes/src/config/read-config.test.ts
@@ -1,0 +1,404 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { readReleaseNotesConfig } from './read-config'
+import type { ReleaseNotesConfig } from './types'
+
+describe('read-config', () => {
+  const originalEnv = { ...process.env }
+  const temporaryDirectories: string[] = []
+
+  afterEach(async () => {
+    process.env = { ...originalEnv }
+    vi.unstubAllGlobals()
+
+    await Promise.all(temporaryDirectories.map((directory) => rm(directory, { recursive: true, force: true })))
+    temporaryDirectories.length = 0
+  })
+
+  /** Write a JSON config file into a fresh directory and point config discovery at it. */
+  const createJsonConfig = async (config: unknown): Promise<void> => {
+    const directory = await mkdtemp(join(tmpdir(), 'scalar-release-notes-config-'))
+    temporaryDirectories.push(directory)
+
+    await writeFile(join(directory, 'release-notes.config.json'), JSON.stringify(config))
+    process.env.INIT_CWD = directory
+  }
+
+  /**
+   * Write an ES module config file. Unlike JSON, it can hold an explicit `undefined`, which is
+   * what the layered fallbacks have to survive.
+   */
+  const createModuleConfig = async (source: string): Promise<void> => {
+    const directory = await mkdtemp(join(tmpdir(), 'scalar-release-notes-config-'))
+    temporaryDirectories.push(directory)
+
+    await writeFile(join(directory, 'release-notes.config.mjs'), source)
+    process.env.INIT_CWD = directory
+  }
+
+  it('resolves a built-in provider name from a config file', async () => {
+    await createJsonConfig({ provider: 'openai' })
+
+    const config = await readReleaseNotesConfig()
+
+    expect(config.builtInProviderName).toBe('openai')
+    expect(config.provider.name).toBe('openai')
+  })
+
+  it('hands a config-level model to the built-in provider', async () => {
+    await createJsonConfig({ provider: 'anthropic', model: 'claude-opus-4-1' })
+
+    const config = await readReleaseNotesConfig()
+
+    expect(config.model).toBe('claude-opus-4-1')
+    expect(config.provider.defaultModel).toBe('claude-opus-4-1')
+  })
+
+  it('carries a config-level apiKeyEnv through resolution', async () => {
+    await createJsonConfig({
+      provider: 'anthropic',
+      apiKeyEnv: 'CUSTOM_ANTHROPIC_KEY',
+    })
+
+    const config = await readReleaseNotesConfig()
+
+    expect(config.apiKeyEnv).toBe('CUSTOM_ANTHROPIC_KEY')
+    expect(config.builtInProviderName).toBe('anthropic')
+  })
+
+  // A config written for one provider must not hand its model id, or its API key, to another.
+  it('drops config-level model and apiKeyEnv when the CLI switches provider', async () => {
+    await createJsonConfig({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      apiKeyEnv: 'MY_ANTHROPIC_KEY',
+    })
+
+    const config = await readReleaseNotesConfig({ provider: 'openai' })
+
+    expect(config.builtInProviderName).toBe('openai')
+    expect(config.model).toBeUndefined()
+    expect(config.apiKeyEnv).toBeUndefined()
+    expect(config.provider.defaultModel).toBe('gpt-4.1-mini')
+  })
+
+  // The leak this guards against: an Anthropic key travelling to api.openai.com as a Bearer token.
+  it('does not hand the config API key to a provider the CLI switched to', async () => {
+    process.env.MY_ANTHROPIC_KEY = 'sk-anthropic'
+    process.env.OPENAI_API_KEY = 'sk-openai'
+    await createJsonConfig({
+      provider: 'anthropic',
+      apiKeyEnv: 'MY_ANTHROPIC_KEY',
+    })
+
+    const config = await readReleaseNotesConfig({ provider: 'openai' })
+
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ choices: [{ message: { content: '{}' } }] }), {
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+    vi.stubGlobal('fetch', fetchSpy)
+
+    await config.provider.generateJson({
+      systemPrompt: 'system',
+      userPrompt: 'user',
+      schema: {},
+      maxOutputTokens: 16,
+    })
+
+    const headers = fetchSpy.mock.calls[0]?.[1]?.headers as Record<string, string>
+    expect(headers.authorization).toBe('Bearer sk-openai')
+  })
+
+  it('keeps config-level model and apiKeyEnv when the CLI names the same provider', async () => {
+    await createJsonConfig({
+      provider: 'anthropic',
+      model: 'claude-opus-4-1',
+      apiKeyEnv: 'MY_ANTHROPIC_KEY',
+    })
+
+    const config = await readReleaseNotesConfig({ provider: 'anthropic' })
+
+    expect(config.model).toBe('claude-opus-4-1')
+    expect(config.apiKeyEnv).toBe('MY_ANTHROPIC_KEY')
+  })
+
+  // A config with no `provider` already resolves to anthropic, so naming it on the command
+  // line changes nothing and must not discard the config's model or apiKeyEnv.
+  it('keeps config-level model and apiKeyEnv when the CLI names the default provider', async () => {
+    await createJsonConfig({
+      model: 'claude-opus-4-1',
+      apiKeyEnv: 'MY_ANTHROPIC_KEY',
+    })
+
+    const config = await readReleaseNotesConfig({ provider: 'anthropic' })
+
+    expect(config.model).toBe('claude-opus-4-1')
+    expect(config.apiKeyEnv).toBe('MY_ANTHROPIC_KEY')
+    expect(config.provider.defaultModel).toBe('claude-opus-4-1')
+  })
+
+  it('drops config-level settings when the CLI switches away from a custom provider', async () => {
+    process.env.INIT_CWD = import.meta.dirname
+    const provider = { name: 'internal-agent', generateJson: async () => ({}) }
+
+    const config = await readReleaseNotesConfig({ provider: 'openai' }, {
+      provider,
+      model: 'internal-model',
+      apiKeyEnv: 'INTERNAL_KEY',
+    } satisfies ReleaseNotesConfig)
+
+    expect(config.builtInProviderName).toBe('openai')
+    expect(config.model).toBeUndefined()
+    expect(config.apiKeyEnv).toBeUndefined()
+  })
+
+  it('hands a config-level model to a custom provider', async () => {
+    process.env.INIT_CWD = import.meta.dirname
+    const provider = { name: 'internal-agent', generateJson: async () => ({}) }
+
+    const config = await readReleaseNotesConfig({}, {
+      provider,
+      model: 'internal-model',
+    } satisfies ReleaseNotesConfig)
+
+    expect(config.model).toBe('internal-model')
+  })
+
+  it('drops a config-level apiKeyEnv that a custom provider cannot use', async () => {
+    process.env.INIT_CWD = import.meta.dirname
+    const provider = { name: 'internal-agent', generateJson: async () => ({}) }
+
+    const config = await readReleaseNotesConfig({}, {
+      provider,
+      apiKeyEnv: 'INTERNAL_KEY',
+    } satisfies ReleaseNotesConfig)
+
+    expect(config.builtInProviderName).toBeNull()
+    expect(config.apiKeyEnv).toBeUndefined()
+  })
+
+  // The same leak as the CLI case, one layer down: the file config picks the provider while the
+  // base config supplies settings written for a different one.
+  it('does not carry base config settings onto a provider the config file switched to', async () => {
+    await createJsonConfig({ provider: 'openai' })
+
+    const config = await readReleaseNotesConfig({}, {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5',
+      apiKeyEnv: 'MY_ANTHROPIC_KEY',
+    } satisfies ReleaseNotesConfig)
+
+    expect(config.builtInProviderName).toBe('openai')
+    expect(config.model).toBeUndefined()
+    expect(config.apiKeyEnv).toBeUndefined()
+    expect(config.provider.defaultModel).toBe('gpt-4.1-mini')
+  })
+
+  it('carries base config settings onto a config file that names no provider', async () => {
+    await createJsonConfig({ products: [] })
+
+    const config = await readReleaseNotesConfig({}, {
+      provider: 'anthropic',
+      model: 'claude-opus-4-1',
+    } satisfies ReleaseNotesConfig)
+
+    expect(config.model).toBe('claude-opus-4-1')
+  })
+
+  // A config that names no provider is relying on the anthropic default, so its settings were
+  // written for anthropic and must not follow the CLI to a different provider.
+  it('does not carry settings from a provider-less config onto a provider the CLI switched to', async () => {
+    process.env.MY_ANTHROPIC_KEY = 'sk-anthropic'
+    process.env.OPENAI_API_KEY = 'sk-openai'
+    await createJsonConfig({
+      model: 'claude-sonnet-4-5',
+      apiKeyEnv: 'MY_ANTHROPIC_KEY',
+    })
+
+    const config = await readReleaseNotesConfig({ provider: 'openai' })
+
+    expect(config.model).toBeUndefined()
+    expect(config.apiKeyEnv).toBeUndefined()
+    expect(config.provider.defaultModel).toBe('gpt-4.1-mini')
+  })
+
+  it('does not carry settings from a provider-less base config onto a switched provider', async () => {
+    await createJsonConfig({ provider: 'openai' })
+
+    const config = await readReleaseNotesConfig({}, {
+      model: 'claude-sonnet-4-5',
+      apiKeyEnv: 'MY_ANTHROPIC_KEY',
+    } satisfies ReleaseNotesConfig)
+
+    expect(config.model).toBeUndefined()
+    expect(config.apiKeyEnv).toBeUndefined()
+  })
+
+  // `null` is what a JSON round-trip produces for an unset field, so it must not be a provider.
+  it('treats a null model as unset', async () => {
+    await createJsonConfig({ provider: 'anthropic', model: null })
+
+    const config = await readReleaseNotesConfig({}, {
+      model: 'claude-opus-4-1',
+    } satisfies ReleaseNotesConfig)
+
+    expect(config.model).toBe('claude-opus-4-1')
+  })
+
+  it('treats an empty apiKeyEnv as unset', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test'
+    await createJsonConfig({ provider: 'anthropic', apiKeyEnv: '', model: '' })
+
+    const config = await readReleaseNotesConfig()
+
+    expect(config.apiKeyEnv).toBeUndefined()
+    expect(config.model).toBeUndefined()
+    expect(config.provider.defaultModel).toBe('claude-sonnet-4-5')
+  })
+
+  it('treats a null provider as unset', async () => {
+    await createJsonConfig({ provider: null, model: 'claude-opus-4-1' })
+
+    const config = await readReleaseNotesConfig()
+
+    expect(config.builtInProviderName).toBe('anthropic')
+    expect(config.model).toBe('claude-opus-4-1')
+  })
+
+  it('lets the CLI model and apiKeyEnv override the config file', async () => {
+    await createJsonConfig({
+      provider: 'anthropic',
+      model: 'claude-opus-4-1',
+      apiKeyEnv: 'CONFIG_KEY',
+    })
+
+    const config = await readReleaseNotesConfig({
+      model: 'claude-sonnet-4-5',
+      apiKeyEnv: 'CLI_KEY',
+    })
+
+    expect(config.model).toBe('claude-sonnet-4-5')
+    expect(config.apiKeyEnv).toBe('CLI_KEY')
+  })
+
+  it('keeps a custom provider object as-is', async () => {
+    process.env.INIT_CWD = import.meta.dirname
+    const provider = { name: 'internal-agent', generateJson: async () => ({}) }
+
+    const config = await readReleaseNotesConfig({}, {
+      provider,
+    } satisfies ReleaseNotesConfig)
+
+    expect(config.provider).toBe(provider)
+    expect(config.builtInProviderName).toBeNull()
+  })
+
+  it('defaults to the anthropic provider when none is configured', async () => {
+    process.env.INIT_CWD = import.meta.dirname
+
+    const config = await readReleaseNotesConfig()
+
+    expect(config.builtInProviderName).toBe('anthropic')
+  })
+
+  it('lets the CLI provider override a config-level provider name', async () => {
+    await createJsonConfig({ provider: 'anthropic' })
+
+    const config = await readReleaseNotesConfig({ provider: 'openai' })
+
+    expect(config.builtInProviderName).toBe('openai')
+    expect(config.provider.name).toBe('openai')
+  })
+
+  // A JSON config cannot hold a function, so a `provider` object read from JSON is always
+  // unusable. Failing here beats crashing later with `provider.generateJson is not a function`.
+  it('throws when the configured provider is neither a known name nor a provider object', async () => {
+    await createJsonConfig({ provider: { name: 'anthropic' } })
+
+    await expect(readReleaseNotesConfig()).rejects.toThrow('Unsupported provider')
+  })
+
+  it('enables pull request context by default', async () => {
+    process.env.INIT_CWD = import.meta.dirname
+
+    const config = await readReleaseNotesConfig()
+
+    expect(config.github.pullRequestContext).toBe(true)
+  })
+
+  it('keeps a disabled pull request context from the config file', async () => {
+    await createJsonConfig({
+      github: { repo: 'example/repo', pullRequestContext: false },
+    })
+
+    const config = await readReleaseNotesConfig()
+
+    expect(config.github.pullRequestContext).toBe(false)
+  })
+
+  it('keeps a base config prompt that the file config sets to undefined', async () => {
+    await createModuleConfig('export default { prompts: { productDescriptionFallback: undefined } }\n')
+
+    const config = await readReleaseNotesConfig({}, { prompts: { productDescriptionFallback: 'a Scalar product' } })
+
+    expect(config.prompts.productDescriptionFallback).toBe('a Scalar product')
+  })
+
+  it('keeps base config github values that the file config sets to null', async () => {
+    await createJsonConfig({
+      github: { baseBranch: null, pullRequestContext: null },
+    })
+
+    const config = await readReleaseNotesConfig({}, { github: { baseBranch: 'release', pullRequestContext: false } })
+
+    expect(config.github.baseBranch).toBe('release')
+    expect(config.github.pullRequestContext).toBe(false)
+  })
+
+  // A `__proto__` key in a config file must stay inert data instead of re-pointing the prototype.
+  it('does not let a config file key reach through the prototype chain', async () => {
+    await createJsonConfig(JSON.parse('{"github":{"__proto__":{"repo":"evil/repo"},"baseBranch":"release"}}'))
+
+    const config = await readReleaseNotesConfig()
+
+    expect(config.github.repo).toBeUndefined()
+    expect(config.github.baseBranch).toBe('release')
+  })
+
+  it('keeps base config github values that the file config sets to undefined', async () => {
+    await createModuleConfig(
+      'export default { github: { repo: undefined, baseBranch: undefined, pullRequestContext: undefined } }\n',
+    )
+
+    const config = await readReleaseNotesConfig(
+      {},
+      {
+        github: {
+          repo: 'example/repo',
+          baseBranch: 'release',
+          pullRequestContext: false,
+        },
+      },
+    )
+
+    expect(config.github.repo).toBe('example/repo')
+    expect(config.github.baseBranch).toBe('release')
+    expect(config.github.pullRequestContext).toBe(false)
+  })
+
+  it('lets the CLI disable pull request context enabled in the config file', async () => {
+    await createJsonConfig({
+      github: { repo: 'example/repo', pullRequestContext: true },
+    })
+
+    const config = await readReleaseNotesConfig({ pullRequestContext: false })
+
+    expect(config.github.pullRequestContext).toBe(false)
+  })
+})

--- a/packages/release-notes/src/config/read-config.ts
+++ b/packages/release-notes/src/config/read-config.ts
@@ -7,6 +7,7 @@ import { createOpenAIProvider } from '../providers/openai'
 import type {
   BuiltInProviderName,
   GithubOptions,
+  ProviderOption,
   ReleaseNotesConfig,
   ReleaseNotesProvider,
   ResolvedReleaseNotesConfig,
@@ -26,6 +27,11 @@ export type CliConfigOverrides = {
   apiKeyEnv?: string
   repo?: string
   baseBranch?: string
+  /**
+   * Only `false` has an effect: the CLI can turn pull request context off, but never
+   * back on over a config file that disabled it.
+   */
+  pullRequestContext?: boolean
 }
 
 const pathExists = async (path: string): Promise<boolean> => {
@@ -83,11 +89,129 @@ export const createBuiltInProvider = (options: {
   return createAnthropicProvider({ apiKey, model: options.model })
 }
 
-const resolveGithub = (configGithub: GithubOptions | undefined, overrides: CliConfigOverrides): GithubOptions => {
+/** Provider used when neither the config nor the CLI names one. */
+const DEFAULT_PROVIDER: BuiltInProviderName = 'anthropic'
+
+const isBuiltInProviderName = (value: unknown): value is BuiltInProviderName =>
+  value === 'anthropic' || value === 'openai'
+
+const isReleaseNotesProvider = (value: unknown): value is ReleaseNotesProvider =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as { generateJson?: unknown }).generateJson === 'function'
+
+/** One layer of configuration that can select a provider and describe how to build it. */
+type ProviderLayer = {
+  provider?: ProviderOption
+  model?: string
+  apiKeyEnv?: string
+}
+
+/**
+ * Pick the provider, and the model and API key environment variable that belong with it.
+ *
+ * `model` and `apiKeyEnv` describe whichever provider their own layer selects, so they are only
+ * carried over from layers that select the winning provider. That keeps settings written for one
+ * provider from reaching another: a config written for Anthropic never hands an Anthropic model
+ * id, or an Anthropic API key, to OpenAI.
+ *
+ * A layer that names no provider is not provider-agnostic: it selects whatever the next layer
+ * down selects. When no layer names one, they all select the default provider, which is the
+ * provider each of them would have used on its own.
+ *
+ * Layers are ordered by precedence, highest first.
+ */
+const resolveProviderSelection = (
+  layers: readonly ProviderLayer[],
+): { selection: ProviderOption; model?: string; apiKeyEnv?: string } => {
+  // Treat `null` as unset, so a JSON round-trip that nulls a field falls through to a lower layer.
+  // An empty string is a typo rather than a setting: naming no environment variable at all beats
+  // resolving `process.env['']` and reporting a missing API key.
+  const optional = (value: string | null | undefined): string | undefined =>
+    value === '' ? undefined : (value ?? undefined)
+  const normalized = layers.map((layer) => ({
+    provider: layer.provider ?? undefined,
+    model: optional(layer.model),
+    apiKeyEnv: optional(layer.apiKeyEnv),
+  }))
+  const effectiveProviders = normalized.map(
+    (_, index) =>
+      normalized
+        .slice(index)
+        .map((layer) => layer.provider)
+        .find((provider) => provider !== undefined) ?? DEFAULT_PROVIDER,
+  )
+  const selection = effectiveProviders[0] ?? DEFAULT_PROVIDER
+  const applicable = normalized.filter((_, index) => effectiveProviders[index] === selection)
+
   return {
-    repo: overrides.repo ?? configGithub?.repo,
-    baseBranch: overrides.baseBranch ?? configGithub?.baseBranch ?? 'main',
-    token: configGithub?.token ?? process.env.GITHUB_TOKEN,
+    selection,
+    model: applicable.find((layer) => layer.model !== undefined)?.model,
+    apiKeyEnv: applicable.find((layer) => layer.apiKeyEnv !== undefined)?.apiKeyEnv,
+  }
+}
+
+/**
+ * Turn a provider name or provider object into a constructed provider.
+ */
+const resolveProvider = (
+  selection: ProviderOption,
+  model?: string,
+  apiKeyEnv?: string,
+): { provider: ReleaseNotesProvider; builtInProviderName: BuiltInProviderName | null } => {
+  // A custom provider is used as-is. It builds itself, so apiKeyEnv is meaningless here,
+  // though `model` still reaches it later through generateJson.
+  if (isReleaseNotesProvider(selection)) {
+    return { provider: selection, builtInProviderName: null }
+  }
+
+  if (isBuiltInProviderName(selection)) {
+    return {
+      provider: createBuiltInProvider({ provider: selection, model, apiKeyEnv }),
+      builtInProviderName: selection,
+    }
+  }
+
+  throw new Error('Unsupported provider. Use "anthropic", "openai", or a provider object with a generateJson function.')
+}
+
+/**
+ * Merge option objects, highest precedence first, ignoring keys a layer left unset.
+ *
+ * Unlike an object spread, an explicit `undefined` or `null` in one layer never wipes a value a
+ * lower layer set, and fields this file does not know about are carried through untouched. Every
+ * key is optional in the result, so this suits option types whose fields are all optional.
+ */
+const layerOptions = <T extends object>(layers: readonly (T | undefined)[]): Partial<T> => {
+  const merged = new Map<string, unknown>()
+
+  for (const layer of [...layers].reverse()) {
+    for (const [key, value] of Object.entries(layer ?? {})) {
+      if (value !== undefined && value !== null) {
+        merged.set(key, value)
+      }
+    }
+  }
+
+  // `Object.fromEntries` defines own properties, so a `__proto__` key from a config file stays
+  // inert data rather than re-pointing the prototype the way an assignment would.
+  return Object.fromEntries(merged) as Partial<T>
+}
+
+/** Layers are ordered by precedence, highest first, matching `layerOptions`. */
+const resolveGithub = (
+  githubLayers: readonly (GithubOptions | undefined)[],
+  overrides: CliConfigOverrides,
+): GithubOptions => {
+  const github = layerOptions(githubLayers)
+
+  return {
+    ...github,
+    repo: overrides.repo ?? github.repo,
+    baseBranch: overrides.baseBranch ?? github.baseBranch ?? 'main',
+    token: github.token ?? process.env.GITHUB_TOKEN,
+    // The CLI flag can only turn pull request context off, never back on.
+    pullRequestContext: overrides.pullRequestContext === false ? false : (github.pullRequestContext ?? true),
   }
 }
 
@@ -98,28 +222,22 @@ export const readReleaseNotesConfig = async (
 ): Promise<ResolvedReleaseNotesConfig> => {
   const configPath = overrides.config ? resolve(cwd, overrides.config) : await findConfigPath(cwd)
   const fileConfig = configPath ? await loadConfigFile(configPath) : {}
-  const config: ReleaseNotesConfig = {
-    ...baseConfig,
-    ...fileConfig,
-    github: {
-      ...baseConfig.github,
-      ...fileConfig.github,
-    },
-    prompts: {
-      ...baseConfig.prompts,
-      ...fileConfig.prompts,
-    },
-    products: fileConfig.products ?? baseConfig.products,
-    provider: fileConfig.provider ?? baseConfig.provider,
-  }
-  const provider = overrides.provider
-    ? createBuiltInProvider({ provider: overrides.provider, model: overrides.model, apiKeyEnv: overrides.apiKeyEnv })
-    : config.provider
+
+  const { selection, model, apiKeyEnv } = resolveProviderSelection([
+    { provider: overrides.provider, model: overrides.model, apiKeyEnv: overrides.apiKeyEnv },
+    { provider: fileConfig.provider, model: fileConfig.model, apiKeyEnv: fileConfig.apiKeyEnv },
+    { provider: baseConfig.provider, model: baseConfig.model, apiKeyEnv: baseConfig.apiKeyEnv },
+  ])
+  const { provider, builtInProviderName } = resolveProvider(selection, model, apiKeyEnv)
 
   return {
     provider,
-    products: config.products ?? [],
-    github: resolveGithub(config.github, overrides),
-    prompts: config.prompts ?? {},
+    builtInProviderName,
+    model,
+    // A custom provider built itself, so the environment variable never applied to it.
+    apiKeyEnv: builtInProviderName ? apiKeyEnv : undefined,
+    products: fileConfig.products ?? baseConfig.products ?? [],
+    github: resolveGithub([fileConfig.github, baseConfig.github], overrides),
+    prompts: layerOptions([fileConfig.prompts, baseConfig.prompts]),
   }
 }

--- a/packages/release-notes/src/config/types.ts
+++ b/packages/release-notes/src/config/types.ts
@@ -29,6 +29,11 @@ export type ProductPromptContext = {
 
 export type PromptContext = {
   product: ProductPromptContext
+  /**
+   * Whether a "Pull request context" block will be present in the user prompt. Mirrors what the
+   * default system prompt reacts to, so a custom prompt can describe the same inputs.
+   */
+  includePullRequestContext: boolean
 }
 
 export type PromptOptions = {
@@ -45,6 +50,12 @@ export type GithubOptions = {
   baseBranch?: string
   /** GitHub token for PR context fetching. */
   token?: string
+  /**
+   * Whether to fetch referenced pull requests and feed their titles and descriptions
+   * to the AI provider. Defaults to `true`. Set to `false` to skip the GitHub API
+   * calls entirely and generate from the CHANGELOG alone.
+   */
+  pullRequestContext?: boolean
 }
 
 /**
@@ -65,14 +76,52 @@ export type ReleaseNotesProvider = {
 
 export type BuiltInProviderName = 'anthropic' | 'openai'
 
+/** A built-in provider selected by name, or a custom pluggable provider. */
+export type ProviderOption = BuiltInProviderName | ReleaseNotesProvider
+
+/**
+ * User-facing release notes configuration, as written in a `release-notes.config.*` file.
+ */
 export type ReleaseNotesConfig = {
-  provider?: ReleaseNotesProvider
+  /**
+   * Either a built-in provider name (`'anthropic'` or `'openai'`) that is created with
+   * its defaults, or a custom provider object. Defaults to `'anthropic'`.
+   */
+  provider?: ProviderOption
+  /** Model id handed to the provider. Falls back to the provider's own default model. */
+  model?: string
+  /**
+   * Environment variable that holds the built-in provider API key. Defaults to
+   * `ANTHROPIC_API_KEY` or `OPENAI_API_KEY`. Ignored by custom providers.
+   */
+  apiKeyEnv?: string
+  /** Release note targets. */
   products?: readonly ReleaseNotesProduct[]
+  /** GitHub settings for PR context and changelog links. */
   github?: GithubOptions
+  /** Prompt customisation hooks. */
   prompts?: PromptOptions
 }
 
-export type ResolvedReleaseNotesConfig = Required<Pick<ReleaseNotesConfig, 'github' | 'prompts'>> &
-  Omit<ReleaseNotesConfig, 'github' | 'prompts'> & {
-    products: readonly ReleaseNotesProduct[]
-  }
+/**
+ * Release notes configuration after file discovery, CLI overrides, and provider construction.
+ */
+export type ResolvedReleaseNotesConfig = {
+  /** The provider to call, already constructed. */
+  provider: ReleaseNotesProvider
+  /**
+   * Set when the provider came from a built-in name, so callers can check for its API key
+   * before running. `null` for custom providers.
+   */
+  builtInProviderName: BuiltInProviderName | null
+  /** Model id handed to the provider. Falls back to the provider's own default model. */
+  model?: string
+  /** Environment variable that holds the built-in provider API key. */
+  apiKeyEnv?: string
+  /** Release note targets. */
+  products: readonly ReleaseNotesProduct[]
+  /** GitHub settings for PR context and changelog links. */
+  github: GithubOptions
+  /** Prompt customisation hooks. */
+  prompts: PromptOptions
+}

--- a/packages/release-notes/src/core/generate-release-note.test.ts
+++ b/packages/release-notes/src/core/generate-release-note.test.ts
@@ -21,6 +21,52 @@ describe('generate-release-note', () => {
     expect(prompt).toContain('Pull request context')
   })
 
+  it('omits the pull request input line when there is no pull request context', () => {
+    const prompt = buildSystemPrompt({ product, includePullRequestContext: false })
+
+    expect(prompt).not.toContain('Pull request context')
+    expect(prompt).toContain('Dependency CHANGELOG')
+  })
+
+  it('describes pull request context in the system prompt only when pull requests are supplied', async () => {
+    const systemPrompts: string[] = []
+    const provider = {
+      name: 'test',
+      generateJson: ({ systemPrompt }: { systemPrompt: string }) => {
+        systemPrompts.push(systemPrompt)
+        return Promise.resolve({ version: '1.2.3', title: 'Imports are easier' })
+      },
+    }
+    const options = {
+      packageName: '@example/client',
+      version: '1.2.3',
+      date: '2026-06-19',
+      changelogSection: '- Added an import flow',
+      releaseUrl: 'https://github.com/example/repo/blob/main/CHANGELOG.md#123',
+      product,
+      provider,
+    }
+
+    await generateReleaseNote(options)
+    await generateReleaseNote({
+      ...options,
+      pullRequests: new Map([[1, { number: 1, title: 'First', body: 'First body' }]]),
+    })
+
+    expect(systemPrompts[0]).not.toContain('Pull request context')
+    expect(systemPrompts[1]).toContain('Pull request context')
+  })
+
+  it('tells a custom system prompt whether pull request context is present', () => {
+    const systemPrompt = vi.fn(() => 'custom prompt')
+
+    buildSystemPrompt({ product, prompts: { systemPrompt }, includePullRequestContext: false })
+    buildSystemPrompt({ product, prompts: { systemPrompt } })
+
+    expect(systemPrompt).toHaveBeenNthCalledWith(1, { product, includePullRequestContext: false })
+    expect(systemPrompt).toHaveBeenNthCalledWith(2, { product, includePullRequestContext: true })
+  })
+
   it('renders dependency changelog context', () => {
     const block = buildDependencyChangelogContext([
       {

--- a/packages/release-notes/src/core/generate-release-note.ts
+++ b/packages/release-notes/src/core/generate-release-note.ts
@@ -38,7 +38,23 @@ export type GenerateReleaseNoteOptions = {
   signal?: AbortSignal
 }
 
-export const buildDefaultSystemPrompt = (product: ProductPromptContext): string => {
+export const buildDefaultSystemPrompt = (
+  product: ProductPromptContext,
+  options: { includePullRequestContext?: boolean } = {},
+): string => {
+  const inputs = [
+    'Inputs:',
+    '- The CHANGELOG section is the source of truth for what changed in the released package.',
+    '- "Dependency CHANGELOG" blocks may follow with sections from dependencies that ship inside this release. Treat their entries as user-facing changes that landed in the parent release.',
+  ]
+
+  // Only advertise the pull request block when the prompt actually carries one.
+  if (options.includePullRequestContext !== false) {
+    inputs.push(
+      '- A "Pull request context" block may follow with each PR\'s title and description. Use it to understand the why behind each entry, but do not invent details that are not supported by these inputs.',
+    )
+  }
+
   return [
     `You write release notes for ${product.displayName} - ${product.description}.`,
     'You are summarising a Changesets-style CHANGELOG section for users reading curated release notes.',
@@ -50,10 +66,7 @@ export const buildDefaultSystemPrompt = (product: ProductPromptContext): string 
     '- Talk about user-facing changes only. Skip refactors, dependency bumps, internal CI changes, and chores.',
     '- If every entry is a chore or dependency bump, return a single short note that says polish and bug fixes shipped.',
     '',
-    'Inputs:',
-    '- The CHANGELOG section is the source of truth for what changed in the released package.',
-    '- "Dependency CHANGELOG" blocks may follow with sections from dependencies that ship inside this release. Treat their entries as user-facing changes that landed in the parent release.',
-    '- A "Pull request context" block may follow with each PR\'s title and description. Use it to understand the why behind each entry, but do not invent details that are not supported by these inputs.',
+    ...inputs,
     '',
     'Output format:',
     '- You MUST respond with a single JSON object and nothing else. No markdown fences, no commentary.',
@@ -65,8 +78,17 @@ export const buildDefaultSystemPrompt = (product: ProductPromptContext): string 
   ].join('\n')
 }
 
-export const buildSystemPrompt = (options: { product: ProductPromptContext; prompts?: PromptOptions }): string => {
-  return options.prompts?.systemPrompt?.({ product: options.product }) ?? buildDefaultSystemPrompt(options.product)
+export const buildSystemPrompt = (options: {
+  product: ProductPromptContext
+  prompts?: PromptOptions
+  includePullRequestContext?: boolean
+}): string => {
+  const includePullRequestContext = options.includePullRequestContext !== false
+
+  return (
+    options.prompts?.systemPrompt?.({ product: options.product, includePullRequestContext }) ??
+    buildDefaultSystemPrompt(options.product, { includePullRequestContext })
+  )
 }
 
 export const buildPullRequestContext = (pullRequests: ReadonlyMap<number, PullRequestSummary> | undefined): string => {
@@ -209,7 +231,8 @@ export const generateReleaseNote = async (options: GenerateReleaseNoteOptions): 
     displayName: options.packageName,
     description: options.prompts?.productDescriptionFallback ?? 'an open-source package',
   }
-  const systemPrompt = buildSystemPrompt({ product, prompts: options.prompts })
+  const includePullRequestContext = (options.pullRequests?.size ?? 0) > 0
+  const systemPrompt = buildSystemPrompt({ product, prompts: options.prompts, includePullRequestContext })
   const baseUserPrompt = buildUserPrompt(options)
 
   let userPrompt = baseUserPrompt

--- a/packages/release-notes/src/core/run-release-notes-generator.test.ts
+++ b/packages/release-notes/src/core/run-release-notes-generator.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
-import { buildChangelogUrl } from './run-release-notes-generator'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ReleaseNotesProduct } from '../config/types'
+import { buildChangelogUrl, runReleaseNotesGeneratorForProduct } from './run-release-notes-generator'
 
 describe('run-release-notes-generator', () => {
   it('builds changelog links from configured GitHub options', () => {
@@ -12,5 +17,83 @@ describe('run-release-notes-generator', () => {
     })
 
     expect(url).toBe('https://github.com/example/repo/blob/release/packages/client/CHANGELOG.md#123beta1')
+  })
+
+  describe('pull request context', () => {
+    const temporaryDirectories: string[] = []
+
+    afterEach(async () => {
+      vi.restoreAllMocks()
+
+      await Promise.all(temporaryDirectories.map((directory) => rm(directory, { recursive: true, force: true })))
+      temporaryDirectories.length = 0
+    })
+
+    /** A package whose changelog references a pull request, so PR fetching has something to find. */
+    const createProduct = async (): Promise<ReleaseNotesProduct> => {
+      const directory = await mkdtemp(join(tmpdir(), 'scalar-release-notes-generator-'))
+      temporaryDirectories.push(directory)
+
+      const changelogPath = join(directory, 'CHANGELOG.md')
+      await writeFile(join(directory, 'package.json'), JSON.stringify({ name: '@example/client', version: '1.0.0' }))
+      await writeFile(
+        changelogPath,
+        ['# @example/client', '', '## 1.0.0', '', '- Added an import flow (#123)'].join('\n'),
+      )
+
+      return {
+        slug: 'client',
+        packageName: '@example/client',
+        displayName: 'Example Client',
+        description: 'an API client for Example',
+        changelogPath,
+        outputPath: join(directory, 'RELEASE_NOTES.json'),
+      }
+    }
+
+    const provider = {
+      name: 'test',
+      generateJson: async () => ({ version: '1.0.0', title: 'Imports are easier' }),
+    }
+
+    it('skips the GitHub API entirely when pull request context is disabled', async () => {
+      const product = await createProduct()
+      const fetchImpl = vi.fn<typeof fetch>()
+      vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+      const result = await runReleaseNotesGeneratorForProduct({
+        product,
+        provider,
+        github: { repo: 'example/repo', pullRequestContext: false },
+        writeMarkdown: false,
+        fetchImpl,
+      })
+
+      expect(fetchImpl).not.toHaveBeenCalled()
+      expect(result.generated).toBe(true)
+
+      const written = JSON.parse(await readFile(result.outputPath, 'utf-8')) as Array<{ version: string }>
+      expect(written).toEqual([expect.objectContaining({ version: '1.0.0' })])
+    })
+
+    it('fetches referenced pull requests by default', async () => {
+      const product = await createProduct()
+      const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+        new Response(JSON.stringify({ number: 123, title: 'Add an import flow', body: 'Why it matters.' }), {
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+      await runReleaseNotesGeneratorForProduct({
+        product,
+        provider,
+        github: { repo: 'example/repo' },
+        writeMarkdown: false,
+        fetchImpl,
+      })
+
+      expect(fetchImpl).toHaveBeenCalledWith('https://api.github.com/repos/example/repo/pulls/123', expect.anything())
+    })
   })
 })

--- a/packages/release-notes/src/core/run-release-notes-generator.ts
+++ b/packages/release-notes/src/core/run-release-notes-generator.ts
@@ -156,10 +156,13 @@ export const runReleaseNotesGeneratorForProduct = async (
   })
   const changelogSection = section ?? ''
   const dependencyChangelogText = dependencyChangelogs.map((entry) => entry.changelogSection).join('\n')
-  const pullRequestNumbers = extractPullRequestNumbers(
-    [changelogSection, dependencyChangelogText].filter(Boolean).join('\n'),
-    options.github?.repo,
-  )
+  const includePullRequestContext = options.github?.pullRequestContext !== false
+  const pullRequestNumbers = includePullRequestContext
+    ? extractPullRequestNumbers(
+        [changelogSection, dependencyChangelogText].filter(Boolean).join('\n'),
+        options.github?.repo,
+      )
+    : []
   const pullRequests =
     pullRequestNumbers.length && options.github?.repo
       ? await fetchPullRequests({

--- a/packages/release-notes/src/index.ts
+++ b/packages/release-notes/src/index.ts
@@ -1,12 +1,14 @@
 export { createReleaseNotesGeneratorCommand, releaseNotesGenerator } from './commands/generate'
 export { createSyncReleaseNotesMarkdownCommand, syncReleaseNotesMarkdown } from './commands/sync-markdown'
 export { defineReleaseNotesConfig } from './config/define-config'
-export { createBuiltInProvider, readReleaseNotesConfig } from './config/read-config'
+export { createBuiltInProvider, hasBuiltInProviderApiKey, readReleaseNotesConfig } from './config/read-config'
 export type {
   BuiltInProviderName,
   GithubOptions,
   ProductPromptContext,
+  PromptContext,
   PromptOptions,
+  ProviderOption,
   ReleaseNotesConfig,
   ReleaseNotesProduct,
   ReleaseNotesProvider,

--- a/release-notes.config.ts
+++ b/release-notes.config.ts
@@ -1,6 +1,7 @@
 import { defineReleaseNotesConfig } from './packages/release-notes/dist/index.js'
 
 export default defineReleaseNotesConfig({
+  provider: 'anthropic',
   products: [
     {
       slug: 'api-client',


### PR DESCRIPTION
## What

Two gaps in `@scalar/release-notes`:

**1. A config file could not select a built-in provider.** `ReleaseNotesConfig.provider` only accepted a fully constructed provider object, so `release-notes.config.json` — a supported discovery target — could never pick one, because a provider carries a `generateJson` **function** and JSON cannot hold one. Worse, a JSON config with a `provider` key broke silently: `usesBuiltInProvider` evaluated to `false`, the missing-API-key guard was skipped, and the run died later with `provider.generateJson is not a function`.

**2. There was no way to turn off pull request context.** Every run scraped `#123` refs out of the changelog, fetched each PR from the GitHub REST API, and injected up to 4000 characters of PR body into the prompt. The only escape was unsetting `github.repo`, which also breaks changelog links.

## Changes

- `provider` accepts `'anthropic' | 'openai'` or a custom provider object; `model` and `apiKeyEnv` become config fields.
- Provider resolution is consolidated in `read-config.ts`, removing a duplicated block in `generate.ts` and with it the missing-guard bug. An unusable `provider` value now throws a clear error.
- `github.pullRequestContext: false` / `--no-pull-request-context` skips PR fetching entirely — no GitHub API calls, CHANGELOG-only prompt.
- The default system prompt no longer advertises a "Pull request context" block when none was fetched (a pre-existing wart, since the block was already absent whenever zero PRs came back).

### Settings follow their own provider

`model` and `apiKeyEnv` apply only to the provider selected in the same layer of configuration. Selecting a different provider — with `--provider`, or in a config file overriding a base config — drops the model id and API key environment variable that came with the provider it replaced. A config that names no provider counts as selecting the default one.

Without this, `--provider openai` against an Anthropic config would have sent the Anthropic API key to `api.openai.com` as a Bearer token. There is a test that stubs `fetch` and asserts the outbound `Authorization` header.

## Compatibility

Backward compatible at runtime: a config passing a provider object is unchanged. `ResolvedReleaseNotesConfig` changed shape and `PromptContext` gained a field — both type-level, both called out in the changeset, and nothing outside this package imports them. `minor` bump on a `0.1.x` package.

`sync-release-notes-markdown` also reads the config, so it now validates `provider` too even though it does no AI work. That is stricter validation for an AI-free command, and it surfaces a broken config earlier.

## Testing

53 tests pass (`pnpm vitest packages/release-notes --run`), up from 24. New coverage includes a new `read-config.test.ts` (the file had none). Every new guard was mutation-verified: reverting it makes its specific test fail.

Verified end to end against the real repo config and a real changelog, with a `fetch` spy recording outbound hosts:

- `ANTHROPIC_API_KEY= …/cli.js --all --dry-run` — the config-level provider name is accepted and the run skips cleanly with no key.
- Default run → `api.github.com` + `api.anthropic.com`.
- `--no-pull-request-context` → `api.anthropic.com` only, no GitHub calls.

`types:check`, `biome`, `prettier`, and `knip` are clean.

## Ticket

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
