### PR TITLE
fix(nextjs-openapi): extract responses from variable handlers

### DIFF
--- a/.changeset/openapi-handler-todos.md
+++ b/.changeset/openapi-handler-todos.md
@@ -1,0 +1,6 @@
+---
+'@scalar/nextjs-openapi': patch
+'@scalar/ts-to-openapi': patch
+---
+
+Extract parameters and JSON responses from variable handlers, including concise arrows and multiple declarations. Safely read declaration names and JSDoc.

--- a/packages/nextjs-openapi/src/path.test.ts
+++ b/packages/nextjs-openapi/src/path.test.ts
@@ -1,0 +1,129 @@
+import { ScriptTarget, createProgram, createSourceFile } from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+import { getPathSchema } from './path'
+
+describe('path', () => {
+  const program = createProgram([], {})
+
+  it('recognizes a variable with an HTTP method identifier', () => {
+    const source = createSourceFile('route.ts', 'export const GET = () => {}', ScriptTarget.Latest, true)
+
+    expect(getPathSchema(source, program)).toStrictEqual({
+      get: {
+        summary: 'use to set the summary',
+        description: 'use jsdoc tag to set the description',
+        parameters: [],
+        responses: {},
+      },
+    })
+  })
+
+  it.each(['export const { GET } = handlers', 'export const [GET] = handlers', 'export const config = {}'])(
+    'ignores unsupported variable names: %s',
+    (code) => {
+      const source = createSourceFile('route.ts', code, ScriptTarget.Latest, true)
+
+      expect(getPathSchema(source, program)).toStrictEqual({})
+    },
+  )
+
+  it.each([
+    'async (_request: Request, { params }: { params: { id: string } }) => { return Response.json("created", { status: 201 }) }',
+    '(_request: Request, { params }: { params: { id: string } }) => Response.json("created", { status: 201 })',
+    'async function (_request: Request, { params }: { params: { id: string } }) { return Response.json("created", { status: 201 }) }',
+    'function handler(_request: Request, { params }: { params: { id: string } }) { return NextResponse.json("created", { status: 201 }) }',
+  ])('extracts parameters and responses from a variable handler: %s', (handler) => {
+    const source = createSourceFile(
+      'route.ts',
+      `/**
+       * Create a resource
+       * @description Creates the requested resource.
+       */
+      export const POST = ${handler}`,
+      ScriptTarget.Latest,
+      true,
+    )
+
+    expect(getPathSchema(source, program)).toStrictEqual({
+      post: {
+        summary: 'Create a resource',
+        description: 'Creates the requested resource.',
+        parameters: [{ name: 'id', schema: { type: 'string' }, in: 'path' }],
+        responses: {
+          '201': {
+            description: 'TODO: grab this from jsdoc and add a default',
+            content: { 'application/json': { schema: { type: 'string', example: 'created' } } },
+          },
+        },
+      },
+    })
+  })
+
+  it('extracts each method independently when a statement declares multiple variables', () => {
+    const source = createSourceFile(
+      'route.ts',
+      `export const config = {}, GET = () => Response.json("read"),
+        POST = function () { return Response.json("written", { status: 201 }) }`,
+      ScriptTarget.Latest,
+      true,
+    )
+
+    expect(getPathSchema(source, program)).toStrictEqual({
+      get: {
+        summary: 'use to set the summary',
+        description: 'use jsdoc tag to set the description',
+        parameters: [],
+        responses: {
+          '200': {
+            description: 'TODO: grab this from jsdoc and add a default',
+            content: { 'application/json': { schema: { type: 'string', example: 'read' } } },
+          },
+        },
+      },
+      post: {
+        summary: 'use to set the summary',
+        description: 'use jsdoc tag to set the description',
+        parameters: [],
+        responses: {
+          '201': {
+            description: 'TODO: grab this from jsdoc and add a default',
+            content: { 'application/json': { schema: { type: 'string', example: 'written' } } },
+          },
+        },
+      },
+    })
+  })
+
+  it('keeps function declarations equivalent to variable handlers', () => {
+    const source = createSourceFile(
+      'route.ts',
+      'export function GET() { return Response.json("read") }',
+      ScriptTarget.Latest,
+      true,
+    )
+    const variableSource = createSourceFile(
+      'route.ts',
+      'export const GET = () => Response.json("read")',
+      ScriptTarget.Latest,
+      true,
+    )
+
+    expect(getPathSchema(source, program)).toStrictEqual(getPathSchema(variableSource, program))
+  })
+
+  it.each(['export const GET = handlers.get', 'export const GET = createHandler()', 'export let GET'])(
+    'preserves metadata for handlers whose implementation is not inline: %s',
+    (code) => {
+      const source = createSourceFile('route.ts', code, ScriptTarget.Latest, true)
+
+      expect(getPathSchema(source, program)).toStrictEqual({
+        get: {
+          summary: 'use to set the summary',
+          description: 'use jsdoc tag to set the description',
+          responses: {},
+        },
+      })
+    },
+  )
+})

