### PR TITLE
chore(draggable): improve the playground layout

### DIFF
--- a/.changeset/draggable-playground.md
+++ b/.changeset/draggable-playground.md
@@ -1,0 +1,5 @@
+---
+'@scalar/draggable': patch
+---
+
+Add Scalar styling, drag instructions, and a responsive layout to the playground.

--- a/packages/draggable/package.json
+++ b/packages/draggable/package.json
@@ -51,6 +51,8 @@
     "vue": "catalog:*"
   },
   "devDependencies": {
+    "@scalar/themes": "workspace:*",
+    "@tailwindcss/vite": "catalog:*",
     "@vitejs/plugin-vue": "catalog:*",
     "vite": "catalog:*",
     "vue": "catalog:*"

--- a/packages/draggable/playground/App.vue
+++ b/packages/draggable/playground/App.vue
@@ -75,23 +75,80 @@ const onDragEnd = (draggingItem: DraggingItem, hoveredItem: HoveredItem) => {
 </script>
 
 <template>
-  <div>This is an example of Draggable</div>
-  <ul
-    @dragenter.prevent
-    @dragover.prevent>
-    <SidebarItem
-      v-for="id in sidebar.children"
-      :id="id"
-      :key="id"
-      :items="sidebar.items"
-      :parentIds="[]"
-      @onDragEnd="onDragEnd" />
-  </ul>
-  <div>#TODO make this pretty :)</div>
+  <main class="scalar-app light-mode bg-b-1 text-c-1 min-h-screen font-sans">
+    <div class="mx-auto max-w-5xl px-6 py-12 sm:px-10">
+      <header class="mb-10 border-b pb-8">
+        <p class="text-c-2 mb-3 text-sm font-medium">Scalar / Draggable</p>
+        <h1 class="mb-3 text-xl font-bold tracking-tight">
+          Make room for your teams.
+        </h1>
+        <p class="text-c-2 max-w-xl text-base leading-relaxed">
+          Try reordering a nested list. Move teams between groups or give them a
+          new place of their own.
+        </p>
+      </header>
+      <div class="grid items-start gap-10 sm:grid-cols-2">
+        <section
+          aria-labelledby="teams-heading"
+          class="overflow-hidden rounded-lg border">
+          <div
+            class="bg-b-2 flex items-center justify-between border-b px-4 py-3">
+            <h2
+              id="teams-heading"
+              class="text-base font-medium">
+              Your teams
+            </h2>
+            <span class="text-c-2 text-sm">
+              {{ sidebar.children.length }} at the top level
+            </span>
+          </div>
+          <div
+            aria-label="Draggable teams"
+            class="p-2"
+            @dragenter.prevent
+            @dragover.prevent>
+            <SidebarItem
+              v-for="id in sidebar.children"
+              :id="id"
+              :key="id"
+              :items="sidebar.items"
+              :parentIds="[]"
+              @onDragEnd="onDragEnd" />
+          </div>
+        </section>
+        <aside
+          aria-labelledby="instructions-heading"
+          class="py-2">
+          <h2
+            id="instructions-heading"
+            class="mb-5 text-lg font-medium">
+            Three ways to move
+          </h2>
+          <ol class="text-c-2 space-y-6 text-base leading-relaxed">
+            <li>
+              <h3 class="text-c-1 mb-1 font-medium">01 — Pick up a team</h3>
+              Drag any team row to start moving it. A group brings its nested
+              teams along.
+            </li>
+            <li>
+              <h3 class="text-c-1 mb-1 font-medium">
+                02 — Choose its position
+              </h3>
+              Hover near the top or bottom edge of another row to place it
+              before or after that team.
+            </li>
+            <li>
+              <h3 class="text-c-1 mb-1 font-medium">03 — Create a group</h3>
+              Hover over the center of a row to nest your team inside it.
+              Release to drop.
+            </li>
+          </ol>
+          <p class="text-c-3 mt-8 border-t pt-4 text-sm">
+            This playground uses mouse or trackpad dragging. Refresh to start
+            over.
+          </p>
+        </aside>
+      </div>
+    </div>
+  </main>
 </template>
-
-<style>
-:root {
-  --scalar-color-blue: #0000ff;
-}
-</style>

--- a/packages/draggable/playground/components/SidebarItem.vue
+++ b/packages/draggable/playground/components/SidebarItem.vue
@@ -22,8 +22,8 @@ defineEmits<{
     @onDragEnd="(...args) => $emit('onDragEnd', ...args)">
     <div>
       <div
-        class="sidebar-item"
-        :style="{ 'padding-left': parentIds.length * 8 + 'px' }">
+        class="sidebar-item text-c-1 hover:bg-b-2 rounded px-3 py-2 text-base"
+        :style="{ 'padding-left': 12 + parentIds.length * 20 + 'px' }">
         {{ items[id]?.name }}
       </div>
       <SidebarItem
@@ -39,7 +39,6 @@ defineEmits<{
 
 <style scoped>
 .sidebar-item {
-  padding: 8px;
   cursor: move;
 }
 </style>

--- a/packages/draggable/playground/main.ts
+++ b/packages/draggable/playground/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 
 import App from './App.vue'
+import './style.css'
 
 createApp(App).mount('#playground')

--- a/packages/draggable/playground/style.css
+++ b/packages/draggable/playground/style.css
@@ -1,0 +1,10 @@
+@import '@scalar/themes/style.css';
+@import '@scalar/themes/tailwind.css';
+
+.scalar-app {
+  @import 'tailwindcss/utilities.css';
+}
+
+body {
+  margin: 0;
+}

--- a/packages/draggable/playground/style.css
+++ b/packages/draggable/playground/style.css
@@ -1,8 +1,8 @@
-@import '@scalar/themes/style.css';
-@import '@scalar/themes/tailwind.css';
+@import "@scalar/themes/style.css";
+@import "@scalar/themes/tailwind.css";
 
 .scalar-app {
-  @import 'tailwindcss/utilities.css';
+  @import "tailwindcss/utilities.css";
 }
 
 body {

--- a/packages/draggable/vite.config.ts
+++ b/packages/draggable/vite.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 
+import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 
@@ -10,7 +11,7 @@ const entryPaths = await findEntryPoints()
 const entry = createLibEntry(entryPaths, import.meta.dirname)
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), tailwindcss()],
   resolve: {
     alias: { '@': resolve(import.meta.dirname, './src') },
     dedupe: ['vue'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1959,6 +1959,12 @@ importers:
         specifier: catalog:*
         version: 3.5.40(typescript@5.9.3)
     devDependencies:
+      '@scalar/themes':
+        specifier: workspace:*
+        version: link:../themes
+      '@tailwindcss/vite':
+        specifier: catalog:*
+        version: 4.3.3(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))
       '@vitejs/plugin-vue':
         specifier: catalog:*
         version: 6.0.8(vite@8.1.5(@types/node@24.10.13)(esbuild@0.27.3)(jiti@2.7.0)(terser@5.31.2)(tsx@4.21.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))


### PR DESCRIPTION
Add Scalar styling, drag instructions, and a responsive layout to the playground.

Build, tests, and type checks pass. Checked reordering, nesting, group moves, and mobile layout in the browser.

## Visual

![Before](https://github.com/scalar/scalar/blob/19695a9008ee19af65f56238f814adcdec47a3ab/todo-audit-artifacts/draggable_before.png?raw=true)

![After](https://github.com/scalar/scalar/blob/19695a9008ee19af65f56238f814adcdec47a3ab/todo-audit-artifacts/draggable_after.png?raw=true)

![Mobile](https://github.com/scalar/scalar/blob/19695a9008ee19af65f56238f814adcdec47a3ab/todo-audit-artifacts/draggable_mobile.png?raw=true)

![Nested groups](https://github.com/scalar/scalar/blob/19695a9008ee19af65f56238f814adcdec47a3ab/todo-audit-artifacts/draggable_nested.png?raw=true)
