### PR TITLE
fix(api-reference): copy the displayed response example

### DIFF
--- a/.changeset/response-examples.md
+++ b/.changeset/response-examples.md
@@ -1,0 +1,6 @@
+---
+'@scalar/api-reference': patch
+'@scalar/workspace-store': patch
+---
+
+Copy the example shown in the response card, including named, generated, referenced, and falsy values.

--- a/packages/api-reference/src/features/example-responses/ExampleResponse.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponse.vue
@@ -1,52 +1,28 @@
 <script lang="ts" setup>
-import { getResolvedRefDeep } from '@scalar/blocks/code-example'
 import { ScalarCodeBlock } from '@scalar/components/code-block'
 import { ScalarVirtualCodeBlock } from '@scalar/components/virtual-code-block'
-import { prettyPrintJson } from '@scalar/helpers/json/pretty-print-json'
-import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 import type {
   ExampleObject,
   MediaTypeObject,
-  SchemaObject,
 } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
 import { computed } from 'vue'
 
 import { useLocalization } from '@/features/localization'
 
-const { example, response } = defineProps<{
+import { getExampleContent } from './helpers/get-example-content'
+
+const { example, response, content } = defineProps<{
   response: MediaTypeObject | undefined
   example: ExampleObject | undefined
+  /** Reuse the card's formatted value so generation and copying cannot diverge. */
+  content?: string
 }>()
 const { translate } = useLocalization()
 
-/** Get content from the appropriate source */
-const getContent = () => {
-  if (example !== undefined) {
-    return getResolvedRefDeep(example)?.value ?? ''
-  }
-
-  if (response?.schema) {
-    return getExampleFromSchema(
-      // Should be safe to deep resolve the schema here because we don't have to do any sibling resolution for example generation
-      getResolvedRefDeep(response.schema) as SchemaObject,
-      {
-        emptyString: 'string',
-        mode: 'read',
-      },
-    )
-  }
-
-  return undefined
-}
-
-/** Pre-pretty printed content string, avoids multiple pretty prints*/
-const prettyPrintedContent = computed(() => {
-  const content = getContent()
-  if (content === undefined) {
-    return undefined
-  }
-  return prettyPrintJson(content)
-})
+/** Preformatted content is shared with the response card clipboard action. */
+const prettyPrintedContent = computed(
+  () => content ?? getExampleContent(response, example),
+)
 
 const VIRTUALIZATION_THRESHOLD = 20_000
 

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.test.ts
@@ -351,7 +351,97 @@ describe('ExampleResponses', () => {
 
     await copyButton.trigger('click')
 
-    expect(mockCopyToClipboard).toHaveBeenCalledWith({ foo: 'bar' })
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('{\n  "foo": "bar"\n}')
+  })
+
+  it('copies the selected named example and follows response changes', async () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                examples: { first: { value: { id: 1 } }, second: { value: { id: 2 } } },
+              },
+            },
+          },
+          '404': {
+            description: 'Missing',
+            content: { 'application/json': { example: 'Not found' } },
+          },
+        },
+      },
+    })
+
+    await wrapper.getComponent({ name: 'ExamplePicker' }).vm.$emit('update:modelValue', 'second')
+    await wrapper.get('button[aria-label="Copy example value"]').trigger('click')
+    expect(mockCopyToClipboard).toHaveBeenLastCalledWith('{\n  "id": 2\n}')
+    expect(wrapper.getComponent({ name: 'ScalarCodeBlock' }).props('prettyPrintedContent')).toBe('{\n  "id": 2\n}')
+
+    await wrapper.getComponent({ name: 'ExampleResponseTabList' }).vm.$emit('change', 1)
+    await wrapper.get('button[aria-label="Copy example value"]').trigger('click')
+    expect(mockCopyToClipboard).toHaveBeenLastCalledWith('Not found')
+    expect(wrapper.getComponent({ name: 'ScalarCodeBlock' }).props('prettyPrintedContent')).toBe('Not found')
+  })
+
+  it.each([
+    { value: 0, content: '0' },
+    { value: false, content: 'false' },
+    { value: '', content: '' },
+  ])('copies the falsy example $value', async ({ value, content }) => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': { description: 'OK', content: { 'application/json': { example: value } } },
+        },
+      },
+    })
+
+    await wrapper.get('button[aria-label="Copy example value"]').trigger('click')
+    expect(mockCopyToClipboard).toHaveBeenLastCalledWith(content)
+    expect(wrapper.getComponent({ name: 'ScalarCodeBlock' }).props('prettyPrintedContent')).toBe(content)
+  })
+
+  it('copies a resolved example reference', async () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': {
+                examples: {
+                  linked: { $ref: '#/components/examples/Linked', '$ref-value': { value: { linked: true } } },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    await wrapper.get('button[aria-label="Copy example value"]').trigger('click')
+    expect(mockCopyToClipboard).toHaveBeenLastCalledWith('{\n  "linked": true\n}')
+  })
+
+  it('copies the displayed generated example', async () => {
+    const wrapper = mount(ExampleResponses, {
+      props: {
+        responses: {
+          '200': {
+            description: 'OK',
+            content: {
+              'application/json': { schema: coerceValue(SchemaObjectSchema, { type: 'string', example: 'Generated' }) },
+            },
+          },
+        },
+      },
+    })
+
+    await wrapper.get('button[aria-label="Copy example value"]').trigger('click')
+    expect(mockCopyToClipboard).toHaveBeenLastCalledWith('Generated')
+    expect(wrapper.getComponent({ name: 'ScalarCodeBlock' }).props('prettyPrintedContent')).toBe('Generated')
   })
 
   it('toggles between schema and example view', async () => {

--- a/packages/api-reference/src/features/example-responses/ExampleResponses.vue
+++ b/packages/api-reference/src/features/example-responses/ExampleResponses.vue
@@ -25,12 +25,9 @@ import { useLocalization } from '@/features/localization'
 import ExampleResponse from './ExampleResponse.vue'
 import ExampleResponseTab from './ExampleResponseTab.vue'
 import ExampleResponseTabList from './ExampleResponseTabList.vue'
+import { getExampleContent } from './helpers/get-example-content'
 import { hasResponseContent } from './helpers/has-response-content'
 import { normalizeMimeTypeObject } from './helpers/normalize-mime-type-object'
-
-/**
- * TODO: copyToClipboard isn't using the right content if there are multiple examples
- */
 
 const { responses, selectedExample, eventBus, selectedContentTypes } =
   defineProps<{
@@ -173,6 +170,16 @@ const changeTab = (index: number) => {
   selectedExampleKey.value = resolveExampleKey(selectedExample)
 }
 
+const exampleContent = computed(() =>
+  getExampleContent(currentResponseContent.value, currentExample.value),
+)
+
+const copyExample = (): void => {
+  if (exampleContent.value !== undefined) {
+    copyToClipboard(exampleContent.value)
+  }
+}
+
 const showSchema = ref(false)
 </script>
 <template>
@@ -192,10 +199,11 @@ const showSchema = ref(false)
 
       <template #actions>
         <button
-          v-if="currentResponseContent?.example"
+          v-if="exampleContent !== undefined"
+          :aria-label="translate('common.copyExample')"
           class="code-copy"
           type="button"
-          @click="() => copyToClipboard(currentResponseContent?.example)">
+          @click="copyExample">
           <ScalarIcon
             icon="Clipboard"
             width="12px" />
@@ -224,6 +232,7 @@ const showSchema = ref(false)
       <ExampleResponse
         v-else
         :id="id"
+        :content="exampleContent"
         :example="currentExample"
         :response="currentResponseContent" />
     </ScalarCardSection>

--- a/packages/api-reference/src/features/example-responses/helpers/get-example-content.ts
+++ b/packages/api-reference/src/features/example-responses/helpers/get-example-content.ts
@@ -1,0 +1,32 @@
+import { getResolvedRefDeep } from '@scalar/blocks/code-example'
+import { prettyPrintJson } from '@scalar/helpers/json/pretty-print-json'
+import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
+import type {
+  ExampleObject,
+  MediaTypeObject,
+  SchemaObject,
+} from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
+
+/** Keep the displayed response and its clipboard action on the same resolved, formatted value. */
+export const getExampleContent = (
+  response: MediaTypeObject | undefined,
+  example: ExampleObject | undefined,
+): string | undefined => {
+  if (example !== undefined) {
+    return prettyPrintJson(getResolvedRefDeep(example)?.value ?? '')
+  }
+
+  if (response?.schema) {
+    const content = getExampleFromSchema(getResolvedRefDeep(response.schema) as SchemaObject, {
+      emptyString: 'string',
+      mode: 'read',
+    })
+    if (content === undefined) {
+      return undefined
+    }
+    // Schema generation returns unknown, but produces JSON values supported by the formatter.
+    return prettyPrintJson(content as Parameters<typeof prettyPrintJson>[0])
+  }
+
+  return undefined
+}

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example.test.ts
@@ -8,6 +8,15 @@ import { describe, expect, it } from 'vitest'
 import { getExample } from './get-example'
 
 describe('content-based parameters', () => {
+  it.each([0, false, ''])('keeps an explicit falsy example %s ahead of a schema default', (value) => {
+    expect(
+      getExample({ example: value, schema: { type: 'string', default: 'fallback' } }, undefined, undefined),
+    ).toStrictEqual({ value })
+    expect(
+      getExample({ content: { 'application/json': { example: value } } }, undefined, 'application/json'),
+    ).toStrictEqual({ value })
+  })
+
   it('returns example value when content param has application/json with object value', () => {
     const param = {
       content: {

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example.ts
@@ -13,7 +13,7 @@ const getExampleFromExamples = (
   exampleField: MediaTypeObject['example'],
   exampleName: string | undefined,
 ): ExampleObject | undefined => {
-  if (!examples && !exampleField) {
+  if (!examples && exampleField === undefined) {
     return undefined
   }
 


### PR DESCRIPTION
Copy the example shown in the response card, including named, generated, referenced, and falsy values.

Tested with response and workspace-store tests, type checks, and a browser clipboard check.

## Visual

![Selected response example](https://github.com/scalar/scalar/blob/19695a9008ee19af65f56238f814adcdec47a3ab/todo-audit-artifacts/response_example_context.png?raw=true)
