### PR TITLE
fix(api-reference): match SDK installation rendering

### DIFF
--- a/.changeset/calm-dots-render.md
+++ b/.changeset/calm-dots-render.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-reference': patch
+---
+
+Match SDK installation code blocks to the default client library rendering

--- a/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.vue
+++ b/packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.vue
@@ -202,7 +202,8 @@ const focusTab = (index: number) => {
   void nextTick(() => {
     tabsRef.value
       ?.querySelectorAll<HTMLButtonElement>('[role="tab"]')
-      [index]?.focus()
+      .item(index)
+      ?.focus()
   })
 }
 
@@ -393,6 +394,14 @@ onBeforeUnmount(() => {
   border-top: none;
   border-bottom-left-radius: var(--scalar-radius-xl);
   border-bottom-right-radius: var(--scalar-radius-xl);
+}
+.selected-client :deep(.markdown pre code) {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
 }
 .client-libraries-heading {
   font-size: var(--scalar-small);


### PR DESCRIPTION
## Summary

- match fenced SDK installation commands with the default client library footer rendering
- remove the nested code block margin, padding, background, border, radius, and shadow while preserving the shared client library card

## Testing

- `pnpm eslint packages/api-reference/src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.vue`
- `pnpm exec vitest --config vitest.config.ts --run --pool=threads src/blocks/scalar-sdk-installation-instructions/components/SdkInstallationInstructions.test.ts` (13 tests passed)
- visually verified with the provided `Scalar API.json` API description

## Notes

- `pnpm --filter @scalar/api-reference types:check` stalled without output and was interrupted
- `pnpm knip` reached warning-only output, then remained idle and was interrupted