### PR TITLE
docs(sso): require the Entra ID signing option Scalar accepts

### DIFF
--- a/documentation/guides/sso/providers/microsoft-entra-id.md
+++ b/documentation/guides/sso/providers/microsoft-entra-id.md
@@ -74,9 +74,15 @@ Copy the IdP details from Microsoft Entra ID into Scalar:
 
 ![](../../../assets/sso/microsoft-entra-id/scalar-service-provider-details.png)
 
-## 7. Enable Token Encryption
+## 7. Set the Signing Option
 
-Scalar requires token encryption for SAML assertions. Download the encryption certificate from the Scalar and import it into Microsoft Entra ID under **Token encryption**:
+In the **SAML Certificates** card, click **Edit** and set **Signing Option** to **Sign SAML response and assertion**. Leave **Signing Algorithm** at SHA-256 and save.
+
+> Microsoft Entra ID defaults to **Sign SAML assertion**. Once token encryption is enabled in the next step, that default causes Scalar to reject the sign-in with "Invalid SAML signature state". Scalar needs the SAML response to be signed as well as the assertion.
+
+## 8. Enable Token Encryption
+
+Scalar requires token encryption for SAML assertions. Without it, sign-in attempts are sent back to the Scalar login page. Download the encryption certificate from Scalar and import it into Microsoft Entra ID under **Token encryption**:
 
 ### Import the Encryption Certificate
 
@@ -93,3 +99,9 @@ Scalar requires token encryption for SAML assertions. Download the encryption ce
 ## Done!
 
 Your organization is now ready to use Scalar SSO with Microsoft Entra ID! If you run into any issues, double-check your settings - or just [reach out to our support team](mailto:support@scalar.com), we're here to help!
+
+## Troubleshooting
+
+* **"Invalid SAML signature state" after signing in with Microsoft** - the **Signing Option** in the SAML Certificates card is still set to **Sign SAML assertion**. Change it to **Sign SAML response and assertion** (step 7).
+* **Sent back to the Scalar login page without an error** - token encryption is not enabled for the application, or the wrong certificate was imported. Re-check step 8.
+* **Users cannot be matched to their Scalar account** - the **Unique User Identifier (Name ID)** claim under **Attributes & Claims** must be the user's email address (`user.mail` or `user.userprincipalname`).


### PR DESCRIPTION
## Problem

Customers who follow the Microsoft Entra ID guide to the letter end up with SAML sign-in failing at `https://identity.scalar.com/acs` with a 401 "Invalid SAML signature state".

Entra defaults the **Signing Option** in the SAML Certificates card to **Sign SAML assertion**. The guide has customers enable token encryption (step 7) but never mentions the signing option. With encryption on and only the assertion signed, Scalar's ACS handler cannot re-verify the assertion signature and rejects the login. The working Entra tenants all use **Sign SAML response and assertion**; the ones hitting the 401 were left on the default. The guide currently gives no way to discover this.

## Solution

- Add a new step 7, **Set the Signing Option**, telling customers to switch to **Sign SAML response and assertion** before enabling token encryption, with a callout explaining why the default fails.
- Renumber token encryption to step 8 and note that leaving it off sends users back to the Scalar login page (a different symptom from the signature error).
- Add a **Troubleshooting** section mapping the three symptoms seen in support to their fix: the signature-state error, the silent redirect to login, and users not matching an account because the Name ID claim is not an email address.

The new step has no screenshot yet. Every other step on this page has one, so a capture of the Signing Option dropdown in the SAML Certificates edit pane should be added before this leaves draft.

## Checklist

- [x] I explained why the change is needed.
- [ ] I added a changeset. (docs only, no package change)
- [ ] I added tests. (docs only)
- [x] I updated the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJL1TUmyd8LDy1B8xrZhoc

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJL1TUmyd8LDy1B8xrZhoc)_