### PR TITLE
fix(api-reference): stop rendering discriminator base property twice

### DIFF
--- a/.changeset/discriminator-duplicate-base-property.md
+++ b/.changeset/discriminator-duplicate-base-property.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Stop rendering a discriminator base property twice. When a property's schema is a bare `discriminator.mapping` base (an object with `properties` and a `discriminator` but no explicit `oneOf`/`anyOf`), the inferred variant selector already shows those properties inside each variant, because the variants `allOf` back to the base. The base object block is no longer rendered alongside the selector, so properties like the discriminator field are shown once instead of twice.

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -593,6 +593,89 @@ describe('Schema', () => {
       // inferred variant dropdown alone.
       expect(wrapper.text()).toContain('sharedAllOfProp')
     })
+
+    // https://github.com/scalar/scalar/issues/9861
+    // A property whose schema is a bare `discriminator.mapping` base (rendered
+    // through `SchemaProperty`, e.g. a request body's `data` field) must not
+    // render its base properties both as a plain object block AND inside the
+    // inferred oneOf variants (which `allOf` back to the base).
+    it('does not render base properties twice for a discriminator-mapping property', async () => {
+      const configSchema = {
+        type: 'object',
+        required: ['formatVersion'],
+        properties: {
+          formatVersion: { type: 'string' },
+        },
+        discriminator: {
+          propertyName: 'formatVersion',
+          mapping: {
+            '2.2': '#/components/schemas/Config_v2_2',
+            '2.3': '#/components/schemas/Config_v2_3',
+          },
+        },
+      }
+
+      const document = {
+        components: {
+          schemas: {
+            Config: configSchema,
+            Config_v2_2: {
+              allOf: [
+                { $ref: '#/components/schemas/Config', '$ref-value': configSchema },
+                { type: 'object', properties: { fieldA: { type: 'string' } } },
+              ],
+            },
+            Config_v2_3: {
+              allOf: [
+                { $ref: '#/components/schemas/Config', '$ref-value': configSchema },
+                { type: 'object', properties: { fieldB: { type: 'string' } } },
+              ],
+            },
+          },
+        },
+      }
+
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          name: 'Request Body',
+          schema: coerceValue(SchemaObjectSchema, {
+            type: 'object',
+            properties: {
+              data: { $ref: '#/components/schemas/Config', '$ref-value': configSchema },
+            },
+          }),
+          options: { expandAllSchemaProperties: true, document: document as never },
+        },
+      })
+
+      // The names of every rendered `formatVersion` property row (there should be
+      // exactly one, and it must live inside the variant selector's panel).
+      const formatVersionRows = () =>
+        wrapper.findAll('.property-name').filter((node) => node.text().trim() === 'formatVersion')
+
+      // Exactly one variant selector, inferred from the mapping.
+      expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
+
+      // `formatVersion` renders once, inside the selected variant — not a second
+      // time as a base object block outside the selector.
+      expect(formatVersionRows()).toHaveLength(1)
+      expect(formatVersionRows()[0]!.element.closest('.composition-panel')).not.toBeNull()
+      expect(wrapper.text()).toContain('fieldA')
+      expect(wrapper.text()).not.toContain('fieldB')
+
+      // Switching variants keeps the single, in-panel `formatVersion` — the base
+      // block never reappears alongside the other variant.
+      const listbox = wrapper.findComponent({ name: 'ScalarListbox' })
+      await listbox.vm.$emit('update:modelValue', { id: '1', label: 'Config_v2_3' })
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.findAll('.composition-selector')).toHaveLength(1)
+      expect(formatVersionRows()).toHaveLength(1)
+      expect(formatVersionRows()[0]!.element.closest('.composition-panel')).not.toBeNull()
+      expect(wrapper.text()).toContain('fieldB')
+      expect(wrapper.text()).not.toContain('fieldA')
+    })
   })
 
   describe('additionalProperties Vue prop', () => {

--- a/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
+++ b/packages/api-reference/src/components/Content/Schema/SchemaProperty.vue
@@ -52,7 +52,10 @@ import type { SchemaOptions } from '@/components/Content/Schema/types'
 import { useLocalization } from '@/features/localization'
 import { SpecificationExtension } from '@/features/specification-extension'
 
-import { getCompositionsToRender } from './helpers/get-compositions-to-render'
+import {
+  getCompositionsToRender,
+  inferDiscriminatorMappingComposition,
+} from './helpers/get-compositions-to-render'
 import { getEnumValues } from './helpers/get-enum-values'
 import { getPropertyDescription } from './helpers/get-property-description'
 import { getRefName } from './helpers/get-ref-name'
@@ -213,6 +216,21 @@ const hasComplexArrayItemsComputed = computed(() =>
 /** Check if enum should be displayed (from value schema or from propertyNames) */
 const hasEnum = computed(() => enumValues.value.length > 0)
 
+/**
+ * The `oneOf` inferred from a bare `discriminator.mapping`, or `null` when there
+ * is nothing to infer. Computed once and shared: `shouldRenderObjectProperties`
+ * uses it to suppress the duplicate base object block, and `compositionsToRender`
+ * passes it on so the inference does not run twice per render.
+ */
+const inferredDiscriminatorComposition = computed(() =>
+  optimizedValue.value
+    ? inferDiscriminatorMappingComposition(
+        optimizedValue.value,
+        props.options.document,
+      )
+    : null,
+)
+
 /** Determine if object properties should be displayed */
 const shouldRenderObjectProperties = computed(() => {
   const value = optimizedValue.value
@@ -228,6 +246,34 @@ const shouldRenderObjectProperties = computed(() => {
   // rendered result (see `mergeAllOfSchemas`), so rendering a separate object
   // block here would show those properties twice. Let the composition handle it.
   if ('allOf' in value) {
+    return false
+  }
+
+  // A *plain* bare `discriminator.mapping` base (no explicit `oneOf`/`anyOf` and
+  // no `allOf` of its own) is rendered as an inferred `oneOf` composition below,
+  // whose variants `allOf` back to this base type and therefore already include
+  // its properties (including the discriminator property). Rendering the base
+  // object block here as well would show those properties a second time, outside
+  // the selector. `Schema.vue` renders the two mutually exclusively; mirror that
+  // here so the property and the model render the base identically.
+  // See https://github.com/scalar/scalar/issues/9861
+  //
+  // This intentionally shows the base only through its variants, matching the
+  // discriminator contract that each mapped variant extends the base. A malformed
+  // mapping whose variants do not include the base (or a base carrying only
+  // `additionalProperties`/`patternProperties`) would surface those fields solely
+  // via the variants — the same behavior `Schema.vue` already has for the model.
+  //
+  // A base that composes itself via `allOf` is excluded: `optimizeValueForDisplay`
+  // flattens its members up into `properties`, and those contribute fields the
+  // inferred variants do not carry, so the block must still render them. The check
+  // reads the raw `props.schema` because the flattening has already erased `allOf`
+  // from the optimized `value`.
+  const composesWithAllOf =
+    !!props.schema &&
+    typeof props.schema === 'object' &&
+    'allOf' in props.schema
+  if (!composesWithAllOf && inferredDiscriminatorComposition.value) {
     return false
   }
 
@@ -313,7 +359,11 @@ const shouldDisplayHeadingComputed = computed(() =>
 
 /** Computes which compositions should be rendered and with which values */
 const compositionsToRender = computed(() =>
-  getCompositionsToRender(optimizedValue.value, props.options.document),
+  getCompositionsToRender(
+    optimizedValue.value,
+    props.options.document,
+    inferredDiscriminatorComposition.value,
+  ),
 )
 
 /**

--- a/packages/api-reference/src/components/Content/Schema/helpers/get-compositions-to-render.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/get-compositions-to-render.ts
@@ -88,12 +88,19 @@ export const inferDiscriminatorMappingComposition = (
 export const getCompositionsToRender = (
   value: SchemaObject | undefined,
   document?: DocumentSchemaLookup,
+  /**
+   * The `oneOf` inferred from a bare `discriminator.mapping`, when the caller has
+   * already computed it. `SchemaProperty` needs the same value to decide whether
+   * to suppress the duplicate base object block, so it passes it here to avoid
+   * inferring twice. Omit it and it is inferred from `value`.
+   */
+  inferredDiscriminatorComposition: SchemaObject | null = value
+    ? inferDiscriminatorMappingComposition(value, document)
+    : null,
 ): CompositionToRender[] => {
   if (!value) {
     return []
   }
-
-  const inferredDiscriminatorComposition = inferDiscriminatorMappingComposition(value, document)
 
   return compositions
     .map((composition) => {


### PR DESCRIPTION
Splits the logic fix out of #9863 so it can land against current `main`. That PR also carried a CSS fix whose selectors went stale after the schema-layout refactors (#10074, #10126) and needs re-authoring — this PR is the rendering logic only.

When a property's schema is a bare `discriminator.mapping` base (an object with `properties` and a `discriminator`, but no explicit `oneOf`/`anyOf`/`allOf`), the inferred variant selector already shows the base properties inside each variant, because the variants `allOf` back to the base. We now suppress the separate base object block, so properties like the discriminator field render once instead of twice — mirroring how `Schema.vue` already renders the model. A base that composes itself via `allOf` still renders its block, since flattening contributes fields the variants do not carry. The inference is computed once in `SchemaProperty` and passed into `getCompositionsToRender` so it does not run twice per render.

## Ticket

Ref #9861

Fixes the duplicate-property half of the issue. The secondary "oneOf directly on the body level" spacing bug is the deferred CSS follow-up (the stale part of #9863).