### PR TITLE
fix(api-reference): stop recursive inherited variant selectors

### DIFF
--- a/.changeset/friendly-alert-variants.md
+++ b/.changeset/friendly-alert-variants.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Fix recursive variant selectors for schemas whose `oneOf` or `anyOf` variants inherit their base through `allOf`. Keep inherited fields and independent choices without showing sibling variant fields or overflowing the stack when all schema properties are expanded.

--- a/packages/api-reference/src/components/Content/Schema/Schema.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/Schema.test.ts
@@ -10,6 +10,76 @@ import { SCHEMA_EXPANSION_SYMBOL, createSchemaExpansionStore } from './helpers/s
 import Schema from './Schema.vue'
 
 describe('Schema', () => {
+  it.each([false, true])(
+    'keeps inherited alert variants separate with expandAllSchemaProperties=%s',
+    async (expandAllSchemaProperties) => {
+      // The base lists variants which inherit it through allOf (discussion #1202).
+      const store = createWorkspaceStore()
+      await store.addDocument({
+        name: 'alerts',
+        document: {
+          openapi: '3.0.3',
+          info: { title: 'Alerts', version: '1.0' },
+          paths: {},
+          components: {
+            schemas: {
+              AlertRule: {
+                type: 'object',
+                properties: { type: { type: 'string', enum: ['ANOMALY', 'MANUAL'] } },
+                discriminator: { propertyName: 'type' },
+                oneOf: [{ $ref: '#/components/schemas/AnomalyRule' }, { $ref: '#/components/schemas/ManualRule' }],
+              },
+              AnomalyRule: {
+                type: 'object',
+                allOf: [
+                  { $ref: '#/components/schemas/AlertRule' },
+                  { type: 'object', properties: { sensitivity: { type: 'number' } } },
+                ],
+              },
+              ManualRule: {
+                type: 'object',
+                allOf: [
+                  { $ref: '#/components/schemas/AlertRule' },
+                  { type: 'object', properties: { thresholds: { type: 'array', items: { type: 'number' } } } },
+                ],
+              },
+            },
+          },
+        },
+      })
+      const document = store.workspace.documents.alerts as { components: { schemas: Record<string, SchemaObject> } }
+      const wrapper = mount(Schema, {
+        props: {
+          eventBus: null,
+          noncollapsible: true,
+          options: { expandAllSchemaProperties },
+          schema: document.components.schemas.AlertRule,
+        },
+      })
+
+      const picker = wrapper.findComponent({ name: 'ScalarListbox' })
+      expect(picker.props('options')).toEqual([
+        { id: '0', label: 'AnomalyRule' },
+        { id: '1', label: 'ManualRule' },
+      ])
+      expect(wrapper.findAllComponents({ name: 'ScalarListbox' }).length).toBe(1)
+      expect(wrapper.text()).toContain('sensitivity')
+      expect(wrapper.text()).not.toContain('thresholds')
+
+      await picker.vm.$emit('update:modelValue', { id: '1', label: 'ManualRule' })
+      await nextTick()
+      expect(wrapper.findAllComponents({ name: 'ScalarListbox' }).length).toBe(1)
+      expect(wrapper.text()).toContain('thresholds')
+      expect(wrapper.text()).not.toContain('sensitivity')
+
+      await picker.vm.$emit('update:modelValue', { id: '0', label: 'AnomalyRule' })
+      await nextTick()
+      expect(wrapper.text()).toContain('sensitivity')
+      expect(wrapper.text()).not.toContain('thresholds')
+      wrapper.unmount()
+    },
+  )
+
   describe('shouldShowDescription computed property', () => {
     it('shows the base description of the first allOf schema', () => {
       const wrapper = mount(Schema, {

--- a/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.test.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.test.ts
@@ -78,6 +78,51 @@ describe('partitionAllOfCompositions', () => {
     expect(segments.some((segment) => segment.kind === 'object')).toBe(true)
   })
 
+  it.each(['oneOf', 'anyOf'] as const)(
+    'keeps base fields and independent choices when an inherited %s points back to the variant',
+    (composition) => {
+      const independentChoice = [{ type: 'string' }, { type: 'number' }]
+      const schema = {
+        $ref: '#/components/schemas/Variant',
+        type: 'object',
+        allOf: [
+          {
+            $ref: '#/components/schemas/Base',
+            '$ref-value': {
+              type: 'object',
+              properties: { id: { type: 'string' } },
+              required: ['id'],
+              [composition]: [{ $ref: '#/components/schemas/Variant' }, { $ref: '#/components/schemas/OtherVariant' }],
+            },
+          },
+          { oneOf: independentChoice },
+          { type: 'object', properties: { value: { type: 'number' } } },
+        ],
+      } as SchemaObject
+      const original = structuredClone(schema)
+
+      const { segments } = partitionAllOfCompositions(schema)
+      expect(segments.map((segment) => segment.kind)).toEqual(['object', 'choice', 'object'])
+      const base = segments[0]
+      expect(base?.kind).toBe('object')
+      if (base?.kind === 'object') {
+        expect(base.schema).toHaveProperty('properties', { id: { type: 'string' } })
+        expect(base.schema).toHaveProperty('required', ['id'])
+      }
+      expect(segments[1]).toEqual({
+        kind: 'choice',
+        composition: 'oneOf',
+        value: { oneOf: independentChoice },
+        choiceIndex: 1,
+      })
+      expect(segments[2]).toEqual({
+        kind: 'object',
+        schema: { type: 'object', properties: { value: { type: 'number' } } },
+      })
+      expect(schema).toEqual(original)
+    },
+  )
+
   it('drops pure-constraint members (not / if-then-else) from object segments', () => {
     const schema = {
       allOf: [

--- a/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.ts
+++ b/packages/api-reference/src/components/Content/Schema/helpers/partition-all-of-compositions.ts
@@ -22,7 +22,7 @@ const CHOICE_KEYWORDS: ChoiceKeyword[] = ['oneOf', 'anyOf']
 
 type Member =
   | { kind: 'object'; schema: SchemaObject }
-  | { kind: 'choice'; composition: ChoiceKeyword; value: SchemaObject }
+  | { kind: 'choice'; composition: ChoiceKeyword; value: SchemaObject; inheritedSelection: boolean }
 
 /**
  * Flattens a member's own (non-composition) properties and every `oneOf`/`anyOf`
@@ -59,8 +59,22 @@ const collectMembers = (schema: SchemaObject, out: Member[], seenRefs: Set<strin
 
   for (const keyword of CHOICE_KEYWORDS) {
     const value = keyword === 'oneOf' ? oneOf : anyOf
+    // A variant inherits its base fields through allOf, but the base's choice
+    // containing that variant has already been selected. Rendering it again
+    // would re-enter the variant and expose fields from the other branches.
+    const selectsAncestor =
+      Array.isArray(value) &&
+      value.some((branch) => {
+        const ref = branch && typeof branch === 'object' && '$ref' in branch ? branch.$ref : undefined
+        return typeof ref === 'string' && seenRefs.has(ref)
+      })
     if (Array.isArray(value) && value.length > 0) {
-      out.push({ kind: 'choice', composition: keyword, value: { [keyword]: value } as unknown as SchemaObject })
+      out.push({
+        kind: 'choice',
+        composition: keyword,
+        value: { [keyword]: value } as unknown as SchemaObject,
+        inheritedSelection: selectsAncestor,
+      })
     }
   }
 
@@ -131,7 +145,8 @@ export const partitionAllOfCompositions = (schema: SchemaObject | undefined): { 
   if (Object.keys(rest).length > 0) {
     members.push({ kind: 'object', schema: rest as SchemaObject })
   }
-  const seenRefs = new Set<string>()
+  const schemaRef = '$ref' in schema ? schema.$ref : undefined
+  const seenRefs = new Set<string>(typeof schemaRef === 'string' ? [schemaRef] : [])
   for (const rawMember of allOf) {
     if (rawMember && typeof rawMember === 'object') {
       const resolved = resolve.schema(rawMember) as SchemaObject & { $ref?: string }
@@ -158,6 +173,9 @@ export const partitionAllOfCompositions = (schema: SchemaObject | undefined): { 
   for (const member of members) {
     if (member.kind === 'object') {
       objectRun.push(member.schema)
+    } else if (member.inheritedSelection) {
+      // Hidden inherited choices still occupy an ordinal in the request example.
+      choiceIndex++
     } else {
       flushObjectRun()
       // `choiceIndex` is the ordinal used to build the composition-selection key


### PR DESCRIPTION
Fix the schema picker for variants that inherit their base through `allOf`. Selecting a variant now shows only its fields, and expanding all fields no longer crashes.

Schema tests and browser checks pass. Existing type and environment errors block full validation.

## Ticket

See [discussion #1202](https://github.com/scalar/scalar/discussions/1202).
