### PR TITLE
fix(api-client): keep focus while editing body field names

### DIFF
--- a/.changeset/tidy-keys-stay-focused.md
+++ b/.changeset/tidy-keys-stay-focused.md
@@ -1,0 +1,5 @@
+---
+"@scalar/api-client": patch
+---
+
+Keep focus while editing request body field names by saving name changes on blur.

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBodyForm.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBodyForm.test.ts
@@ -4,8 +4,11 @@ import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, readonly, ref } from 'vue'
 
+import { CodeInputLite } from '@/v2/components/code-input'
+
 import RequestBodyForm from './RequestBodyForm.vue'
 import RequestTable from './RequestTable.vue'
+import RequestTableRow from './RequestTableRow.vue'
 
 // Mock the useFileDialog hook
 const mockFiles = ref<FileList | null>(null)
@@ -461,4 +464,44 @@ describe('RequestBodyForm', () => {
     ])
     reopened.unmount()
   })
+  it.each(['multipart/form-data', 'application/x-www-form-urlencoded'])(
+    'keeps body key focus and saves on blur or send for %s',
+    async (contentType) => {
+      const wrapper = mount(RequestBodyForm, {
+        attachTo: document.body,
+        props: {
+          example: { value: { existing: 'value' } },
+          selectedContentType: contentType,
+          environment: defaultEnvironment,
+        },
+      })
+      try {
+        for (const index of [0, 1]) {
+          const row = wrapper.findAllComponents(RequestTableRow)[index]!
+          const input = row.findAllComponents(CodeInputLite)[0]!
+          const editor = input.get('[contenteditable="true"]').element as HTMLElement
+          editor.focus()
+          const eventCount = wrapper.emitted('update:formValue')?.length ?? 0
+          let name = row.props('data').name
+          for (const character of 'note') {
+            name += character
+            input.vm.$emit('update:modelValue', name)
+            await nextTick()
+            expect(document.activeElement).toBe(editor)
+            expect(wrapper.emitted('update:formValue')?.length ?? 0).toBe(eventCount)
+          }
+          if (index === 0) {
+            input.vm.$emit('blur', name, new FocusEvent('blur'))
+          } else {
+            editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true, bubbles: true }))
+          }
+          await nextTick()
+          expect(wrapper.findComponent(RequestTable).props('data')[index]?.name).toBe(name)
+          expect(wrapper.emitted('update:formValue')?.length).toBe(eventCount + 1)
+        }
+      } finally {
+        wrapper.unmount()
+      }
+    },
+  )
 })

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBodyForm.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBodyForm.vue
@@ -118,6 +118,7 @@ const handleFileUpload = (index: number) => {
   <template v-if="selectedContentType === 'multipart/form-data'">
     <RequestTable
       :data="localFormBodyRows"
+      deferKeyUpdates
       :environment="environment"
       showUploadButton
       @deleteRow="handleDeleteRow"
@@ -130,6 +131,7 @@ const handleFileUpload = (index: number) => {
   <template v-else>
     <RequestTable
       :data="localFormBodyRows"
+      deferKeyUpdates
       :environment="environment"
       @deleteRow="handleDeleteRow"
       @upsertRow="handleUpsertRow" />

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBodyStructured.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBodyStructured.test.ts
@@ -4,8 +4,11 @@ import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
 
+import { CodeInputLite } from '@/v2/components/code-input'
+
 import RequestBodyStructured from './RequestBodyStructured.vue'
 import RequestTable from './RequestTable.vue'
+import RequestTableRow from './RequestTableRow.vue'
 
 const defaultEnvironment: XScalarEnvironment = {
   color: 'blue',
@@ -117,4 +120,40 @@ describe('RequestBodyStructured', () => {
       ['age', '40'],
     ])
   })
+  it.each(['application/json', 'application/yaml'])(
+    'keeps body key focus and saves on blur or send for %s',
+    async (contentType) => {
+      const wrapper = mount(RequestBodyStructured, {
+        attachTo: document.body,
+        props: { parsedValue: { existing: 'value' }, contentType, environment: defaultEnvironment },
+      })
+      try {
+        for (const index of [0, 1]) {
+          const row = wrapper.findAllComponents(RequestTableRow)[index]!
+          const input = row.findAllComponents(CodeInputLite)[0]!
+          const editor = input.get('[contenteditable="true"]').element as HTMLElement
+          editor.focus()
+          const eventCount = wrapper.emitted('update:value')?.length ?? 0
+          let name = row.props('data').name
+          for (const character of 'note') {
+            name += character
+            input.vm.$emit('update:modelValue', name)
+            await nextTick()
+            expect(document.activeElement).toBe(editor)
+            expect(wrapper.emitted('update:value')?.length ?? 0).toBe(eventCount)
+          }
+          if (index === 0) {
+            input.vm.$emit('blur', name, new FocusEvent('blur'))
+          } else {
+            editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true, bubbles: true }))
+          }
+          await nextTick()
+          expect(wrapper.findComponent(RequestTable).props('data')[index]?.name).toBe(name)
+          expect(wrapper.emitted('update:value')?.length).toBe(eventCount + 1)
+        }
+      } finally {
+        wrapper.unmount()
+      }
+    },
+  )
 })

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestBodyStructured.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestBodyStructured.vue
@@ -100,6 +100,7 @@ const handleDeleteRow = (index: number) => {
 <template>
   <RequestTable
     :data="localRows"
+    deferKeyUpdates
     :environment="environment"
     label="Body"
     @deleteRow="handleDeleteRow"

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTable.vue
@@ -15,11 +15,14 @@ import {
 const {
   data,
   hasCheckboxDisabled,
+  deferKeyUpdates,
   showUploadButton,
   showAddRowPlaceholder = true,
   environment,
 } = defineProps<{
   data: TableRow[]
+  /** Save key edits on blur so changing a body name does not replace the focused row. */
+  deferKeyUpdates?: boolean
   /** Hide the enabled column */
   hasCheckboxDisabled?: boolean
   invalidParams?: Set<string>
@@ -109,6 +112,7 @@ const getRowKey = (row: TableRow, index: number): string => {
       v-for="(row, index) in displayData"
       :key="getRowKey(row, index)"
       :data="row"
+      :deferKeyUpdates="deferKeyUpdates"
       :environment="environment"
       :hasCheckboxDisabled="hasCheckboxDisabled"
       :invalidParams="invalidParams"

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestTableRow.vue
@@ -74,10 +74,13 @@ const {
   data,
   environment,
   hasCheckboxDisabled,
+  deferKeyUpdates,
   invalidParams,
   showUploadButton,
 } = defineProps<{
   data: TableRow
+  /** Keep key edits local until blur when the row identity depends on its name. */
+  deferKeyUpdates?: boolean
   hasCheckboxDisabled?: boolean
   invalidParams?: Set<string>
   label?: string
@@ -173,7 +176,7 @@ const validationResult = computed(() =>
 /** Handle row updates while preserving existing properties */
 const handleUpdateRow = (
   payload: Partial<{ name: string; value: string; isDisabled: boolean }>,
-  options: { shouldRenameExpandedRow?: boolean } = {},
+  options: { shouldRenameExpandedRow?: boolean; commitKey?: boolean } = {},
 ): void => {
   // Update our local state
   if (payload.name !== undefined) {
@@ -196,8 +199,9 @@ const handleUpdateRow = (
 
   if (
     payload.name !== undefined &&
-    data.sourceParameterValuePath &&
-    !options.shouldRenameExpandedRow
+    (deferKeyUpdates || data.sourceParameterValuePath) &&
+    !options.shouldRenameExpandedRow &&
+    !options.commitKey
   ) {
     return
   }
@@ -214,8 +218,8 @@ const handleUpdateRow = (
 }
 
 /**
- * Commit a key edit when the input loses focus. Expanded-object rows defer their rename to blur (see
- * handleUpdateRow), so we only emit when the key actually changed — focusing and blurring the field
+ * Commit a key edit when the input loses focus. Body and expanded-object rows defer their rename to blur (see
+ * handleUpdateRow), so we only emit when the key actually changed. Focusing and blurring the field
  * without typing should not re-emit the row or silently reset its disabled state. The current
  * disabled state is passed through so a renamed row keeps it.
  */
@@ -231,8 +235,22 @@ const handleKeyBlur = (newName: string): void => {
 
   handleUpdateRow(
     { name: newName, isDisabled: isDisabled.value },
-    { shouldRenameExpandedRow: Boolean(data.sourceParameterValuePath) },
+    {
+      shouldRenameExpandedRow: Boolean(data.sourceParameterValuePath),
+      commitKey: true,
+    },
   )
+}
+
+/** Save a pending body key before the send shortcut reaches the request handler. */
+const handleKeydown = (event: KeyboardEvent): void => {
+  if (
+    deferKeyUpdates &&
+    event.key === 'Enter' &&
+    (event.metaKey || event.ctrlKey)
+  ) {
+    handleKeyBlur(name.value)
+  }
 }
 </script>
 
@@ -260,6 +278,7 @@ const handleKeyBlur = (newName: string): void => {
         placeholder="Key"
         :required="Boolean(data.isRequired)"
         @blur="(v) => handleKeyBlur(v)"
+        @keydown.capture="handleKeydown"
         @navigate="(route) => emit('navigate', route)"
         @update:modelValue="(v) => handleUpdateRow({ name: v })" />
     </DataTableCell>


### PR DESCRIPTION
Keep focus while typing body field names. Save the name when leaving the field or using the send shortcut. Covers multipart, URL-encoded, JSON, and YAML forms.

Tested in the browser. All 1,811 API-client tests, type checks, and the scoped unused-code check pass.

## Visual

Before and after typing `note` with one click:

<img src="https://raw.githubusercontent.com/scalar/scalar/3f2d0433c282f6c00d2092ebd943a54e400f28ce/before.png" alt="Before: only n is entered" width="480" />
<img src="https://raw.githubusercontent.com/scalar/scalar/3f2d0433c282f6c00d2092ebd943a54e400f28ce/after.png" alt="After: note is entered and focus stays in the field" width="480" />

## Ticket

Fixes #10147
