### PR TITLE
fix(mock-server): serve deprecated response schemas instead of an empty body

### DIFF
--- a/.changeset/mock-deprecated-response-schemas.md
+++ b/.changeset/mock-deprecated-response-schemas.md
@@ -1,0 +1,6 @@
+---
+'@scalar/workspace-store': patch
+'@scalar/mock-server': patch
+---
+
+Serve deprecated response schemas from the mock instead of answering a declared JSON response with an empty body. `getExampleFromSchema` takes a new `includeDeprecated` option for callers that must produce a value satisfying the schema; a response header whose schema generates nothing is no longer deleted.

--- a/.changeset/mock-deprecated-response-schemas.md
+++ b/.changeset/mock-deprecated-response-schemas.md
@@ -3,4 +3,4 @@
 '@scalar/mock-server': patch
 ---
 
-Serve deprecated response schemas from the mock instead of answering a declared JSON response with an empty body. `getExampleFromSchema` takes a new `includeDeprecated` option for callers that must produce a value satisfying the schema; a response header whose schema generates nothing is no longer deleted.
+Serve deprecated response schemas from the mock instead of answering a declared JSON response with an empty body, and generate a deprecated AsyncAPI message payload instead of sending `null`. `getExampleFromSchema` takes a new `includeDeprecated` option for callers that must produce a value satisfying the schema. A declared response header that generates no value is now skipped rather than clearing a header of the same name the mock already set, such as the CORS headers.

--- a/packages/mock-server/src/create-asyncapi-mock-server.test.ts
+++ b/packages/mock-server/src/create-asyncapi-mock-server.test.ts
@@ -48,6 +48,42 @@ describe('createAsyncApiMockServer', () => {
     expect(body).toContain('symbol')
   })
 
