### PR TITLE
test(components): cover sidebar content and accessible attributes

### DIFF
--- a/.changeset/sidebar-content-tests.md
+++ b/.changeset/sidebar-content-tests.md
@@ -1,0 +1,5 @@
+---
+'@scalar/components': patch
+---
+
+Test sidebar content and accessible attribute forwarding.

--- a/packages/components/src/components/ScalarSidebar/ScalarSidebar.test.ts
+++ b/packages/components/src/components/ScalarSidebar/ScalarSidebar.test.ts
@@ -9,5 +9,22 @@ describe('ScalarSidebar', () => {
     expect(wrapper.exists()).toBe(true)
   })
 
-  // TODO: Add more tests
+  it('renders sidebar content', () => {
+    const wrapper = mount(ScalarSidebar, {
+      slots: { default: '<nav aria-label="API navigation">Endpoints</nav>' },
+    })
+
+    expect(wrapper.text()).toBe('Endpoints')
+    expect(wrapper.get('nav').attributes('aria-label')).toBe('API navigation')
+  })
+
+  it('forwards accessible attributes to the sidebar', () => {
+    const wrapper = mount(ScalarSidebar, {
+      attrs: { 'aria-label': 'API sidebar', 'aria-describedby': 'sidebar-help', tabindex: 0 },
+    })
+
+    expect(wrapper.attributes('aria-label')).toBe('API sidebar')
+    expect(wrapper.attributes('aria-describedby')).toBe('sidebar-help')
+    expect(wrapper.attributes('tabindex')).toBe('0')
+  })
 })


### PR DESCRIPTION
Test sidebar content and accessible attribute forwarding.

Component tests and type checks pass.
