### PR TITLE
fix(api-client): enable form body row when typing a value

### DIFF
--- a/.changeset/spotty-lions-jump.md
+++ b/.changeset/spotty-lions-jump.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+Typing a value into an unchecked optional form body row now enables that row, so the value is sent with the request. This matches how optional query parameters already behave.

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.test.ts
@@ -323,6 +323,46 @@ describe('getFormBodyRows', () => {
       expect(byName['mode']?.isDisabled).toBe(true)
     })
 
+    it('marks auto-disabled optional properties as disabled by default so typing enables them (issue #10145)', () => {
+      // isDisabledByDefault lets RequestTableRow auto-enable a row when the user types a value,
+      // mirroring how optional parameters behave. Required rows are enabled, so it stays unset.
+      const example: ExampleObject = { value: { name: '', note: '' } }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: { type: 'string' },
+          note: { type: 'string' },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'application/x-www-form-urlencoded', formBodySchema)
+      const byName = Object.fromEntries(result.map((row) => [row.name, row]))
+
+      expect(byName['note']?.isDisabledByDefault).toBe(true)
+      expect(byName['name']?.isDisabledByDefault).toBe(false)
+    })
+
+    it('does not mark a row from a stored form-row array as disabled by default (issue #10145)', () => {
+      // An explicit isDisabled means the user already decided, so the row is not disabled by
+      // default and must not auto-enable on typing.
+      const example: ExampleObject = {
+        value: [{ name: 'note', value: '', isDisabled: true }],
+      }
+      const formBodySchema: SchemaObject = {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          name: { type: 'string' },
+          note: { type: 'string' },
+        },
+      }
+
+      const result = getFormBodyRows(example, 'application/x-www-form-urlencoded', formBodySchema)
+      expect(result[0]?.isDisabled).toBe(true)
+      expect(result[0]?.isDisabledByDefault).toBeUndefined()
+    })
+
     it('keeps an explicit isDisabled from a stored form-row array (issue #10045)', () => {
       // Once the user checks an optional box the value is stored as a row array with an
       // explicit isDisabled, which must win over the schema-derived default.

--- a/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
+++ b/packages/api-client/src/v2/blocks/request-block/helpers/get-form-body-rows.ts
@@ -179,6 +179,10 @@ export const getFormBodyRows = (
       Object.hasOwn(schemaWithProperties.properties, name)
     ) {
       row.isDisabled = !row.isRequired
+      // Mark the row as disabled by default (no explicit `isDisabled` was stored) so typing a
+      // value auto-enables it in `RequestTableRow`, matching how optional parameters behave. An
+      // explicit `isDisabled` from a stored form-row array skips this branch and keeps winning.
+      row.isDisabledByDefault = row.isDisabled
     }
     return row
   }


### PR DESCRIPTION
Typing a value into an unchecked optional form body row did not enable the row, so the value stayed visible but was left out of the request. This already works for query parameters.

The auto-enable in `RequestTableRow` is gated on `isDisabledByDefault`. `create-parameter-rows.ts` sets that flag, but `get-form-body-rows.ts` only set `isDisabled`, so the auto-enable never fired for form bodies. This sets `isDisabledByDefault` on the rows it auto-disables. An explicit `isDisabled` from a stored form row still wins, so a deliberate opt-out is kept.

## Ticket

Fixes #10145
