### PR TITLE
test(openapi-validator): check duplicate required properties

### DIFF
--- a/.changeset/quiet-trees-validate.md
+++ b/.changeset/quiet-trees-validate.md
@@ -1,0 +1,5 @@
+---
+'@scalar/openapi-validator': patch
+---
+
+Add regression coverage for duplicate required property names.

--- a/packages/openapi-validator/tests/openapi3-examples/3.0/fail/duplicateRequired.test.ts
+++ b/packages/openapi-validator/tests/openapi3-examples/3.0/fail/duplicateRequired.test.ts
@@ -3,12 +3,16 @@ import { describe, expect, it } from 'vitest'
 import { validate } from '../../../../src/index'
 import duplicateRequired from './duplicateRequired.yaml?raw'
 
-describe.todo('duplicateRequired', () => {
-  it('returns an error', async () => {
+describe('duplicateRequired', () => {
+  it('rejects duplicate required property names', async () => {
     const result = await validate(duplicateRequired)
 
-    expect(result.errors?.[0]?.message).toBe('something something duplicate required properties')
-    expect(result.errors?.length).toBe(1)
+    expect(result.errors).toStrictEqual([
+      {
+        message: 'uniqueItems must NOT have duplicate items (items ## 1 and 0 are identical)',
+        path: '/components/schemas/test/required',
+      },
+    ])
     expect(result.valid).toBe(false)
   })
 })


### PR DESCRIPTION
Enable the test for duplicate required property names. Check the exact error message and schema path.
