### PR TITLE
fix(docusaurus): use the Docusaurus route type

### DIFF
--- a/.changeset/docusaurus-route-types.md
+++ b/.changeset/docusaurus-route-types.md
@@ -1,0 +1,5 @@
+---
+'@scalar/docusaurus': patch
+---
+
+Use the Docusaurus route type for the API reference configuration.

--- a/integrations/docusaurus/src/ScalarDocusaurus.tsx
+++ b/integrations/docusaurus/src/ScalarDocusaurus.tsx
@@ -1,3 +1,4 @@
+import type { RouteConfig } from '@docusaurus/types'
 import type { CreateApiReference } from '@scalar/types'
 import Layout from '@theme/Layout'
 import React, { useEffect, useId, useRef } from 'react'
@@ -5,15 +6,13 @@ import React, { useEffect, useId, useRef } from 'react'
 import './theme.css'
 
 type Props = {
-  route: {
+  route: RouteConfig & {
     /**
      * The API reference configuration, pre-serialized in the plugin (Node) to a JavaScript object
      * literal string. We cannot receive it as a plain object because Docusaurus JSON-serializes route
      * props, which drops function-valued options like `onBeforeRequest`. See issue #6933.
      */
     configuration: string
-    /** Not sure where the route type is for docusaurus, couldn't find one with an ID, TODO: replace with that */
-    id: string
   }
 }
 


### PR DESCRIPTION
Use the Docusaurus route type for the API reference configuration.

All 19 tests and the type check pass.
