### PR TITLE
fix(api-client): hide code snippet section when all clients are hidden

### DIFF
--- a/.changeset/plain-pianos-listen.md
+++ b/.changeset/plain-pianos-listen.md
@@ -1,0 +1,5 @@
+---
+'@scalar/api-client': patch
+---
+
+fix: hide the code snippet section when all clients are hidden

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestCodeSnippet.test.ts
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestCodeSnippet.test.ts
@@ -1,8 +1,9 @@
 import type { ClientOptionGroup, CodeExampleProps } from '@scalar/blocks/code-example'
 import type { WorkspaceEventBus } from '@scalar/workspace-store/events'
 import type { OperationObject } from '@scalar/workspace-store/schemas/v3.1/strict/openapi-document'
-import { shallowMount } from '@vue/test-utils'
+import { mount, shallowMount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, vShow, withDirectives } from 'vue'
 
 import RequestCodeSnippet from './RequestCodeSnippet.vue'
 
@@ -99,7 +100,24 @@ describe('RequestCodeSnippet', () => {
         props: createProps(),
       })
 
-      expect(wrapper.find('collapsible-section-stub').isVisible()).toBe(false)
+      expect(wrapper.find('collapsible-section-stub').exists()).toBe(false)
+    })
+
+    /**
+     * The parent (RequestBlock) puts its own `v-show` on this component. Two v-shows
+     * write the same root `style.display`, and the parent's truthy one wins, so a
+     * `v-show` here would leave an empty "Code Snippet" section on screen.
+     *
+     * @see https://github.com/scalar/scalar/issues/7986
+     */
+    it('stays hidden even when a parent v-show is truthy', () => {
+      const Parent = defineComponent({
+        render: () => withDirectives(h(RequestCodeSnippet, createProps()), [[vShow, true]]),
+      })
+
+      const wrapper = mount(Parent)
+
+      expect(wrapper.text()).not.toContain('Code Snippet')
     })
   })
 })

--- a/packages/api-client/src/v2/blocks/request-block/components/RequestCodeSnippet.vue
+++ b/packages/api-client/src/v2/blocks/request-block/components/RequestCodeSnippet.vue
@@ -107,7 +107,7 @@ const hasClients = computed(() =>
 
 <template>
   <CollapsibleSection
-    v-show="hasClients"
+    v-if="hasClients"
     class="group/preview w-full border-t"
     :defaultOpen="false">
     <template #title>Code Snippet</template>


### PR DESCRIPTION
## Problem

<img width="705" height="96" alt="image" src="https://github.com/user-attachments/assets/7919ccf3-a9ac-46c7-9426-da20e78472d9" />
<br><br>

With `hiddenClients: true`, the API client still renders an empty **Code Snippet** section: a collapsible with no client selected and a blank code block showing just line `1`.

This is [#7986](https://github.com/scalar/scalar/issues/7986), which [#7992](https://github.com/scalar/scalar/pull/7992) intended to fix. That PR's logic was right (no clients → hide the section), but the mechanism it used never took effect, so the issue is still reproducible on current `main` (also reported against 1.57.1 in [this comment](https://github.com/scalar/scalar/issues/7986#issuecomment-4458594325)).

The cause is two competing `v-show` directives on the same element:

- `RequestCodeSnippet.vue` puts `v-show="hasClients"` on its `CollapsibleSection` root.
- `RequestBlock.vue` puts `v-show="selectedFilter === 'All'"` on the `<RequestCodeSnippet>` component itself.

Both write `style.display` on the *same* root element, and the parent's directive is applied last. With the filter on `All` (the default) it resets `display` to `''`, wiping the `display: none` the component just set.

Verified by mounting: on its own the component gets `style="display: none"`; wrapped in a parent with a truthy `v-show` it gets `style=""` and the section becomes visible.

## Solution

Swap the component's `v-show="hasClients"` for `v-if`, so when there are no clients there is no element left for the parent's directive to un-hide.

The existing visibility test was asserting on a stub in isolation, which is why the clash was invisible to it. It now checks `.exists()`, and a regression test mounts the component under a truthy parent `v-show` to cover the actual failure mode.

## Checklist

- [x] I explained why the change is needed.
- [x] I added a changeset. <!-- pnpm changeset -->
- [x] I added tests.
- [ ] I updated the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
