### PR TITLE
test(repo): enable passing `.todo` tests and remove stale comments

### DIFF
--- a/.changeset/test-comment-todos.md
+++ b/.changeset/test-comment-todos.md
@@ -1,0 +1,9 @@
+---
+'@scalar/api-client': patch
+'@scalar/api-reference': patch
+'@scalar/openapi-parser': patch
+'@scalar/openapi-validator': patch
+'@scalar/void-server': patch
+---
+
+Restore modal and single-file reference tests, update layout selectors, and remove stale comments. Named-resource resolution remains unsupported and is tested explicitly.

--- a/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/DeleteRequestAuthModal.test.ts
+++ b/packages/api-client/src/v2/blocks/scalar-auth-selector-block/components/DeleteRequestAuthModal.test.ts
@@ -1,65 +1,75 @@
-import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { useModal } from '@scalar/components/modal'
+import { DOMWrapper, enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
 
-import DeleteRequestAuthModal from '@/v2/blocks/scalar-auth-selector-block/components/DeleteRequestAuthModal.vue'
+import DeleteRequestAuthModal from './DeleteRequestAuthModal.vue'
 
-describe.todo('DeleteRequestAuthModal', () => {
-  const getState = (open: boolean) => ({
-    hide: () => {
-      return
-    },
-    show: () => {
-      return
-    },
-    open,
-  })
+describe('DeleteRequestAuthModal', () => {
+  enableAutoUnmount(afterEach)
 
-  it('renders modal content with label', () => {
-    const label = 'Test Label'
+  const mountModal = (label: string) => {
+    const state = useModal()
     const wrapper = mount(DeleteRequestAuthModal, {
       attachTo: document.body,
-      props: {
-        state: getState(true),
-        label,
-      },
+      props: { state, label },
     })
+    return { state, wrapper }
+  }
 
-    expect(wrapper.text()).toContain('This cannot be undone')
-    expect(wrapper.text()).toContain(label)
+  // Headless UI teleports the dialog outside the mounted component.
+  const getDialog = (): ReturnType<DOMWrapper<Element>['get']> => new DOMWrapper(document.body).get('[role="dialog"]')
+
+  it('renders the security scheme label and warning after opening', async () => {
+    const { state } = mountModal('Test Label')
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+
+    state.show()
+    await flushPromises()
+
+    const dialog = getDialog()
+    expect(dialog.get('h2').text()).toBe('Delete Security Scheme')
+    expect(dialog.get('p').text()).toBe(
+      "This cannot be undone. You're about to delete the Test Label security scheme from the collection.",
+    )
+    expect(dialog.get('button[type="submit"]').text()).toBe('Delete Test Label')
   })
 
-  it('emits close when clicking Cancel', async () => {
-    const wrapper = mount(DeleteRequestAuthModal, {
-      attachTo: document.body,
-      props: {
-        state: getState(true),
-        label: 'Alpha',
-      },
-    })
+  it('emits close without deleting when cancelling', async () => {
+    const { state, wrapper } = mountModal('Alpha')
+    state.show()
+    await flushPromises()
 
-    const buttons = wrapper.findAll('button')
-    const cancelButton = buttons.find((b) => b.text() === 'Cancel')
-    expect(cancelButton, 'Cancel button should exist').toBeTruthy()
+    const cancel = getDialog().get('button[type="button"]')
+    expect(cancel.text()).toBe('Cancel')
+    await cancel.trigger('click')
 
-    await cancelButton!.trigger('click')
-    expect(wrapper.emitted('close')?.length).toBe(1)
+    expect(wrapper.emitted('close')).toStrictEqual([[]])
+    expect(wrapper.emitted('delete')).toBeUndefined()
   })
 
-  it('emits delete when confirming', async () => {
-    const label = 'Beta'
-    const wrapper = mount(DeleteRequestAuthModal, {
-      attachTo: document.body,
-      props: {
-        state: getState(true),
-        label,
-      },
-    })
+  it('emits delete without cancellation when confirming', async () => {
+    const { state, wrapper } = mountModal('Beta')
+    state.show()
+    await flushPromises()
 
-    const buttons = wrapper.findAll('button')
-    const deleteButton = buttons.find((b) => b.text() === `Delete ${label}`)
-    expect(deleteButton, 'Delete button should exist').toBeTruthy()
+    const confirm = getDialog().get('button[type="submit"]')
+    expect(confirm.text()).toBe('Delete Beta')
+    await confirm.trigger('click')
 
-    await deleteButton!.trigger('click')
-    expect(wrapper.emitted('delete')?.length).toBe(1)
+    expect(wrapper.emitted('delete')).toStrictEqual([[]])
+    expect(wrapper.emitted('close')).toBeUndefined()
+  })
+
+  it('hides the dialog without deleting when its state is closed', async () => {
+    const { state, wrapper } = mountModal('Beta')
+    state.show()
+    await flushPromises()
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull()
+
+    state.hide()
+    await flushPromises()
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+    expect(wrapper.emitted('delete')).toBeUndefined()
   })
 })

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-ref-name.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-ref-name.ts
@@ -1,9 +1,8 @@
 import { REGEX } from '@scalar/helpers/regex/regex-helpers'
 
 /**
- * Gets the "name" of the schema from the ref path
- * TODO: this will change so fix it when the new refs are out
- * Then add tests
+ * Gets the final reference segment for display, including external references.
+ * Use getSchemaRefName when the name must link to a local model.
  *
  * @example SchemaName from #/components/schemas/SchemaName
  */

--- a/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/optimize-value-for-display.ts
@@ -53,9 +53,9 @@ function mergeSchemaProperties(...objects: (Record<string, unknown> | undefined)
 }
 
 /**
- * Optimize the value by removing nulls from compositions and merging root properties.
- *
- * TODO: figure out what this does
+ * Normalize compositions for display without changing the source schema. Null branches
+ * become nullable state, single branches are flattened, and shared properties and
+ * required fields are merged into variants so the renderer keeps their full context.
  */
 export function optimizeValueForDisplay(value: SchemaObject | undefined): SchemaObject | undefined {
   if (!value || typeof value !== 'object') {

--- a/packages/api-reference/test/configuration/layout.e2e.ts
+++ b/packages/api-reference/test/configuration/layout.e2e.ts
@@ -49,9 +49,7 @@ test.describe('layout', () => {
 
     await page.goto(example)
 
-    // We need another selector here, because the layout is just different.
-    // TODO: Ideally, we'd have the same 'region' selector for both layouts.
-    await expect(page.locator('.section-accordion-wrapper')).toBeVisible()
-    await expect(page.locator('.section-accordion-wrapper')).toHaveAttribute('layout', 'classic')
+    await expect(page.getByRole('region', { name: 'user-tag', exact: true })).toBeVisible()
+    await expect(page.getByRole('region', { name: 'user-tag', exact: true })).toHaveAttribute('layout', 'classic')
   })
 })

--- a/packages/openapi-parser/tests/references/one-file/one-file.test.ts
+++ b/packages/openapi-parser/tests/references/one-file/one-file.test.ts
@@ -1,24 +1,82 @@
+import { createServer } from 'node:http'
+import { relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { describe, expect, it } from 'vitest'
 
-import { normalize } from '@/utils/normalize'
+import { fetchUrls } from '@/plugins/fetch-urls/fetch-urls'
+import { readFiles } from '@/plugins/read-files/read-files'
+import { load } from '@/utils/load/load'
 import { resolveReferences } from '@/utils/resolve-references'
 
+import pointers from './pointers.json'
 import specification from './specification.json'
 
-// Single-file schema with internal $refs
-describe.todo('one-file', () => {
-  it('relative path', () => {
-    const schema = resolveReferences(normalize(specification))
+const filename = fileURLToPath(new URL('./pointers.json', import.meta.url))
+const expected = {
+  valid: true,
+  errors: [],
+  schema: {
+    type: 'object',
+    properties: {
+      name: { type: 'string', minLength: 1 },
+      alias: { type: 'string', minLength: 1, description: 'An alternate name' },
+    },
+    $defs: { nonEmptyString: { type: 'string', minLength: 1 } },
+  },
+}
 
-    expect(schema).not.toBe(undefined)
-    // TODO: Expectation
+describe('one-file', () => {
+  it.each([
+    { label: 'relative path', path: relative(process.cwd(), filename) },
+    { label: 'absolute path', path: filename },
+  ])('resolves internal references loaded from a $label', async ({ path }) => {
+    const loaded = await load(path, { plugins: [readFiles()] })
+
+    expect(loaded.errors).toStrictEqual([])
+    expect(resolveReferences(loaded.filesystem)).toStrictEqual(expected)
   })
 
-  it('absolute path', async () => {
-    //
+  it('resolves internal references loaded from a URL', async () => {
+    const server = createServer((_request, response) => {
+      response.setHeader('Content-Type', 'application/json')
+      response.end(JSON.stringify(pointers))
+    })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected a TCP server address')
+      }
+      const loaded = await load(`http://127.0.0.1:${address.port}/pointers.json`, { plugins: [fetchUrls()] })
+
+      expect(loaded.errors).toStrictEqual([])
+      expect(resolveReferences(loaded.filesystem)).toStrictEqual(expected)
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    }
   })
 
-  it('URL', async () => {
-    //
+  it('resolves the original fixture pointers and reports its unsupported resource names', () => {
+    // Named $id/$anchor resolution is a separate resolver feature. Keep this original
+    // fixture covered without treating unresolved names as a successfully resolved document.
+    const result = resolveReferences(specification)
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toStrictEqual([
+      { code: 'EXTERNAL_REFERENCE_NOT_FOUND', message: "Can't resolve external reference: non-empty-string" },
+      { code: 'EXTERNAL_REFERENCE_NOT_FOUND', message: "Can't resolve external reference: person" },
+      { code: 'EXTERNAL_REFERENCE_NOT_FOUND', message: "Can't resolve external reference: address" },
+    ])
+    expect(result.schema).toHaveProperty(['properties', 'name', 'properties', 'last'], {
+      ...specification.$defs.nonEmptyString,
+      description: "The person's last name",
+    })
+    expect(result.schema).toHaveProperty(['properties', 'schoolAddress'], {
+      ...specification.$defs.address,
+      description: "The person's school address",
+    })
+    expect(specification.properties.name.properties.last.$ref).toBe('#/$defs/nonEmptyString')
   })
 })

--- a/packages/openapi-parser/tests/references/one-file/pointers.json
+++ b/packages/openapi-parser/tests/references/one-file/pointers.json
@@ -1,0 +1,10 @@
+{
+  "type": "object",
+  "properties": {
+    "name": { "$ref": "#/$defs/nonEmptyString" },
+    "alias": { "$ref": "#/properties/name", "description": "An alternate name" }
+  },
+  "$defs": {
+    "nonEmptyString": { "type": "string", "minLength": 1 }
+  }
+}

--- a/packages/openapi-validator/tests/openapi3-examples/3.0/fail/license_identifier.test.ts
+++ b/packages/openapi-validator/tests/openapi3-examples/3.0/fail/license_identifier.test.ts
@@ -7,11 +7,7 @@ describe('license_identifier', () => {
   it('returns an error', async () => {
     const result = await validate(license_identifier)
 
-    // TODO: Swagger Editor
-    //
-    // Structural error at info.license
-    // should NOT have additional properties
-    // additionalProperty: identifier
+    // License identifiers are not supported by this OpenAPI 3.0 document.
     expect(result.errors?.[0]?.message).toBe('Property identifier is not expected to be here')
     expect(result.valid).toBe(false)
   })

--- a/packages/void-server/src/utils/get-body.ts
+++ b/packages/void-server/src/utils/get-body.ts
@@ -9,9 +9,6 @@ export async function getBody(c: Context) {
   // (Multipart) form data
   if (contentType?.includes('application/x-www-form-urlencoded') || contentType?.includes('multipart/form-data')) {
     try {
-      // TODO: This is just for debugging purposes, remove it later
-      // const body = await c.req.raw.body
-      // It should actually be this:
       const body = transformFormData(
         await c.req.parseBody({
           dot: true,


### PR DESCRIPTION
Restore modal and single-file reference tests, update layout selectors, and remove stale comments. Named-resource resolution remains unsupported and is tested explicitly.

Affected package tests and type checks pass, including both layout browser tests.
