### PR TITLE
fix(workspace-store): skip extensions when extracting paths

### DIFF
--- a/.changeset/paths-extension-todo.md
+++ b/.changeset/paths-extension-todo.md
@@ -1,0 +1,5 @@
+---
+'@scalar/workspace-store': patch
+---
+
+Skip Paths Object extension keys so they cannot be mistaken for API paths. Add a regression test with an operation-shaped extension.

--- a/packages/workspace-store/src/server.test.ts
+++ b/packages/workspace-store/src/server.test.ts
@@ -1121,6 +1121,19 @@ describe('create-server-store', () => {
 })
 
 describe('filter-http-methods-only', () => {
+  it('ignores Paths Object extensions even when they contain HTTP method names', () => {
+    const result = filterHttpMethodsOnly({
+      'x-metadata': { get: { description: 'Not an operation' } },
+      '/path': {
+        get: { description: 'List items' },
+        // @ts-expect-error Exercise an extension alongside a real operation.
+        'x-metadata': { post: { description: 'Not an operation either' } },
+      },
+    })
+
+    expect(result).toStrictEqual({ '/path': { get: { description: 'List items' } } })
+  })
+
   it('should only keep the http methods', () => {
     const result = filterHttpMethodsOnly({
       '/path': {

--- a/packages/workspace-store/src/server.ts
+++ b/packages/workspace-store/src/server.ts
@@ -147,8 +147,12 @@ const preserveBundledExternals = (source: Record<string, unknown>, target: Recor
 export function filterHttpMethodsOnly(paths: PathsObject): Record<string, Record<string, OperationObject>> {
   const result: Record<string, Record<string, OperationObject>> = {}
 
-  // Todo: skip extension properties
   for (const [path, pathItemRef] of Object.entries(paths)) {
+    // Paths Object extensions can contain objects that resemble HTTP operations.
+    if (path.startsWith('x-')) {
+      continue
+    }
+
     const filteredMethods: Record<string, OperationObject> = {}
 
     forEachPathItemOperation(pathItemRef, (method, operation) => {


### PR DESCRIPTION
Skip Paths Object extension keys so they cannot be mistaken for API paths. Add a regression test with an operation-shaped extension.

Workspace-store tests and type checks pass.