+  it('serves a generated message for a deprecated payload schema', async () => {
+    // `deprecated` marks a payload as discouraged, not as absent, so omitting it emitted an empty
+    // frame for a channel that declares a payload.
+    const { app } = await createAsyncApiMockServer({
+      document: {
+        asyncapi: '3.1.0',
+        info: { title: 'Legacy Prices', version: '1.0.0' },
+        servers: { production: { host: 'localhost', protocol: 'sse' } },
+        channels: {
+          prices: {
+            address: 'prices',
+            messages: {
+              priceUpdate: {
+                contentType: 'application/json',
+                payload: {
+                  deprecated: true,
+                  type: 'object',
+                  required: ['symbol'],
+                  properties: { symbol: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+        operations: {
+          streamPrices: { action: 'receive', channel: { $ref: '#/channels/prices' } },
+        },
+      },
+    })
+
+    const response = await app.request('/prices')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('data: {"symbol":"string"}')
+  })
+
   it('lets custom transports claim channels (extension point)', async () => {
     const claimed: string[] = []
     const signalr: MockTransport = {

--- a/packages/mock-server/src/create-asyncapi-mock-server.test.ts
+++ b/packages/mock-server/src/create-asyncapi-mock-server.test.ts
@@ -49,8 +49,8 @@ describe('createAsyncApiMockServer', () => {
   })
 
   it('serves a generated message for a deprecated payload schema', async () => {
-    // `deprecated` marks a payload as discouraged, not as absent, so omitting it emitted an empty
-    // frame for a channel that declares a payload.
+    // `deprecated` marks a payload as discouraged, not as absent, so omitting it sent the channel's
+    // declared payload as `data: null` — `encode` falls back to `null` for a generated `undefined`.
     const { app } = await createAsyncApiMockServer({
       document: {
         asyncapi: '3.1.0',

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -1824,9 +1824,12 @@ describe('createMockServer', () => {
 
       expect(response.status).toBe(200)
       expect(response.headers.get('Content-Type')).toBe('application/json')
-      // Asserted as text rather than parsed JSON: the bug under test is a zero-byte body, and
-      // `.json()` would throw on it instead of reporting what came back.
-      expect(await response.text()).toBe('{"id":"string"}')
+
+      // Read as text first so a zero-byte body — the bug under test — reports as an empty string
+      // rather than a parse error, then compare parsed so the assertion does not pin key order.
+      const text = await response.text()
+      expect(text).not.toBe('')
+      expect(JSON.parse(text)).toStrictEqual({ id: 'string' })
     })
 
     it('includes a required deprecated property in the generated body', async () => {
@@ -1927,10 +1930,11 @@ describe('createMockServer', () => {
 
       const server = await createMockServer({ document })
 
-      const response = await server.request('/things', { headers: { Origin: 'https://example.com' } })
+      const response = await server.request('/things')
 
       expect(response.status).toBe(200)
-      // Set by `cors()`, and deleted rather than skipped when the generated value is passed through.
+      // The wildcard `cors()` sets by default, not an echoed request origin. Passing the generated
+      // value straight through deletes this instead of leaving it alone.
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
     })
   })

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -1783,6 +1783,120 @@ describe('createMockServer', () => {
     expect((await server.request('/v1/jobs/42', { method: 'POST' })).status).toBe(404)
   })
 
+  // `deprecated` marks a field as discouraged, not as absent from the wire, so a mocked response has
+  // to keep it: without these the mock answered a declared `application/json` response with zero
+  // bytes, and a generated client that decodes the declared body raised on it.
+  describe('deprecated response schemas', () => {
+    it('serves a generated body for a response whose whole schema is deprecated', async () => {
+      // Regression: an API deprecated end to end (cohere's finetuning endpoints) came back `200`
+      // with an empty body, because the annotation is tested on the root schema too.
+      const document = {
+        openapi: '3.1.0',
+        info: { title: 'Finetuning API', version: '1.0.0' },
+        paths: {
+          '/finetuning': {
+            post: {
+              responses: {
+                '200': {
+                  description: 'Created',
+                  // Reached through a `$ref`, the way the failing responses reach theirs.
+                  content: { 'application/json': { schema: { $ref: '#/components/schemas/FinetunedModel' } } },
+                },
+              },
+            },
+          },
+        },
+        components: {
+          schemas: {
+            FinetunedModel: {
+              deprecated: true,
+              type: 'object',
+              required: ['id'],
+              properties: { id: { type: 'string' } },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/finetuning', { method: 'POST' })
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Type')).toBe('application/json')
+      // Asserted as text rather than parsed JSON: the bug under test is a zero-byte body, and
+      // `.json()` would throw on it instead of reporting what came back.
+      expect(await response.text()).toBe('{"id":"string"}')
+    })
+
+    it('includes a required deprecated property in the generated body', async () => {
+      // A deprecated server still returns the field, so dropping a required one made the generated
+      // body violate the very schema it was generated from.
+      const document = {
+        openapi: '3.1.0',
+        info: { title: 'Model API', version: '1.0.0' },
+        paths: {
+          '/models': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'Model',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        required: ['name', 'legacyName'],
+                        properties: { name: { type: 'string' }, legacyName: { type: 'string', deprecated: true } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/models')
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('{"name":"string","legacyName":"string"}')
+    })
+
+    it('sets a response header whose schema is deprecated', async () => {
+      // Hono *deletes* a header when handed `undefined`, so a header schema that generated nothing
+      // did not merely come out empty — it removed a header the document declares.
+      const document = {
+        openapi: '3.1.0',
+        info: { title: 'Header API', version: '1.0.0' },
+        paths: {
+          '/things': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                  headers: {
+                    'X-Legacy-Id': { schema: { type: 'string', deprecated: true, example: 'legacy-1' } },
+                  },
+                  content: { 'application/json': { example: { ok: true } } },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/things')
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('X-Legacy-Id')).toBe('legacy-1')
+    })
+  })
+
   describe('path keys with a query string', () => {
     /** Build a document with a plain path key and a variant that pins `beta=true`. */
     const documentWithBetaVariant = (paths: string[]) => ({

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -1862,12 +1862,17 @@ describe('createMockServer', () => {
       const response = await server.request('/models')
 
       expect(response.status).toBe(200)
-      expect(await response.text()).toBe('{"name":"string","legacyName":"string"}')
+
+      // Read as text first so a zero-byte body — the bug under test — reports as an empty string
+      // rather than a parse error, then compare parsed so the assertion does not pin key order.
+      const text = await response.text()
+      expect(text).not.toBe('')
+      expect(JSON.parse(text)).toStrictEqual({ name: 'string', legacyName: 'string' })
     })
 
     it('sets a response header whose schema is deprecated', async () => {
-      // Hono *deletes* a header when handed `undefined`, so a header schema that generated nothing
-      // did not merely come out empty — it removed a header the document declares.
+      // A header value is generated from its schema like any other, so the annotation suppressed it
+      // there too and the declared header went out missing rather than merely empty.
       const document = {
         openapi: '3.1.0',
         info: { title: 'Header API', version: '1.0.0' },
@@ -1894,6 +1899,39 @@ describe('createMockServer', () => {
 
       expect(response.status).toBe(200)
       expect(response.headers.get('X-Legacy-Id')).toBe('legacy-1')
+    })
+
+    it('leaves other headers alone when a header schema generates nothing', async () => {
+      // A header value that comes back `undefined` has to be skipped, not handed to `c.header()`:
+      // Hono treats `undefined` as a delete, and the header loop runs before `Content-Type` is set
+      // and after the CORS middleware, so the casualty is a header something else already set.
+      const document = {
+        openapi: '3.1.0',
+        info: { title: 'Header API', version: '1.0.0' },
+        paths: {
+          '/things': {
+            get: {
+              responses: {
+                '200': {
+                  description: 'OK',
+                  // An unresolvable `$ref` resolves to `undefined`, so nothing is generated for it —
+                  // independent of the deprecation gate, which is what isolates the guard below.
+                  headers: { 'Access-Control-Allow-Origin': { schema: { $ref: '#/components/schemas/Missing' } } },
+                  content: { 'application/json': { example: { ok: true } } },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/things', { headers: { Origin: 'https://example.com' } })
+
+      expect(response.status).toBe(200)
+      // Set by `cors()`, and deleted rather than skipped when the generated value is passed through.
+      expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
     })
   })
 

--- a/packages/mock-server/src/create-mock-server.test.ts
+++ b/packages/mock-server/src/create-mock-server.test.ts
@@ -1825,11 +1825,9 @@ describe('createMockServer', () => {
       expect(response.status).toBe(200)
       expect(response.headers.get('Content-Type')).toBe('application/json')
 
-      // Read as text first so a zero-byte body — the bug under test — reports as an empty string
-      // rather than a parse error, then compare parsed so the assertion does not pin key order.
-      const text = await response.text()
-      expect(text).not.toBe('')
-      expect(JSON.parse(text)).toStrictEqual({ id: 'string' })
+      // Asserted as text, not parsed JSON: the bug under test is a zero-byte body, which shows up
+      // here as a clean diff against `''` where `.json()` would throw before reporting anything.
+      expect(await response.text()).toBe('{"id":"string"}')
     })
 
     it('includes a required deprecated property in the generated body', async () => {
@@ -1866,11 +1864,7 @@ describe('createMockServer', () => {
 
       expect(response.status).toBe(200)
 
-      // Read as text first so a zero-byte body — the bug under test — reports as an empty string
-      // rather than a parse error, then compare parsed so the assertion does not pin key order.
-      const text = await response.text()
-      expect(text).not.toBe('')
-      expect(JSON.parse(text)).toStrictEqual({ name: 'string', legacyName: 'string' })
+      expect(await response.text()).toBe('{"name":"string","legacyName":"string"}')
     })
 
     it('sets a response header whose schema is deprecated', async () => {
@@ -1903,11 +1897,13 @@ describe('createMockServer', () => {
       expect(response.status).toBe(200)
       expect(response.headers.get('X-Legacy-Id')).toBe('legacy-1')
     })
+  })
 
-    it('leaves other headers alone when a header schema generates nothing', async () => {
-      // A header value that comes back `undefined` has to be skipped, not handed to `c.header()`:
-      // Hono treats `undefined` as a delete, and the header loop runs before `Content-Type` is set
-      // and after the CORS middleware, so the casualty is a header something else already set.
+  describe('response headers', () => {
+    it('does not delete an already-set header when a declared header schema generates nothing', async () => {
+      // Hono treats `undefined` as a delete, so a header value that generates nothing has to be
+      // skipped rather than passed to `c.header()`. This loop is the first thing to set the declared
+      // headers, so what a delete actually removes is a header set earlier by middleware.
       const document = {
         openapi: '3.1.0',
         info: { title: 'Header API', version: '1.0.0' },
@@ -1917,8 +1913,9 @@ describe('createMockServer', () => {
               responses: {
                 '200': {
                   description: 'OK',
-                  // An unresolvable `$ref` resolves to `undefined`, so nothing is generated for it —
-                  // independent of the deprecation gate, which is what isolates the guard below.
+                  // An unresolvable `$ref` resolves to `undefined`, so nothing is generated for it.
+                  // Note an empty schema would not do: that generates `null`, which the guard has
+                  // always skipped, so it could not tell the two guards apart.
                   headers: { 'Access-Control-Allow-Origin': { schema: { $ref: '#/components/schemas/Missing' } } },
                   content: { 'application/json': { example: { ok: true } } },
                 },
@@ -1933,8 +1930,7 @@ describe('createMockServer', () => {
       const response = await server.request('/things')
 
       expect(response.status).toBe(200)
-      // The wildcard `cors()` sets by default, not an echoed request origin. Passing the generated
-      // value straight through deletes this instead of leaving it alone.
+      // The wildcard `cors()` sets by default, not an echoed request origin.
       expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
     })
   })

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -53,15 +53,17 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   Object.keys(headers).forEach((header) => {
     const headerObject = getResolvedRef(headers[header])
     // `includeDeprecated` keeps a header whose schema is annotated `deprecated` from generating
-    // nothing. Only that option is passed, so this site stays off `generateResponseExample`: its
-    // `emptyString` switches on format-based generation, which would turn a header declaring
-    // `format: 'date-time'` into a fabricated timestamp instead of the empty string it emits today.
+    // nothing. Only that option is passed, so this site stays off `generateResponseExample`, whose
+    // other two options would each change what a document's declared headers emit today:
+    // `emptyString` turns a bare `type: 'string'` header into the literal `string` and switches on
+    // format-based generation (a `format: 'date-time'` header would emit a fabricated timestamp),
+    // and `mode: 'read'` would drop a `writeOnly` header entirely.
     const value = headerObject?.schema
       ? (getExampleFromSchema(getResolvedRefDeep(headerObject.schema), { includeDeprecated: true }) as string)
       : null
     // Loose check on purpose: Hono *deletes* a header when handed `undefined`. This loop is the first
-    // thing to set the declared headers, so what a delete can actually remove is a header an earlier
-    // middleware set — `cors()` sets `Access-Control-Allow-Origin` before the handler runs.
+    // thing to set the declared headers, so in practice a delete removes a header set earlier by
+    // middleware — `cors()` sets `Access-Control-Allow-Origin` before the handler runs.
     if (value != null) {
       c.header(header, value)
     }

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -12,6 +12,7 @@ import { findPreferredResponseKey } from '@/utils/find-preferred-response-key'
 import { generateResponseExample } from '@/utils/generate-response-example'
 import { normalizeResponseBody } from '@/utils/normalize-response-body'
 import { parsePreferHeader } from '@/utils/parse-prefer-header'
+import { pathParameters } from '@/utils/path-parameters'
 import { selectResponseExample } from '@/utils/select-response-example'
 import { serializeResponseBody } from '@/utils/serialize-response-body'
 
@@ -52,13 +53,15 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   Object.keys(headers).forEach((header) => {
     const headerObject = getResolvedRef(headers[header])
     // `includeDeprecated` keeps a header whose schema is annotated `deprecated` from generating
-    // nothing. Only that option is passed: `emptyString`/`variables` would change header values a
-    // document already declares, so this site deliberately stays off `generateResponseExample`.
+    // nothing. Only that option is passed, so this site stays off `generateResponseExample`: its
+    // `emptyString` switches on format-based generation, which would turn a header declaring
+    // `format: 'date-time'` into a fabricated timestamp instead of the empty string it emits today.
     const value = headerObject?.schema
       ? (getExampleFromSchema(getResolvedRefDeep(headerObject.schema), { includeDeprecated: true }) as string)
       : null
-    // Loose check on purpose: Hono *deletes* a header when handed `undefined`, so a generated value
-    // that comes back `undefined` has to be treated like the absent case rather than set.
+    // Loose check on purpose: Hono *deletes* a header when handed `undefined`. This loop is the first
+    // thing to set the declared headers, so what a delete can actually remove is a header an earlier
+    // middleware set — `cors()` sets `Access-Control-Allow-Origin` before the handler runs.
     if (value != null) {
       c.header(header, value)
     }
@@ -94,7 +97,8 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   const responseSchema = acceptedResponse?.schema ? getResolvedRefDeep(acceptedResponse.schema) : undefined
 
   /** Generates the response body from the schema, or returns `undefined` when there is no schema. */
-  const generateFromSchema = (): unknown => (responseSchema ? generateResponseExample(responseSchema, c) : undefined)
+  const generateFromSchema = (): unknown =>
+    responseSchema ? generateResponseExample(responseSchema, pathParameters(c)) : undefined
 
   // Server-Sent Events are a framed, multi-event wire format, so they cannot go out as one buffered
   // body: a client reading the stream expects `data:` lines terminated by a blank line. Everything

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -9,9 +9,9 @@ import type { StatusCode } from 'hono/utils/http-status'
 
 import { collectSseEvents, isEventStreamContentType } from '@/utils/collect-sse-events'
 import { findPreferredResponseKey } from '@/utils/find-preferred-response-key'
+import { generateResponseExample } from '@/utils/generate-response-example'
 import { normalizeResponseBody } from '@/utils/normalize-response-body'
 import { parsePreferHeader } from '@/utils/parse-prefer-header'
-import { pathParameters } from '@/utils/path-parameters'
 import { selectResponseExample } from '@/utils/select-response-example'
 import { serializeResponseBody } from '@/utils/serialize-response-body'
 
@@ -51,10 +51,15 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   const headers = selectedResponse?.headers ?? {}
   Object.keys(headers).forEach((header) => {
     const headerObject = getResolvedRef(headers[header])
+    // `includeDeprecated` keeps a header whose schema is annotated `deprecated` from generating
+    // nothing. Only that option is passed: `emptyString`/`variables` would change header values a
+    // document already declares, so this site deliberately stays off `generateResponseExample`.
     const value = headerObject?.schema
-      ? (getExampleFromSchema(getResolvedRefDeep(headerObject.schema)) as string)
+      ? (getExampleFromSchema(getResolvedRefDeep(headerObject.schema), { includeDeprecated: true }) as string)
       : null
-    if (value !== null) {
+    // Loose check on purpose: Hono *deletes* a header when handed `undefined`, so a generated value
+    // that comes back `undefined` has to be treated like the absent case rather than set.
+    if (value != null) {
       c.header(header, value)
     }
   })
@@ -89,14 +94,7 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   const responseSchema = acceptedResponse?.schema ? getResolvedRefDeep(acceptedResponse.schema) : undefined
 
   /** Generates the response body from the schema, or returns `undefined` when there is no schema. */
-  const generateFromSchema = (): unknown =>
-    responseSchema
-      ? getExampleFromSchema(responseSchema, {
-          emptyString: 'string',
-          variables: pathParameters(c),
-          mode: 'read',
-        })
-      : undefined
+  const generateFromSchema = (): unknown => (responseSchema ? generateResponseExample(responseSchema, c) : undefined)
 
   // Server-Sent Events are a framed, multi-event wire format, so they cannot go out as one buffered
   // body: a client reading the stream expects `data:` lines terminated by a blank line. Everything

--- a/packages/mock-server/src/routes/mock-any-response.ts
+++ b/packages/mock-server/src/routes/mock-any-response.ts
@@ -52,12 +52,8 @@ export function mockAnyResponse(c: Context, operation: OpenAPIV3_1.OperationObje
   const headers = selectedResponse?.headers ?? {}
   Object.keys(headers).forEach((header) => {
     const headerObject = getResolvedRef(headers[header])
-    // `includeDeprecated` keeps a header whose schema is annotated `deprecated` from generating
-    // nothing. Only that option is passed, so this site stays off `generateResponseExample`, whose
-    // other two options would each change what a document's declared headers emit today:
-    // `emptyString` turns a bare `type: 'string'` header into the literal `string` and switches on
-    // format-based generation (a `format: 'date-time'` header would emit a fabricated timestamp),
-    // and `mode: 'read'` would drop a `writeOnly` header entirely.
+    // Headers need `includeDeprecated` but none of `generateResponseExample`'s other options — see
+    // the note on that helper for why passing them would change what declared headers emit.
     const value = headerObject?.schema
       ? (getExampleFromSchema(getResolvedRefDeep(headerObject.schema), { includeDeprecated: true }) as string)
       : null

--- a/packages/mock-server/src/routes/mock-handler-response.ts
+++ b/packages/mock-server/src/routes/mock-handler-response.ts
@@ -1,15 +1,14 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
-import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 import type { Context } from 'hono'
 import { accepts } from 'hono/accepts'
 import type { StatusCode } from 'hono/utils/http-status'
 
 import { buildHandlerContext } from '@/utils/build-handler-context'
 import { executeHandler } from '@/utils/execute-handler'
+import { generateResponseExample } from '@/utils/generate-response-example'
 import { normalizeResponseBody } from '@/utils/normalize-response-body'
 import { parsePreferHeader } from '@/utils/parse-prefer-header'
-import { pathParameters } from '@/utils/path-parameters'
 import { selectResponseExample } from '@/utils/select-response-example'
 
 /**
@@ -67,14 +66,7 @@ function getExampleFromResponse(
   return selectedExample
     ? normalizeResponseBody(selectedExample.value, responseSchema)
     : responseSchema
-      ? normalizeResponseBody(
-          getExampleFromSchema(responseSchema, {
-            emptyString: 'string',
-            variables: pathParameters(c),
-            mode: 'read',
-          }),
-          responseSchema,
-        )
+      ? normalizeResponseBody(generateResponseExample(responseSchema, c), responseSchema)
       : null
 }
 

--- a/packages/mock-server/src/routes/mock-handler-response.ts
+++ b/packages/mock-server/src/routes/mock-handler-response.ts
@@ -9,6 +9,7 @@ import { executeHandler } from '@/utils/execute-handler'
 import { generateResponseExample } from '@/utils/generate-response-example'
 import { normalizeResponseBody } from '@/utils/normalize-response-body'
 import { parsePreferHeader } from '@/utils/parse-prefer-header'
+import { pathParameters } from '@/utils/path-parameters'
 import { selectResponseExample } from '@/utils/select-response-example'
 
 /**
@@ -66,7 +67,7 @@ function getExampleFromResponse(
   return selectedExample
     ? normalizeResponseBody(selectedExample.value, responseSchema)
     : responseSchema
-      ? normalizeResponseBody(generateResponseExample(responseSchema, c), responseSchema)
+      ? normalizeResponseBody(generateResponseExample(responseSchema, pathParameters(c)), responseSchema)
       : null
 }
 

--- a/packages/mock-server/src/utils/build-handler-context.ts
+++ b/packages/mock-server/src/utils/build-handler-context.ts
@@ -79,7 +79,7 @@ function getExampleFromResponse(
   return acceptedResponse.example !== undefined
     ? normalizeResponseBody(acceptedResponse.example, responseSchema)
     : responseSchema
-      ? normalizeResponseBody(generateResponseExample(responseSchema, c), responseSchema)
+      ? normalizeResponseBody(generateResponseExample(responseSchema, pathParameters(c)), responseSchema)
       : null
 }
 

--- a/packages/mock-server/src/utils/build-handler-context.ts
+++ b/packages/mock-server/src/utils/build-handler-context.ts
@@ -1,11 +1,11 @@
 import type { OpenAPIV3_1 } from '@scalar/openapi-types'
 import { getResolvedRef } from '@scalar/workspace-store/helpers/get-resolved-ref'
 import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
-import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 import type { Context } from 'hono'
 import { accepts } from 'hono/accepts'
 
 import { store } from '../libs/store'
+import { generateResponseExample } from './generate-response-example'
 import { normalizeResponseBody } from './normalize-response-body'
 import { pathParameters } from './path-parameters'
 import { type StoreOperationTracking, createStoreWrapper } from './store-wrapper'
@@ -79,14 +79,7 @@ function getExampleFromResponse(
   return acceptedResponse.example !== undefined
     ? normalizeResponseBody(acceptedResponse.example, responseSchema)
     : responseSchema
-      ? normalizeResponseBody(
-          getExampleFromSchema(responseSchema, {
-            emptyString: 'string',
-            variables: pathParameters(c),
-            mode: 'read',
-          }),
-          responseSchema,
-        )
+      ? normalizeResponseBody(generateResponseExample(responseSchema, c), responseSchema)
       : null
 }
 

--- a/packages/mock-server/src/utils/generate-message.ts
+++ b/packages/mock-server/src/utils/generate-message.ts
@@ -35,9 +35,13 @@ export function generateMessage(channel: ResolvedChannel, messageId?: string): M
     // Prefer an explicit example, mirroring response-example selection in the REST mocker.
     value = message.examples[0]
   } else if (message.payload) {
+    // `includeDeprecated` keeps a payload annotated `deprecated` from generating an empty frame —
+    // the same invariant `generateResponseExample` owns for HTTP bodies. This call site cannot reuse
+    // that helper: there is no Hono context here, and it deliberately passes no `variables`.
     value = getExampleFromSchema(getResolvedRefDeep(message.payload) as Parameters<typeof getExampleFromSchema>[0], {
       emptyString: 'string',
       mode: 'read',
+      includeDeprecated: true,
     })
   }
 

--- a/packages/mock-server/src/utils/generate-message.ts
+++ b/packages/mock-server/src/utils/generate-message.ts
@@ -1,7 +1,7 @@
 import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
 
 import type { MockMessage, ResolvedChannel, ResolvedMessage } from '@/transports/types'
-import { generateResponseExample } from '@/utils/generate-response-example'
+import { type ExampleSchema, generateResponseExample } from '@/utils/generate-response-example'
 
 /** Encode a generated value to a wire string. Strings pass through; everything else is JSON. */
 function encode(value: unknown): string {
@@ -35,11 +35,9 @@ export function generateMessage(channel: ResolvedChannel, messageId?: string): M
     // Prefer an explicit example, mirroring response-example selection in the REST mocker.
     value = message.examples[0]
   } else if (message.payload) {
-    // No `variables`: a channel message is not generated per request, so there are no path
-    // parameters to substitute.
-    value = generateResponseExample(
-      getResolvedRefDeep(message.payload) as Parameters<typeof generateResponseExample>[0],
-    )
+    // No `variables`: `generateMessage` is never handed the Hono context, so a channel route's path
+    // parameters are not in scope for `x-variable` substitution. It does run per request.
+    value = generateResponseExample(getResolvedRefDeep(message.payload) as ExampleSchema)
   }
 
   return {

--- a/packages/mock-server/src/utils/generate-message.ts
+++ b/packages/mock-server/src/utils/generate-message.ts
@@ -1,7 +1,7 @@
 import { getResolvedRefDeep } from '@scalar/workspace-store/helpers/get-resolved-ref-deep'
-import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 
 import type { MockMessage, ResolvedChannel, ResolvedMessage } from '@/transports/types'
+import { generateResponseExample } from '@/utils/generate-response-example'
 
 /** Encode a generated value to a wire string. Strings pass through; everything else is JSON. */
 function encode(value: unknown): string {
@@ -15,7 +15,7 @@ function encode(value: unknown): string {
 /**
  * Generate an encoded mock frame for a channel message — the AsyncAPI analogue of the REST
  * mocker's response generation. Prefers a defined example, otherwise generates a value from the
- * message payload schema with the same `getExampleFromSchema` the HTTP mocker uses.
+ * message payload schema through the same `generateResponseExample` the HTTP mocker uses.
  *
  * @param channel - The resolved channel to mock a message for.
  * @param messageId - Which message to emit; defaults to the channel's first message.
@@ -35,14 +35,11 @@ export function generateMessage(channel: ResolvedChannel, messageId?: string): M
     // Prefer an explicit example, mirroring response-example selection in the REST mocker.
     value = message.examples[0]
   } else if (message.payload) {
-    // `includeDeprecated` keeps a payload annotated `deprecated` from generating an empty frame —
-    // the same invariant `generateResponseExample` owns for HTTP bodies. This call site cannot reuse
-    // that helper: there is no Hono context here, and it deliberately passes no `variables`.
-    value = getExampleFromSchema(getResolvedRefDeep(message.payload) as Parameters<typeof getExampleFromSchema>[0], {
-      emptyString: 'string',
-      mode: 'read',
-      includeDeprecated: true,
-    })
+    // No `variables`: a channel message is not generated per request, so there are no path
+    // parameters to substitute.
+    value = generateResponseExample(
+      getResolvedRefDeep(message.payload) as Parameters<typeof generateResponseExample>[0],
+    )
   }
 
   return {

--- a/packages/mock-server/src/utils/generate-response-example.ts
+++ b/packages/mock-server/src/utils/generate-response-example.ts
@@ -1,0 +1,31 @@
+import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
+import type { Context } from 'hono'
+
+import { pathParameters } from '@/utils/path-parameters'
+
+/** The schema shape `getExampleFromSchema` accepts, so callers do not have to name it themselves. */
+type ExampleSchema = Parameters<typeof getExampleFromSchema>[0]
+
+/**
+ * Generate a mocked response body from a response schema.
+ *
+ * Every response the mock serves has to satisfy the schema it declares, which is why this passes
+ * `includeDeprecated: true`: `deprecated` marks a field as discouraged, not absent, so omitting it
+ * answered a declared JSON response with zero bytes (or dropped a required property). Centralizing
+ * the option set keeps a newly added response path from quietly missing it.
+ *
+ * Not for response headers. They pass no `emptyString`/`variables` today, and routing them through
+ * here would change the header values a document already declares — they set
+ * `includeDeprecated: true` on their own call instead.
+ *
+ * @param schema - The resolved response schema to generate a value for.
+ * @param c - The Hono context, read for the path parameters exposed as `x-variable` values.
+ * @returns The generated example value, or `undefined` when the schema yields nothing.
+ */
+export const generateResponseExample = (schema: ExampleSchema, c: Context): unknown =>
+  getExampleFromSchema(schema, {
+    emptyString: 'string',
+    variables: pathParameters(c),
+    mode: 'read',
+    includeDeprecated: true,
+  })

--- a/packages/mock-server/src/utils/generate-response-example.ts
+++ b/packages/mock-server/src/utils/generate-response-example.ts
@@ -1,7 +1,7 @@
 import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
 
 /** The schema shape `getExampleFromSchema` accepts, so callers do not have to name it themselves. */
-type ExampleSchema = Parameters<typeof getExampleFromSchema>[0]
+export type ExampleSchema = Parameters<typeof getExampleFromSchema>[0]
 
 /**
  * Generate a mocked response value from a schema the mock has declared.
@@ -12,10 +12,11 @@ type ExampleSchema = Parameters<typeof getExampleFromSchema>[0]
  * response with zero bytes and dropped required properties. Owning the option set in one place keeps
  * a newly added response path from quietly missing that.
  *
- * Not for response headers. Each of the other options here would change what an already-declared
- * header emits: `emptyString` yields the literal `string` for a bare `type: 'string'` and switches on
- * format-based generation, and `mode: 'read'` drops a `writeOnly` header. Headers set
- * `includeDeprecated` on their own call instead.
+ * Not for response headers. Two of the options here would change what an already-declared header
+ * emits: `emptyString` yields the literal `string` for a bare `type: 'string'` and switches on
+ * format-based generation (a `format: 'date-time'` header would emit a fabricated timestamp), and
+ * `mode: 'read'` drops a `writeOnly` header entirely. Headers set `includeDeprecated` on their own
+ * call instead.
  *
  * @param schema - The resolved schema to generate a value for.
  * @param variables - Values for `x-variable` substitution, usually a request's path parameters.

--- a/packages/mock-server/src/utils/generate-response-example.ts
+++ b/packages/mock-server/src/utils/generate-response-example.ts
@@ -1,31 +1,31 @@
 import { getExampleFromSchema } from '@scalar/workspace-store/request-example'
-import type { Context } from 'hono'
-
-import { pathParameters } from '@/utils/path-parameters'
 
 /** The schema shape `getExampleFromSchema` accepts, so callers do not have to name it themselves. */
 type ExampleSchema = Parameters<typeof getExampleFromSchema>[0]
 
 /**
- * Generate a mocked response body from a response schema.
+ * Generate a mocked response value from a schema the mock has declared.
  *
- * Every response the mock serves has to satisfy the schema it declares, which is why this passes
- * `includeDeprecated: true`: `deprecated` marks a field as discouraged, not absent, so omitting it
- * answered a declared JSON response with zero bytes (or dropped a required property). Centralizing
- * the option set keeps a newly added response path from quietly missing it.
+ * Every value the mock puts on the wire — an HTTP body, an SSE frame, a channel message — has to
+ * satisfy the schema it was declared with, which is why this passes `includeDeprecated: true`:
+ * `deprecated` marks a field as discouraged, not absent, so omitting it answered a declared JSON
+ * response with zero bytes and dropped required properties. Owning the option set in one place keeps
+ * a newly added response path from quietly missing that.
  *
- * Not for response headers. They pass no `emptyString`/`variables` today, and routing them through
- * here would change the header values a document already declares — they set
- * `includeDeprecated: true` on their own call instead.
+ * Not for response headers. `emptyString` switches on format-based value generation
+ * (`makeUpRandomData`), so a header declaring `format: 'date-time'` would start emitting a
+ * fabricated timestamp where it emits an empty string today. Headers set `includeDeprecated` on
+ * their own call instead.
  *
- * @param schema - The resolved response schema to generate a value for.
- * @param c - The Hono context, read for the path parameters exposed as `x-variable` values.
- * @returns The generated example value, or `undefined` when the schema yields nothing.
+ * @param schema - The resolved schema to generate a value for.
+ * @param variables - Values for `x-variable` substitution, usually a request's path parameters.
+ *   Omitted by callers that have no request in scope, such as channel messages.
+ * @returns The generated value, or `undefined` when the schema yields nothing.
  */
-export const generateResponseExample = (schema: ExampleSchema, c: Context): unknown =>
+export const generateResponseExample = (schema: ExampleSchema, variables?: Record<string, unknown>): unknown =>
   getExampleFromSchema(schema, {
     emptyString: 'string',
-    variables: pathParameters(c),
+    variables,
     mode: 'read',
     includeDeprecated: true,
   })

--- a/packages/mock-server/src/utils/generate-response-example.ts
+++ b/packages/mock-server/src/utils/generate-response-example.ts
@@ -12,10 +12,10 @@ type ExampleSchema = Parameters<typeof getExampleFromSchema>[0]
  * response with zero bytes and dropped required properties. Owning the option set in one place keeps
  * a newly added response path from quietly missing that.
  *
- * Not for response headers. `emptyString` switches on format-based value generation
- * (`makeUpRandomData`), so a header declaring `format: 'date-time'` would start emitting a
- * fabricated timestamp where it emits an empty string today. Headers set `includeDeprecated` on
- * their own call instead.
+ * Not for response headers. Each of the other options here would change what an already-declared
+ * header emits: `emptyString` yields the literal `string` for a bare `type: 'string'` and switches on
+ * format-based generation, and `mode: 'read'` drops a `writeOnly` header. Headers set
+ * `includeDeprecated` on their own call instead.
  *
  * @param schema - The resolved schema to generate a value for.
  * @param variables - Values for `x-variable` substitution, usually a request's path parameters.

--- a/packages/mock-server/src/x-handler.test.ts
+++ b/packages/mock-server/src/x-handler.test.ts
@@ -1061,6 +1061,90 @@ describe('x-handler', () => {
     expect(data.custom).not.toBe('example-value')
   })
 
+  // `deprecated` marks a field as discouraged, not as absent, so the two places an `x-handler`
+  // response is generated from a schema have to keep it — otherwise a declared body came back empty.
+  describe('deprecated response schemas', () => {
+    it('falls back to a generated body when the response schema is deprecated', async () => {
+      const document = {
+        openapi: '3.1.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        paths: {
+          '/legacy': {
+            get: {
+              // Returning nothing sends the mock to the declared response for the body.
+              'x-handler': 'return undefined;',
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        deprecated: true,
+                        type: 'object',
+                        required: ['id'],
+                        properties: { id: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/legacy')
+
+      expect(response.status).toBe(200)
+      // Asserted as text: the bug under test is a zero-byte body, which `.json()` would throw on.
+      expect(await response.text()).toBe('{"id":"string"}')
+    })
+
+    it('exposes a generated body for a deprecated schema through res[statusCode]', async () => {
+      const document = {
+        openapi: '3.1.0',
+        info: {
+          title: 'Test API',
+          version: '1.0.0',
+        },
+        paths: {
+          '/legacy': {
+            get: {
+              'x-handler': "return res['200'];",
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: {
+                        deprecated: true,
+                        type: 'object',
+                        required: ['id'],
+                        properties: { id: { type: 'string' } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+
+      const server = await createMockServer({ document })
+
+      const response = await server.request('/legacy')
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('{"id":"string"}')
+    })
+  })
+
   describe('res object with example responses', () => {
     it('handler can access explicit example via res[statusCode]', async () => {
       const document = {

--- a/packages/mock-server/src/x-handler.test.ts
+++ b/packages/mock-server/src/x-handler.test.ts
@@ -1164,7 +1164,7 @@ describe('x-handler', () => {
         '/items/{id}': {
           get: {
             'x-handler': handler,
-            'responses': {
+            responses: {
               '200': {
                 description: 'OK',
                 content: {

--- a/packages/mock-server/src/x-handler.test.ts
+++ b/packages/mock-server/src/x-handler.test.ts
@@ -1115,7 +1115,11 @@ describe('x-handler', () => {
         paths: {
           '/legacy': {
             get: {
-              'x-handler': "return res['200'];",
+              // Wrapped in an object on purpose. Returning `res['200']` bare would send an
+              // unpopulated value down the `result === undefined` path in `mockHandlerResponse`,
+              // which generates the body again from the same response — so the assertion would pass
+              // even with this call site unfixed. Wrapping keeps the failure visible as `{}`.
+              'x-handler': "return { fromRes: res['200'] };",
               responses: {
                 '200': {
                   description: 'OK',
@@ -1141,7 +1145,7 @@ describe('x-handler', () => {
       const response = await server.request('/legacy')
 
       expect(response.status).toBe(200)
-      expect(await response.text()).toBe('{"id":"string"}')
+      expect(await response.text()).toBe('{"fromRes":{"id":"string"}}')
     })
   })
 

--- a/packages/mock-server/src/x-handler.test.ts
+++ b/packages/mock-server/src/x-handler.test.ts
@@ -1149,6 +1149,58 @@ describe('x-handler', () => {
     })
   })
 
+  // `generateResponseExample` takes the `x-variable` values as an ordinary optional argument, so
+  // dropping it at a call site is not a type error. These pin the substitution at the two sites an
+  // `x-handler` reaches, which the deprecated cases above cannot see.
+  describe('x-variable substitution in generated responses', () => {
+    /** A document whose response schema reads the path parameter through `x-variable`. */
+    const documentWithVariableResponse = (handler: string) => ({
+      openapi: '3.1.0',
+      info: {
+        title: 'Test API',
+        version: '1.0.0',
+      },
+      paths: {
+        '/items/{id}': {
+          get: {
+            'x-handler': handler,
+            'responses': {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: { id: { 'type': 'string', 'example': 'unsubstituted', 'x-variable': 'id' } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    it('substitutes path parameters in the fallback body', async () => {
+      const server = await createMockServer({ document: documentWithVariableResponse('return undefined;') })
+
+      const response = await server.request('/items/42')
+
+      expect(await response.text()).toBe('{"id":"42"}')
+    })
+
+    it('substitutes path parameters in res[statusCode]', async () => {
+      const server = await createMockServer({
+        document: documentWithVariableResponse("return { fromRes: res['200'] };"),
+      })
+
+      const response = await server.request('/items/42')
+
+      expect(await response.text()).toBe('{"fromRes":{"id":"42"}}')
+    })
+  })
+
   describe('res object with example responses', () => {
     it('handler can access explicit example via res[statusCode]', async () => {
       const document = {

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.test.ts
@@ -1864,6 +1864,112 @@ describe('getExampleFromSchema', () => {
     })
   })
 
+  it('keeps deprecated properties with includeDeprecated', () => {
+    expect(
+      getExampleFromSchema(
+        coerceValue(SchemaObjectSchema, {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              example: 'test',
+            },
+            oldField: {
+              type: 'string',
+              example: 'still on the wire',
+              deprecated: true,
+            },
+          },
+        }),
+        { includeDeprecated: true },
+      ),
+    ).toStrictEqual({
+      name: 'test',
+      oldField: 'still on the wire',
+    })
+  })
+
+  it('omits a deprecated root schema entirely', () => {
+    // The annotation is tested on every schema including the root, so a wholly deprecated response
+    // schema generates nothing at all — which is what answered a declared JSON body with zero bytes.
+    expect(
+      getExampleFromSchema(
+        coerceValue(SchemaObjectSchema, {
+          deprecated: true,
+          type: 'object',
+          required: ['id'],
+          properties: { id: { type: 'string' } },
+        }),
+      ),
+    ).toBeUndefined()
+  })
+
+  it('generates a value for a deprecated root schema with includeDeprecated', () => {
+    expect(
+      getExampleFromSchema(
+        coerceValue(SchemaObjectSchema, {
+          deprecated: true,
+          type: 'object',
+          required: ['id'],
+          properties: { id: { type: 'string' } },
+        }),
+        { includeDeprecated: true },
+      ),
+    ).toStrictEqual({ id: '' })
+  })
+
+  it('omits a required deprecated property, violating the schema', () => {
+    // `required` does not rescue the property: without the flag the generated object breaks the very
+    // contract it was generated from, which is why a mock response needs the opt-in.
+    expect(
+      getExampleFromSchema(
+        coerceValue(SchemaObjectSchema, {
+          type: 'object',
+          required: ['name', 'legacyName'],
+          properties: {
+            name: { type: 'string' },
+            legacyName: { type: 'string', deprecated: true },
+          },
+        }),
+      ),
+    ).toStrictEqual({ name: '' })
+  })
+
+  it('keeps a required deprecated property with includeDeprecated', () => {
+    expect(
+      getExampleFromSchema(
+        coerceValue(SchemaObjectSchema, {
+          type: 'object',
+          required: ['name', 'legacyName'],
+          properties: {
+            name: { type: 'string' },
+            legacyName: { type: 'string', deprecated: true },
+          },
+        }),
+        { includeDeprecated: true },
+      ),
+    ).toStrictEqual({ name: '', legacyName: '' })
+  })
+
+  it('does not leak a cached example between includeDeprecated and the default', () => {
+    // `resultCache` is a module global keyed by schema identity plus the serialized options, and its
+    // lookup runs before the annotation is tested. If the flag were missing from that key, whichever
+    // caller ran first would decide the answer for the other one.
+    const schema = coerceValue(SchemaObjectSchema, {
+      type: 'object',
+      properties: {
+        name: { type: 'string', example: 'test' },
+        oldField: { type: 'string', example: 'legacy', deprecated: true },
+      },
+    })
+
+    expect(getExampleFromSchema(schema, { includeDeprecated: true })).toStrictEqual({
+      name: 'test',
+      oldField: 'legacy',
+    })
+    expect(getExampleFromSchema(schema)).toStrictEqual({ name: 'test' })
+  })
+
   it('expands objects and arrays in arrays (without a type)', () => {
     expect(
       getExampleFromSchema(

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -854,7 +854,7 @@ export const getExampleFromSchema = (
   // Determine if we should generate realistic example data
   const makeUpRandomData = !!options?.emptyString
 
-  // Early exits for schemas that should not be included (deprecated, readOnly, writeOnly, omitEmptyAndOptionalProperties)
+  // Early exits for schemas that should not be included (deprecated unless opted in, readOnly, writeOnly, omitEmptyAndOptionalProperties)
   if (shouldOmitProperty(_schema, parentSchema, name, options)) {
     seen.delete(targetValue)
     return undefined

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -170,11 +170,13 @@ const shouldOmitProperty = (
   schema: SchemaObject,
   parentSchema: SchemaObject | undefined,
   propertyName: string | undefined,
-  options: Pick<GetExampleFromSchemaOptions, 'omitEmptyAndOptionalProperties' | 'mode'> | undefined,
+  options:
+    | Pick<GetExampleFromSchemaOptions, 'omitEmptyAndOptionalProperties' | 'mode' | 'includeDeprecated'>
+    | undefined,
 ): boolean => {
   // Early exits for schemas that should not be included (deprecated, readOnly, writeOnly)
   if (
-    schema.deprecated ||
+    (schema.deprecated && options?.includeDeprecated !== true) ||
     (options?.mode === 'write' && schema.readOnly) ||
     (options?.mode === 'read' && schema.writeOnly)
   ) {
@@ -727,6 +729,14 @@ type GetExampleFromSchemaOptions = {
   variables?: Record<string, unknown>
   /** Whether to omit empty and optional properties. */
   omitEmptyAndOptionalProperties?: boolean
+  /**
+   * Whether to keep schemas annotated `deprecated: true`.
+   *
+   * `deprecated` says a field is discouraged, not that it is absent from the wire, so a caller
+   * that must produce a value satisfying the schema — a mock server response, for instance —
+   * sets this. Defaults to omitting, which is what a request-body form-filler wants.
+   */
+  includeDeprecated?: boolean
   /** Selected oneOf/anyOf variants keyed by schema path. */
   compositionSelection?: Record<string, number>
 }
@@ -739,6 +749,11 @@ const createOptionsCacheKey = (options: GetExampleFromSchemaOptions | undefined)
     mode: options?.mode,
     variables: options?.variables,
     omitEmptyAndOptionalProperties: options?.omitEmptyAndOptionalProperties,
+    // Load-bearing: `resultCache` is a module global keyed by schema identity plus this string, and
+    // the lookup happens before `shouldOmitProperty` runs. Without this entry an include-caller's
+    // populated object could be handed back to a default caller, and vice versa. `JSON.stringify`
+    // drops `undefined`, so existing callers' keys stay byte-identical.
+    includeDeprecated: options?.includeDeprecated,
     compositionSelection: options?.compositionSelection
       ? Object.entries(options.compositionSelection).sort(([a], [b]) => a.localeCompare(b))
       : undefined,

--- a/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
+++ b/packages/workspace-store/src/request-example/builder/helpers/get-example-from-schema.ts
@@ -174,7 +174,7 @@ const shouldOmitProperty = (
     | Pick<GetExampleFromSchemaOptions, 'omitEmptyAndOptionalProperties' | 'mode' | 'includeDeprecated'>
     | undefined,
 ): boolean => {
-  // Early exits for schemas that should not be included (deprecated, readOnly, writeOnly)
+  // Early exits for schemas that should not be included (deprecated unless opted in, readOnly, writeOnly)
   if (
     (schema.deprecated && options?.includeDeprecated !== true) ||
     (options?.mode === 'write' && schema.readOnly) ||


### PR DESCRIPTION
## Problem

`getExampleFromSchema` omitted every schema annotated `deprecated: true`, unconditionally and on **every** schema including the root. Note the asymmetry it grew up beside: `readOnly` and `writeOnly` are gated on a caller-supplied `mode`, while `deprecated` had no switch at all.

That is defensible for the request-body form-filler the builder was written for — you do not want to pre-fill a discouraged field. It is not defensible for anything that must produce a value satisfying a schema it just declared. In both JSON Schema 2020-12 §9.3 and OpenAPI, `deprecated` is a **lifecycle annotation**: the field is discouraged, not absent. A real deprecated server still returns it.

So `@scalar/mock-server` was serving bodies that violated its own contract:

| Document served by `createMockServer` | Before |
| --- | --- |
| `200` → `application/json`, root schema `deprecated: true` | **`200`, `content-type: application/json`, zero-byte body** |
| `200` → object, `required: ['id','legacy']`, `legacy` deprecated | **`{"id":"string"}`** — violates its own `required` |
| AsyncAPI channel with a `deprecated` message payload | **`data: null`** |
| `200` with a declared response header whose schema generates nothing | **the header is deleted** — see below |

The first row is what motivated this: an API deprecated end to end (Cohere's finetuning endpoints) answered `200 application/json` with nothing in it, and every generated client that decodes a declared body raised on it.

The header row is a separate latent bug found while fixing the first. `getExampleFromSchema` returning `undefined` was handed straight to `c.header(name, value)`, and Hono treats `undefined` as a **delete** rather than a no-op. Because the header loop runs after `cors()` — which sets `Access-Control-Allow-Origin` before `await next()` — what actually got removed was a header the middleware had already set.

## Solution

An **opt-in** `includeDeprecated` option, not a change of semantics. Only `@scalar/mock-server` passes it; every other caller's output is byte-identical. Ships as a `patch`.

**`@scalar/workspace-store`** — three edits that had to land together, because `GetExampleFromSchemaOptions` is not exported and the flag cannot be set from outside the module:

1. `includeDeprecated?: boolean` on the options type.
2. `shouldOmitProperty` gates the annotation test on it. `readOnly`/`writeOnly` are untouched.
3. **The options cache key gets the flag.** This one is load-bearing and easy to miss: `resultCache` is a module-global `WeakMap` keyed by schema identity plus the serialized options, and its lookup runs *before* the annotation is tested. Without the key entry an include-caller's populated object could be served to a default caller — regressing existing behaviour, not just the mock. `JSON.stringify` drops `undefined`, so every existing caller's key string stays byte-identical.

**`@scalar/mock-server`** — all five places it generates a value that must satisfy a declared schema now opt in. Four of them share the option set through a new `generateResponseExample`, so a newly added response path cannot quietly miss the invariant. Response headers stay off it deliberately: `emptyString` would turn a bare `type: 'string'` header into the literal `string` and switch on format-based generation (`format: 'date-time'` → a fabricated timestamp), and `mode: 'read'` would drop a `writeOnly` header entirely. They pass `includeDeprecated` alone, and the guard widens to `value != null`.

Request-example builders are untouched — `get-request-body-example.ts` and the two `blocks` HAR builders keep omitting deprecated fields, which is what a form-filler wants.

### Deliberately out of scope

`@scalar/api-reference` (`example-responses/helpers/get-example-content.ts`) and `@scalar/openapi-to-markdown` (`MarkdownReference.vue`) render response examples through the same builder and carry the identical defect — a response whose schema is `deprecated: true` displays **no example at all** today. Opting them in is a product call about what documentation should show, so it is tracked separately rather than smuggled into a patch.

### On testing this

An unconditional fix needs one test. An **opt-in** flag regresses the moment someone edits a site that has none, so there is one case per call site, and each was verified in isolation rather than in aggregate:

| Revert, alone | Tests that fail |
| --- | --- |
| the `includeDeprecated` gate | exactly 6 — one per call site |
| the `value != null` guard | exactly 1 |
| `pathParameters(c)` at the two `x-handler` sites | exactly 2 |

That per-site check earned its keep. The first version of the `res['200']` test passed with its call site unfixed: the value came back `undefined`, `normalizeResponseBody` passed it through, the sandbox dropped the key in JSON, and `mockHandlerResponse` then regenerated the body from its *own* already-fixed call. Wrapping the return makes the unfixed case visible as `{}`. Likewise the first header test used an empty schema, which generates `null` — skipped by the old guard too, so it could not tell the two operators apart; a dangling `$ref` is what generates `undefined`.

Also confirmed by differential run, since `deprecated` is an annotation keyword with no assertion behaviour: with `validateRequest: true`, a document carrying the annotation and the same document stripped of it return byte-identical statuses and `violations` payloads across requests exercising the path, query, required-body, property and `additionalProperties` validators.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset.
- [x] I added tests.
- [ ] I updated the documentation. <!-- No user-facing docs cover per-keyword generation rules; `deprecated`/`readOnly`/`writeOnly` appear in neither the mock-server guide nor its skill. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qj2gY9ni4hUXU5EiG6WCV

---
_Generated by [Claude Code](https://claude.ai/code/session_019Qj2gY9ni4hUXU5EiG6WCV)_