--- a/packages/nextjs-openapi/src/path.ts
+++ b/packages/nextjs-openapi/src/path.ts
@@ -7,7 +7,9 @@ import {
   type ParameterDeclaration,
   type Program,
   type SourceFile,
+  isArrowFunction,
   isFunctionDeclaration,
+  isFunctionExpression,
   isIdentifier,
   isParameter,
   isPropertySignature,
@@ -90,17 +92,24 @@ export const getPathSchema = (sourceFile: SourceFile, program: Program): OpenAPI
       }
     }
 
-    // TODO: variables
+    // A statement can declare several route handlers alongside other variables.
     else if (isVariableStatement(statement)) {
-      // TODO: Remove this typecast. It looks totally incompatible
-      const method = checkForMethod(statement.declarationList.declarations[0]?.name as Identifier)
-      if (method) {
+      for (const declaration of statement.declarationList.declarations) {
+        const method = isIdentifier(declaration.name) ? checkForMethod(declaration.name) : null
+        if (!method) {
+          continue
+        }
+
         const { title, description } = getJSDocFromNode(statement)
-        const responses = generateResponses(statement, typeChecker)
+        const initializer = declaration.initializer
+        const handler =
+          initializer && (isArrowFunction(initializer) || isFunctionExpression(initializer)) ? initializer : undefined
+
         path[method] = {
           summary: title,
           description,
-          responses,
+          ...(handler ? { parameters: extractPathParams(handler.parameters[1], program) } : {}),
+          responses: generateResponses(handler, typeChecker),
         } as OpenAPIV3_1.OperationObject
       }
     }

--- a/packages/ts-to-openapi/src/js-doc.test.ts
+++ b/packages/ts-to-openapi/src/js-doc.test.ts
@@ -1,0 +1,57 @@
+import { ScriptTarget, createSourceFile } from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+import { getJSDocFromNode } from './js-doc'
+
+describe('js-doc', () => {
+  it.each(['', '/** */', '// An ordinary comment'])('handles absent or empty documentation: %s', (comment) => {
+    const source = createSourceFile('route.ts', `${comment}\nexport function GET() {}`, ScriptTarget.Latest, true)
+
+    expect(getJSDocFromNode(source.statements[0]!)).toStrictEqual({
+      title: 'use to set the summary',
+      description: 'use jsdoc tag to set the description',
+    })
+  })
+
+  it('extracts a summary and multiline description', () => {
+    const source = createSourceFile(
+      'route.ts',
+      '/** List users\n * Returns active users.\n * Includes their names.\n */\nexport function GET() {}',
+      ScriptTarget.Latest,
+      true,
+    )
+
+    expect(getJSDocFromNode(source.statements[0]!)).toStrictEqual({
+      title: 'List users',
+      description: 'Returns active users.\nIncludes their names.',
+    })
+  })
+
+  it('lets explicit tags override the prose', () => {
+    const source = createSourceFile(
+      'route.ts',
+      '/** Original title\n * Original description\n * @summary List users\n * @description Returns users.\n */\nexport function GET() {}',
+      ScriptTarget.Latest,
+      true,
+    )
+
+    expect(getJSDocFromNode(source.statements[0]!)).toStrictEqual({
+      title: 'List users',
+      description: 'Returns users.',
+    })
+  })
+
+  it('preserves the first documentation block when several are attached', () => {
+    const source = createSourceFile(
+      'route.ts',
+      '/** First title\n * First description\n */\n/** Second title */\nexport function GET() {}',
+      ScriptTarget.Latest,
+      true,
+    )
+
+    expect(getJSDocFromNode(source.statements[0]!)).toStrictEqual({
+      title: 'First title',
+      description: 'First description',
+    })
+  })
+})

--- a/packages/ts-to-openapi/src/js-doc.ts
+++ b/packages/ts-to-openapi/src/js-doc.ts
@@ -1,10 +1,9 @@
-import type { JSDoc, Node } from 'typescript'
+import { type Node, isJSDoc } from 'typescript'
 
 /**
  * Extract items from jsDoc comments
  *
  * TODO:
- * - figure out how to narrow type using helpers
  * - return all tags
  */
 export const getJSDocFromNode = (node: Node): { title: string; description: string } => {
@@ -12,12 +11,9 @@ export const getJSDocFromNode = (node: Node): { title: string; description: stri
   let title = 'use to set the summary'
   let description = 'use jsdoc tag to set the description'
 
-  // Check for jsDoc - todo properly narrow type using typescript lib
-  if ('jsDoc' in node && Array.isArray(node.jsDoc)) {
-    const jsDoc: JSDoc = node.jsDoc[0]
+  const jsDoc = 'jsDoc' in node && Array.isArray(node.jsDoc) ? node.jsDoc.find(isJSDoc) : undefined
+  if (jsDoc) {
     const comment = jsDoc.comment?.toString()
-
-    // getAllJSDocTags(node, predicate, tag)
 
     // Check for multiple lines to set both summary and description
     if (comment) {

--- a/packages/ts-to-openapi/src/responses.ts
+++ b/packages/ts-to-openapi/src/responses.ts
@@ -94,21 +94,23 @@ export const generateResponses = (node: Node | undefined, typeChecker: TypeCheck
   const statements = Array.from(generator)
 
   return statements.reduce<OpenAPIV3_1.ResponsesObject>((prev, statement) => {
+    // Concise arrow handlers yield their expression directly; block handlers yield return statements.
+    const expression = isReturnStatement(statement) ? statement.expression : statement
+
     // Check for a Response.json
     if (
-      isReturnStatement(statement) &&
-      statement.expression &&
-      isCallExpression(statement.expression) &&
-      statement.expression.expression &&
-      isPropertyAccessExpression(statement.expression.expression) &&
-      statement.expression.expression.name.escapedText === 'json' &&
-      statement.expression.expression.expression &&
-      isIdentifier(statement.expression.expression.expression) &&
+      expression &&
+      isCallExpression(expression) &&
+      expression.expression &&
+      isPropertyAccessExpression(expression.expression) &&
+      expression.expression.name.escapedText === 'json' &&
+      expression.expression.expression &&
+      isIdentifier(expression.expression.expression) &&
       // we will probably pass comparator in
-      (statement.expression.expression.expression.escapedText === 'Response' ||
-        statement.expression.expression.expression.escapedText === 'NextResponse')
+      (expression.expression.expression.escapedText === 'Response' ||
+        expression.expression.expression.escapedText === 'NextResponse')
     ) {
-      const [payload, options] = statement.expression.arguments
+      const [payload, options] = expression.arguments
 
       // Grab payload and options schemas
       const schema = getSchemaFromNode(payload!, typeChecker)


### PR DESCRIPTION
Extract parameters and JSON responses from variable handlers, including concise arrows and multiple declarations. Safely read declaration names and JSDoc.
